### PR TITLE
DO NOT MERGE: Fix regret test generators list

### DIFF
--- a/.github/workflows/candidate-release.yml
+++ b/.github/workflows/candidate-release.yml
@@ -140,7 +140,7 @@ jobs:
     with:
       candidate_image: "oxia/oxia:${{ needs.prepare.outputs.rc_tag }}"
       stable_image: "oxia/oxia:${{ needs.prepare.outputs.stable_tag }}"
-      generators: "basic-kv"
+      generators: "basic-kv kv-cas kv-ephemeral-notification kv-secondary-index kv-sequence"
     secrets: inherit
 
   # ── Step 4: Manual approval + promote to official release ──

--- a/.github/workflows/candidate-release.yml
+++ b/.github/workflows/candidate-release.yml
@@ -140,6 +140,7 @@ jobs:
     with:
       candidate_image: "oxia/oxia:${{ needs.prepare.outputs.rc_tag }}"
       stable_image: "oxia/oxia:${{ needs.prepare.outputs.stable_tag }}"
+      generators: "basic-kv"
     secrets: inherit
 
   # ── Step 4: Manual approval + promote to official release ──


### PR DESCRIPTION
## Summary
- Override the `generators` input in the candidate-release workflow to use `basic-kv` only
- The reusable workflow default includes `kv-ephemeral` which doesn't match the registered generator name (`kv-ephemeral-notification`), causing the "Setup Regret Tests" job to fail with exit code 22

## Context
- Failed run: https://github.com/oxia-db/oxia/actions/runs/24295866421/job/70945499706
- Error: `POST /api/hypothesis` returns 400 "unknown generator: kv-ephemeral"
- Available generators: `basic-kv`, `kv-cas`, `kv-ephemeral-notification`, `kv-secondary-index`, `kv-sequence`

## Test plan
- [ ] Re-run the candidate release workflow and verify the regret tests pass