### PR TITLE
fixes: support closable health server to avoid being stuck

### DIFF
--- a/common/rpc/closable_health_server.go
+++ b/common/rpc/closable_health_server.go
@@ -65,6 +65,8 @@ func (c *ClosableHeathServer) Watch(request *grpc_health_v1.HealthCheckRequest, 
 }
 
 func (c *ClosableHeathServer) Close() error {
+	c.Shutdown()
+
 	c.cancel()
 	c.Wait()
 

--- a/common/rpc/closable_health_server.go
+++ b/common/rpc/closable_health_server.go
@@ -69,7 +69,6 @@ func (c *ClosableHeathServer) Close() error {
 
 	c.cancel()
 	c.Wait()
-
 	return nil
 }
 

--- a/common/rpc/closable_health_server.go
+++ b/common/rpc/closable_health_server.go
@@ -59,7 +59,7 @@ func (c *ClosableHeathServer) Watch(request *grpc_health_v1.HealthCheckRequest, 
 		case err := <-finishCh:
 			return err
 		case <-c.ctx.Done():
-			return c.ctx.Err()
+			return nil
 		}
 	}
 }

--- a/common/rpc/closable_health_server.go
+++ b/common/rpc/closable_health_server.go
@@ -72,9 +72,9 @@ func (c *ClosableHeathServer) Close() error {
 	return nil
 }
 
