### PR TITLE
feat: introduce committed version IDs to avoid accidentally writing dirty version ID trackers

### DIFF
--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -511,7 +511,7 @@ func (d *db) ReadTerm() (term int64, options TermOptions, err error) {
 
 func (d *db) applyPut(batch WriteBatch, baseVersionId *atomic.Int64, notifications *Notifications,
 	putReq *proto.PutRequest, timestamp uint64,
-	updateOperationCallback UpdateOperationCallback, internal bool) (*proto.PutResponse, error) { //nolint:revive
+	updateOperationCallback UpdateOperationCallback, internal bool) (*proto.PutResponse, error) {
 	var se *proto.StorageEntry
 	var err error
 	var newKey string

--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -511,7 +511,7 @@ func (d *db) ReadTerm() (term int64, options TermOptions, err error) {
 
 func (d *db) applyPut(batch WriteBatch, baseVersionId *atomic.Int64, notifications *Notifications,
 	putReq *proto.PutRequest, timestamp uint64,
-	updateOperationCallback UpdateOperationCallback, internal bool) (*proto.PutResponse, error) {
+	updateOperationCallback UpdateOperationCallback, internal bool) (*proto.PutResponse, error) { //nolint:revive
 	var se *proto.StorageEntry
 	var err error
 	var newKey string

--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -509,9 +509,10 @@ func (d *db) ReadTerm() (term int64, options TermOptions, err error) {
 	return term, options, nil
 }
 
+//nolint:revive
 func (d *db) applyPut(batch WriteBatch, baseVersionId *atomic.Int64, notifications *Notifications,
 	putReq *proto.PutRequest, timestamp uint64,
-	updateOperationCallback UpdateOperationCallback, internal bool) (*proto.PutResponse, error) { //nolint:revive
+	updateOperationCallback UpdateOperationCallback, internal bool) (*proto.PutResponse, error) {
 	var se *proto.StorageEntry
 	var err error
 	var newKey string


### PR DESCRIPTION
### Motivation

introduce committed version IDs to avoid accidentally writing dirty version ID trackers


### Modification

- Introduce the committed version ID to avoid increasing the version if the whole write logic failed.
- Add another condition on TestDBVersionIDWithError to reproduce the issue.