### PR TITLE
fix(session): avoid complete rpc without response

### DIFF
--- a/server/public_rpc_server.go
+++ b/server/public_rpc_server.go
@@ -421,8 +421,8 @@ func (s *publicRpcServer) CloseSession(ctx context.Context, req *proto.CloseSess
 			)
 			return nil, err
 		}
-
 		s.log.Warn("Session not found, it should already closed")
+		return &proto.CloseSessionResponse{}, nil
 	}
 	return res, nil
 }

--- a/server/public_rpc_server.go
+++ b/server/public_rpc_server.go
@@ -414,9 +414,7 @@ func (s *publicRpcServer) CloseSession(ctx context.Context, req *proto.CloseSess
 	}
 	res, err := lc.CloseSession(req)
 	if err != nil {
-		if status.Code(err) == constant.CodeSessionNotFound {
-			s.log.Info("Session not found, it should already closed")
-		} else {
+		if status.Code(err) != constant.CodeSessionNotFound {
 			s.log.Warn("Failed to close session", slog.Any("error", err))
 		}
 		return nil, err

--- a/server/public_rpc_server.go
+++ b/server/public_rpc_server.go
@@ -414,15 +414,12 @@ func (s *publicRpcServer) CloseSession(ctx context.Context, req *proto.CloseSess
 	}
 	res, err := lc.CloseSession(req)
 	if err != nil {
-		if status.Code(err) != constant.CodeSessionNotFound {
-			s.log.Warn(
-				"Failed to close session",
-				slog.Any("error", err),
-			)
-			return nil, err
+		if status.Code(err) == constant.CodeSessionNotFound {
+			s.log.Info("Session not found, it should already closed")
+		} else {
+			s.log.Warn("Failed to close session", slog.Any("error", err))
 		}
-		s.log.Warn("Session not found, it should already closed")
-		return &proto.CloseSessionResponse{}, nil
+		return nil, err
 	}
 	return res, nil
 }


### PR DESCRIPTION
### Motivation

fixes: https://github.com/oxia-db/oxia/issues/745

The current logic will return `nil,nil` to the client when the session is not found. which is confusing the client side because we didn't give the correct response body, but an OK status.