### PR TITLE
[fix] fix raft metadata

### DIFF
--- a/oxiad/coordinator/balancer/scheduler_test.go
+++ b/oxiad/coordinator/balancer/scheduler_test.go
@@ -39,17 +39,22 @@ func (m *mockStatusResource) Load() *model.ClusterStatus {
 	return m.status
 }
 
-func (m *mockStatusResource) ApplyChanges(_ *model.ClusterConfig, _ resource.EnsembleSupplier) (*model.ClusterStatus, map[int64]string, []int64) {
-	return m.status, nil, nil
+func (m *mockStatusResource) ApplyChanges(_ *model.ClusterConfig, _ resource.EnsembleSupplier) (*model.ClusterStatus, map[int64]string, []int64, error) {
+	return m.status, nil, nil, nil
 }
 
-func (m *mockStatusResource) Update(newStatus *model.ClusterStatus) {
+func (m *mockStatusResource) Update(newStatus *model.ClusterStatus) error {
 	m.status = newStatus
+	return nil
 }
 
-func (m *mockStatusResource) UpdateShardMetadata(_ string, _ int64, _ model.ShardMetadata) {}
+func (*mockStatusResource) UpdateShardMetadata(_ string, _ int64, _ model.ShardMetadata) error {
+	return nil
+}
 
-func (m *mockStatusResource) DeleteShardMetadata(_ string, _ int64) {}
+func (*mockStatusResource) DeleteShardMetadata(_ string, _ int64) error {
+	return nil
+}
 
 func (m *mockStatusResource) IsReady(_ *model.ClusterConfig) bool {
 	return true

--- a/oxiad/coordinator/controller/shard_controller.go
+++ b/oxiad/coordinator/controller/shard_controller.go
@@ -427,7 +427,9 @@ func (s *shardController) deleteShard() error {
 		)
 	}
 
-	s.statusResource.DeleteShardMetadata(s.namespace, s.shard)
+	if err := s.statusResource.DeleteShardMetadata(s.namespace, s.shard); err != nil {
+		return err
+	}
 	s.eventListener.ShardDeleted(s.shard)
 	return s.close()
 }
@@ -508,7 +510,10 @@ func (s *shardController) handlePeriodicTasks() {
 	}
 
 	// Update the shard status
-	s.statusResource.UpdateShardMetadata(s.namespace, s.shard, mutShardMeta)
+	if err := s.statusResource.UpdateShardMetadata(s.namespace, s.shard, mutShardMeta); err != nil {
+		s.log.Warn("Failed to persist shard metadata update", slog.Any("error", err))
+		return
+	}
 	s.metadata.Store(mutShardMeta)
 }
 

--- a/oxiad/coordinator/controller/shard_controller_election.go
+++ b/oxiad/coordinator/controller/shard_controller_election.go
@@ -449,7 +449,9 @@ func (e *ShardElection) start() (model.Server, error) {
 		metadata.Term++
 		metadata.Ensemble = e.refreshedEnsemble(metadata.Ensemble)
 	})
