### PR TITLE
Pin Pebble disk format to a specific version

### DIFF
--- a/server/kv/kv_pebble.go
+++ b/server/kv/kv_pebble.go
@@ -225,7 +225,7 @@ func newKVPebble(factory *PebbleFactory, namespace string, shardId int64) (KV, e
 			),
 		},
 
-		FormatMajorVersion: pebble.FormatNewest,
+		FormatMajorVersion: pebble.FormatVirtualSSTables,
 	}
 
 	if factory.options.InMemory {


### PR DESCRIPTION
It's safer to use the specific version for broader compatibility with downgrades