### PR TITLE
Fixed panic in coordinator when not initialized

### DIFF
--- a/coordinator/balancer/load_balancer.go
+++ b/coordinator/balancer/load_balancer.go
@@ -38,6 +38,8 @@ type Options struct {
 type LoadBalancer interface {
 	io.Closer
 
+	Start()
+
 	Trigger()
 
 	Action() <-chan actions.Action

--- a/coordinator/balancer/scheduler.go
+++ b/coordinator/balancer/scheduler.go
@@ -389,7 +389,11 @@ func (r *nodeBasedBalancer) rebalanceLeader() {
 
 	maxLeadersNodeID, maxLeaders, minLeaders := r.rankLeaders(nodeLeaders)
 
-	nsAndShards := nodeLeaders[maxLeadersNodeID]
+	nsAndShards, ok := nodeLeaders[maxLeadersNodeID]
+	if !ok {
+		// No leaders to check
+		return
+	}
 
 	for iter := nsAndShards.Iterator(); iter.Next(); {
 		nsAndShard := iter.Value()
@@ -472,12 +476,17 @@ func (r *nodeBasedBalancer) rankLeaders(nodeLeaders map[string]*arraylist.List[u
 	return maxLeadersNodeID, maxLeaders, minLeaders
 }
 
+func (r *nodeBasedBalancer) Start() {
+	r.startBackgroundScheduler()
+	r.startBackgroundNotifier()
+}
+
 func NewLoadBalancer(options Options) LoadBalancer {
 	ctx, cancelFunc := context.WithCancel(options.Context)
 	logger := slog.With(
 		slog.String("component", "load-balancer"))
 
-	nb := &nodeBasedBalancer{
+	return &nodeBasedBalancer{
 		WaitGroup:               &sync.WaitGroup{},
 		Logger:                  logger,
 		ctx:                     ctx,
@@ -493,7 +502,4 @@ func NewLoadBalancer(options Options) LoadBalancer {
 		shardQuarantineShardMap: &sync.Map{},
 		triggerCh:               make(chan any, 1),
 	}
-	nb.startBackgroundScheduler()
-	nb.startBackgroundNotifier()
-	return nb
 }

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -490,5 +490,6 @@ func NewCoordinator(meta metadata.Provider,
 		"component": "coordinator-action-worker",
 	}, c.startBackgroundActionWorker)
 
+	c.loadBalancer.Start()
 	return c, nil
 }


### PR DESCRIPTION
Coordinator is waiting for all storage nodes to come up the first time. The shard rebalancer is causing a panic after 30sec

```
Oct  7 12:28:23.311313 INF start shard rebalance avg-shard-ratio=+Inf component=load-balancer max-node-load-ratio=0 min-node-load-ratio=0 quarantine-nodes=[]
Oct  7 12:28:23.311867 INF end shard rebalance avg-shard-ratio=+Inf component=load-balancer max-node-load-ratio=0 min-node-load-ratio=0
Oct  7 12:28:23.312078 INF start leader rebalance component=load-balancer node-leaders={} quarantine-shards=[]
Oct  7 12:28:23.312220 INF end leader rebalance component=load-balancer
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x105f13b98]

goroutine 29 [running]:
github.com/emirpasic/gods/v2/lists/arraylist.(*List[...]).Size(...)
	/Users/mmerli/go/pkg/mod/github.com/emirpasic/gods/v2@v2.0.0-alpha.0.20250312000129-1d83d5ae39fb/lists/arraylist/arraylist.go:105
github.com/emirpasic/gods/v2/lists/arraylist.(*Iterator[...]).Next(...)
	/Users/mmerli/go/pkg/mod/github.com/emirpasic/gods/v2@v2.0.0-alpha.0.20250312000129-1d83d5ae39fb/lists/arraylist/iterator.go:28
github.com/oxia-db/oxia/coordinator/balancer.(*nodeBasedBalancer).rebalanceLeader(0x140001e98c0)
	/Users/mmerli/prg/oxia/coordinator/balancer/scheduler.go:394 +0x208
github.com/oxia-db/oxia/coordinator/balancer.(*nodeBasedBalancer).startBackgroundNotifier.func1()
	/Users/mmerli/prg/oxia/coordinator/balancer/scheduler.go:359 +0xc8
github.com/oxia-db/oxia/common/process.DoWithLabels.func1({0x106af1048?, 0x140001ca000?})
	/Users/mmerli/prg/oxia/common/process/pprof.go:46 +0x24
runtime/pprof.Do({0x106af1080?, 0x14000472370?}, {{0x140004a4020?, 0x1046f67e4?, 0x14000126ee8?}}, 0x140004f6f88)
	/Users/mmerli/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/runtime/pprof/runtime.go:51 +0x78
github.com/oxia-db/oxia/common/process.DoWithLabels({0x106af1080, 0x14000472370}, 0x14000162150, 0x1400028d0b0)
	/Users/mmerli/prg/oxia/common/process/pprof.go:42 +0x1b4
created by github.com/oxia-db/oxia/coordinator/balancer.(*nodeBasedBalancer).startBackgroundNotifier in goroutine 1
	/Users/mmerli/prg/oxia/coordinator/balancer/scheduler.go:348 +0x134
```