-	e.statusResource.UpdateShardMetadata(e.namespace, e.shard, mutShardMeta)
+	if err := e.statusResource.UpdateShardMetadata(e.namespace, e.shard, mutShardMeta); err != nil {
+		return model.Server{}, errors.Wrap(err, "failed to persist election start metadata")
+	}
 
 	if e.changeEnsembleAction != nil {
 		e.prepareIfChangeEnsemble(&mutShardMeta)
@@ -499,7 +501,9 @@ func (e *ShardElection) start() (model.Server, error) {
 	leader := mutShardMeta.Leader
 	leaderEntry := candidatesStatus[*leader]
 
-	e.statusResource.UpdateShardMetadata(e.namespace, e.shard, mutShardMeta)
+	if err := e.statusResource.UpdateShardMetadata(e.namespace, e.shard, mutShardMeta); err != nil {
+		return model.Server{}, errors.Wrap(err, "failed to persist elected leader metadata")
+	}
 	e.meta.Store(mutShardMeta)
 	if e.eventListener != nil {
 		e.eventListener.LeaderElected(e.shard, newLeader, maps.Keys(followers))

--- a/oxiad/coordinator/controller/split_controller.go
+++ b/oxiad/coordinator/controller/split_controller.go
@@ -235,7 +235,9 @@ func (sc *SplitController) updatePhase(newPhase model.SplitPhase) {
 		}
 	}
 
-	sc.statusResource.Update(cloned)
+	if err := sc.statusResource.Update(cloned); err != nil {
+		sc.log.Warn("Failed to persist split phase", slog.Any("error", err))
+	}
 }
 
 // runBootstrap validates preconditions, fences child ensemble members, elects
@@ -650,7 +652,11 @@ func (sc *SplitController) abort() {
 
 	// Delete child shards from status.
 	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		sc.statusResource.DeleteShardMetadata(sc.namespace, childId)
+		if err := sc.statusResource.DeleteShardMetadata(sc.namespace, childId); err != nil {
+			sc.log.Warn("Failed to delete child shard metadata during abort",
+				slog.Int64("child-shard", childId),
+				slog.Any("error", err))
+		}
 	}
 
 	// Clear parent split metadata.
@@ -699,7 +705,11 @@ func (sc *SplitController) updateShardMeta(shardId int64, fn func(meta *model.Sh
 	if meta, exists := ns.Shards[shardId]; exists {
 		fn(&meta)
 		ns.Shards[shardId] = meta
-		sc.statusResource.Update(cloned)
+		if err := sc.statusResource.Update(cloned); err != nil {
+			sc.log.Warn("Failed to persist shard metadata",
+				slog.Int64("shard", shardId),
+				slog.Any("error", err))
+		}
 	}
 }
 

--- a/oxiad/coordinator/controller/split_controller_test.go
+++ b/oxiad/coordinator/controller/split_controller_test.go
@@ -136,7 +136,7 @@ func setupSplitTest(t *testing.T, phase model.SplitPhase) (
 		ShardIdGenerator: 3,
 	}
 
-	statusRes.Update(clusterStatus)
+	require.NoError(t, statusRes.Update(clusterStatus))
 	listener := newMockSplitEventListener()
 
 	return rpcMock, statusRes, listener
@@ -283,7 +283,7 @@ func TestSplitController_ResumeFromCatchUp(t *testing.T) {
 	rightMeta.Leader = &rs1
 	rightMeta.Term = 1
 	ns.Shards[2] = rightMeta
-	statusRes.Update(cloned)
+	require.NoError(t, statusRes.Update(cloned))
 
 	queueCatchUpResponses(rpcMock)
 	queueCutoverResponses(rpcMock)
@@ -406,7 +406,7 @@ func TestSplitController_TimeoutDuringCatchUp(t *testing.T) {
 	parentMeta.Split.ParentTermAtBootstrap = 5
 	ns.Shards[0] = parentMeta
 
-	statusRes.Update(cloned)
+	require.NoError(t, statusRes.Update(cloned))
 
 	// Queue RemoveObserver responses (abort will call these)
 	rpcMock.GetNode(ps1).RemoveObserverResponse(nil)
@@ -471,7 +471,7 @@ func TestSplitController_ParentTermChangeDuringCatchUp(t *testing.T) {
 	parentMeta.Split.ParentTermAtBootstrap = 5 // Was 5 during Bootstrap
 	ns.Shards[0] = parentMeta
 
-	statusRes.Update(cloned)
+	require.NoError(t, statusRes.Update(cloned))
 
 	// The controller should detect term change and reset to Bootstrap.
 	// Queue Bootstrap responses -- note: parent leader is now ps2 (after election)
@@ -676,7 +676,7 @@ func TestSplitController_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
 	parentMeta.Split.ParentTermAtBootstrap = 5
 	ns.Shards[0] = parentMeta
 
-	statusRes.Update(cloned)
+	require.NoError(t, statusRes.Update(cloned))
 
 	// Queue RemoveObserver responses (abort will call these)
 	rpcMock.GetNode(ps1).RemoveObserverResponse(nil)
@@ -742,7 +742,7 @@ func TestSplitController_ChildFollowersDeadCommitStalls(t *testing.T) {
 	parentMeta.Split.ParentTermAtBootstrap = 5
 	ns.Shards[0] = parentMeta
 
-	statusRes.Update(cloned)
+	require.NoError(t, statusRes.Update(cloned))
 
 	// Queue RemoveObserver responses (abort will call these)
 	rpcMock.GetNode(ps1).RemoveObserverResponse(nil)
@@ -819,7 +819,7 @@ func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 	}
 	ns.Shards[0] = parentMeta
 
-	statusRes.Update(cloned)
+	require.NoError(t, statusRes.Update(cloned))
 
 	// CatchUp detects left child leader changed (ls1 -> ls2).
 	// It RemoveObserver(old leader) on parent, then falls back to Bootstrap.

--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -807,7 +807,7 @@ func NewCoordinator(meta metadata.Provider,
 	})
 
 	clusterConfig := c.configResource.Load()
-	clusterStatus := c.statusResource.Load()
+	_ = c.statusResource.Load()
 
 	// init node controller
 	for _, node := range clusterConfig.Servers {
@@ -825,7 +825,7 @@ func NewCoordinator(meta metadata.Provider,
 	} else {
 		c.Info("Checking cluster config", slog.Any("clusterConfig", clusterConfig))
 	}
-	clusterStatus, _, _, err = c.statusResource.ApplyChanges(clusterConfig, c.selectNewEnsemble)
+	clusterStatus, _, _, err := c.statusResource.ApplyChanges(clusterConfig, c.selectNewEnsemble)
 	if err != nil {
 		c.cancel()
 		return nil, errors.Wrap(err, "failed to initialize cluster status")

--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -167,7 +167,12 @@ func (c *coordinator) ConfigChanged(newConfig *model.ClusterConfig) {
 		sc.SyncServerAddress()
 	}
 
-	clusterStatus, shardsToAdd, shardsToDelete := c.statusResource.ApplyChanges(newConfig, c.selectNewEnsemble)
+	clusterStatus, shardsToAdd, shardsToDelete, err := c.statusResource.ApplyChanges(newConfig, c.selectNewEnsemble)
+	if err != nil {
+		c.Error("Failed to apply cluster changes", slog.Any("error", err))
+		c.cancel()
+		return
+	}
 	for shard, namespace := range shardsToAdd {
 		shardMetadata := clusterStatus.Namespaces[namespace].Shards[shard]
 		if namespaceConfig, exist := c.configResource.NamespaceConfig(namespace); exist {
@@ -286,6 +291,17 @@ func (c *coordinator) Close() error {
 		err = multierr.Append(err, nc.Close())
 	}
 	return err
+}
+
+func (c *coordinator) monitorLeadershipLoss(ch <-chan struct{}) {
+	defer c.Done()
+
+	select {
+	case <-ch:
+		c.Error("Coordinator lost metadata leadership, stopping control loops")
+		c.cancel()
+	case <-c.ctx.Done():
+	}
 }
 
 func (c *coordinator) BecameUnavailable(node model.Server) {
@@ -579,7 +595,9 @@ func (c *coordinator) InitiateSplit(namespace string, parentShardId int64, split
 	}
 
 	// Persist
-	c.statusResource.Update(cloned)
+	if err := c.statusResource.Update(cloned); err != nil {
+		return 0, 0, errors.Wrap(err, "failed to persist split metadata")
+	}
 
 	c.Info("Split initiated",
 		slog.Int64("parent-shard", parentShardId),
@@ -746,18 +764,33 @@ func NewCoordinator(meta metadata.Provider,
 		drainingNodes:         make(map[string]controller.DataServerController),
 		rpc:                   rpcProvider,
 	}
+	c.ctx, c.cancel = context.WithCancel(context.Background())
 	c.ccrWg.Add(1)
+	var err error
 
 	// Ensure we are to become the leader coordinator
 	c.Info("Waiting to become leader")
 	if err := meta.WaitToBecomeLeader(); err != nil {
+		c.cancel()
 		return nil, errors.Wrap(err, "failed to wait in becoming leader")
 	}
 	c.Info("This coordinator is now leader")
 
-	c.ctx, c.cancel = context.WithCancel(context.Background())
+	if leadershipAware, ok := meta.(metadata.LeadershipAwareProvider); ok {
+		c.Add(1)
+		go c.monitorLeadershipLoss(leadershipAware.LeadershipLost())
+	}
+
 	c.assignmentsChanged = concurrent.NewConditionContext(c)
-	c.statusResource = resource.NewStatusResource(meta)
+	if c.statusResource, err = resource.NewStatusResourceWithErrorContext(c.ctx, meta); err != nil {
+		c.cancel()
+		return nil, errors.Wrap(err, "failed to create status resource")
+	}
+	storedClusterStatus, _, err := meta.Get()
+	if err != nil {
+		c.cancel()
+		return nil, errors.Wrap(err, "failed to load persisted cluster status")
+	}
 
 	c.configResource = resource.NewClusterConfigResource(c.ctx, clusterConfigProvider, clusterConfigNotificationsCh, c)
 
@@ -782,7 +815,7 @@ func NewCoordinator(meta metadata.Provider,
 	}
 
 	// init status
-	if clusterStatus == nil {
+	if storedClusterStatus == nil {
 		// Before initializing the cluster, it's better to make sure we
 		// have all the nodes available, otherwise the coordinator might be
 		// the first component in getting started and will print out a lot
@@ -792,7 +825,11 @@ func NewCoordinator(meta metadata.Provider,
 	} else {
 		c.Info("Checking cluster config", slog.Any("clusterConfig", clusterConfig))
 	}
-	clusterStatus, _, _ = c.statusResource.ApplyChanges(clusterConfig, c.selectNewEnsemble)
+	clusterStatus, _, _, err = c.statusResource.ApplyChanges(clusterConfig, c.selectNewEnsemble)
+	if err != nil {
+		c.cancel()
+		return nil, errors.Wrap(err, "failed to initialize cluster status")
+	}
 
 	// init shard controller
 	for ns, shards := range clusterStatus.Namespaces {

--- a/oxiad/coordinator/coordinator_authority_test.go
+++ b/oxiad/coordinator/coordinator_authority_test.go
@@ -34,7 +34,7 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 	}
 
 	statusResource := resource.NewStatusResource(metadata.NewMetadataProviderMemory())
-	statusResource.Update(&model.ClusterStatus{
+	require.NoError(t, statusResource.Update(&model.ClusterStatus{
 		Namespaces: map[string]model.NamespaceStatus{
 			"default": {
 				ReplicationFactor: 1,
@@ -51,7 +51,7 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 				},
 			},
 		},
-	})
+	}))
 
 	clusterConfig := model.ClusterConfig{
 		Namespaces: []model.NamespaceConfig{{
@@ -98,7 +98,7 @@ func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
 	}
 
 	statusResource := resource.NewStatusResource(metadata.NewMetadataProviderMemory())
-	statusResource.Update(&model.ClusterStatus{
+	require.NoError(t, statusResource.Update(&model.ClusterStatus{
 		Namespaces: map[string]model.NamespaceStatus{
 			"default": {
 				ReplicationFactor: 1,
@@ -116,7 +116,7 @@ func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
 				},
 			},
 		},
-	})
+	}))
 
 	clusterConfig := model.ClusterConfig{
 		Namespaces: []model.NamespaceConfig{{

--- a/oxiad/coordinator/coordinator_leadership_test.go
+++ b/oxiad/coordinator/coordinator_leadership_test.go
@@ -1,0 +1,79 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	"github.com/oxia-db/oxia/oxiad/coordinator/model"
+)
+
+type leadershipLostDuringStartupProvider struct {
+	leadershipLostCh chan struct{}
+}
+
+func newLeadershipLostDuringStartupProvider() *leadershipLostDuringStartupProvider {
+	return &leadershipLostDuringStartupProvider{
+		leadershipLostCh: make(chan struct{}, 1),
+	}
+}
+
+func (*leadershipLostDuringStartupProvider) Close() error {
+	return nil
+}
+
+func (p *leadershipLostDuringStartupProvider) Get() (*model.ClusterStatus, metadata.Version, error) {
+	return nil, metadata.NotExists, errors.New("not leader")
+}
+
+func (*leadershipLostDuringStartupProvider) Store(*model.ClusterStatus, metadata.Version) (metadata.Version, error) {
+	return metadata.NotExists, errors.New("not leader")
+}
+
+func (p *leadershipLostDuringStartupProvider) WaitToBecomeLeader() error {
+	p.leadershipLostCh <- struct{}{}
+	return nil
+}
+
+func (p *leadershipLostDuringStartupProvider) LeadershipLost() <-chan struct{} {
+	return p.leadershipLostCh
+}
+
+func TestNewCoordinatorStopsStartupWhenLeadershipIsAlreadyLost(t *testing.T) {
+	meta := newLeadershipLostDuringStartupProvider()
+
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := NewCoordinator(meta, func() (model.ClusterConfig, error) {
+			return model.ClusterConfig{}, nil
+		}, nil, nil)
+		resultCh <- err
+	}()
+
+	select {
+	case err := <-resultCh:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for coordinator startup to stop after leadership loss")
+	}
+}

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -47,3 +47,7 @@ type Provider interface {
 
 	WaitToBecomeLeader() error
 }
+
+type LeadershipAwareProvider interface {
+	LeadershipLost() <-chan struct{}
+}

--- a/oxiad/coordinator/metadata/metadata_raft.go
+++ b/oxiad/coordinator/metadata/metadata_raft.go
@@ -33,17 +33,23 @@ import (
 )
 
 type metadataProviderRaft struct {
-	sync.Mutex
-
 	sc    *stateContainer
 	raft  *raft.Raft
 	store *kvRaftStore
-	log   *slog.Logger
+
+	transport              *raft.NetworkTransport
+	leadershipLostCh       chan struct{}
+	leadershipNotifyCh     chan bool
+	leadershipNotifyStopCh chan struct{}
+	closeOnce              sync.Once
+	log                    *slog.Logger
 }
 
 func (mpr *metadataProviderRaft) WaitToBecomeLeader() error {
-	<-mpr.raft.LeaderCh()
-	return nil
+	if err := mpr.waitForLeaderState(); err != nil {
+		return err
+	}
+	return mpr.waitForAppliedState()
 }
 
 func NewMetadataProviderRaft(
@@ -52,13 +58,16 @@ func NewMetadataProviderRaft(
 	raftDataDir string,
 ) (Provider, error) {
 	mpr := &metadataProviderRaft{
-		sc:  newStateContainer(slog.With(slog.String("component", "metadata-provider-raft-state-container"))),
-		log: slog.With(slog.String("component", "metadata-provider-raft")),
+		sc:                     newStateContainer(slog.With(slog.String("component", "metadata-provider-raft-state-container"))),
+		leadershipLostCh:       make(chan struct{}, 1),
+		leadershipNotifyCh:     make(chan bool, 8),
+		leadershipNotifyStopCh: make(chan struct{}),
+		log:                    slog.With(slog.String("component", "metadata-provider-raft")),
 	}
 
 	// Ensure data dir per node
-	nodeId := raftAddress
-	dataDir := filepath.Join(raftDataDir, nodeId)
+	nodeID := raftAddress
+	dataDir := filepath.Join(raftDataDir, nodeID)
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		return nil, errors.Wrap(err, "failed to create data dir")
 	}
@@ -67,51 +76,78 @@ func NewMetadataProviderRaft(
 	config := raft.DefaultConfig()
 	config.HeartbeatTimeout = 5 * time.Second
 	config.ElectionTimeout = 10 * time.Second
-	config.LocalID = raft.ServerID(nodeId)
+	config.LocalID = raft.ServerID(nodeID)
 	config.LogLevel = "INFO"
 	levelVar := &slog.LevelVar{}
 	levelVar.Set(slog.LevelInfo)
 	config.Logger = slog2hclog.New(mpr.log, levelVar)
+	config.NotifyCh = mpr.leadershipNotifyCh
+
+	var raftNode *raft.Raft
+	var store *kvRaftStore
+	var transport *raft.NetworkTransport
+	var snapshotStore *raft.FileSnapshotStore
+	cleanup := true
+	defer func() {
+		if !cleanup {
+			return
+		}
+		if raftNode != nil {
+			_ = raftNode.Shutdown().Error()
+		}
+		if transport != nil {
+			_ = transport.Close()
+		}
+		if store != nil {
+			_ = store.Close()
+		}
+	}()
 
 	// Create TCP transport for Raft
 	addr, err := net.ResolveTCPAddr("tcp", raftAddress)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to resolve raft address")
 	}
-	transport, err := raft.NewTCPTransport(raftAddress, addr, 3, 10*time.Second, os.Stderr)
+	transport, err = raft.NewTCPTransportWithLogger(raftAddress, addr, 3, 10*time.Second, config.Logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create raft transport")
 	}
 
 	// Create stable store and log store
-	mpr.store, err = newKVRaftStore(filepath.Join(dataDir, "store"))
+	store, err = newKVRaftStore(filepath.Join(dataDir, "store"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create data store")
 	}
 
 	// Create snapshot store
-	snapshotStore, err := raft.NewFileSnapshotStoreWithLogger(dataDir, 2, config.Logger)
+	snapshotStore, err = raft.NewFileSnapshotStoreWithLogger(dataDir, 2, config.Logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create snapshot store")
 	}
 
 	// Create Raft node
-	mpr.raft, err = raft.NewRaft(config, mpr.sc, mpr.store, mpr.store, snapshotStore, transport)
+	raftNode, err = raft.NewRaft(config, mpr.sc, store, store, snapshotStore, transport)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create raft node")
 	}
 
-	if hasState, err := raft.HasExistingState(mpr.store, mpr.store, snapshotStore); err != nil {
+	if hasState, err := raft.HasExistingState(store, store, snapshotStore); err != nil {
 		return nil, errors.Wrap(err, "failed to check existing state")
 	} else if !hasState {
 		configuration := raft.Configuration{
 			Servers: getRaftServers(raftBootstrapNodes),
 		}
-		future := mpr.raft.BootstrapCluster(configuration)
+		future := raftNode.BootstrapCluster(configuration)
 		if err := future.Error(); err != nil {
-			return nil, errors.Wrap(err, "failed to create raft node")
+			return nil, errors.Wrap(err, "failed to bootstrap raft cluster")
 		}
 	}
+
+	mpr.raft = raftNode
+	mpr.store = store
+	mpr.transport = transport
+	go mpr.watchLeadershipChanges(mpr.raft.State() == raft.Leader)
+	cleanup = false
 
 	return mpr, nil
 }
@@ -128,10 +164,16 @@ func getRaftServers(bootstrapNodes []string) []raft.Server {
 }
 
 func (mpr *metadataProviderRaft) Close() error {
-	return multierr.Combine(
-		mpr.raft.Shutdown().Error(),
-		mpr.store.Close(),
-	)
+	var err error
+	mpr.closeOnce.Do(func() {
+		err = multierr.Combine(
+			mpr.raft.Shutdown().Error(),
+			mpr.transport.Close(),
+			mpr.store.Close(),
+		)
+		close(mpr.leadershipNotifyStopCh)
+	})
+	return err
 }
 
 func toVersion(v int64) Version {
@@ -139,32 +181,39 @@ func toVersion(v int64) Version {
 }
 
 func fromVersion(v Version) int64 {
-	n, _ := strconv.ParseInt(string(v), 10, 64)
+	n, err := strconv.ParseInt(string(v), 10, 64)
+	if err != nil {
+		panic(ErrMetadataBadVersion)
+	}
 	return n
 }
 
 func (mpr *metadataProviderRaft) Get() (cs *model.ClusterStatus, version Version, err error) {
-	mpr.Lock()
-	defer mpr.Unlock()
+	if err = mpr.raft.VerifyLeader().Error(); err != nil {
+		return nil, NotExists, err
+	}
+	if err = mpr.waitForAppliedState(); err != nil {
+		return nil, NotExists, err
+	}
+
+	state, currentVersion := mpr.sc.CloneState()
 
 	mpr.log.Debug("Get metadata",
-		slog.Any("cluster-status", mpr.sc.State),
-		slog.Any("current-version", mpr.sc.CurrentVersion))
-	return mpr.sc.State, toVersion(mpr.sc.CurrentVersion), nil
+		slog.Any("cluster-status", state),
+		slog.Any("current-version", currentVersion))
+	return state, toVersion(currentVersion), nil
 }
 
 func (mpr *metadataProviderRaft) Store(cs *model.ClusterStatus, expectedVersion Version) (newVersion Version, err error) {
-	mpr.Lock()
-	defer mpr.Unlock()
-
 	if err = mpr.raft.VerifyLeader().Error(); err != nil {
 		return NotExists, err
 	}
 
+	_, currentVersion := mpr.sc.CloneState()
 	mpr.log.Debug("Store into raft",
 		slog.Any("cluster-status", cs),
 		slog.Any("expected-version", expectedVersion),
-		slog.Any("current-version", mpr.sc.CurrentVersion))
+		slog.Any("current-version", currentVersion))
 
 	cmd := raftOpCmd{
 		NewState:        cs.Clone(),
@@ -183,7 +232,7 @@ func (mpr *metadataProviderRaft) Store(cs *model.ClusterStatus, expectedVersion 
 
 	applyRes, ok := future.Response().(*applyResult)
 	if !ok {
-		return NotExists, errors.Wrap(err, "failed to apply new cluster state")
+		return NotExists, errors.Errorf("unexpected raft apply response type %T", future.Response())
 	}
 
 	if !applyRes.changeApplied {
@@ -191,4 +240,58 @@ func (mpr *metadataProviderRaft) Store(cs *model.ClusterStatus, expectedVersion 
 	}
 
 	return toVersion(applyRes.newVersion), nil
+}
+
+func (mpr *metadataProviderRaft) LeadershipLost() <-chan struct{} {
+	return mpr.leadershipLostCh
+}
+
+func (mpr *metadataProviderRaft) waitForLeaderState() error {
+	if mpr.raft.State() == raft.Leader {
+		return nil
+	}
+
+	leaderCh := mpr.raft.LeaderCh()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case isLeader, ok := <-leaderCh:
+			if !ok {
+				return raft.ErrRaftShutdown
+			}
+			if isLeader {
+				return nil
+			}
+		case <-ticker.C:
+			switch mpr.raft.State() {
+			case raft.Leader:
+				return nil
+			case raft.Shutdown:
+				return raft.ErrRaftShutdown
+			}
+		}
+	}
+}
+
+func (mpr *metadataProviderRaft) waitForAppliedState() error {
+	return mpr.raft.Barrier(30 * time.Second).Error()
+}
+
+func (mpr *metadataProviderRaft) watchLeadershipChanges(wasLeader bool) {
+	for {
+		select {
+		case <-mpr.leadershipNotifyStopCh:
+			return
+		case isLeader := <-mpr.leadershipNotifyCh:
+			if wasLeader && !isLeader {
+				select {
+				case mpr.leadershipLostCh <- struct{}{}:
+				default:
+				}
+			}
+			wasLeader = isLeader
+		}
+	}
 }

--- a/oxiad/coordinator/metadata/metadata_raft.go
+++ b/oxiad/coordinator/metadata/metadata_raft.go
@@ -146,7 +146,7 @@ func NewMetadataProviderRaft(
 	mpr.raft = raftNode
 	mpr.store = store
 	mpr.transport = transport
-	go mpr.watchLeadershipChanges(mpr.raft.State() == raft.Leader)
+	go mpr.startWatchingLeadershipChanges()
 	cleanup = false
 
 	return mpr, nil
@@ -279,7 +279,13 @@ func (mpr *metadataProviderRaft) waitForAppliedState() error {
 	return mpr.raft.Barrier(30 * time.Second).Error()
 }
 
-func (mpr *metadataProviderRaft) watchLeadershipChanges(wasLeader bool) {
+func (mpr *metadataProviderRaft) startWatchingLeadershipChanges() {
+	initialState := mpr.raft.State()
+	mpr.watchLeadershipChanges(initialState == raft.Leader)
+}
+
+func (mpr *metadataProviderRaft) watchLeadershipChanges(initialIsLeader bool) {
+	wasLeader := initialIsLeader
 	for {
 		select {
 		case <-mpr.leadershipNotifyStopCh:

--- a/oxiad/coordinator/metadata/metadata_raft_fsm.go
+++ b/oxiad/coordinator/metadata/metadata_raft_fsm.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"sync"
 
 	"github.com/hashicorp/raft"
 	"go.uber.org/multierr"
@@ -31,9 +32,16 @@ type raftOpCmd struct {
 }
 
 type stateContainer struct {
+	sync.RWMutex `json:"-"`
+
 	State          *model.ClusterStatus `json:"state"`
 	CurrentVersion int64                `json:"current_version"`
-	log            *slog.Logger
+	log            *slog.Logger         `json:"-"`
+}
+
+type stateSnapshot struct {
+	State          *model.ClusterStatus `json:"state"`
+	CurrentVersion int64                `json:"current_version"`
 }
 
 func newStateContainer(log *slog.Logger) *stateContainer {
@@ -46,7 +54,6 @@ func newStateContainer(log *slog.Logger) *stateContainer {
 
 // Apply applies a Raft log entry to the FSM.
 func (sc *stateContainer) Apply(logEntry *raft.Log) any {
-	// Each log entry contains the whole state
 	opCmd := raftOpCmd{}
 	err := json.Unmarshal(logEntry.Data, &opCmd)
 	if err != nil {
@@ -54,6 +61,9 @@ func (sc *stateContainer) Apply(logEntry *raft.Log) any {
 			slog.Any("error", err))
 		return &applyResult{changeApplied: false}
 	}
+
+	sc.Lock()
+	defer sc.Unlock()
 
 	if opCmd.ExpectedVersion != sc.CurrentVersion {
 		sc.log.Warn("Failed to apply raft state",
@@ -64,7 +74,11 @@ func (sc *stateContainer) Apply(logEntry *raft.Log) any {
 		return &applyResult{changeApplied: false}
 	}
 
-	sc.State = opCmd.NewState
+	if opCmd.NewState == nil {
+		sc.State = nil
+	} else {
+		sc.State = opCmd.NewState.Clone()
+	}
 	sc.CurrentVersion++
 
 	sc.log.Info("Applied raft log entry",
@@ -74,31 +88,63 @@ func (sc *stateContainer) Apply(logEntry *raft.Log) any {
 
 // Snapshot returns a snapshot of the FSM.
 func (sc *stateContainer) Snapshot() (raft.FSMSnapshot, error) {
+	state, version := sc.CloneState()
 	return &stateContainer{
-		State:          sc.State.Clone(),
-		CurrentVersion: sc.CurrentVersion,
+		State:          state,
+		CurrentVersion: version,
 	}, nil
 }
 
 // Restore stores the key-value pairs from a snapshot.
-func (sc *stateContainer) Restore(rc io.ReadCloser) error {
+func (sc *stateContainer) Restore(rc io.ReadCloser) (err error) {
+	defer func() {
+		err = multierr.Append(err, rc.Close())
+	}()
+
 	dec := json.NewDecoder(rc)
+	snapshot := stateSnapshot{}
+	if err := dec.Decode(&snapshot); err != nil {
+		return err
+	}
+
+	sc.Lock()
+	defer sc.Unlock()
+
+	sc.State = snapshot.State
+	sc.CurrentVersion = snapshot.CurrentVersion
 	sc.log.Info("Restored metadata state from snapshot",
 		slog.Any("cluster-status", sc))
-	return multierr.Combine(
-		dec.Decode(sc),
-		rc.Close(),
-	)
+	return nil
 }
 
 func (sc *stateContainer) Persist(sink raft.SnapshotSink) error {
-	value, err := json.Marshal(sc)
+	state, version := sc.CloneState()
+	value, err := json.Marshal(stateSnapshot{
+		State:          state,
+		CurrentVersion: version,
+	})
 	if err != nil {
 		return multierr.Combine(err, sink.Cancel())
 	}
 
-	_, err = sink.Write(value)
-	return multierr.Combine(err, sink.Cancel(), sink.Close())
+	n, err := sink.Write(value)
+	if err != nil {
+		return multierr.Combine(err, sink.Cancel())
+	}
+	if n != len(value) {
+		return multierr.Combine(io.ErrShortWrite, sink.Cancel())
+	}
+	return sink.Close()
+}
+
+func (sc *stateContainer) CloneState() (*model.ClusterStatus, int64) {
+	sc.RLock()
+	defer sc.RUnlock()
+
+	if sc.State == nil {
+		return nil, sc.CurrentVersion
+	}
+	return sc.State.Clone(), sc.CurrentVersion
 }
 
 func (*stateContainer) Release() {}

--- a/oxiad/coordinator/metadata/metadata_raft_fsm.go
+++ b/oxiad/coordinator/metadata/metadata_raft_fsm.go
@@ -32,11 +32,11 @@ type raftOpCmd struct {
 }
 
 type stateContainer struct {
-	sync.RWMutex `json:"-"`
+	sync.RWMutex
 
 	State          *model.ClusterStatus `json:"state"`
 	CurrentVersion int64                `json:"current_version"`
-	log            *slog.Logger         `json:"-"`
+	log            *slog.Logger
 }
 
 type stateSnapshot struct {

--- a/oxiad/coordinator/metadata/metadata_raft_fsm_test.go
+++ b/oxiad/coordinator/metadata/metadata_raft_fsm_test.go
@@ -1,0 +1,119 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testSnapshotSink struct {
+	data       []byte
+	writeErr   error
+	shortWrite bool
+	closed     bool
+	cancelled  bool
+}
+
+func (*testSnapshotSink) ID() string {
+	return "test-snapshot"
+}
+
+func (s *testSnapshotSink) Write(p []byte) (int, error) {
+	if s.writeErr != nil {
+		return 0, s.writeErr
+	}
+	if s.shortWrite {
+		return len(p) - 1, nil
+	}
+	s.data = append(s.data, p...)
+	return len(p), nil
+}
+
+func (s *testSnapshotSink) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *testSnapshotSink) Cancel() error {
+	s.cancelled = true
+	return nil
+}
+
+func TestStateContainerSnapshotPersistsNilState(t *testing.T) {
+	sc := newStateContainer(slog.Default())
+
+	snapshot, err := sc.Snapshot()
+	require.NoError(t, err)
+
+	sink := &testSnapshotSink{}
+	require.NoError(t, snapshot.Persist(sink))
+
+	assert.True(t, sink.closed)
+	assert.False(t, sink.cancelled)
+	assert.JSONEq(t, `{"state":null,"current_version":-1}`, string(sink.data))
+}
+
+func TestStateContainerPersistCancelsOnWriteError(t *testing.T) {
+	sc := newStateContainer(slog.Default())
+	snapshot, err := sc.Snapshot()
+	require.NoError(t, err)
+
+	sink := &testSnapshotSink{writeErr: errors.New("write failed")}
+	err = snapshot.Persist(sink)
+
+	require.Error(t, err)
+	assert.True(t, sink.cancelled)
+	assert.False(t, sink.closed)
+}
+
+func TestStateContainerPersistCancelsOnShortWrite(t *testing.T) {
+	sc := newStateContainer(slog.Default())
+	snapshot, err := sc.Snapshot()
+	require.NoError(t, err)
+
+	sink := &testSnapshotSink{shortWrite: true}
+	err = snapshot.Persist(sink)
+
+	require.ErrorIs(t, err, io.ErrShortWrite)
+	assert.True(t, sink.cancelled)
+	assert.False(t, sink.closed)
+}
+
+type errCloseReadCloser struct {
+	io.Reader
+	closeErr error
+}
+
+func (r *errCloseReadCloser) Close() error {
+	return r.closeErr
+}
+
+func TestStateContainerRestoreReturnsCloseError(t *testing.T) {
+	sc := newStateContainer(slog.Default())
+
+	err := sc.Restore(&errCloseReadCloser{
+		Reader:   bytes.NewBufferString(`{"state":null,"current_version":3}`),
+		closeErr: errors.New("close failed"),
+	})
+
+	require.EqualError(t, err, "close failed")
+}

--- a/oxiad/coordinator/metadata/metadata_raft_store.go
+++ b/oxiad/coordinator/metadata/metadata_raft_store.go
@@ -35,8 +35,15 @@ type kvRaftStore struct {
 }
 
 func newKVRaftStore(path string) (store *kvRaftStore, err error) {
+	return newKVRaftStoreWithFactory(path, kvstore.NewPebbleKVFactory)
+}
+
+func newKVRaftStoreWithFactory(
+	path string,
+	newFactory func(options *kvstore.FactoryOptions) (kvstore.Factory, error),
+) (store *kvRaftStore, err error) {
 	store = &kvRaftStore{}
-	if store.factory, err = kvstore.NewPebbleKVFactory(&kvstore.FactoryOptions{
+	if store.factory, err = newFactory(&kvstore.FactoryOptions{
 		DataDir:     path,
 		CacheSizeMB: 1,
 		UseWAL:      true,
@@ -46,6 +53,11 @@ func newKVRaftStore(path string) (store *kvRaftStore, err error) {
 	}
 
 	if store.kv, err = store.factory.NewKV("raft", 0, proto.KeySortingType_NATURAL); err != nil {
+		closeErr := store.factory.Close()
+		store.factory = nil
+		if closeErr != nil {
+			return nil, multierr.Combine(err, closeErr)
+		}
 		return nil, err
 	}
 
@@ -68,6 +80,7 @@ const logKeyFormat = "log-%020d"
 var (
 	logKeyMin = fmt.Sprintf(logKeyFormat, 0)
 	logKeyMax = fmt.Sprintf(logKeyFormat, uint64(math.MaxUint64))
+	logKeyEnd = logKeyMax + "\x00"
 )
 
 func (s *kvRaftStore) FirstIndex() (uint64, error) {
@@ -105,6 +118,9 @@ func (s *kvRaftStore) GetLog(index uint64, log *raft.Log) error {
 	key := fmt.Sprintf(logKeyFormat, index)
 	_, value, closer, err := s.kv.Get(key, kvstore.ComparisonEqual, kvstore.NoInternalKeys)
 	if err != nil {
+		if errors.Is(err, kvstore.ErrKeyNotFound) {
+			return raft.ErrLogNotFound
+		}
 		return err
 	}
 
@@ -118,8 +134,12 @@ func (s *kvRaftStore) StoreLog(log *raft.Log) error {
 	return s.StoreLogs([]*raft.Log{log})
 }
 
-func (s *kvRaftStore) StoreLogs(logs []*raft.Log) error {
+func (s *kvRaftStore) StoreLogs(logs []*raft.Log) (err error) {
 	wb := s.kv.NewWriteBatch()
+	defer func() {
+		err = multierr.Append(err, wb.Close())
+	}()
+
 	for _, log := range logs {
 		key := fmt.Sprintf(logKeyFormat, log.Index)
 
@@ -133,15 +153,15 @@ func (s *kvRaftStore) StoreLogs(logs []*raft.Log) error {
 		}
 	}
 
-	return multierr.Combine(
-		wb.Commit(),
-		wb.Close(),
-	)
+	return wb.Commit()
 }
 
 func (s *kvRaftStore) DeleteRange(minInclusive, maxInclusive uint64) error {
 	minKeyInclusive := fmt.Sprintf(logKeyFormat, minInclusive)
-	maxKeyExclusive := fmt.Sprintf(logKeyFormat, maxInclusive+1)
+	maxKeyExclusive := logKeyEnd
+	if maxInclusive != math.MaxUint64 {
+		maxKeyExclusive = fmt.Sprintf(logKeyFormat, maxInclusive+1)
+	}
 	wb := s.kv.NewWriteBatch()
 
 	return multierr.Combine(

--- a/oxiad/coordinator/metadata/metadata_raft_store_test.go
+++ b/oxiad/coordinator/metadata/metadata_raft_store_test.go
@@ -79,8 +79,10 @@ func (f *fakeFactory) Close() error {
 	return nil
 }
 
+var errNotImplemented = errors.New("not implemented")
+
 func (*fakeFactory) NewSnapshotLoader(string, int64) (kvstore.SnapshotLoader, error) {
-	return nil, nil
+	return nil, errNotImplemented
 }
 
 func (*fakeFactory) NewKV(string, int64, proto.KeySortingType) (kvstore.KV, error) {

--- a/oxiad/coordinator/metadata/metadata_raft_store_test.go
+++ b/oxiad/coordinator/metadata/metadata_raft_store_test.go
@@ -1,0 +1,197 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"errors"
+	"io"
+	"math"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxiad/common/crc"
+	"github.com/oxia-db/oxia/oxiad/dataserver/database/kvstore"
+)
+
+func TestKVRaftStoreGetLogMissingReturnsErrLogNotFound(t *testing.T) {
+	store, err := newKVRaftStore(filepath.Join(t.TempDir(), "raft-store"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	err = store.GetLog(1, &raft.Log{})
+	assert.ErrorIs(t, err, raft.ErrLogNotFound)
+}
+
+func TestKVRaftStoreDeleteRangeHandlesMaxUint64(t *testing.T) {
+	store, err := newKVRaftStore(filepath.Join(t.TempDir(), "raft-store"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	require.NoError(t, store.StoreLogs([]*raft.Log{
+		{Index: 1, Term: 1, Type: raft.LogCommand, Data: []byte("one")},
+		{Index: 2, Term: 1, Type: raft.LogCommand, Data: []byte("two")},
+	}))
+
+	require.NoError(t, store.DeleteRange(1, math.MaxUint64))
+
+	assert.ErrorIs(t, store.GetLog(1, &raft.Log{}), raft.ErrLogNotFound)
+	assert.ErrorIs(t, store.GetLog(2, &raft.Log{}), raft.ErrLogNotFound)
+}
+
+func TestKVRaftStoreStoreLogsReturnsCloseError(t *testing.T) {
+	closeErr := errors.New("close failed")
+	wb := &fakeWriteBatch{closeErr: closeErr}
+	store := &kvRaftStore{kv: &fakeKV{wb: wb}}
+
+	err := store.StoreLog(&raft.Log{Index: 1, Term: 1})
+
+	assert.ErrorIs(t, err, closeErr)
+	assert.True(t, wb.closed)
+}
+
+type fakeFactory struct {
+	closed bool
+}
+
+func (f *fakeFactory) Close() error {
+	f.closed = true
+	return nil
+}
+
+func (*fakeFactory) NewSnapshotLoader(string, int64) (kvstore.SnapshotLoader, error) {
+	return nil, nil
+}
+
+func (*fakeFactory) NewKV(string, int64, proto.KeySortingType) (kvstore.KV, error) {
+	return nil, errors.New("new kv failed")
+}
+
+func TestKVRaftStoreClosesFactoryWhenNewKVFails(t *testing.T) {
+	factory := &fakeFactory{}
+
+	_, err := newKVRaftStoreWithFactory(t.TempDir(), func(*kvstore.FactoryOptions) (kvstore.Factory, error) {
+		return factory, nil
+	})
+
+	require.EqualError(t, err, "new kv failed")
+	assert.True(t, factory.closed)
+}
+
+type fakeKV struct {
+	wb kvstore.WriteBatch
+}
+
+func (f *fakeKV) NewWriteBatch() kvstore.WriteBatch {
+	return f.wb
+}
+
+func (*fakeKV) Close() error {
+	return nil
+}
+
+func (*fakeKV) Get(string, kvstore.ComparisonType, kvstore.IteratorOpts) (string, []byte, io.Closer, error) {
+	panic("not implemented")
+}
+
+func (*fakeKV) KeyRangeScan(string, string, kvstore.IteratorOpts) (kvstore.KeyIterator, error) {
+	panic("not implemented")
+}
+
+func (*fakeKV) KeyRangeScanReverse(string, string, kvstore.IteratorOpts) (kvstore.ReverseKeyIterator, error) {
+	panic("not implemented")
+}
+
+func (*fakeKV) KeyIterator(kvstore.IteratorOpts) (kvstore.KeyIterator, error) {
+	panic("not implemented")
+}
+
+func (*fakeKV) RangeScan(string, string, kvstore.IteratorOpts) (kvstore.KeyValueIterator, error) {
+	panic("not implemented")
+}
+
+func (*fakeKV) Snapshot() (kvstore.Snapshot, error) {
+	panic("not implemented")
+}
+
+func (*fakeKV) Flush() error {
+	panic("not implemented")
+}
+
+func (*fakeKV) Delete() error {
+	panic("not implemented")
+}
+
+type fakeWriteBatch struct {
+	closeErr error
+	closed   bool
+}
+
+func (*fakeWriteBatch) Put(string, []byte) error {
+	return nil
+}
+
+func (*fakeWriteBatch) Delete(string) error {
+	panic("not implemented")
+}
+
+func (*fakeWriteBatch) Get(string) ([]byte, io.Closer, error) {
+	panic("not implemented")
+}
+
+func (*fakeWriteBatch) FindLower(string) (string, error) {
+	panic("not implemented")
+}
+
+func (*fakeWriteBatch) DeleteRange(string, string) error {
+	panic("not implemented")
+}
+
+func (*fakeWriteBatch) KeyRangeScan(string, string) (kvstore.KeyIterator, error) {
+	panic("not implemented")
+}
+
+func (*fakeWriteBatch) RangeScan(string, string) (kvstore.KeyValueIterator, error) {
+	panic("not implemented")
+}
+
+func (*fakeWriteBatch) Count() int {
+	return 0
+}
+
+func (*fakeWriteBatch) Size() int {
+	return 0
+}
+
+func (*fakeWriteBatch) Commit() error {
+	return nil
+}
+
+func (*fakeWriteBatch) Checksum(init crc.Checksum) crc.Checksum {
+	return init
+}
+
+func (f *fakeWriteBatch) Close() error {
+	f.closed = true
+	return f.closeErr
+}

--- a/oxiad/coordinator/metadata/metadata_raft_test.go
+++ b/oxiad/coordinator/metadata/metadata_raft_test.go
@@ -15,31 +15,28 @@
 package metadata
 
 import (
-	"context"
 	"fmt"
+	"net"
 	"path/filepath"
+	"reflect"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
 
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
-
-	"github.com/oxia-db/oxia/common/concurrent"
 )
 
 type testRaftClusterProvider struct {
-	providers []Provider
-	leader    Provider
+	cluster *testRaftCluster
+	leader  Provider
 }
 
 func (t testRaftClusterProvider) Close() error {
-	for _, p := range t.providers {
-		if err := p.Close(); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return t.cluster.Close()
 }
 
 func (t testRaftClusterProvider) Get() (cs *model.ClusterStatus, version Version, err error) {
@@ -57,34 +54,355 @@ func (t testRaftClusterProvider) WaitToBecomeLeader() error {
 func newTestRaftClusterProvider(t *testing.T) Provider {
 	t.Helper()
 
-	// start a cluster
-	trc := &testRaftClusterProvider{}
+	cluster := newTestRaftCluster(t)
+	return &testRaftClusterProvider{
+		cluster: cluster,
+		leader:  cluster.waitForLeader(t),
+	}
+}
+
+func TestMetadataProviderRaftGetReturnsClone(t *testing.T) {
+	provider := newTestRaftClusterProvider(t)
+	t.Cleanup(func() {
+		require.NoError(t, provider.Close())
+	})
+
+	leaderName := "leader"
+	_, err := provider.Store(&model.ClusterStatus{
+		Namespaces: map[string]model.NamespaceStatus{
+			"default": {
+				Shards: map[int64]model.ShardMetadata{
+					1: {
+						Leader: &model.Server{
+							Name:     &leaderName,
+							Public:   "public-1",
+							Internal: "internal-1",
+						},
+					},
+				},
+			},
+		},
+	}, NotExists)
+	require.NoError(t, err)
+
+	clusterStatus, _, err := provider.Get()
+	require.NoError(t, err)
+	shard := clusterStatus.Namespaces["default"].Shards[1]
+	shard.Leader.Public = "mutated"
+
+	clusterStatus, _, err = provider.Get()
+	require.NoError(t, err)
+	assert.Equal(t, "public-1", clusterStatus.Namespaces["default"].Shards[1].Leader.Public)
+}
+
+func TestMetadataProviderRaftCloseReleasesTransport(t *testing.T) {
+	addr := newTestTCPAddress(t)
+	dataDir := t.TempDir()
+
+	provider, err := NewMetadataProviderRaft(addr, []string{addr}, dataDir)
+	require.NoError(t, err)
+	require.NoError(t, provider.WaitToBecomeLeader())
+	require.NoError(t, provider.Close())
+
+	provider, err = NewMetadataProviderRaft(addr, []string{addr}, dataDir)
+	require.NoError(t, err)
+	require.NoError(t, provider.Close())
+}
+
+func TestMetadataProviderRaftWatchLeadershipChangesNotifiesLossTransitions(t *testing.T) {
+	mpr := &metadataProviderRaft{
+		leadershipLostCh:       make(chan struct{}, 4),
+		leadershipNotifyCh:     make(chan bool, 4),
+		leadershipNotifyStopCh: make(chan struct{}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		mpr.watchLeadershipChanges(false)
+	}()
+
+	mpr.leadershipNotifyCh <- true
+	mpr.leadershipNotifyCh <- false
+	requireReceiveLeadershipLoss(t, mpr.leadershipLostCh)
+
+	mpr.leadershipNotifyCh <- false
+	requireNoLeadershipLoss(t, mpr.leadershipLostCh)
+
+	mpr.leadershipNotifyCh <- true
+	mpr.leadershipNotifyCh <- false
+	requireReceiveLeadershipLoss(t, mpr.leadershipLostCh)
+
+	close(mpr.leadershipNotifyStopCh)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for leadership watcher to stop")
+	}
+}
+
+func TestMetadataProviderRaftLeadershipLostOnLeaderRestart(t *testing.T) {
+	cluster := newTestRaftCluster(t)
+	t.Cleanup(func() {
+		require.NoError(t, cluster.Close())
+	})
+
+	expected := testClusterStatus(1)
+	leader := cluster.waitForLeader(t)
+	version, err := leader.Store(expected, NotExists)
+	require.NoError(t, err)
+	cluster.requireSingleLeader(t)
+	cluster.requireReplicatedState(t, expected, version)
+
+	leaderIdx := cluster.indexOf(leader)
+	require.NotEqual(t, -1, leaderIdx)
+	lostCh := leader.LeadershipLost()
+
+	cluster.restartNode(t, leaderIdx)
+
+	requireReceiveLeadershipLoss(t, lostCh)
+	cluster.requireSingleLeader(t)
+	cluster.requireReplicatedState(t, expected, version)
+}
+
+func TestMetadataProviderRaftThreeNodeClusterMaintainsStateAcrossRepeatedRestarts(t *testing.T) {
+	cluster := newTestRaftCluster(t)
+	t.Cleanup(func() {
+		require.NoError(t, cluster.Close())
+	})
+
+	leader := cluster.waitForLeader(t)
+	expected := testClusterStatus(1)
+	version, err := leader.Store(expected, NotExists)
+	require.NoError(t, err)
+	cluster.requireSingleLeader(t)
+	cluster.requireReplicatedState(t, expected, version)
+
+	restartOrder := []int{0, 1, 2, 2, 1, 0, 1, 0, 2}
+	for i, nodeIdx := range restartOrder {
+		currentLeader := cluster.waitForLeader(t)
+		if cluster.indexOf(currentLeader) == nodeIdx {
+			cluster.restartNode(t, nodeIdx)
+			requireReceiveLeadershipLoss(t, currentLeader.LeadershipLost())
+		} else {
+			cluster.restartNode(t, nodeIdx)
+		}
+
+		cluster.requireSingleLeader(t)
+		cluster.requireReplicatedState(t, expected, version)
+
+		expected = testClusterStatus(i + 2)
+		leader = cluster.waitForLeader(t)
+		version, err = leader.Store(expected, version)
+		require.NoError(t, err)
+
+		cluster.requireSingleLeader(t)
+		cluster.requireReplicatedState(t, expected, version)
+	}
+}
+
+func newTestTCPAddress(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	return listener.Addr().String()
+}
+
+func requireReceiveLeadershipLoss(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for leadership loss notification")
+	}
+}
+
+func requireNoLeadershipLoss(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+		t.Fatal("received unexpected leadership loss notification")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+type testRaftCluster struct {
+	bootstrapServers []string
+	dataDirs         []string
+	providers        []*metadataProviderRaft
+}
+
+func newTestRaftCluster(t *testing.T) *testRaftCluster {
+	t.Helper()
+
 	baseDir := t.TempDir()
-	bootstrapServers := []string{"127.0.0.1:9000", "127.0.0.1:9001", "127.0.0.1:9002"}
-
-	for i := 0; i < 3; i++ {
-		addr := fmt.Sprintf("127.0.0.1:%d", 9000+i)
-		dataDir := filepath.Join(baseDir, fmt.Sprintf("data-%d", i))
-		p, err := NewMetadataProviderRaft(addr, bootstrapServers, dataDir)
-		assert.NoError(t, err)
-
-		trc.providers = append(trc.providers, p)
+	bootstrapServers := []string{
+		newTestTCPAddress(t),
+		newTestTCPAddress(t),
+		newTestTCPAddress(t),
 	}
 
-	leaderFuture := concurrent.NewFuture[Provider]()
-
-	for i := 0; i < 3; i++ {
-		idx := i
-		go func() {
-			p := trc.providers[idx]
-			err := p.WaitToBecomeLeader()
-			assert.NoError(t, err)
-			leaderFuture.Complete(p)
-		}()
+	cluster := &testRaftCluster{
+		bootstrapServers: bootstrapServers,
+		dataDirs: []string{
+			filepath.Join(baseDir, fmt.Sprintf("data-%d", 0)),
+			filepath.Join(baseDir, fmt.Sprintf("data-%d", 1)),
+			filepath.Join(baseDir, fmt.Sprintf("data-%d", 2)),
+		},
+		providers: make([]*metadataProviderRaft, len(bootstrapServers)),
 	}
 
-	var err error
-	trc.leader, err = leaderFuture.Wait(context.Background())
-	assert.NoError(t, err)
-	return trc
+	for i := range bootstrapServers {
+		cluster.providers[i] = cluster.newProvider(t, i)
+	}
+
+	return cluster
+}
+
+func (c *testRaftCluster) Close() error {
+	var closeErr error
+	for i, provider := range c.providers {
+		if provider == nil {
+			continue
+		}
+		closeErr = multierr.Append(closeErr, provider.Close())
+		c.providers[i] = nil
+	}
+	return closeErr
+}
+
+func (c *testRaftCluster) newProvider(t *testing.T, idx int) *metadataProviderRaft {
+	t.Helper()
+
+	provider, err := NewMetadataProviderRaft(c.bootstrapServers[idx], c.bootstrapServers, c.dataDirs[idx])
+	require.NoError(t, err)
+
+	mpr, ok := provider.(*metadataProviderRaft)
+	require.True(t, ok)
+	return mpr
+}
+
+func (c *testRaftCluster) restartNode(t *testing.T, idx int) {
+	t.Helper()
+
+	if c.providers[idx] != nil {
+		require.NoError(t, c.providers[idx].Close())
+		c.providers[idx] = nil
+	}
+	c.providers[idx] = c.newProvider(t, idx)
+}
+
+func (c *testRaftCluster) waitForLeader(t *testing.T) *metadataProviderRaft {
+	t.Helper()
+	return c.requireSingleLeader(t)
+}
+
+func (c *testRaftCluster) requireSingleLeader(t *testing.T) *metadataProviderRaft {
+	t.Helper()
+
+	var leader *metadataProviderRaft
+	require.Eventually(t, func() bool {
+		leaders := make([]*metadataProviderRaft, 0, len(c.providers))
+		for _, provider := range c.providers {
+			if provider == nil {
+				continue
+			}
+			if provider.raft.State() == raft.Leader && provider.raft.VerifyLeader().Error() == nil {
+				leaders = append(leaders, provider)
+			}
+		}
+		if len(leaders) != 1 {
+			return false
+		}
+		leader = leaders[0]
+		return true
+	}, 30*time.Second, 100*time.Millisecond)
+	return leader
+}
+
+func (c *testRaftCluster) requireReplicatedState(t *testing.T, expected *model.ClusterStatus, version Version) {
+	t.Helper()
+
+	expectedVersion := fromVersion(version)
+	require.Eventually(t, func() bool {
+		for _, provider := range c.providers {
+			if provider == nil {
+				continue
+			}
+			state, currentVersion := provider.sc.CloneState()
+			if currentVersion != expectedVersion {
+				return false
+			}
+			if !reflect.DeepEqual(state, expected) {
+				return false
+			}
+		}
+		return true
+	}, 30*time.Second, 100*time.Millisecond)
+}
+
+func (c *testRaftCluster) indexOf(target *metadataProviderRaft) int {
+	for i, provider := range c.providers {
+		if provider == target {
+			return i
+		}
+	}
+	return -1
+}
+
+func testClusterStatus(seed int) *model.ClusterStatus {
+	leaderName := fmt.Sprintf("leader-%d", seed)
+	leader := model.Server{
+		Name:     &leaderName,
+		Public:   fmt.Sprintf("public-%d", seed),
+		Internal: fmt.Sprintf("internal-%d", seed),
+	}
+	follower1 := model.Server{
+		Public:   fmt.Sprintf("follower-%d-a-public", seed),
+		Internal: fmt.Sprintf("follower-%d-a-internal", seed),
+	}
+	follower2 := model.Server{
+		Public:   fmt.Sprintf("follower-%d-b-public", seed),
+		Internal: fmt.Sprintf("follower-%d-b-internal", seed),
+	}
+
+	status := &model.ClusterStatus{
+		Namespaces: map[string]model.NamespaceStatus{
+			"default": {
+				ReplicationFactor: 3,
+				Shards: map[int64]model.ShardMetadata{
+					0: {
+						Status:   model.ShardStatusSteadyState,
+						Term:     int64(seed),
+						Leader:   &leader,
+						Ensemble: []model.Server{leader, follower1, follower2},
+						Int32HashRange: model.Int32HashRange{
+							Min: 0,
+							Max: uint32(100 + seed),
+						},
+					},
+				},
+			},
+			fmt.Sprintf("ns-%d", seed): {
+				ReplicationFactor: 1,
+				Shards: map[int64]model.ShardMetadata{
+					int64(seed): {
+						Status: model.ShardStatusUnknown,
+						Term:   int64(seed * 10),
+						Int32HashRange: model.Int32HashRange{
+							Min: uint32(seed),
+							Max: uint32(1000 + seed),
+						},
+					},
+				},
+			},
+		},
+		ShardIdGenerator: int64(seed * 100),
+		ServerIdx:        uint32(seed),
+	}
+	return status.Clone()
 }

--- a/oxiad/coordinator/model/cluster_common.go
+++ b/oxiad/coordinator/model/cluster_common.go
@@ -30,6 +30,20 @@ type ServerMetadata struct {
 	Labels map[string]string `json:"labels" yaml:"labels"`
 }
 
+func (sv Server) Clone() Server {
+	var name *string
+	if sv.Name != nil {
+		cloned := *sv.Name
+		name = &cloned
+	}
+
+	return Server{
+		Name:     name,
+		Public:   sv.Public,
+		Internal: sv.Internal,
+	}
+}
+
 func (sv *Server) GetIdentifier() string {
 	if sv.Name == nil {
 		return sv.Internal

--- a/oxiad/coordinator/model/cluster_status.go
+++ b/oxiad/coordinator/model/cluster_status.go
@@ -133,7 +133,7 @@ func (sm ShardMetadata) Clone() ShardMetadata {
 	r := ShardMetadata{
 		Status:                  sm.Status,
 		Term:                    sm.Term,
-		Leader:                  sm.Leader,
+		Leader:                  nil,
 		Ensemble:                make([]Server, len(sm.Ensemble)),
 		RemovedNodes:            make([]Server, len(sm.RemovedNodes)),
 		PendingDeleteShardNodes: make([]Server, len(sm.PendingDeleteShardNodes)),
@@ -141,9 +141,19 @@ func (sm ShardMetadata) Clone() ShardMetadata {
 		Split:                   sm.Split.Clone(),
 	}
 
-	copy(r.Ensemble, sm.Ensemble)
-	copy(r.RemovedNodes, sm.RemovedNodes)
-	copy(r.PendingDeleteShardNodes, sm.PendingDeleteShardNodes)
+	if sm.Leader != nil {
+		leader := sm.Leader.Clone()
+		r.Leader = &leader
+	}
+	for i, server := range sm.Ensemble {
+		r.Ensemble[i] = server.Clone()
+	}
+	for i, server := range sm.RemovedNodes {
+		r.RemovedNodes[i] = server.Clone()
+	}
+	for i, server := range sm.PendingDeleteShardNodes {
+		r.PendingDeleteShardNodes[i] = server.Clone()
+	}
 
 	return r
 }

--- a/oxiad/coordinator/model/cluster_status_test.go
+++ b/oxiad/coordinator/model/cluster_status_test.go
@@ -21,6 +21,11 @@ import (
 )
 
 func TestClusterStatus_Clone(t *testing.T) {
+	leaderName := "leader-1"
+	followerName1 := "follower-1"
+	followerName2 := "follower-2"
+	removedName := "removed-1"
+
 	cs1 := &ClusterStatus{
 		Namespaces: map[string]NamespaceStatus{
 			"test-ns": {
@@ -30,18 +35,22 @@ func TestClusterStatus_Clone(t *testing.T) {
 						Status: ShardStatusSteadyState,
 						Term:   1,
 						Leader: &Server{
+							Name:     &leaderName,
 							Public:   "l1",
 							Internal: "l1",
 						},
 						Ensemble: []Server{{
+							Name:     &followerName1,
 							Public:   "f1",
 							Internal: "f1",
 						}, {
+							Name:     &followerName2,
 							Public:   "f2",
 							Internal: "f2",
 						}},
 						Int32HashRange: Int32HashRange{},
 						RemovedNodes: []Server{{
+							Name:     &removedName,
 							Public:   "r1",
 							Internal: "r1",
 						}},
@@ -62,6 +71,9 @@ func TestClusterStatus_Clone(t *testing.T) {
 	assert.NotSame(t, &cs1.Namespaces, &cs2.Namespaces)
 	assert.Equal(t, cs1.Namespaces["test-ns"].Shards, cs2.Namespaces["test-ns"].Shards)
 	assert.Equal(t, cs1.Namespaces["test-ns"].Shards[0], cs2.Namespaces["test-ns"].Shards[0])
+	assert.NotSame(t, cs1.Namespaces["test-ns"].Shards[0].Leader, cs2.Namespaces["test-ns"].Shards[0].Leader)
+	assert.NotSame(t, cs1.Namespaces["test-ns"].Shards[0].Leader.Name, cs2.Namespaces["test-ns"].Shards[0].Leader.Name)
+	assert.NotSame(t, &cs1.Namespaces["test-ns"].Shards[0].Ensemble[0], &cs2.Namespaces["test-ns"].Shards[0].Ensemble[0])
 
 	assert.Equal(t, cs1.ShardIdGenerator, cs2.ShardIdGenerator)
 	assert.Equal(t, cs1.ServerIdx, cs2.ServerIdx)

--- a/oxiad/coordinator/option/option.go
+++ b/oxiad/coordinator/option/option.go
@@ -152,41 +152,52 @@ func (mo *MetadataOptions) Validate() error {
 			return errors.New("k8s-configmap-name must be set with metadata=configmap")
 		}
 	case metadata.ProviderNameRaft:
-		if mo.Raft.Address == "" {
-			return errors.New("raft-address must be set with metadata=raft")
-		}
-		if _, _, err := net.SplitHostPort(mo.Raft.Address); err != nil {
-			return fmt.Errorf("raft-address must be a host:port address: %w", err)
-		}
-		if mo.Raft.DataDir == "" {
-			return errors.New("raft-data-dir must be set with metadata=raft")
-		}
-		if len(mo.Raft.BootstrapNodes) == 0 {
-			return errors.New("raft-bootstrap-nodes must be set with metadata=raft")
-		}
-		seenBootstrapNodes := make(map[string]struct{}, len(mo.Raft.BootstrapNodes))
-		containsLocalNode := false
-		for _, node := range mo.Raft.BootstrapNodes {
-			if node == "" {
-				return errors.New("raft-bootstrap-nodes cannot contain empty entries")
-			}
-			if _, _, err := net.SplitHostPort(node); err != nil {
-				return fmt.Errorf("raft-bootstrap-nodes entry %q must be a host:port address: %w", node, err)
-			}
-			if _, exists := seenBootstrapNodes[node]; exists {
-				return fmt.Errorf("raft-bootstrap-nodes contains duplicate node %q", node)
-			}
-			seenBootstrapNodes[node] = struct{}{}
-			if node == mo.Raft.Address {
-				containsLocalNode = true
-			}
-		}
-		if !containsLocalNode {
-			return fmt.Errorf("raft-address %q must be included in raft-bootstrap-nodes", mo.Raft.Address)
+		if err := mo.validateRaftOptions(); err != nil {
+			return err
 		}
 	case metadata.ProviderNameFile, metadata.ProviderNameMemory:
 	default:
 		return errors.New(`must be one of "memory", "configmap", "raft" or "file"`)
+	}
+	return nil
+}
+
+func (mo *MetadataOptions) validateRaftOptions() error {
+	if mo.Raft.Address == "" {
+		return errors.New("raft-address must be set with metadata=raft")
+	}
+	if _, _, err := net.SplitHostPort(mo.Raft.Address); err != nil {
+		return fmt.Errorf("raft-address must be a host:port address: %w", err)
+	}
+	if mo.Raft.DataDir == "" {
+		return errors.New("raft-data-dir must be set with metadata=raft")
+	}
+	if len(mo.Raft.BootstrapNodes) == 0 {
+		return errors.New("raft-bootstrap-nodes must be set with metadata=raft")
+	}
+	return mo.validateRaftBootstrapNodes()
+}
+
+func (mo *MetadataOptions) validateRaftBootstrapNodes() error {
+	seenBootstrapNodes := make(map[string]struct{}, len(mo.Raft.BootstrapNodes))
+	containsLocalNode := false
+	for _, node := range mo.Raft.BootstrapNodes {
+		if node == "" {
+			return errors.New("raft-bootstrap-nodes cannot contain empty entries")
+		}
+		if _, _, err := net.SplitHostPort(node); err != nil {
+			return fmt.Errorf("raft-bootstrap-nodes entry %q must be a host:port address: %w", node, err)
+		}
+		if _, exists := seenBootstrapNodes[node]; exists {
+			return fmt.Errorf("raft-bootstrap-nodes contains duplicate node %q", node)
+		}
+		seenBootstrapNodes[node] = struct{}{}
+		if node == mo.Raft.Address {
+			containsLocalNode = true
+		}
+	}
+	if !containsLocalNode {
+		return fmt.Errorf("raft-address %q must be included in raft-bootstrap-nodes", mo.Raft.Address)
 	}
 	return nil
 }

--- a/oxiad/coordinator/option/option.go
+++ b/oxiad/coordinator/option/option.go
@@ -17,6 +17,7 @@ package option
 import (
 	"errors"
 	"fmt"
+	"net"
 
 	"go.uber.org/multierr"
 
@@ -153,6 +154,35 @@ func (mo *MetadataOptions) Validate() error {
 	case metadata.ProviderNameRaft:
 		if mo.Raft.Address == "" {
 			return errors.New("raft-address must be set with metadata=raft")
+		}
+		if _, _, err := net.SplitHostPort(mo.Raft.Address); err != nil {
+			return fmt.Errorf("raft-address must be a host:port address: %w", err)
+		}
+		if mo.Raft.DataDir == "" {
+			return errors.New("raft-data-dir must be set with metadata=raft")
+		}
+		if len(mo.Raft.BootstrapNodes) == 0 {
+			return errors.New("raft-bootstrap-nodes must be set with metadata=raft")
+		}
+		seenBootstrapNodes := make(map[string]struct{}, len(mo.Raft.BootstrapNodes))
+		containsLocalNode := false
+		for _, node := range mo.Raft.BootstrapNodes {
+			if node == "" {
+				return errors.New("raft-bootstrap-nodes cannot contain empty entries")
+			}
+			if _, _, err := net.SplitHostPort(node); err != nil {
+				return fmt.Errorf("raft-bootstrap-nodes entry %q must be a host:port address: %w", node, err)
+			}
+			if _, exists := seenBootstrapNodes[node]; exists {
+				return fmt.Errorf("raft-bootstrap-nodes contains duplicate node %q", node)
+			}
+			seenBootstrapNodes[node] = struct{}{}
+			if node == mo.Raft.Address {
+				containsLocalNode = true
+			}
+		}
+		if !containsLocalNode {
+			return fmt.Errorf("raft-address %q must be included in raft-bootstrap-nodes", mo.Raft.Address)
 		}
 	case metadata.ProviderNameFile, metadata.ProviderNameMemory:
 	default:

--- a/oxiad/coordinator/option/option_test.go
+++ b/oxiad/coordinator/option/option_test.go
@@ -1,0 +1,64 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package option
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+)
+
+func TestMetadataOptionsValidateRaftRequiresBootstrapNodes(t *testing.T) {
+	opts := MetadataOptions{
+		ProviderName: metadata.ProviderNameRaft,
+		Raft: RaftMetadata{
+			Address: "127.0.0.1:6645",
+			DataDir: "/tmp/raft",
+		},
+	}
+
+	err := opts.Validate()
+	assert.EqualError(t, err, "raft-bootstrap-nodes must be set with metadata=raft")
+}
+
+func TestMetadataOptionsValidateRaftRejectsDuplicateBootstrapNodes(t *testing.T) {
+	opts := MetadataOptions{
+		ProviderName: metadata.ProviderNameRaft,
+		Raft: RaftMetadata{
+			Address:        "127.0.0.1:6645",
+			DataDir:        "/tmp/raft",
+			BootstrapNodes: []string{"127.0.0.1:6645", "127.0.0.1:6645"},
+		},
+	}
+
+	err := opts.Validate()
+	assert.EqualError(t, err, `raft-bootstrap-nodes contains duplicate node "127.0.0.1:6645"`)
+}
+
+func TestMetadataOptionsValidateRaftRequiresLocalAddressInBootstrapNodes(t *testing.T) {
+	opts := MetadataOptions{
+		ProviderName: metadata.ProviderNameRaft,
+		Raft: RaftMetadata{
+			Address:        "127.0.0.1:6645",
+			DataDir:        "/tmp/raft",
+			BootstrapNodes: []string{"127.0.0.1:6646"},
+		},
+	}
+
+	err := opts.Validate()
+	assert.EqualError(t, err, `raft-address "127.0.0.1:6645" must be included in raft-bootstrap-nodes`)
+}

--- a/oxiad/coordinator/resource/status_resource.go
+++ b/oxiad/coordinator/resource/status_resource.go
@@ -32,13 +32,13 @@ type EnsembleSupplier func(namespaceConfig *model.NamespaceConfig, status *model
 type StatusResource interface {
 	Load() *model.ClusterStatus
 
-	ApplyChanges(config *model.ClusterConfig, ensembleSupplier EnsembleSupplier) (*model.ClusterStatus, map[int64]string, []int64)
+	ApplyChanges(config *model.ClusterConfig, ensembleSupplier EnsembleSupplier) (*model.ClusterStatus, map[int64]string, []int64, error)
 
-	Update(newStatus *model.ClusterStatus)
+	Update(newStatus *model.ClusterStatus) error
 
-	UpdateShardMetadata(namespace string, shard int64, shardMetadata model.ShardMetadata)
+	UpdateShardMetadata(namespace string, shard int64, shardMetadata model.ShardMetadata) error
 
-	DeleteShardMetadata(namespace string, shard int64)
+	DeleteShardMetadata(namespace string, shard int64) error
 
 	IsReady(clusterConfig *model.ClusterConfig) bool
 
@@ -65,10 +65,12 @@ var _ StatusResource = &status{}
 type status struct {
 	*slog.Logger
 	metadata metadata.Provider
+	ctx      context.Context
 
 	lock             sync.RWMutex
 	current          *model.ClusterStatus
 	currentVersionID metadata.Version
+	loaded           bool
 	changeCh         chan struct{}
 }
 
@@ -107,154 +109,205 @@ func WaitForCondition(ctx context.Context, sr StatusResource, triggerFn func(), 
 
 // ensureLoaded loads the status from the metadata store if not already loaded.
 // Caller must hold s.lock for writing.
-func (s *status) ensureLoaded() {
-	if s.current != nil {
-		return
+func (s *status) ensureLoaded() error {
+	if s.loaded {
+		return nil
 	}
-	_ = backoff.RetryNotify(func() error {
+	err := backoff.RetryNotify(func() error {
 		clusterStatus, version, err := s.metadata.Get()
 		if err != nil {
 			return err
 		}
 		s.current = clusterStatus
 		s.currentVersionID = version
+		s.loaded = true
 		return nil
-	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+	}, backoff.WithContext(backoff.NewExponentialBackOff(), s.ctx), func(err error, duration time.Duration) {
 		s.Warn(
 			"failed to load status, retrying later",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
 		)
 	})
-	if s.current == nil {
-		s.current = &model.ClusterStatus{}
-	}
+	return err
 }
 
 func (s *status) Load() *model.ClusterStatus {
 	s.lock.RLock()
-	if s.current != nil {
+	if s.loaded {
 		defer s.lock.RUnlock()
-		return s.current
+		if s.current == nil {
+			return model.NewClusterStatus()
+		}
+		return s.current.Clone()
 	}
 	s.lock.RUnlock()
 
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.ensureLoaded()
-	return s.current
+	if err := s.ensureLoaded(); err != nil {
+		panic(err)
+	}
+	if s.current == nil {
+		return model.NewClusterStatus()
+	}
+	return s.current.Clone()
 }
 
-func (s *status) ApplyChanges(config *model.ClusterConfig, ensembleSupplier EnsembleSupplier) (*model.ClusterStatus, map[int64]string, []int64) {
+func (s *status) ApplyChanges(config *model.ClusterConfig, ensembleSupplier EnsembleSupplier) (*model.ClusterStatus, map[int64]string, []int64, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.ensureLoaded()
-	newStatus := s.current.Clone()
+	if err := s.ensureLoaded(); err != nil {
+		return nil, nil, nil, err
+	}
+	current := s.current
+	if current == nil {
+		current = model.NewClusterStatus()
+	}
+	newStatus := current.Clone()
 	shardsToAdd, shardsToDelete := util.ApplyClusterChanges(config, newStatus, ensembleSupplier)
 	if len(shardsToAdd) == 0 && len(shardsToDelete) == 0 {
-		return newStatus, shardsToAdd, shardsToDelete
+		return newStatus, shardsToAdd, shardsToDelete, nil
 	}
-	_ = backoff.RetryNotify(func() error {
+	err := backoff.RetryNotify(func() error {
 		versionID, err := s.metadata.Store(newStatus, s.currentVersionID)
 		if err != nil {
 			return err
 		}
-		s.current = newStatus
+		s.current = newStatus.Clone()
 		s.currentVersionID = versionID
 		return nil
-	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+	}, backoff.WithContext(backoff.NewExponentialBackOff(), s.ctx), func(err error, duration time.Duration) {
 		s.Warn(
 			"failed to apply cluster changes, retrying later",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
 		)
 	})
+	if err != nil {
+		return newStatus, shardsToAdd, shardsToDelete, err
+	}
 	s.notifyChange()
-	return newStatus, shardsToAdd, shardsToDelete
+	return newStatus, shardsToAdd, shardsToDelete, nil
 }
 
-func (s *status) Update(newStatus *model.ClusterStatus) {
+func (s *status) Update(newStatus *model.ClusterStatus) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	_ = backoff.RetryNotify(func() error {
+	if err := s.ensureLoaded(); err != nil {
+		return err
+	}
+	err := backoff.RetryNotify(func() error {
 		versionID, err := s.metadata.Store(newStatus, s.currentVersionID)
 		if err != nil {
 			return err
 		}
-		s.current = newStatus
+		s.current = newStatus.Clone()
 		s.currentVersionID = versionID
 		return nil
-	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+	}, backoff.WithContext(backoff.NewExponentialBackOff(), s.ctx), func(err error, duration time.Duration) {
 		s.Warn(
 			"failed to update status, retrying later",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
 		)
 	})
+	if err != nil {
+		return err
+	}
 	s.notifyChange()
+	return nil
 }
 
-func (s *status) UpdateShardMetadata(namespace string, shard int64, shardMetadata model.ShardMetadata) {
+func (s *status) UpdateShardMetadata(namespace string, shard int64, shardMetadata model.ShardMetadata) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	clonedStatus := s.current.Clone()
-	ns, exist := clonedStatus.Namespaces[namespace]
-	if !exist {
-		return
+	if err := s.ensureLoaded(); err != nil {
+		return err
 	}
-	ns.Shards[shard] = shardMetadata.Clone()
-	_ = backoff.RetryNotify(func() error {
+	if s.current == nil {
+		return nil
+	}
+	_, exist := s.current.Namespaces[namespace]
+	if !exist {
+		return nil
+	}
+	clonedStatus := s.current.Clone()
+	namespaceStatus := clonedStatus.Namespaces[namespace]
+	namespaceStatus.Shards[shard] = shardMetadata.Clone()
+	clonedStatus.Namespaces[namespace] = namespaceStatus
+	err := backoff.RetryNotify(func() error {
 		versionID, err := s.metadata.Store(clonedStatus, s.currentVersionID)
 		if err != nil {
 			return err
 		}
-		s.current = clonedStatus
+		s.current = clonedStatus.Clone()
 		s.currentVersionID = versionID
 		return nil
-	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+	}, backoff.WithContext(backoff.NewExponentialBackOff(), s.ctx), func(err error, duration time.Duration) {
 		s.Warn(
 			"failed to update shard metadata, retrying later",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
 		)
 	})
+	if err != nil {
+		return err
+	}
 	s.notifyChange()
+	return nil
 }
 
-func (s *status) DeleteShardMetadata(namespace string, shard int64) {
+func (s *status) DeleteShardMetadata(namespace string, shard int64) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	clonedStatus := s.current.Clone()
-	ns, exist := clonedStatus.Namespaces[namespace]
+	if err := s.ensureLoaded(); err != nil {
+		return err
+	}
+	if s.current == nil {
+		return nil
+	}
+	_, exist := s.current.Namespaces[namespace]
 	if !exist {
-		return
+		return nil
 	}
-	delete(ns.Shards, shard)
-	if len(ns.Shards) == 0 {
+	clonedStatus := s.current.Clone()
+	namespaceStatus := clonedStatus.Namespaces[namespace]
+	delete(namespaceStatus.Shards, shard)
+	if len(namespaceStatus.Shards) == 0 {
 		delete(clonedStatus.Namespaces, namespace)
+	} else {
+		clonedStatus.Namespaces[namespace] = namespaceStatus
 	}
-	_ = backoff.RetryNotify(func() error {
+	err := backoff.RetryNotify(func() error {
 		versionID, err := s.metadata.Store(clonedStatus, s.currentVersionID)
 		if err != nil {
 			return err
 		}
-		s.current = clonedStatus
+		s.current = clonedStatus.Clone()
 		s.currentVersionID = versionID
 		return nil
-	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+	}, backoff.WithContext(backoff.NewExponentialBackOff(), s.ctx), func(err error, duration time.Duration) {
 		s.Warn(
 			"failed to delete shard metadata, retrying later",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
 		)
 	})
+	if err != nil {
+		return err
+	}
 	s.notifyChange()
+	return nil
 }
 
 func (s *status) IsReady(clusterConfig *model.ClusterConfig) bool {
 	currentStatus := s.Load()
+	if currentStatus == nil {
+		return false
+	}
 	for _, namespace := range clusterConfig.Namespaces {
 		count := namespace.InitialShardCount
 		name := namespace.Name
@@ -275,16 +328,41 @@ func (s *status) IsReady(clusterConfig *model.ClusterConfig) bool {
 }
 
 func NewStatusResource(meta metadata.Provider) StatusResource {
+	s, err := NewStatusResourceWithError(meta)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func NewStatusResourceWithError(meta metadata.Provider) (StatusResource, error) {
+	return newStatusResource(context.Background(), meta)
+}
+
+func NewStatusResourceWithErrorContext(ctx context.Context, meta metadata.Provider) (StatusResource, error) {
+	return newStatusResource(ctx, meta)
+}
+
+func newStatusResource(ctx context.Context, meta metadata.Provider) (StatusResource, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	s := status{
 		Logger: slog.With(
 			slog.String("component", "status-resource"),
 		),
 		lock:             sync.RWMutex{},
 		metadata:         meta,
+		ctx:              ctx,
 		currentVersionID: metadata.NotExists,
 		current:          nil,
 		changeCh:         make(chan struct{}),
 	}
-	s.Load()
-	return &s
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if err := s.ensureLoaded(); err != nil {
+		return nil, err
+	}
+	return &s, nil
 }

--- a/oxiad/coordinator/resource/status_resource_test.go
+++ b/oxiad/coordinator/resource/status_resource_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	"github.com/oxia-db/oxia/oxiad/coordinator/model"
+)
+
+type failingStoreMetadataProvider struct {
+	storeCalls atomic.Int32
+}
+
+func (*failingStoreMetadataProvider) Close() error {
+	return nil
+}
+
+func (*failingStoreMetadataProvider) Get() (*model.ClusterStatus, metadata.Version, error) {
+	return model.NewClusterStatus(), metadata.NotExists, nil
+}
+
+func (p *failingStoreMetadataProvider) Store(*model.ClusterStatus, metadata.Version) (metadata.Version, error) {
+	p.storeCalls.Add(1)
+	return metadata.NotExists, errors.New("not leader")
+}
+
+func (*failingStoreMetadataProvider) WaitToBecomeLeader() error {
+	return nil
+}
+
+func TestStatusResourceUpdateStopsRetryingWhenContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	provider := &failingStoreMetadataProvider{}
+	statusResource, err := NewStatusResourceWithErrorContext(ctx, provider)
+	require.NoError(t, err)
+
+	cancel()
+	start := time.Now()
+	err = statusResource.Update(model.NewClusterStatus())
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, time.Since(start), 500*time.Millisecond)
+	assert.EqualValues(t, 1, provider.storeCalls.Load())
+}

--- a/tests/coordinator/coordinator_raft_metadata_e2e_test.go
+++ b/tests/coordinator/coordinator_raft_metadata_e2e_test.go
@@ -36,43 +36,44 @@ func TestCoordinator_RaftMetadataRepeatedNodeRestarts(t *testing.T) {
 	coordinators := newRaftMetadataCoordinatorCluster(t, model.ClusterConfig{})
 	defer coordinators.close(t)
 
-	activeIdx, activeCoordinator := coordinators.requireState(t, model.NewClusterStatus())
+	_, initialCoordinator := coordinators.requireState(t, model.NewClusterStatus())
 
 	expectedStatus := testCoordinatorClusterStatus(1)
-	require.NoError(t, activeCoordinator.StatusResource().Update(expectedStatus))
-	activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+	require.NoError(t, initialCoordinator.StatusResource().Update(expectedStatus))
+	activeIdx, _ := coordinators.requireState(t, expectedStatus)
 
 	followerA := nextCoordinatorNode(activeIdx, -1)
 	followerB := nextCoordinatorNode(activeIdx, followerA)
 	restartOrder := []int{followerA, followerB, followerA, followerB, followerA}
 
 	seed := 2
+	var activeCoordinator coordinatorpkg.Coordinator
 	for _, nodeIdx := range restartOrder {
 		coordinators.restartNode(t, nodeIdx)
-		activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+		_, activeCoordinator = coordinators.requireState(t, expectedStatus)
 
 		expectedStatus = testCoordinatorClusterStatus(seed)
 		require.NoError(t, activeCoordinator.StatusResource().Update(expectedStatus))
-		activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+		coordinators.requireState(t, expectedStatus)
 		seed++
 	}
 
 	for i := 0; i < 5; i++ {
 		coordinators.restartNode(t, activeIdx)
-		activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+		_, activeCoordinator = coordinators.requireState(t, expectedStatus)
 
 		expectedStatus = testCoordinatorClusterStatus(seed)
 		require.NoError(t, activeCoordinator.StatusResource().Update(expectedStatus))
-		activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+		activeIdx, _ = coordinators.requireState(t, expectedStatus)
 		seed++
 
 		follower := nextCoordinatorNode(activeIdx, -1)
 		coordinators.restartNode(t, follower)
-		activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+		_, activeCoordinator = coordinators.requireState(t, expectedStatus)
 
 		expectedStatus = testCoordinatorClusterStatus(seed)
 		require.NoError(t, activeCoordinator.StatusResource().Update(expectedStatus))
-		activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+		activeIdx, _ = coordinators.requireState(t, expectedStatus)
 		seed++
 	}
 }

--- a/tests/coordinator/coordinator_raft_metadata_e2e_test.go
+++ b/tests/coordinator/coordinator_raft_metadata_e2e_test.go
@@ -1,0 +1,334 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"net"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/common/rpc"
+	coordinatorpkg "github.com/oxia-db/oxia/oxiad/coordinator"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	"github.com/oxia-db/oxia/oxiad/coordinator/model"
+	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
+)
+
+func TestCoordinator_RaftMetadataRepeatedNodeRestarts(t *testing.T) {
+	coordinators := newRaftMetadataCoordinatorCluster(t, model.ClusterConfig{})
+	defer coordinators.close(t)
+
+	activeIdx, activeCoordinator := coordinators.requireState(t, model.NewClusterStatus())
+
+	expectedStatus := testCoordinatorClusterStatus(1)
+	require.NoError(t, activeCoordinator.StatusResource().Update(expectedStatus))
+	activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+
+	followerA := nextCoordinatorNode(activeIdx, -1)
+	followerB := nextCoordinatorNode(activeIdx, followerA)
+	restartOrder := []int{followerA, followerB, followerA, followerB, followerA}
+
+	seed := 2
+	for _, nodeIdx := range restartOrder {
+		coordinators.restartNode(t, nodeIdx)
+		activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+
+		expectedStatus = testCoordinatorClusterStatus(seed)
+		require.NoError(t, activeCoordinator.StatusResource().Update(expectedStatus))
+		activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+		seed++
+	}
+
+	for i := 0; i < 5; i++ {
+		coordinators.restartNode(t, activeIdx)
+		activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+
+		expectedStatus = testCoordinatorClusterStatus(seed)
+		require.NoError(t, activeCoordinator.StatusResource().Update(expectedStatus))
+		activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+		seed++
+
+		follower := nextCoordinatorNode(activeIdx, -1)
+		coordinators.restartNode(t, follower)
+		activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+
+		expectedStatus = testCoordinatorClusterStatus(seed)
+		require.NoError(t, activeCoordinator.StatusResource().Update(expectedStatus))
+		activeIdx, activeCoordinator = coordinators.requireState(t, expectedStatus)
+		seed++
+	}
+}
+
+type raftMetadataCoordinatorCluster struct {
+	mu sync.Mutex
+
+	bootstrapNodes []string
+	dataDirs       []string
+	clusterConfig  model.ClusterConfig
+	clientPool     rpc.ClientPool
+	rpcProvider    rpc2.Provider
+
+	nodes  []raftMetadataCoordinatorNode
+	active map[int]coordinatorpkg.Coordinator
+	errors map[int]error
+}
+
+type raftMetadataCoordinatorNode struct {
+	provider   metadata.Provider
+	done       chan struct{}
+	generation uint64
+}
+
+func newRaftMetadataCoordinatorCluster(t *testing.T, clusterConfig model.ClusterConfig) *raftMetadataCoordinatorCluster {
+	t.Helper()
+
+	baseDir := t.TempDir()
+	bootstrapNodes := []string{
+		newCoordinatorRaftAddress(t),
+		newCoordinatorRaftAddress(t),
+		newCoordinatorRaftAddress(t),
+	}
+
+	clientPool := rpc.NewClientPool(nil, nil)
+	cluster := &raftMetadataCoordinatorCluster{
+		bootstrapNodes: bootstrapNodes,
+		dataDirs: []string{
+			filepath.Join(baseDir, "node-0"),
+			filepath.Join(baseDir, "node-1"),
+			filepath.Join(baseDir, "node-2"),
+		},
+		clusterConfig: clusterConfig,
+		clientPool:    clientPool,
+		rpcProvider:   rpc2.NewRpcProvider(clientPool),
+		nodes:         make([]raftMetadataCoordinatorNode, len(bootstrapNodes)),
+		active:        make(map[int]coordinatorpkg.Coordinator),
+		errors:        make(map[int]error),
+	}
+
+	for i := range bootstrapNodes {
+		cluster.startNode(t, i)
+	}
+
+	return cluster
+}
+
+func (c *raftMetadataCoordinatorCluster) startNode(t *testing.T, idx int) {
+	t.Helper()
+
+	provider, err := metadata.NewMetadataProviderRaft(c.bootstrapNodes[idx], c.bootstrapNodes, c.dataDirs[idx])
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	c.mu.Lock()
+	node := &c.nodes[idx]
+	node.generation++
+	generation := node.generation
+	node.provider = provider
+	node.done = done
+	delete(c.errors, idx)
+	c.mu.Unlock()
+
+	go func() {
+		defer close(done)
+
+		coordinatorInstance, err := coordinatorpkg.NewCoordinator(
+			provider,
+			func() (model.ClusterConfig, error) { return c.clusterConfig, nil },
+			nil,
+			c.rpcProvider,
+		)
+
+		c.mu.Lock()
+		current := c.nodes[idx].generation == generation && c.nodes[idx].provider == provider
+		if err != nil {
+			if current {
+				c.errors[idx] = err
+			}
+			c.mu.Unlock()
+			return
+		}
+		if !current {
+			c.mu.Unlock()
+			_ = coordinatorInstance.Close()
+			return
+		}
+		c.active[idx] = coordinatorInstance
+		c.mu.Unlock()
+	}()
+}
+
+func (c *raftMetadataCoordinatorCluster) restartNode(t *testing.T, idx int) {
+	t.Helper()
+
+	c.stopNode(t, idx)
+	c.startNode(t, idx)
+}
+
+func (c *raftMetadataCoordinatorCluster) stopNode(t *testing.T, idx int) {
+	t.Helper()
+
+	c.mu.Lock()
+	node := &c.nodes[idx]
+	node.generation++
+	provider := node.provider
+	done := node.done
+	coordinatorInstance := c.active[idx]
+	node.provider = nil
+	node.done = nil
+	delete(c.active, idx)
+	delete(c.errors, idx)
+	c.mu.Unlock()
+
+	if coordinatorInstance != nil {
+		assert.NoError(t, coordinatorInstance.Close())
+	}
+	if provider != nil {
+		assert.NoError(t, provider.Close())
+	}
+	if done != nil {
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second):
+			t.Fatalf("timed out waiting for coordinator node %d to stop", idx)
+		}
+	}
+}
+
+func (c *raftMetadataCoordinatorCluster) close(t *testing.T) {
+	t.Helper()
+
+	for i := range c.nodes {
+		c.stopNode(t, i)
+	}
+	assert.NoError(t, c.clientPool.Close())
+}
+
+func (c *raftMetadataCoordinatorCluster) requireState(
+	t *testing.T,
+	expected *model.ClusterStatus,
+) (int, coordinatorpkg.Coordinator) {
+	t.Helper()
+
+	var activeIdx int
+	var activeCoordinator coordinatorpkg.Coordinator
+	require.Eventually(t, func() bool {
+		idx, coordinatorInstance, ok := c.singleActiveCoordinator()
+		if !ok {
+			return false
+		}
+
+		leaderCount, metadataState := c.metadataLeaderState()
+		if leaderCount != 1 {
+			return false
+		}
+
+		if !reflect.DeepEqual(normalizeClusterStatus(metadataState), normalizeClusterStatus(expected)) {
+			return false
+		}
+
+		if !reflect.DeepEqual(
+			normalizeClusterStatus(coordinatorInstance.StatusResource().Load()),
+			normalizeClusterStatus(expected),
+		) {
+			return false
+		}
+
+		activeIdx = idx
+		activeCoordinator = coordinatorInstance
+		return true
+	}, 45*time.Second, 100*time.Millisecond)
+
+	return activeIdx, activeCoordinator
+}
+
+func (c *raftMetadataCoordinatorCluster) singleActiveCoordinator() (int, coordinatorpkg.Coordinator, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.errors) > 0 {
+		return 0, nil, false
+	}
+	if len(c.active) != 1 {
+		return 0, nil, false
+	}
+	for idx, coordinatorInstance := range c.active {
+		return idx, coordinatorInstance, true
+	}
+	return 0, nil, false
+}
+
+func (c *raftMetadataCoordinatorCluster) metadataLeaderState() (int, *model.ClusterStatus) {
+	c.mu.Lock()
+	providers := make([]metadata.Provider, 0, len(c.nodes))
+	for i := range c.nodes {
+		if c.nodes[i].provider != nil {
+			providers = append(providers, c.nodes[i].provider)
+		}
+	}
+	c.mu.Unlock()
+
+	leaders := 0
+	var leaderState *model.ClusterStatus
+	for _, provider := range providers {
+		state, _, err := provider.Get()
+		if err != nil {
+			continue
+		}
+		leaders++
+		leaderState = state
+	}
+	return leaders, leaderState
+}
+
+func normalizeClusterStatus(status *model.ClusterStatus) *model.ClusterStatus {
+	if status == nil {
+		return model.NewClusterStatus()
+	}
+	return status.Clone()
+}
+
+func nextCoordinatorNode(current int, excluded int) int {
+	for i := 0; i < 3; i++ {
+		if i != current && i != excluded {
+			return i
+		}
+	}
+	panic("failed to find coordinator node")
+}
+
+func newCoordinatorRaftAddress(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, listener.Close())
+	}()
+	return listener.Addr().String()
+}
+
+func testCoordinatorClusterStatus(seed int) *model.ClusterStatus {
+	return &model.ClusterStatus{
+		Namespaces:       map[string]model.NamespaceStatus{},
+		ShardIdGenerator: int64(seed * 100),
+		ServerIdx:        uint32(seed),
+	}
+}

--- a/tests/coordinator/coordinator_test.go
+++ b/tests/coordinator/coordinator_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/oxiad/coordinator"
 	metadata2 "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
@@ -60,7 +61,7 @@ func TestCoordinatorInitiateLeaderElection(t *testing.T) {
 		Int32HashRange:          model.Int32HashRange{Min: 2000, Max: 100000},
 	}
 	statusResource := coordinatorInstance.StatusResource()
-	statusResource.UpdateShardMetadata("default", 1, metadata)
+	require.NoError(t, statusResource.UpdateShardMetadata("default", 1, metadata))
 
 	status := statusResource.Load()
 	assert.EqualValues(t, status.Namespaces["default"].Shards[1], metadata)


### PR DESCRIPTION
### Motivation

  The coordinator's Raft metadata provider had several critical issues:

  1. Data races: stateContainer.Get() returned direct references to internal state, allowing callers to bypass locks and mutate FSM memory, causing state corruption under concurrent access.
  2. Split-brain risk: When a node lost Raft leadership, the coordinator continued running and could simultaneously perform shard elections and state updates alongside the new leader.
  3. Silent failures: StatusResource methods (Update, DeleteShardMetadata, etc.) silently discarded persistence errors. backoff.RetryNotify results were dropped (_ =), causing infinite retries when a node lost leadership with no way to terminate.
  4. Resource leaks: NewMetadataProviderRaft did not clean up already-created transport/store on initialization failure. Close() did not close the transport.
  5. Data corruption: DeleteRange caused integer overflow when maxInclusive == MaxUint64, producing an incorrect delete range. Snapshot.Persist did not check for short writes and called Cancel() on the success path.

### Changes

  Thread Safety & Data Isolation

  - Changed stateContainer from sync.Mutex to sync.RWMutex; added CloneState() returning a deep copy.
  - Get() now returns a Clone() copy to prevent external mutation of internal state.
  - ShardMetadata.Clone() performs deep copies of Leader, Ensemble, and RemovedNodes (including Name pointers).
  - Added Server.Clone() method.

  Leader Verification & Consistency

  - Get() and Store() now call raft.VerifyLeader() before operating to ensure the node is still the leader.
  - Get() calls raft.Barrier() to guarantee linearizable reads.
  - Improved WaitToBecomeLeader() to wait for leader state confirmation, then wait for all committed logs to be applied.

  Leadership Loss Detection

  - Added LeadershipAwareProvider interface exposing a LeadershipLost() channel.
  - Watches Raft NotifyCh for leadership transitions and signals the coordinator on loss.
  - coordinator.monitorLeadershipLoss() calls cancel() on loss, terminating all control loops.

  Error Propagation

  - StatusResource methods now return error: Update, UpdateShardMetadata, DeleteShardMetadata, ApplyChanges.
  - All backoff.RetryNotify calls are bound to the coordinator's context, stopping retries on cancellation.
  - Callers (shard_controller, split_controller, election) now check and handle errors appropriately.

  Resource Management

  - NewMetadataProviderRaft uses a defer cleanup to release raft node/transport/store on initialization failure.
  - Close() uses sync.Once and now also closes the transport.
  - kvRaftStore closes the factory if NewKV fails.
  - StoreLogs uses defer to close the WriteBatch.

  Snapshot Persistence Fixes

  - Checks sink.Write return length to detect short writes.
  - Success path calls only sink.Close(); error path calls only sink.Cancel().
  - Restore properly merges decode and close errors.

  Boundary Condition Fixes

  - DeleteRange uses logKeyEnd when maxInclusive == MaxUint64 to avoid integer overflow.
  - GetLog returns raft.ErrLogNotFound when the key does not exist.

  Configuration Validation

  - Validates raft-address as host:port format.
  - Requires raft-data-dir and raft-bootstrap-nodes to be set.
  - Checks bootstrap nodes for duplicates and ensures the local address is included.

  Tests

  - 3-node Raft cluster restart tests (metadata_raft_test.go).
  - FSM snapshot/restore, short write, and close error tests (metadata_raft_fsm_test.go).
  - Store GetLog missing, DeleteRange overflow, and factory cleanup tests (metadata_raft_store_test.go).
  - Configuration validation tests (option_test.go).
  - Context cancellation stops retry test (status_resource_test.go).
  - Coordinator startup leadership loss test (coordinator_leadership_test.go).
  - Multi-node coordinator restart end-to-end test (coordinator_raft_metadata_e2e_test.go).