### PR TITLE
feat: add log format option to server and coordinator config

### DIFF
--- a/cmd/coordinator/cmd.go
+++ b/cmd/coordinator/cmd.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/common/process"
+	"github.com/oxia-db/oxia/oxiad/common/logging"
 	oxiadcommonoption "github.com/oxia-db/oxia/oxiad/common/option"
 	"github.com/oxia-db/oxia/oxiad/coordinator"
 	"github.com/oxia-db/oxia/oxiad/coordinator/option"
@@ -115,12 +116,20 @@ func exec(cmd *cobra.Command, _ []string) {
 				watchableOptions.Notify(temporaryOptions)
 			})
 			v.WatchConfig()
+
+			logOptions := &coordinatorOptions.Observability.Log
+			logging.ReconfigureLogger(logOptions)
+			if logOptions.Format != "" {
+				logging.LogJSON = logOptions.Format == oxiadcommonoption.LogFormatJSON
+				logging.ConfigureLogger()
+			}
 		} else {
 			coordinatorOptions.WithDefault()
 			if err := coordinatorOptions.Validate(); err != nil {
 				return nil, err
 			}
 		}
+
 		return coordinator.NewGrpcServer(context.Background(), watchableOptions)
 	})
 }

--- a/cmd/coordinator/cmd_test.go
+++ b/cmd/coordinator/cmd_test.go
@@ -64,6 +64,7 @@ observability:
     bindAddress: "0.0.0.0:9090"
   log:
     level: "debug"
+    format: "json"
 `
 
 	err := os.WriteFile(configPath, []byte(configContent), 0644)
@@ -97,6 +98,32 @@ observability:
 
 	assert.Equal(t, "0.0.0.0:9090", opts.Observability.Metric.BindAddress)
 	assert.Equal(t, "debug", opts.Observability.Log.Level)
+	assert.Equal(t, "json", opts.Observability.Log.Format)
+}
+
+func TestCoordinator_ConfigurationLogFormatNotConfigured(t *testing.T) {
+	// When config file doesn't set format, it should remain empty
+	// so CLI --log-json flag is preserved
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+metadata:
+  providerName: "file"
+observability:
+  log:
+    level: "debug"
+`
+
+	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	opts := option.NewDefaultOptions()
+	err = codec.TryReadAndInitConf(configPath, opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, "debug", opts.Observability.Log.Level)
+	assert.Empty(t, opts.Observability.Log.Format) // not defaulted, CLI preserved
 }
 
 func TestCoordinator_ConfigurationWithDefaults(t *testing.T) {

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/dataserver/database/kvstore"
 
 	"github.com/oxia-db/oxia/common/process"
+	"github.com/oxia-db/oxia/oxiad/common/logging"
 	"github.com/oxia-db/oxia/oxiad/dataserver"
 )
 
@@ -139,6 +140,13 @@ func exec(cmd *cobra.Command, _ []string) {
 				watchableOptions.Notify(temporaryOptions)
 			})
 			v.WatchConfig()
+
+			logOptions := &dataServerOptions.Observability.Log
+			logging.ReconfigureLogger(logOptions)
+			if logOptions.Format != "" {
+				logging.LogJSON = logOptions.Format == oxiadcommonoption.LogFormatJSON
+				logging.ConfigureLogger()
+			}
 		default:
 			dataServerOptions.WithDefault()
 			if err := dataServerOptions.Validate(); err != nil {

--- a/cmd/server/cmd_test.go
+++ b/cmd/server/cmd_test.go
@@ -66,6 +66,7 @@ observability:
     bindAddress: "0.0.0.0:9090"
   log:
     level: "debug"
+    format: "json"
 `
 
 	err := os.WriteFile(configPath, []byte(configContent), 0644)
@@ -103,6 +104,30 @@ observability:
 
 	assert.Equal(t, "0.0.0.0:9090", opts.Observability.Metric.BindAddress)
 	assert.Equal(t, "debug", opts.Observability.Log.Level)
+	assert.Equal(t, "json", opts.Observability.Log.Format)
+}
+
+func TestServer_ConfigurationLogFormatNotConfigured(t *testing.T) {
+	// When config file doesn't set format, it should remain empty
+	// so CLI --log-json flag is preserved
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+observability:
+  log:
+    level: "debug"
+`
+
+	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	opts := option.NewDefaultOptions()
+	err = codec.TryReadAndInitConf(configPath, opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, "debug", opts.Observability.Log.Level)
+	assert.Empty(t, opts.Observability.Log.Format) // not defaulted, CLI preserved
 }
 
 func TestServer_ConfigurationWithDefaults(t *testing.T) {

--- a/conf/coordinator.yaml
+++ b/conf/coordinator.yaml
@@ -17,3 +17,4 @@ observability:
     bindAddress: "0.0.0.0:8080"
   log:
     level: "info"
+    format: "text"

--- a/conf/dataserver.yaml
+++ b/conf/dataserver.yaml
@@ -24,3 +24,4 @@ observability:
     bindAddress: "0.0.0.0:8080"
   log:
     level: "info"
+    format: "text"

--- a/conf/schema/coordinator.json
+++ b/conf/schema/coordinator.json
@@ -120,6 +120,18 @@
           "examples": [
             "info"
           ]
+        },
+        "format": {
+          "type": "string",
+          "description": "Log format (text or json)",
+          "default": "text",
+          "enum": [
+            "text",
+            "json"
+          ],
+          "examples": [
+            "text"
+          ]
         }
       },
       "additionalProperties": false,