-func NewCancelableHeathServer(ctx context.Context) HealthServer {
+func NewCancelableHealthServer(ctx context.Context) HealthServer {
 	ctx, cancelFunc := context.WithCancel(ctx)
-	return &ClosableHeathServer{
+	return &ClosableHealthServer{
 		ctx:    ctx,
 		cancel: cancelFunc,
 		Server: health.NewServer(),

--- a/common/rpc/closable_health_server.go
+++ b/common/rpc/closable_health_server.go
@@ -35,9 +35,9 @@ type HealthServer interface {
 	Resume()
 }
 
-var _ HealthServer = &ClosableHeathServer{}
+var _ HealthServer = &ClosableHealthServer{}
 
-type ClosableHeathServer struct {
+type ClosableHealthServer struct {
 	sync.WaitGroup
 	*health.Server
 

--- a/common/rpc/closable_health_server.go
+++ b/common/rpc/closable_health_server.go
@@ -35,9 +35,9 @@ type HealthServer interface {
 	Resume()
 }
 
-var _ HealthServer = &CloseableHeathServer{}
+var _ HealthServer = &ClosableHeathServer{}
 
-type CloseableHeathServer struct {
+type ClosableHeathServer struct {
 	sync.WaitGroup
 	*health.Server
 
@@ -46,7 +46,7 @@ type CloseableHeathServer struct {
 }
 
 // Watch support to monitor the context of server to allow close health server manually.
-func (c *CloseableHeathServer) Watch(request *grpc_health_v1.HealthCheckRequest, g grpc.ServerStreamingServer[grpc_health_v1.HealthCheckResponse]) error {
+func (c *ClosableHeathServer) Watch(request *grpc_health_v1.HealthCheckRequest, g grpc.ServerStreamingServer[grpc_health_v1.HealthCheckResponse]) error {
 	finishCh := make(chan error, 1)
 	c.Add(1)
 	go func() {
@@ -64,7 +64,7 @@ func (c *CloseableHeathServer) Watch(request *grpc_health_v1.HealthCheckRequest,
 	}
 }
 
-func (c *CloseableHeathServer) Close() error {
+func (c *ClosableHeathServer) Close() error {
 	c.cancel()
 	c.Wait()
 
@@ -73,7 +73,7 @@ func (c *CloseableHeathServer) Close() error {
 
 func NewCancelableHeathServer(ctx context.Context) HealthServer {
 	ctx, cancelFunc := context.WithCancel(ctx)
-	return &CloseableHeathServer{
+	return &ClosableHeathServer{
 		ctx:    ctx,
 		cancel: cancelFunc,
 		Server: health.NewServer(),

--- a/common/rpc/closable_health_server.go
+++ b/common/rpc/closable_health_server.go
@@ -46,7 +46,7 @@ type ClosableHealthServer struct {
 }
 
 // Watch support to monitor the context of server to allow close health server manually.
-func (c *ClosableHeathServer) Watch(request *grpc_health_v1.HealthCheckRequest, g grpc.ServerStreamingServer[grpc_health_v1.HealthCheckResponse]) error {
+func (c *ClosableHealthServer) Watch(request *grpc_health_v1.HealthCheckRequest, g grpc.ServerStreamingServer[grpc_health_v1.HealthCheckResponse]) error {
 	finishCh := make(chan error, 1)
 	c.Add(1)
 	go func() {
@@ -64,7 +64,7 @@ func (c *ClosableHeathServer) Watch(request *grpc_health_v1.HealthCheckRequest, 
 	}
 }
 
-func (c *ClosableHeathServer) Close() error {
+func (c *ClosableHealthServer) Close() error {
 	c.Shutdown()
 
 	c.cancel()
@@ -72,7 +72,7 @@ func (c *ClosableHeathServer) Close() error {
 	return nil
 }
 
-func NewCancelableHealthServer(ctx context.Context) HealthServer {
+func NewClosableHealthServer(ctx context.Context) HealthServer {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	return &ClosableHealthServer{
 		ctx:    ctx,

--- a/common/rpc/closeable_health_server.go
+++ b/common/rpc/closeable_health_server.go
@@ -1,0 +1,81 @@
+// Copyright 2025 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+type HealthServer interface {
+	io.Closer
+	grpc_health_v1.HealthServer
+
+	SetServingStatus(service string, servingStatus grpc_health_v1.HealthCheckResponse_ServingStatus)
+
+	Shutdown()
+
+	Resume()
+}
+
+var _ HealthServer = &CloseableHeathServer{}
+
+type CloseableHeathServer struct {
+	sync.WaitGroup
+	*health.Server
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// Watch support to monitor the context of server to allow close health server manually.
+func (c *CloseableHeathServer) Watch(request *grpc_health_v1.HealthCheckRequest, g grpc.ServerStreamingServer[grpc_health_v1.HealthCheckResponse]) error {
+	finishCh := make(chan error, 1)
+	c.Add(1)
+	go func() {
+		finishCh <- c.Server.Watch(request, g)
+		c.Done()
+	}()
+
+	for {
+		select {
+		case err := <-finishCh:
+			return err
+		case <-c.ctx.Done():
+			return c.ctx.Err()
+		}
+	}
+}
+
+func (c *CloseableHeathServer) Close() error {
+	c.cancel()
+	c.Wait()
+
+	return nil
+}
+
+func NewCancelableHeathServer(ctx context.Context) HealthServer {
+	ctx, cancelFunc := context.WithCancel(ctx)
+	return &CloseableHeathServer{
+		ctx:    ctx,
+		cancel: cancelFunc,
+		Server: health.NewServer(),
+	}
+}

--- a/server/assignment_dispatcher.go
+++ b/server/assignment_dispatcher.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
@@ -56,7 +55,7 @@ type shardAssignmentDispatcher struct {
 	clients      map[int64]chan *proto.ShardAssignments
 	nextClientId int64
 	standalone   bool
-	healthServer *health.Server
+	healthServer rpc.HealthServer
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -248,7 +247,7 @@ func (s *shardAssignmentDispatcher) updateShardAssignment(assignments *proto.Sha
 	return nil
 }
 
-func NewShardAssignmentDispatcher(healthServer *health.Server) ShardAssignmentsDispatcher {
+func NewShardAssignmentDispatcher(healthServer rpc.HealthServer) ShardAssignmentsDispatcher {
 	s := &shardAssignmentDispatcher{
 		assignments:  nil,
 		healthServer: healthServer,
@@ -273,7 +272,7 @@ func NewShardAssignmentDispatcher(healthServer *health.Server) ShardAssignmentsD
 }
 
 func NewStandaloneShardAssignmentDispatcher(numShards uint32) ShardAssignmentsDispatcher {
-	assignmentDispatcher := NewShardAssignmentDispatcher(health.NewServer()).(*shardAssignmentDispatcher) //nolint:revive
+	assignmentDispatcher := NewShardAssignmentDispatcher(rpc.NewCancelableHeathServer(context.Background())).(*shardAssignmentDispatcher) //nolint:revive
 	assignmentDispatcher.standalone = true
 	res := &proto.ShardAssignments{
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{

--- a/server/assignment_dispatcher.go
+++ b/server/assignment_dispatcher.go
@@ -272,7 +272,7 @@ func NewShardAssignmentDispatcher(healthServer rpc.HealthServer) ShardAssignment
 }
 
 func NewStandaloneShardAssignmentDispatcher(numShards uint32) ShardAssignmentsDispatcher {
-	assignmentDispatcher := NewShardAssignmentDispatcher(rpc.NewCancelableHeathServer(context.Background())).(*shardAssignmentDispatcher) //nolint:revive
+	assignmentDispatcher := NewShardAssignmentDispatcher(rpc.NewClosableHealthServer(context.Background())).(*shardAssignmentDispatcher) //nolint:revive
 	assignmentDispatcher.standalone = true
 	res := &proto.ShardAssignments{
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{

--- a/server/assignment_dispatcher_test.go
+++ b/server/assignment_dispatcher_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 	pb "google.golang.org/protobuf/proto"
@@ -86,8 +85,8 @@ func TestShardAssignmentDispatcher_Initialized(t *testing.T) {
 }
 
 func TestShardAssignmentDispatcher_ReadinessProbe(t *testing.T) {
-	healthServer := health.NewServer()
-	dispatcher := NewShardAssignmentDispatcher(rpc.NewCancelableHeathServer(t.Context()))
+	healthServer := rpc.NewCancelableHeathServer(t.Context())
+	dispatcher := NewShardAssignmentDispatcher(healthServer)
 	coordinatorStream := newMockShardAssignmentControllerStream()
 	go func() {
 		err := dispatcher.PushShardAssignments(coordinatorStream)

--- a/server/assignment_dispatcher_test.go
+++ b/server/assignment_dispatcher_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestUninitializedAssignmentDispatcher(t *testing.T) {
-	dispatcher := NewShardAssignmentDispatcher(health.NewServer())
+	dispatcher := NewShardAssignmentDispatcher(rpc.NewCancelableHeathServer(t.Context()))
 	mockClient := newMockShardAssignmentClientStream()
 	assert.False(t, dispatcher.Initialized())
 	req := &proto.ShardAssignmentsRequest{Namespace: constant.DefaultNamespace}
@@ -45,7 +45,7 @@ func TestUninitializedAssignmentDispatcher(t *testing.T) {
 }
 
 func TestShardAssignmentDispatcher_Initialized(t *testing.T) {
-	dispatcher := NewShardAssignmentDispatcher(health.NewServer())
+	dispatcher := NewShardAssignmentDispatcher(rpc.NewCancelableHeathServer(t.Context()))
 	coordinatorStream := newMockShardAssignmentControllerStream()
 	go func() {
 		err := dispatcher.PushShardAssignments(coordinatorStream)
@@ -87,7 +87,7 @@ func TestShardAssignmentDispatcher_Initialized(t *testing.T) {
 
 func TestShardAssignmentDispatcher_ReadinessProbe(t *testing.T) {
 	healthServer := health.NewServer()
-	dispatcher := NewShardAssignmentDispatcher(healthServer)
+	dispatcher := NewShardAssignmentDispatcher(rpc.NewCancelableHeathServer(t.Context()))
 	coordinatorStream := newMockShardAssignmentControllerStream()
 	go func() {
 		err := dispatcher.PushShardAssignments(coordinatorStream)
@@ -133,7 +133,7 @@ func TestShardAssignmentDispatcher_AddClient(t *testing.T) {
 	shard1InitialAssignment := newShardAssignment(1, "server2", 100, math.MaxUint32)
 	shard1UpdatedAssignment := newShardAssignment(1, "server3", 100, math.MaxUint32)
 
-	dispatcher := NewShardAssignmentDispatcher(health.NewServer())
+	dispatcher := NewShardAssignmentDispatcher(rpc.NewCancelableHeathServer(t.Context()))
 
 	coordinatorStream := newMockShardAssignmentControllerStream()
 	go func() {
@@ -215,7 +215,7 @@ func TestShardAssignmentDispatcher_AddClient(t *testing.T) {
 }
 
 func TestShardAssignmentDispatcher_MultipleNamespaces(t *testing.T) {
-	dispatcher := NewShardAssignmentDispatcher(health.NewServer())
+	dispatcher := NewShardAssignmentDispatcher(rpc.NewCancelableHeathServer(t.Context()))
 
 	coordinatorStream := newMockShardAssignmentControllerStream()
 	go func() {

--- a/server/assignment_dispatcher_test.go
+++ b/server/assignment_dispatcher_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestUninitializedAssignmentDispatcher(t *testing.T) {
-	dispatcher := NewShardAssignmentDispatcher(rpc.NewCancelableHeathServer(t.Context()))
+	dispatcher := NewShardAssignmentDispatcher(rpc.NewClosableHealthServer(t.Context()))
 	mockClient := newMockShardAssignmentClientStream()
 	assert.False(t, dispatcher.Initialized())
 	req := &proto.ShardAssignmentsRequest{Namespace: constant.DefaultNamespace}
@@ -44,7 +44,7 @@ func TestUninitializedAssignmentDispatcher(t *testing.T) {
 }
 
 func TestShardAssignmentDispatcher_Initialized(t *testing.T) {
-	dispatcher := NewShardAssignmentDispatcher(rpc.NewCancelableHeathServer(t.Context()))
+	dispatcher := NewShardAssignmentDispatcher(rpc.NewClosableHealthServer(t.Context()))
 	coordinatorStream := newMockShardAssignmentControllerStream()
 	go func() {
 		err := dispatcher.PushShardAssignments(coordinatorStream)
@@ -85,7 +85,7 @@ func TestShardAssignmentDispatcher_Initialized(t *testing.T) {
 }
 
 func TestShardAssignmentDispatcher_ReadinessProbe(t *testing.T) {
-	healthServer := rpc.NewCancelableHeathServer(t.Context())
+	healthServer := rpc.NewClosableHealthServer(t.Context())
 	dispatcher := NewShardAssignmentDispatcher(healthServer)
 	coordinatorStream := newMockShardAssignmentControllerStream()
 	go func() {
@@ -132,7 +132,7 @@ func TestShardAssignmentDispatcher_AddClient(t *testing.T) {
 	shard1InitialAssignment := newShardAssignment(1, "server2", 100, math.MaxUint32)
 	shard1UpdatedAssignment := newShardAssignment(1, "server3", 100, math.MaxUint32)
 
-	dispatcher := NewShardAssignmentDispatcher(rpc.NewCancelableHeathServer(t.Context()))
+	dispatcher := NewShardAssignmentDispatcher(rpc.NewClosableHealthServer(t.Context()))
 
 	coordinatorStream := newMockShardAssignmentControllerStream()
 	go func() {
@@ -214,7 +214,7 @@ func TestShardAssignmentDispatcher_AddClient(t *testing.T) {
 }
 
 func TestShardAssignmentDispatcher_MultipleNamespaces(t *testing.T) {
-	dispatcher := NewShardAssignmentDispatcher(rpc.NewCancelableHeathServer(t.Context()))
+	dispatcher := NewShardAssignmentDispatcher(rpc.NewClosableHealthServer(t.Context()))
 
 	coordinatorStream := newMockShardAssignmentControllerStream()
 	go func() {

--- a/server/internal_rpc_server.go
+++ b/server/internal_rpc_server.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -43,12 +42,12 @@ type internalRpcServer struct {
 	shardsDirector       ShardsDirector
 	assignmentDispatcher ShardAssignmentsDispatcher
 	grpcServer           rpc.GrpcServer
-	healthServer         *health.Server
+	healthServer         rpc.HealthServer
 	log                  *slog.Logger
 }
 
 func newInternalRpcServer(grpcProvider rpc.GrpcProvider, bindAddress string, shardsDirector ShardsDirector,
-	assignmentDispatcher ShardAssignmentsDispatcher, healthServer *health.Server, tlsConf *tls.Config) (*internalRpcServer, error) {
+	assignmentDispatcher ShardAssignmentsDispatcher, healthServer rpc.HealthServer, tlsConf *tls.Config) (*internalRpcServer, error) {
 	server := &internalRpcServer{
 		shardsDirector:       shardsDirector,
 		assignmentDispatcher: assignmentDispatcher,

--- a/server/internal_rpc_server_test.go
+++ b/server/internal_rpc_server_test.go
@@ -22,14 +22,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/oxia-db/oxia/common/rpc"
 )
 
 func TestInternalHealthCheck(t *testing.T) {
-	healthServer := health.NewServer()
+	healthServer := rpc.NewCancelableHeathServer(t.Context())
 	server, err := newInternalRpcServer(rpc.Default, "localhost:0", nil,
 		NewShardAssignmentDispatcher(healthServer), healthServer, nil)
 	assert.NoError(t, err)

--- a/server/internal_rpc_server_test.go
+++ b/server/internal_rpc_server_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestInternalHealthCheck(t *testing.T) {
-	healthServer := rpc.NewCancelableHeathServer(t.Context())
+	healthServer := rpc.NewClosableHealthServer(t.Context())
 	server, err := newInternalRpcServer(rpc.Default, "localhost:0", nil,
 		NewShardAssignmentDispatcher(healthServer), healthServer, nil)
 	assert.NoError(t, err)

--- a/server/server.go
+++ b/server/server.go
@@ -91,7 +91,7 @@ func NewWithGrpcProvider(config Config, provider rpc.GrpcProvider, replicationRp
 			SyncData:    true,
 		}),
 		kvFactory:    kvFactory,
-		healthServer: rpc.NewCancelableHeathServer(context.Background()),
+		healthServer: rpc.NewClosableHealthServer(context.Background()),
 	}
 
 	s.shardsDirector = NewShardsDirector(config, s.walFactory, s.kvFactory, replicationRpcProvider)


### PR DESCRIPTION
### Motivation

Supports closable health servers to avoid the GRPC server graceful shutdown getting stuck due to the client watch stream not being closed.


### Modification

- Introduce a component named `ClosableHeathServer`
- Close the `ClosableHeathServer` when the server closes.
- Add a test for that.