### PR TITLE
security: add input validation and DoS prevention for gRPC

### DIFF
--- a/oxiad/common/rpc/grpc_server.go
+++ b/oxiad/common/rpc/grpc_server.go
@@ -35,10 +35,11 @@ import (
 )
 
 const (
-	maxGrpcFrameSize                         = 16 * 1024 * 1024
-	defaultGrpcServerKeepAliveMinTime        = 5 * time.Second
-	defaultGrpcServerKeepPermitWithoutStream = true
-	ReadinessProbeService                    = "oxia-readiness"
+	maxGrpcFrameSize                                = 16 * 1024 * 1024
+	defaultMaxConcurrentStreams              uint32 = 1000
+	defaultGrpcServerKeepAliveMinTime               = 5 * time.Second
+	defaultGrpcServerKeepPermitWithoutStream        = true
+	ReadinessProbeService                           = "oxia-readiness"
 )
 
 type GrpcServer interface {
@@ -104,7 +105,7 @@ func newDefaultGrpcProvider(name, bindAddress string, registerFunc func(grpc.Ser
 			grpc.ChainStreamInterceptor(streamInterceptors...),
 			grpc.ChainUnaryInterceptor(unaryInterceptors...),
 			grpc.MaxRecvMsgSize(maxGrpcFrameSize),
-			grpc.MaxConcurrentStreams(1000),
+			grpc.MaxConcurrentStreams(defaultMaxConcurrentStreams),
 			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 				MinTime:             defaultGrpcServerKeepAliveMinTime,
 				PermitWithoutStream: defaultGrpcServerKeepPermitWithoutStream,

--- a/oxiad/common/rpc/grpc_server.go
+++ b/oxiad/common/rpc/grpc_server.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	maxGrpcFrameSize                         = 256 * 1024 * 1024
+	maxGrpcFrameSize                         = 16 * 1024 * 1024
 	defaultGrpcServerKeepAliveMinTime        = 5 * time.Second
 	defaultGrpcServerKeepPermitWithoutStream = true
 	ReadinessProbeService                    = "oxia-readiness"
@@ -104,6 +104,7 @@ func newDefaultGrpcProvider(name, bindAddress string, registerFunc func(grpc.Ser
 			grpc.ChainStreamInterceptor(streamInterceptors...),
 			grpc.ChainUnaryInterceptor(unaryInterceptors...),
 			grpc.MaxRecvMsgSize(maxGrpcFrameSize),
+			grpc.MaxConcurrentStreams(1000),
 			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 				MinTime:             defaultGrpcServerKeepAliveMinTime,
 				PermitWithoutStream: defaultGrpcServerKeepPermitWithoutStream,

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -112,6 +112,10 @@ func (s *publicRpcServer) Write(ctx context.Context, write *proto.WriteRequest) 
 		slog.Any("req", write),
 	)
 
+	if err := validateWriteRequest(write); err != nil {
+		return nil, err
+	}
+
 	lc, err := s.getLeader(write.Shard)
 	if err != nil {
 		return nil, err
@@ -147,6 +151,11 @@ func procesWriteStream(streamCtx context.Context, finished chan<- error, stream 
 		}
 		if req == nil {
 			channel.PushNoBlock(finished, errors.New("stream closed"))
+			return
+		}
+
+		if err := validateWriteRequest(req); err != nil {
+			channel.PushNoBlock(finished, err)
 			return
 		}
 

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -131,6 +131,11 @@ func (s *publicRpcServer) Write(ctx context.Context, write *proto.WriteRequest) 
 
 func procesWriteStream(streamCtx context.Context, finished chan<- error, stream proto.OxiaClient_WriteStreamServer, lc lead.LeaderController) {
 	for {
+		if streamCtx.Err() != nil {
+			channel.PushNoBlock(finished, streamCtx.Err())
+			return
+		}
+
 		req, err := stream.Recv()
 		if err != nil {
 			if errors.Is(err, io.EOF) {

--- a/oxiad/dataserver/validation.go
+++ b/oxiad/dataserver/validation.go
@@ -1,0 +1,56 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataserver
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+const (
+	MaxKeySize              = 10 * 1024       // 10 KB
+	MaxValueSize            = 1 * 1024 * 1024 // 1 MB
+	MaxPutsPerWrite         = 10_000
+	MaxDeletesPerWrite      = 10_000
+	MaxDeleteRangesPerWrite = 100
+)
+
+func validateWriteRequest(req *proto.WriteRequest) error {
+	if len(req.Puts) > MaxPutsPerWrite {
+		return status.Errorf(codes.InvalidArgument, "too many puts: %d exceeds maximum %d", len(req.Puts), MaxPutsPerWrite)
+	}
+	if len(req.Deletes) > MaxDeletesPerWrite {
+		return status.Errorf(codes.InvalidArgument, "too many deletes: %d exceeds maximum %d", len(req.Deletes), MaxDeletesPerWrite)
+	}
+	if len(req.DeleteRanges) > MaxDeleteRangesPerWrite {
+		return status.Errorf(codes.InvalidArgument, "too many delete ranges: %d exceeds maximum %d", len(req.DeleteRanges), MaxDeleteRangesPerWrite)
+	}
+	for _, put := range req.Puts {
+		if len(put.Key) > MaxKeySize {
+			return status.Errorf(codes.InvalidArgument, "key size %d exceeds maximum %d", len(put.Key), MaxKeySize)
+		}
+		if len(put.Value) > MaxValueSize {
+			return status.Errorf(codes.InvalidArgument, "value size %d exceeds maximum %d", len(put.Value), MaxValueSize)
+		}
+	}
+	for _, del := range req.Deletes {
+		if len(del.Key) > MaxKeySize {
+			return status.Errorf(codes.InvalidArgument, "key size %d exceeds maximum %d", len(del.Key), MaxKeySize)
+		}
+	}
+	return nil
+}

--- a/oxiad/dataserver/validation.go
+++ b/oxiad/dataserver/validation.go
@@ -52,5 +52,13 @@ func validateWriteRequest(req *proto.WriteRequest) error {
 			return status.Errorf(codes.InvalidArgument, "key size %d exceeds maximum %d", len(del.Key), MaxKeySize)
 		}
 	}
+	for _, dr := range req.DeleteRanges {
+		if len(dr.StartInclusive) > MaxKeySize {
+			return status.Errorf(codes.InvalidArgument, "delete range start key size %d exceeds maximum %d", len(dr.StartInclusive), MaxKeySize)
+		}
+		if len(dr.EndExclusive) > MaxKeySize {
+			return status.Errorf(codes.InvalidArgument, "delete range end key size %d exceeds maximum %d", len(dr.EndExclusive), MaxKeySize)
+		}
+	}
 	return nil
 }

--- a/oxiad/dataserver/validation_test.go
+++ b/oxiad/dataserver/validation_test.go
@@ -89,3 +89,56 @@ func TestValidateWriteRequest_TooManyDeletes(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 	assert.Contains(t, err.Error(), "too many deletes")
 }
+
+func TestValidateWriteRequest_DeleteKeyTooLarge(t *testing.T) {
+	largeKey := strings.Repeat("k", MaxKeySize+1)
+	req := &proto.WriteRequest{
+		Deletes: []*proto.DeleteRequest{
+			{Key: largeKey},
+		},
+	}
+	err := validateWriteRequest(req)
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "key size")
+}
+
+func TestValidateWriteRequest_TooManyDeleteRanges(t *testing.T) {
+	deleteRanges := make([]*proto.DeleteRangeRequest, MaxDeleteRangesPerWrite+1)
+	for i := range deleteRanges {
+		deleteRanges[i] = &proto.DeleteRangeRequest{StartInclusive: "/a", EndExclusive: "/z"}
+	}
+	req := &proto.WriteRequest{DeleteRanges: deleteRanges}
+	err := validateWriteRequest(req)
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "too many delete ranges")
+}
+
+func TestValidateWriteRequest_DeleteRangeBoundaryKeyTooLarge(t *testing.T) {
+	largeKey := strings.Repeat("k", MaxKeySize+1)
+
+	t.Run("start key too large", func(t *testing.T) {
+		req := &proto.WriteRequest{
+			DeleteRanges: []*proto.DeleteRangeRequest{
+				{StartInclusive: largeKey, EndExclusive: "/z"},
+			},
+		}
+		err := validateWriteRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		assert.Contains(t, err.Error(), "delete range start key size")
+	})
+
+	t.Run("end key too large", func(t *testing.T) {
+		req := &proto.WriteRequest{
+			DeleteRanges: []*proto.DeleteRangeRequest{
+				{StartInclusive: "/a", EndExclusive: largeKey},
+			},
+		}
+		err := validateWriteRequest(req)
+		assert.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		assert.Contains(t, err.Error(), "delete range end key size")
+	})
+}

--- a/oxiad/dataserver/validation_test.go
+++ b/oxiad/dataserver/validation_test.go
@@ -1,0 +1,91 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataserver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+func TestValidateWriteRequest_Valid(t *testing.T) {
+	req := &proto.WriteRequest{
+		Puts: []*proto.PutRequest{
+			{Key: "/valid-key", Value: []byte("valid-value")},
+		},
+		Deletes: []*proto.DeleteRequest{
+			{Key: "/delete-key"},
+		},
+		DeleteRanges: []*proto.DeleteRangeRequest{
+			{StartInclusive: "/a", EndExclusive: "/z"},
+		},
+	}
+	assert.NoError(t, validateWriteRequest(req))
+}
+
+func TestValidateWriteRequest_KeyTooLarge(t *testing.T) {
+	largeKey := strings.Repeat("k", MaxKeySize+1)
+	req := &proto.WriteRequest{
+		Puts: []*proto.PutRequest{
+			{Key: largeKey, Value: []byte("value")},
+		},
+	}
+	err := validateWriteRequest(req)
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "key size")
+}
+
+func TestValidateWriteRequest_ValueTooLarge(t *testing.T) {
+	largeValue := make([]byte, MaxValueSize+1)
+	req := &proto.WriteRequest{
+		Puts: []*proto.PutRequest{
+			{Key: "/key", Value: largeValue},
+		},
+	}
+	err := validateWriteRequest(req)
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "value size")
+}
+
+func TestValidateWriteRequest_TooManyPuts(t *testing.T) {
+	puts := make([]*proto.PutRequest, MaxPutsPerWrite+1)
+	for i := range puts {
+		puts[i] = &proto.PutRequest{Key: "/k", Value: []byte("v")}
+	}
+	req := &proto.WriteRequest{Puts: puts}
+	err := validateWriteRequest(req)
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "too many puts")
+}
+
+func TestValidateWriteRequest_TooManyDeletes(t *testing.T) {
+	deletes := make([]*proto.DeleteRequest, MaxDeletesPerWrite+1)
+	for i := range deletes {
+		deletes[i] = &proto.DeleteRequest{Key: "/k"}
+	}
+	req := &proto.WriteRequest{Deletes: deletes}
+	err := validateWriteRequest(req)
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "too many deletes")
+}


### PR DESCRIPTION
## Summary
- Reduce max gRPC frame size from 256 MB to 16 MB to limit memory consumption from oversized messages
- Add `grpc.MaxConcurrentStreams(1000)` to prevent stream-based resource exhaustion
- Add write request validation enforcing max key size (10 KB), value size (1 MB), and batch counts (10k puts, 10k deletes, 100 delete ranges)
- Wire validation into both the unary `Write` RPC and the `WriteStream` path, before reaching the leader controller
- Add context cancellation check at the top of the write stream loop for prompt exit on cancelled streams

## Test plan
- [x] `go build ./oxiad/... ./common/...` passes
- [x] `golangci-lint run ./oxiad/dataserver/... ./oxiad/common/rpc/...` passes (no new issues)
- [x] `go test -v -run TestValidateWriteRequest ./oxiad/dataserver/...` -- all 5 tests pass
- [ ] Verify existing integration tests still pass with the reduced 16 MB frame size
- [ ] Verify that oversized keys/values are rejected with `InvalidArgument` status