--- a/conf/schema/dataserver.json
+++ b/conf/schema/dataserver.json
@@ -76,6 +76,18 @@
           "examples": [
             "info"
           ]
+        },
+        "format": {
+          "type": "string",
+          "description": "Log format (text or json)",
+          "default": "text",
+          "enum": [
+            "text",
+            "json"
+          ],
+          "examples": [
+            "text"
+          ]
         }
       },
       "additionalProperties": false,

--- a/oxiad/common/logging/logger_test.go
+++ b/oxiad/common/logging/logger_test.go
@@ -48,9 +48,30 @@ func TestReconfigureLogger_DynamicLevelChange(t *testing.T) {
 
 func TestReconfigureLogger_NoChangeReturnsFalse(t *testing.T) {
 	LogLevel = slog.LevelInfo
-	LogJSON = true
 	ConfigureLogger()
 
 	changed := ReconfigureLogger(&option.LogOptions{Level: "info"})
 	assert.False(t, changed)
+}
+
+func TestReconfigureLogger_EmptyLevelDefaultsToInfo(t *testing.T) {
+	LogLevel = slog.LevelDebug
+	ConfigureLogger()
+
+	// Empty level defaults to info via ParseLogLevel fallback
+	changed := ReconfigureLogger(&option.LogOptions{})
+	assert.True(t, changed)
+	assert.Equal(t, slog.LevelInfo, LogLevel)
+}
+
+func TestReconfigureLogger_OnlyUpdatesLevel(t *testing.T) {
+	LogLevel = slog.LevelInfo
+	LogJSON = true
+	ConfigureLogger()
+
+	// ReconfigureLogger should only change level, not format
+	changed := ReconfigureLogger(&option.LogOptions{Level: "debug"})
+	assert.True(t, changed)
+	assert.Equal(t, slog.LevelDebug, LogLevel)
+	assert.True(t, LogJSON) // format unchanged
 }

--- a/oxiad/common/option/option.go
+++ b/oxiad/common/option/option.go
@@ -20,10 +20,7 @@ import (
 	"go.uber.org/multierr"
 )
 
-const (
-	DefaultMetricsPort = 8080
-	DefaultLogLevel    = "info"
-)
+const DefaultMetricsPort = 8080
 
 type ObservabilityOptions struct {
 	Metric MetricOptions `yaml:"metric,omitempty" json:"metric,omitempty" jsonschema:"description=Metric configuration for observability"`
@@ -64,14 +61,18 @@ func (*MetricOptions) Validate() error {
 	return nil
 }
 
+const (
+	LogFormatText = "text"
+	LogFormatJSON = "json"
+	DefaultLogFormat = LogFormatText
+)
+
 type LogOptions struct {
-	Level string `yaml:"level,omitempty" json:"level,omitempty" jsonschema:"description=Log level,example=info,default=info"`
+	Level  string `yaml:"level,omitempty" json:"level,omitempty" jsonschema:"description=Log level,example=info,default=info"`
+	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"description=Log format (text or json),example=text,default=text,enum=text,enum=json"`
 }
 
 func (lo *LogOptions) WithDefault() {
-	if lo.Level == "" {
-		lo.Level = DefaultLogLevel
-	}
 }
 
 func (*LogOptions) Validate() error {

--- a/oxiad/common/option/option.go
+++ b/oxiad/common/option/option.go
@@ -62,8 +62,8 @@ func (*MetricOptions) Validate() error {
 }
 
 const (
-	LogFormatText = "text"
-	LogFormatJSON = "json"
+	LogFormatText    = "text"
+	LogFormatJSON    = "json"
 	DefaultLogFormat = LogFormatText
 )
 

--- a/oxiad/common/option/option.go
+++ b/oxiad/common/option/option.go
@@ -72,7 +72,7 @@ type LogOptions struct {
 	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"description=Log format (text or json),example=text,default=text,enum=text,enum=json"`
 }
 
-func (lo *LogOptions) WithDefault() {
+func (*LogOptions) WithDefault() {
 }
 
 func (*LogOptions) Validate() error {


### PR DESCRIPTION
### Motivation

Server and coordinator need a way to configure log format (text/json) via config file, with proper precedence over CLI flags.

### Modification

- Add `Format` field to `LogOptions` with `LogFormatText` and `LogFormatJSON` constants
- Apply config file log format at startup for server and coordinator (config file overrides CLI `--log-json`, absent means CLI preserved)
- Add `format` field to YAML configs and JSON schemas for both dataserver and coordinator
- Remove unused `DefaultLogLevel` from option package (CLI default in `logging` package is the source of truth)
- Keep `LogOptions.WithDefault()` empty — level and format use "empty means not configured" semantics to avoid overriding CLI values