### PR TITLE
fix(obj): fix the potential pooled object leak

### DIFF
--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -762,6 +762,7 @@ func GetStorageEntry(batch WriteBatch, key string) (*proto.StorageEntry, error) 
 		Deserialize(value, se),
 		closer.Close(),
 	); err != nil {
+		se.ReturnToVTPool()
 		return nil, err
 	}
 	return se, nil

--- a/server/secondary_indexes.go
+++ b/server/secondary_indexes.go
@@ -94,15 +94,14 @@ func (secondaryIndexesUpdateCallbackS) OnPut(batch kv.WriteBatch, _ *kv.Notifica
 
 func (secondaryIndexesUpdateCallbackS) OnDelete(batch kv.WriteBatch, _ *kv.Notifications, key string) error {
 	se, err := kv.GetStorageEntry(batch, key)
+	if err != nil {
+		if errors.Is(err, kv.ErrKeyNotFound) {
+			return nil
+		}
+		return err
+	}
 	defer se.ReturnToVTPool()
-
-	if errors.Is(err, kv.ErrKeyNotFound) {
-		return nil
-	}
-	if err == nil {
-		err = deleteSecondaryIndexes(batch, key, se)
-	}
-	return err
+	return deleteSecondaryIndexes(batch, key, se)
 }
 
 func (secondaryIndexesUpdateCallbackS) OnDeleteWithEntry(batch kv.WriteBatch, _ *kv.Notifications, key string, value *proto.StorageEntry) error {


### PR DESCRIPTION
### Motivation

fixes the potential pooled object leak and NPE.

### Modification

- Fixes the potential pooled object leak.
- Avoid the potential nil object causes `se.ReturnToVTPool()` panic.