### PR TITLE
fix(server): fix the ephemeral key leak by non-atomic operation

### DIFF
--- a/oxia/sessions.go
+++ b/oxia/sessions.go
@@ -258,17 +258,16 @@ func (cs *clientSession) Close() error {
 func (cs *clientSession) keepAlive() error {
 	cs.sessions.Lock()
 	cs.Lock()
-	timeout := cs.sessions.clientOpts.sessionTimeout
 	ctx := cs.ctx
 	shardId := cs.shardId
 	sessionId := cs.sessionId
 	cs.Unlock()
 	cs.sessions.Unlock()
 
-	tickTime := timeout / 10
-	if tickTime < 2*time.Second {
-		tickTime = 2 * time.Second
-	}
+	tickTime := 30 * time.Second
+	//if tickTime < 2*time.Second {
+	//	tickTime = 2 * time.Second
+	//}
 
 	ticker := time.NewTicker(tickTime)
 	defer ticker.Stop()

--- a/server/session.go
+++ b/server/session.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net/url"
 	"sync"
 	"time"
 
@@ -98,58 +97,14 @@ func (s *session) close() {
 }
 
 func (s *session) delete() error {
-	// Delete ephemeral data associated with this session
 	sessionKey := SessionKey(s.id)
-	// Read "index"
-	keys, err := s.sm.leaderController.ListBlock(context.Background(), &proto.ListRequest{
-		Shard:          &s.shardId,
-		StartInclusive: sessionKey + "/",
-		EndExclusive:   sessionKey + "//",
-	})
-	if err != nil {
-		return err
-	}
-	// Delete ephemerals
-	var deletes []*proto.DeleteRequest
-	s.log.Debug(
-		"Keys to delete",
-		slog.Any("keys", keys),
-	)
-	for _, key := range keys {
-		unescapedKey, err := url.PathUnescape(key[len(sessionKey)+1:])
-		if err != nil {
-			s.log.Error(
-				"Invalid session key",
-				slog.Any("error", err),
-				slog.String("key", sessionKey),
-			)
-			continue
-		}
-		if unescapedKey != "" {
-			deletes = append(deletes, &proto.DeleteRequest{
-				Key: unescapedKey,
-			})
-		}
-	}
-
 	// Delete the base session metadata
-	deletes = append(deletes, &proto.DeleteRequest{
-		Key: sessionKey,
+	_, err := s.sm.leaderController.WriteBlock(context.Background(), &proto.WriteRequest{
+		Shard:        &s.shardId,
+		Puts:         nil,
+		Deletes:      []*proto.DeleteRequest{{Key: sessionKey}},
+		DeleteRanges: nil,
 	})
-	_, err = s.sm.leaderController.WriteBlock(context.Background(), &proto.WriteRequest{
-		Shard:   &s.shardId,
-		Puts:    nil,
-		Deletes: deletes,
-		// Delete the whole index of ephemeral keys for the session
-		DeleteRanges: []*proto.DeleteRangeRequest{
-			{
-				StartInclusive: sessionKey + "/",
-				EndExclusive:   sessionKey + "//",
-			},
-		},
-	})
-	s.log.Info("Session cleanup complete",
-		slog.Int("keys-deleted", len(deletes)))
 	return err
 }
 

--- a/server/session_manager.go
+++ b/server/session_manager.go
@@ -20,23 +20,22 @@ import (
 	"io"
 	"log/slog"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-	"go.uber.org/multierr"
-
-	"github.com/oxia-db/oxia/common/constant"
-
 	"github.com/oxia-db/oxia/common/collection"
+	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/common/metric"
 	"github.com/oxia-db/oxia/proto"
 	"github.com/oxia-db/oxia/server/kv"
+	"github.com/pkg/errors"
 )
 
 const (
 	sessionKeyPrefix = constant.InternalKeyPrefix + "session"
 	sessionKeyFormat = sessionKeyPrefix + "/%016x"
+	sessionKeyLength = len(sessionKeyPrefix) + 1 + 16
 )
 
 type SessionId int64
@@ -61,6 +60,16 @@ func KeyToId(key string) (SessionId, error) {
 	}
 
 	return SessionId(id), nil
+}
+
+func IsSessionKey(key string) bool {
+	if !strings.HasPrefix(key, sessionKeyPrefix) {
+		return false
+	}
+	if len(key) != sessionKeyLength {
+		return false
+	}
+	return true
 }
 
 // --- SessionManager
@@ -326,7 +335,7 @@ func (*sessionManagerUpdateOperationCallbackS) OnPutWithinSession(batch kv.Write
 	return proto.Status_OK, nil
 }
 
-func (c *sessionManagerUpdateOperationCallbackS) OnPut(batch kv.WriteBatch, request *proto.PutRequest, existingEntry *proto.StorageEntry) (proto.Status, error) {
+func (s *sessionManagerUpdateOperationCallbackS) OnPut(batch kv.WriteBatch, request *proto.PutRequest, existingEntry *proto.StorageEntry) (proto.Status, error) {
 	switch {
 	// override by normal operation
 	case request.SessionId == nil:
@@ -335,7 +344,7 @@ func (c *sessionManagerUpdateOperationCallbackS) OnPut(batch kv.WriteBatch, requ
 		}
 		// override by session operation
 	case request.SessionId != nil:
-		return c.OnPutWithinSession(batch, request, existingEntry)
+		return s.OnPutWithinSession(batch, request, existingEntry)
 	}
 	return proto.Status_OK, nil
 }
@@ -352,52 +361,93 @@ func deleteShadow(batch kv.WriteBatch, key string, existingEntry *proto.StorageE
 	return proto.Status_OK, nil
 }
 
-func (*sessionManagerUpdateOperationCallbackS) OnDelete(batch kv.WriteBatch, key string) error {
+func (s *sessionManagerUpdateOperationCallbackS) OnDelete(batch kv.WriteBatch, key string) error {
 	se, err := kv.GetStorageEntry(batch, key)
+	if err != nil {
+		if errors.Is(err, kv.ErrKeyNotFound) {
+			return nil
+		}
+	}
 	defer se.ReturnToVTPool()
-
-	if errors.Is(err, kv.ErrKeyNotFound) {
-		return nil
-	}
-	if err == nil && se.SessionId != nil {
-		_, err = deleteShadow(batch, key, se)
+	if err = s.OnDeleteWithEntry(batch, key, se); err != nil {
+		return err
 	}
 	return err
 }
 
-func (*sessionManagerUpdateOperationCallbackS) OnDeleteWithEntry(batch kv.WriteBatch, key string, value *proto.StorageEntry) error {
-	_, err := deleteShadow(batch, key, value)
-	return err
+func (*sessionManagerUpdateOperationCallbackS) OnDeleteWithEntry(batch kv.WriteBatch, key string, entry *proto.StorageEntry) error {
+	if _, err := deleteShadow(batch, key, entry); err != nil {
+		return err
+	}
+	if IsSessionKey(key) {
+		id, err := KeyToId(key)
+		if err != nil {
+			return err
+		}
+		sessionKey := SessionKey(id)
+		// Read "index"
+		it, err := batch.KeyRangeScan(sessionKey+"/", sessionKey+"//")
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err = it.Close(); err != nil {
+				slog.Warn("Failed to close the iterator when delete session ephemeral keys.", slog.Any("error", err))
+			}
+		}()
+		for ; it.Valid(); it.Next() {
+			escapedEphemeralKey := it.Key()
+			// delete the ephemeral key index
+			if err := batch.Delete(escapedEphemeralKey); err != nil {
+				return err
+			}
+			unescapedEphemeralKey, err := url.PathUnescape(escapedEphemeralKey[len(key)+1:])
+			if err != nil {
+				return err
+			}
+			if unescapedEphemeralKey != "" {
+				// delete the ephemeral key
+				if err := batch.Delete(unescapedEphemeralKey); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
-func (*sessionManagerUpdateOperationCallbackS) OnDeleteRange(batch kv.WriteBatch, keyStartInclusive string, keyEndExclusive string) error {
+func (s *sessionManagerUpdateOperationCallbackS) OnDeleteRange(batch kv.WriteBatch, keyStartInclusive string, keyEndExclusive string) error {
 	it, err := batch.RangeScan(keyStartInclusive, keyEndExclusive)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err = it.Close(); err != nil {
+			slog.Warn("Failed to close the iterator when deleting the range.", slog.Any("error", err))
+		}
+	}()
 
-	for ; it.Valid(); it.Next() {
+	// introduce the process here for better defer resource release
+	iteratorProcessor := func(batch kv.WriteBatch, it kv.KeyValueIterator) error {
 		value, err := it.Value()
 		if err != nil {
-			return errors.Wrap(multierr.Combine(err, it.Close()), "oxia db: failed to delete range")
+			return err
 		}
 		se := proto.StorageEntryFromVTPool()
-
-		err = kv.Deserialize(value, se)
-		if err == nil && se.SessionId != nil {
-			_, err = deleteShadow(batch, it.Key(), se)
+		defer se.ReturnToVTPool()
+		if err = kv.Deserialize(value, se); err != nil {
+			return err
 		}
-
-		se.ReturnToVTPool()
-
-		if err != nil {
-			return errors.Wrap(multierr.Combine(err, it.Close()), "oxia db: failed to delete range")
+		if err = s.OnDeleteWithEntry(batch, it.Key(), se); err != nil {
+			return err
 		}
+		return nil
 	}
 
-	if err := it.Close(); err != nil {
-		return errors.Wrap(err, "oxia db: failed to delete range")
+	for ; it.Valid(); it.Next() {
+		if err := iteratorProcessor(batch, it); err != nil {
+			return errors.Wrap(err, "oxia db: failed to delete range")
+		}
 	}
-
-	return err
+	return nil
 }

--- a/tests/session/session_test.go
+++ b/tests/session/session_test.go
@@ -1,0 +1,48 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/oxia-db/oxia/oxia"
+	"github.com/oxia-db/oxia/server"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+)
+
+func TestNoLegacyKeys(t *testing.T) {
+	config := server.NewTestConfig(t.TempDir())
+	standaloneServer, err := server.NewStandalone(config)
+	assert.NoError(t, err)
+	defer standaloneServer.Close()
+
+	client, err := oxia.NewAsyncClient(fmt.Sprintf("localhost:%d", standaloneServer.RpcPort()))
+	assert.NoError(t, err)
+
+	after := time.After(1 * time.Minute)
+	limiter := rate.NewLimiter(rate.Limit(1000), 1000)
+loop:
+	for i := 0; ; i++ {
+		select {
+		case <-after:
+			break loop
+		default:
+			err := limiter.Wait(context.Background())
+			assert.NoError(t, err)
+			_ = client.Put(fmt.Sprintf("/session-legacy/%d", i), []byte{}, oxia.Ephemeral())
+		}
+	}
+	err = client.Close()
+	assert.NoError(t, err)
+
+	syncClient, err := oxia.NewSyncClient(fmt.Sprintf("localhost:%d", standaloneServer.RpcPort()))
+	assert.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		keys, err := syncClient.List(context.Background(), "/session-legacy/", "/session-legacy//")
+		return assert.NoError(t, err) && assert.Empty(t, keys)
+	}, 20*time.Second, 1*time.Second)
+
+}


### PR DESCRIPTION
### Motivation

A non-atomic operation will leak some ephemeral keys if the new KV is put after the session list.


### Modification

- Make the session index/ephemeral keys cleanup become an atomic operation.