### PR TITLE
refactor: rename dataserver identity model

### DIFF
--- a/cmd/admin/commons/mock_admin_client.go
+++ b/cmd/admin/commons/mock_admin_client.go
@@ -55,9 +55,9 @@ func (m *MockAdminClient) ListDataServers() ([]*proto.DataServer, error) {
 	return nil, errors.New("no data servers available")
 }
 
-func (m *MockAdminClient) GetDataServer(dataServer string) (*proto.DataServerInfo, error) {
+func (m *MockAdminClient) GetDataServer(dataServer string) (*proto.DataServer, error) {
 	args := m.MethodCalled("GetDataServer", dataServer)
-	if v, ok := args.Get(0).(*proto.DataServerInfo); ok {
+	if v, ok := args.Get(0).(*proto.DataServer); ok {
 		return v, args.Error(1)
 	}
 	return nil, errors.New("data server not found")

--- a/cmd/admin/dataserver/cmd_test.go
+++ b/cmd/admin/dataserver/cmd_test.go
@@ -44,14 +44,18 @@ func Test_cmd_dataServerList(t *testing.T) {
 	commons.MockedAdminClient.On("Close").Return(nil)
 	commons.MockedAdminClient.On("ListDataServers").Return([]*proto.DataServer{
 		{
-			Name:     &serverName1,
-			Public:   "public1",
-			Internal: "internal1",
+			Identity: &proto.DataServerIdentity{
+				Name:     &serverName1,
+				Public:   "public1",
+				Internal: "internal1",
+			},
 		},
 		{
-			Name:     &serverName2,
-			Public:   "public2",
-			Internal: "internal2",
+			Identity: &proto.DataServerIdentity{
+				Name:     &serverName2,
+				Public:   "public2",
+				Internal: "internal2",
+			},
 		},
 	}, nil)
 
@@ -61,12 +65,14 @@ func Test_cmd_dataServerList(t *testing.T) {
 	var dataServers []proto.DataServer
 	assert.NoError(t, json.Unmarshal([]byte(out), &dataServers))
 	assert.Equal(t, 2, len(dataServers))
-	assert.Equal(t, "public1", dataServers[0].GetPublic())
-	assert.Equal(t, "public2", dataServers[1].GetPublic())
-	assert.Equal(t, "internal1", dataServers[0].GetInternal())
-	assert.Equal(t, "internal2", dataServers[1].GetInternal())
-	require.NotNil(t, dataServers[0].Name)
-	require.NotNil(t, dataServers[1].Name)
-	assert.Equal(t, "server-1", *dataServers[0].Name)
-	assert.Equal(t, "internal2", *dataServers[1].Name)
+	require.NotNil(t, dataServers[0].Identity)
+	require.NotNil(t, dataServers[1].Identity)
+	assert.Equal(t, "public1", dataServers[0].Identity.GetPublic())
+	assert.Equal(t, "public2", dataServers[1].Identity.GetPublic())
+	assert.Equal(t, "internal1", dataServers[0].Identity.GetInternal())
+	assert.Equal(t, "internal2", dataServers[1].Identity.GetInternal())
+	require.NotNil(t, dataServers[0].Identity.Name)
+	require.NotNil(t, dataServers[1].Identity.Name)
+	assert.Equal(t, "server-1", *dataServers[0].Identity.Name)
+	assert.Equal(t, "internal2", *dataServers[1].Identity.Name)
 }

--- a/cmd/admin/dataserver/get/cmd.go
+++ b/cmd/admin/dataserver/get/cmd.go
@@ -19,14 +19,15 @@ import (
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
 	cc "github.com/oxia-db/oxia/cmd/client/common"
+	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxia"
 )
 
 var Cmd = &cobra.Command{
 	Use:          "get [data-server]",
-	Short:        "Get a data server",
-	Long:         `Get a data server`,
-	Args:         cobra.ExactArgs(1),
+	Short:        "Get a data server or list data server identities",
+	Long:         `Get a data server or list data server identities`,
+	Args:         cobra.MaximumNArgs(1),
 	RunE:         exec,
 	SilenceUsage: true,
 }
@@ -39,6 +40,23 @@ func exec(cmd *cobra.Command, args []string) error {
 	defer func(client oxia.AdminClient) {
 		_ = client.Close()
 	}(client)
+
+	if len(args) == 0 {
+		dataServers, err := client.ListDataServers()
+		if err != nil {
+			return err
+		}
+
+		identities := make([]*proto.DataServerIdentity, 0, len(dataServers))
+		for _, dataServer := range dataServers {
+			if dataServer == nil || dataServer.Identity == nil {
+				continue
+			}
+			identities = append(identities, dataServer.Identity)
+		}
+		cc.WriteOutput(cmd.OutOrStdout(), identities)
+		return nil
+	}
 
 	dataServer, err := client.GetDataServer(args[0])
 	if err != nil {

--- a/cmd/admin/dataserver/get/cmd.go
+++ b/cmd/admin/dataserver/get/cmd.go
@@ -19,15 +19,14 @@ import (
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
 	cc "github.com/oxia-db/oxia/cmd/client/common"
-	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxia"
 )
 
 var Cmd = &cobra.Command{
-	Use:          "get [data-server]",
-	Short:        "Get a data server or list data server identities",
-	Long:         `Get a data server or list data server identities`,
-	Args:         cobra.MaximumNArgs(1),
+	Use:          "get data-server",
+	Short:        "Get a data server",
+	Long:         `Get a data server`,
+	Args:         cobra.ExactArgs(1),
 	RunE:         exec,
 	SilenceUsage: true,
 }
@@ -40,23 +39,6 @@ func exec(cmd *cobra.Command, args []string) error {
 	defer func(client oxia.AdminClient) {
 		_ = client.Close()
 	}(client)
-
-	if len(args) == 0 {
-		dataServers, err := client.ListDataServers()
-		if err != nil {
-			return err
-		}
-
-		identities := make([]*proto.DataServerIdentity, 0, len(dataServers))
-		for _, dataServer := range dataServers {
-			if dataServer == nil || dataServer.Identity == nil {
-				continue
-			}
-			identities = append(identities, dataServer.Identity)
-		}
-		cc.WriteOutput(cmd.OutOrStdout(), identities)
-		return nil
-	}
 
 	dataServer, err := client.GetDataServer(args[0])
 	if err != nil {

--- a/cmd/admin/dataserver/get/cmd.go
+++ b/cmd/admin/dataserver/get/cmd.go
@@ -23,7 +23,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:          "get data-server",
+	Use:          "get dataserver",
 	Short:        "Get a data server",
 	Long:         `Get a data server`,
 	Args:         cobra.ExactArgs(1),

--- a/cmd/admin/dataserver/get/cmd_test.go
+++ b/cmd/admin/dataserver/get/cmd_test.go
@@ -66,46 +66,10 @@ func Test_cmd_getDataServer(t *testing.T) {
 }
 
 func Test_cmd_getDataServersIdentities(t *testing.T) {
-	serverName1 := "server-1"
-	serverName2 := "internal2"
 	commons.MockedAdminClient = commons.NewMockAdminClient()
-
-	commons.MockedAdminClient.On("Close").Return(nil)
-	commons.MockedAdminClient.On("ListDataServers").Return([]*proto.DataServer{
-		{
-			Identity: &proto.DataServerIdentity{
-				Name:     &serverName1,
-				Public:   "public1",
-				Internal: "internal1",
-			},
-			Metadata: &proto.DataServerMetadata{
-				Labels: map[string]string{"rack": "rack-1"},
-			},
-		},
-		{
-			Identity: &proto.DataServerIdentity{
-				Name:     &serverName2,
-				Public:   "public2",
-				Internal: "internal2",
-			},
-			Metadata: &proto.DataServerMetadata{
-				Labels: map[string]string{"rack": "rack-2"},
-			},
-		},
-	}, nil)
 
 	out, err := runCmd()
 
-	assert.NoError(t, err)
-	var identities []proto.DataServerIdentity
-	assert.NoError(t, json.Unmarshal([]byte(out), &identities))
-	require.Len(t, identities, 2)
-	require.NotNil(t, identities[0].Name)
-	require.NotNil(t, identities[1].Name)
-	assert.Equal(t, serverName1, *identities[0].Name)
-	assert.Equal(t, serverName2, *identities[1].Name)
-	assert.Equal(t, "public1", identities[0].GetPublic())
-	assert.Equal(t, "public2", identities[1].GetPublic())
-	assert.Equal(t, "internal1", identities[0].GetInternal())
-	assert.Equal(t, "internal2", identities[1].GetInternal())
+	assert.Error(t, err)
+	assert.Contains(t, out, "accepts 1 arg(s), received 0")
 }

--- a/cmd/admin/dataserver/get/cmd_test.go
+++ b/cmd/admin/dataserver/get/cmd_test.go
@@ -41,8 +41,8 @@ func Test_cmd_getDataServer(t *testing.T) {
 	commons.MockedAdminClient = commons.NewMockAdminClient()
 
 	commons.MockedAdminClient.On("Close").Return(nil)
-	commons.MockedAdminClient.On("GetDataServer", serverName).Return(&proto.DataServerInfo{
-		DataServer: &proto.DataServer{
+	commons.MockedAdminClient.On("GetDataServer", serverName).Return(&proto.DataServer{
+		Identity: &proto.DataServerIdentity{
 			Name:     &serverName,
 			Public:   "public1",
 			Internal: "internal1",
@@ -55,12 +55,57 @@ func Test_cmd_getDataServer(t *testing.T) {
 	out, err := runCmd(serverName)
 
 	assert.NoError(t, err)
-	var dataServer proto.DataServerInfo
+	var dataServer proto.DataServer
 	assert.NoError(t, json.Unmarshal([]byte(out), &dataServer))
-	require.NotNil(t, dataServer.DataServer)
-	assert.NotNil(t, dataServer.DataServer.Name)
-	assert.Equal(t, serverName, *dataServer.DataServer.Name)
-	assert.Equal(t, "public1", dataServer.DataServer.GetPublic())
-	assert.Equal(t, "internal1", dataServer.DataServer.GetInternal())
+	require.NotNil(t, dataServer.Identity)
+	assert.NotNil(t, dataServer.Identity.Name)
+	assert.Equal(t, serverName, *dataServer.Identity.Name)
+	assert.Equal(t, "public1", dataServer.Identity.GetPublic())
+	assert.Equal(t, "internal1", dataServer.Identity.GetInternal())
 	require.Equal(t, map[string]string{"rack": "rack-1"}, dataServer.Metadata.GetLabels())
+}
+
+func Test_cmd_getDataServersIdentities(t *testing.T) {
+	serverName1 := "server-1"
+	serverName2 := "internal2"
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+
+	commons.MockedAdminClient.On("Close").Return(nil)
+	commons.MockedAdminClient.On("ListDataServers").Return([]*proto.DataServer{
+		{
+			Identity: &proto.DataServerIdentity{
+				Name:     &serverName1,
+				Public:   "public1",
+				Internal: "internal1",
+			},
+			Metadata: &proto.DataServerMetadata{
+				Labels: map[string]string{"rack": "rack-1"},
+			},
+		},
+		{
+			Identity: &proto.DataServerIdentity{
+				Name:     &serverName2,
+				Public:   "public2",
+				Internal: "internal2",
+			},
+			Metadata: &proto.DataServerMetadata{
+				Labels: map[string]string{"rack": "rack-2"},
+			},
+		},
+	}, nil)
+
+	out, err := runCmd()
+
+	assert.NoError(t, err)
+	var identities []proto.DataServerIdentity
+	assert.NoError(t, json.Unmarshal([]byte(out), &identities))
+	require.Len(t, identities, 2)
+	require.NotNil(t, identities[0].Name)
+	require.NotNil(t, identities[1].Name)
+	assert.Equal(t, serverName1, *identities[0].Name)
+	assert.Equal(t, serverName2, *identities[1].Name)
+	assert.Equal(t, "public1", identities[0].GetPublic())
+	assert.Equal(t, "public2", identities[1].GetPublic())
+	assert.Equal(t, "internal1", identities[0].GetInternal())
+	assert.Equal(t, "internal2", identities[1].GetInternal())
 }

--- a/common/proto/admin.pb.go
+++ b/common/proto/admin.pb.go
@@ -163,10 +163,10 @@ func (x *GetDataServerRequest) GetDataServer() string {
 }
 
 type GetDataServerResponse struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	DataServerInfo *DataServerInfo        `protobuf:"bytes,1,opt,name=data_server_info,json=dataServerInfo,proto3" json:"data_server_info,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DataServer    *DataServer            `protobuf:"bytes,1,opt,name=data_server,json=dataServer,proto3" json:"data_server,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetDataServerResponse) Reset() {
@@ -199,9 +199,9 @@ func (*GetDataServerResponse) Descriptor() ([]byte, []int) {
 	return file_admin_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *GetDataServerResponse) GetDataServerInfo() *DataServerInfo {
+func (x *GetDataServerResponse) GetDataServer() *DataServer {
 	if x != nil {
-		return x.DataServerInfo
+		return x.DataServer
 	}
 	return nil
 }
@@ -557,9 +557,10 @@ const file_admin_proto_rawDesc = "" +
 	"\fdata_servers\x18\x01 \x03(\v2\x1c.io.oxia.proto.v1.DataServerR\vdataServers\"7\n" +
 	"\x14GetDataServerRequest\x12\x1f\n" +
 	"\vdata_server\x18\x01 \x01(\tR\n" +
-	"dataServer\"c\n" +
-	"\x15GetDataServerResponse\x12J\n" +
-	"\x10data_server_info\x18\x01 \x01(\v2 .io.oxia.proto.v1.DataServerInfoR\x0edataServerInfo\"\x17\n" +
+	"dataServer\"V\n" +
+	"\x15GetDataServerResponse\x12=\n" +
+	"\vdata_server\x18\x01 \x01(\v2\x1c.io.oxia.proto.v1.DataServerR\n" +
+	"dataServer\"\x17\n" +
 	"\x15ListNamespacesRequest\"8\n" +
 	"\x16ListNamespacesResponse\x12\x1e\n" +
 	"\n" +
@@ -621,11 +622,10 @@ var file_admin_proto_goTypes = []any{
 	(*SplitShardResponse)(nil),      // 10: io.oxia.proto.v1.SplitShardResponse
 	nil,                             // 11: io.oxia.proto.v1.Node.MetadataEntry
 	(*DataServer)(nil),              // 12: io.oxia.proto.v1.DataServer
-	(*DataServerInfo)(nil),          // 13: io.oxia.proto.v1.DataServerInfo
 }
 var file_admin_proto_depIdxs = []int32{
 	12, // 0: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
-	13, // 1: io.oxia.proto.v1.GetDataServerResponse.data_server_info:type_name -> io.oxia.proto.v1.DataServerInfo
+	12, // 1: io.oxia.proto.v1.GetDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
 	11, // 2: io.oxia.proto.v1.Node.metadata:type_name -> io.oxia.proto.v1.Node.MetadataEntry
 	7,  // 3: io.oxia.proto.v1.ListNodesResponse.nodes:type_name -> io.oxia.proto.v1.Node
 	0,  // 4: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest

--- a/common/proto/admin.proto
+++ b/common/proto/admin.proto
@@ -54,7 +54,7 @@ message GetDataServerRequest {
 }
 
 message GetDataServerResponse {
-  DataServerInfo data_server_info = 1;
+  DataServer data_server = 1;
 }
 
 message ListNamespacesRequest {

--- a/common/proto/admin_vtproto.pb.go
+++ b/common/proto/admin_vtproto.pb.go
@@ -81,7 +81,7 @@ func (m *GetDataServerResponse) CloneVT() *GetDataServerResponse {
 		return (*GetDataServerResponse)(nil)
 	}
 	r := new(GetDataServerResponse)
-	r.DataServerInfo = m.DataServerInfo.CloneVT()
+	r.DataServer = m.DataServer.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -312,7 +312,7 @@ func (this *GetDataServerResponse) EqualVT(that *GetDataServerResponse) bool {
 	} else if this == nil || that == nil {
 		return false
 	}
-	if !this.DataServerInfo.EqualVT(that.DataServerInfo) {
+	if !this.DataServer.EqualVT(that.DataServer) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -647,8 +647,8 @@ func (m *GetDataServerResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if m.DataServerInfo != nil {
-		size, err := m.DataServerInfo.MarshalToSizedBufferVT(dAtA[:i])
+	if m.DataServer != nil {
+		size, err := m.DataServer.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
 			return 0, err
 		}
@@ -1025,8 +1025,8 @@ func (m *GetDataServerResponse) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
-	if m.DataServerInfo != nil {
-		l = m.DataServerInfo.SizeVT()
+	if m.DataServer != nil {
+		l = m.DataServer.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -1401,7 +1401,7 @@ func (m *GetDataServerResponse) UnmarshalVT(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field DataServerInfo", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1428,10 +1428,10 @@ func (m *GetDataServerResponse) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.DataServerInfo == nil {
-				m.DataServerInfo = &DataServerInfo{}
+			if m.DataServer == nil {
+				m.DataServer = &DataServer{}
 			}
-			if err := m.DataServerInfo.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+			if err := m.DataServer.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -2467,7 +2467,7 @@ func (m *GetDataServerResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field DataServerInfo", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2494,10 +2494,10 @@ func (m *GetDataServerResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.DataServerInfo == nil {
-				m.DataServerInfo = &DataServerInfo{}
+			if m.DataServer == nil {
+				m.DataServer = &DataServer{}
 			}
-			if err := m.DataServerInfo.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+			if err := m.DataServer.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/common/proto/metadata.pb.go
+++ b/common/proto/metadata.pb.go
@@ -35,7 +35,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-type DataServer struct {
+type DataServerIdentity struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          *string                `protobuf:"bytes,1,opt,name=name,proto3,oneof" json:"name,omitempty"`
 	Public        string                 `protobuf:"bytes,2,opt,name=public,proto3" json:"public,omitempty"`
@@ -44,20 +44,20 @@ type DataServer struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DataServer) Reset() {
-	*x = DataServer{}
+func (x *DataServerIdentity) Reset() {
+	*x = DataServerIdentity{}
 	mi := &file_metadata_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DataServer) String() string {
+func (x *DataServerIdentity) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DataServer) ProtoMessage() {}
+func (*DataServerIdentity) ProtoMessage() {}
 
-func (x *DataServer) ProtoReflect() protoreflect.Message {
+func (x *DataServerIdentity) ProtoReflect() protoreflect.Message {
 	mi := &file_metadata_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -69,26 +69,26 @@ func (x *DataServer) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DataServer.ProtoReflect.Descriptor instead.
-func (*DataServer) Descriptor() ([]byte, []int) {
+// Deprecated: Use DataServerIdentity.ProtoReflect.Descriptor instead.
+func (*DataServerIdentity) Descriptor() ([]byte, []int) {
 	return file_metadata_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *DataServer) GetName() string {
+func (x *DataServerIdentity) GetName() string {
 	if x != nil && x.Name != nil {
 		return *x.Name
 	}
 	return ""
 }
 
-func (x *DataServer) GetPublic() string {
+func (x *DataServerIdentity) GetPublic() string {
 	if x != nil {
 		return x.Public
 	}
 	return ""
 }
 
-func (x *DataServer) GetInternal() string {
+func (x *DataServerIdentity) GetInternal() string {
 	if x != nil {
 		return x.Internal
 	}
@@ -139,28 +139,28 @@ func (x *DataServerMetadata) GetLabels() map[string]string {
 	return nil
 }
 
-type DataServerInfo struct {
+type DataServer struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	DataServer    *DataServer            `protobuf:"bytes,1,opt,name=dataServer,proto3" json:"dataServer,omitempty"`
+	Identity      *DataServerIdentity    `protobuf:"bytes,1,opt,name=identity,proto3" json:"identity,omitempty"`
 	Metadata      *DataServerMetadata    `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DataServerInfo) Reset() {
-	*x = DataServerInfo{}
+func (x *DataServer) Reset() {
+	*x = DataServer{}
 	mi := &file_metadata_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DataServerInfo) String() string {
+func (x *DataServer) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DataServerInfo) ProtoMessage() {}
+func (*DataServer) ProtoMessage() {}
 
-func (x *DataServerInfo) ProtoReflect() protoreflect.Message {
+func (x *DataServer) ProtoReflect() protoreflect.Message {
 	mi := &file_metadata_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -172,19 +172,19 @@ func (x *DataServerInfo) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DataServerInfo.ProtoReflect.Descriptor instead.
-func (*DataServerInfo) Descriptor() ([]byte, []int) {
+// Deprecated: Use DataServer.ProtoReflect.Descriptor instead.
+func (*DataServer) Descriptor() ([]byte, []int) {
 	return file_metadata_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *DataServerInfo) GetDataServer() *DataServer {
+func (x *DataServer) GetIdentity() *DataServerIdentity {
 	if x != nil {
-		return x.DataServer
+		return x.Identity
 	}
 	return nil
 }
 
-func (x *DataServerInfo) GetMetadata() *DataServerMetadata {
+func (x *DataServer) GetMetadata() *DataServerMetadata {
 	if x != nil {
 		return x.Metadata
 	}
@@ -426,7 +426,7 @@ func (x *LoadBalancer) GetQuarantineTime() string {
 type ClusterConfiguration struct {
 	state                 protoimpl.MessageState         `protogen:"open.v1"`
 	Namespaces            []*Namespace                   `protobuf:"bytes,1,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
-	Servers               []*DataServer                  `protobuf:"bytes,2,rep,name=servers,proto3" json:"servers,omitempty"`
+	Servers               []*DataServerIdentity          `protobuf:"bytes,2,rep,name=servers,proto3" json:"servers,omitempty"`
 	AllowExtraAuthorities []string                       `protobuf:"bytes,3,rep,name=allowExtraAuthorities,proto3" json:"allowExtraAuthorities,omitempty"`
 	ServerMetadata        map[string]*DataServerMetadata `protobuf:"bytes,4,rep,name=serverMetadata,proto3" json:"serverMetadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	LoadBalancer          *LoadBalancer                  `protobuf:"bytes,5,opt,name=loadBalancer,proto3" json:"loadBalancer,omitempty"`
@@ -471,7 +471,7 @@ func (x *ClusterConfiguration) GetNamespaces() []*Namespace {
 	return nil
 }
 
-func (x *ClusterConfiguration) GetServers() []*DataServer {
+func (x *ClusterConfiguration) GetServers() []*DataServerIdentity {
 	if x != nil {
 		return x.Servers
 	}
@@ -647,10 +647,10 @@ type ShardMetadata struct {
 	state                   protoimpl.MessageState `protogen:"open.v1"`
 	Status                  string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
 	Term                    int64                  `protobuf:"varint,2,opt,name=term,proto3" json:"term,omitempty"`
-	Leader                  *DataServer            `protobuf:"bytes,3,opt,name=leader,proto3" json:"leader,omitempty"`
-	Ensemble                []*DataServer          `protobuf:"bytes,4,rep,name=ensemble,proto3" json:"ensemble,omitempty"`
-	RemovedNodes            []*DataServer          `protobuf:"bytes,5,rep,name=removedNodes,proto3" json:"removedNodes,omitempty"`
-	PendingDeleteShardNodes []*DataServer          `protobuf:"bytes,6,rep,name=pendingDeleteShardNodes,proto3" json:"pendingDeleteShardNodes,omitempty"`
+	Leader                  *DataServerIdentity    `protobuf:"bytes,3,opt,name=leader,proto3" json:"leader,omitempty"`
+	Ensemble                []*DataServerIdentity  `protobuf:"bytes,4,rep,name=ensemble,proto3" json:"ensemble,omitempty"`
+	RemovedNodes            []*DataServerIdentity  `protobuf:"bytes,5,rep,name=removedNodes,proto3" json:"removedNodes,omitempty"`
+	PendingDeleteShardNodes []*DataServerIdentity  `protobuf:"bytes,6,rep,name=pendingDeleteShardNodes,proto3" json:"pendingDeleteShardNodes,omitempty"`
 	Int32HashRange          *HashRange             `protobuf:"bytes,7,opt,name=int32HashRange,proto3" json:"int32HashRange,omitempty"`
 	Split                   *SplitMetadata         `protobuf:"bytes,8,opt,name=split,proto3" json:"split,omitempty"`
 	unknownFields           protoimpl.UnknownFields
@@ -701,28 +701,28 @@ func (x *ShardMetadata) GetTerm() int64 {
 	return 0
 }
 
-func (x *ShardMetadata) GetLeader() *DataServer {
+func (x *ShardMetadata) GetLeader() *DataServerIdentity {
 	if x != nil {
 		return x.Leader
 	}
 	return nil
 }
 
-func (x *ShardMetadata) GetEnsemble() []*DataServer {
+func (x *ShardMetadata) GetEnsemble() []*DataServerIdentity {
 	if x != nil {
 		return x.Ensemble
 	}
 	return nil
 }
 
-func (x *ShardMetadata) GetRemovedNodes() []*DataServer {
+func (x *ShardMetadata) GetRemovedNodes() []*DataServerIdentity {
 	if x != nil {
 		return x.RemovedNodes
 	}
 	return nil
 }
 
-func (x *ShardMetadata) GetPendingDeleteShardNodes() []*DataServer {
+func (x *ShardMetadata) GetPendingDeleteShardNodes() []*DataServerIdentity {
 	if x != nil {
 		return x.PendingDeleteShardNodes
 	}
@@ -867,9 +867,8 @@ var File_metadata_proto protoreflect.FileDescriptor
 
 const file_metadata_proto_rawDesc = "" +
 	"\n" +
-	"\x0emetadata.proto\x12\x10io.oxia.proto.v1\"b\n" +
-	"\n" +
-	"DataServer\x12\x17\n" +
+	"\x0emetadata.proto\x12\x10io.oxia.proto.v1\"j\n" +
+	"\x12DataServerIdentity\x12\x17\n" +
 	"\x04name\x18\x01 \x01(\tH\x00R\x04name\x88\x01\x01\x12\x16\n" +
 	"\x06public\x18\x02 \x01(\tR\x06public\x12\x1a\n" +
 	"\binternal\x18\x03 \x01(\tR\binternalB\a\n" +
@@ -879,10 +878,9 @@ const file_metadata_proto_rawDesc = "" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x90\x01\n" +
-	"\x0eDataServerInfo\x12<\n" +
 	"\n" +
-	"dataServer\x18\x01 \x01(\v2\x1c.io.oxia.proto.v1.DataServerR\n" +
-	"dataServer\x12@\n" +
+	"DataServer\x12@\n" +
+	"\bidentity\x18\x01 \x01(\v2$.io.oxia.proto.v1.DataServerIdentityR\bidentity\x12@\n" +
 	"\bmetadata\x18\x02 \x01(\v2$.io.oxia.proto.v1.DataServerMetadataR\bmetadata\":\n" +
 	"\fAntiAffinity\x12\x16\n" +
 	"\x06labels\x18\x01 \x03(\tR\x06labels\x12\x12\n" +
@@ -901,12 +899,12 @@ const file_metadata_proto_rawDesc = "" +
 	"\x15_notificationsEnabled\"b\n" +
 	"\fLoadBalancer\x12*\n" +
 	"\x10scheduleInterval\x18\x01 \x01(\tR\x10scheduleInterval\x12&\n" +
-	"\x0equarantineTime\x18\x02 \x01(\tR\x0equarantineTime\"\xd2\x03\n" +
+	"\x0equarantineTime\x18\x02 \x01(\tR\x0equarantineTime\"\xda\x03\n" +
 	"\x14ClusterConfiguration\x12;\n" +
 	"\n" +
 	"namespaces\x18\x01 \x03(\v2\x1b.io.oxia.proto.v1.NamespaceR\n" +
-	"namespaces\x126\n" +
-	"\aservers\x18\x02 \x03(\v2\x1c.io.oxia.proto.v1.DataServerR\aservers\x124\n" +
+	"namespaces\x12>\n" +
+	"\aservers\x18\x02 \x03(\v2$.io.oxia.proto.v1.DataServerIdentityR\aservers\x124\n" +
 	"\x15allowExtraAuthorities\x18\x03 \x03(\tR\x15allowExtraAuthorities\x12b\n" +
 	"\x0eserverMetadata\x18\x04 \x03(\v2:.io.oxia.proto.v1.ClusterConfiguration.ServerMetadataEntryR\x0eserverMetadata\x12B\n" +
 	"\floadBalancer\x18\x05 \x01(\v2\x1e.io.oxia.proto.v1.LoadBalancerR\floadBalancer\x1ag\n" +
@@ -928,14 +926,14 @@ const file_metadata_proto_rawDesc = "" +
 	"\x17childLeadersAtBootstrap\x18\a \x03(\v2<.io.oxia.proto.v1.SplitMetadata.ChildLeadersAtBootstrapEntryR\x17childLeadersAtBootstrap\x1aJ\n" +
 	"\x1cChildLeadersAtBootstrapEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\x03R\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xc1\x03\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe1\x03\n" +
 	"\rShardMetadata\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x12\n" +
-	"\x04term\x18\x02 \x01(\x03R\x04term\x124\n" +
-	"\x06leader\x18\x03 \x01(\v2\x1c.io.oxia.proto.v1.DataServerR\x06leader\x128\n" +
-	"\bensemble\x18\x04 \x03(\v2\x1c.io.oxia.proto.v1.DataServerR\bensemble\x12@\n" +
-	"\fremovedNodes\x18\x05 \x03(\v2\x1c.io.oxia.proto.v1.DataServerR\fremovedNodes\x12V\n" +
-	"\x17pendingDeleteShardNodes\x18\x06 \x03(\v2\x1c.io.oxia.proto.v1.DataServerR\x17pendingDeleteShardNodes\x12C\n" +
+	"\x04term\x18\x02 \x01(\x03R\x04term\x12<\n" +
+	"\x06leader\x18\x03 \x01(\v2$.io.oxia.proto.v1.DataServerIdentityR\x06leader\x12@\n" +
+	"\bensemble\x18\x04 \x03(\v2$.io.oxia.proto.v1.DataServerIdentityR\bensemble\x12H\n" +
+	"\fremovedNodes\x18\x05 \x03(\v2$.io.oxia.proto.v1.DataServerIdentityR\fremovedNodes\x12^\n" +
+	"\x17pendingDeleteShardNodes\x18\x06 \x03(\v2$.io.oxia.proto.v1.DataServerIdentityR\x17pendingDeleteShardNodes\x12C\n" +
 	"\x0eint32HashRange\x18\a \x01(\v2\x1b.io.oxia.proto.v1.HashRangeR\x0eint32HashRange\x125\n" +
 	"\x05split\x18\b \x01(\v2\x1f.io.oxia.proto.v1.SplitMetadataR\x05split\"\xe2\x01\n" +
 	"\x0fNamespaceStatus\x12,\n" +
@@ -971,9 +969,9 @@ func file_metadata_proto_rawDescGZIP() []byte {
 
 var file_metadata_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_metadata_proto_goTypes = []any{
-	(*DataServer)(nil),           // 0: io.oxia.proto.v1.DataServer
+	(*DataServerIdentity)(nil),   // 0: io.oxia.proto.v1.DataServerIdentity
 	(*DataServerMetadata)(nil),   // 1: io.oxia.proto.v1.DataServerMetadata
-	(*DataServerInfo)(nil),       // 2: io.oxia.proto.v1.DataServerInfo
+	(*DataServer)(nil),           // 2: io.oxia.proto.v1.DataServer
 	(*AntiAffinity)(nil),         // 3: io.oxia.proto.v1.AntiAffinity
 	(*HierarchyPolicies)(nil),    // 4: io.oxia.proto.v1.HierarchyPolicies
 	(*Namespace)(nil),            // 5: io.oxia.proto.v1.Namespace
@@ -992,19 +990,19 @@ var file_metadata_proto_goTypes = []any{
 }
 var file_metadata_proto_depIdxs = []int32{
 	13, // 0: io.oxia.proto.v1.DataServerMetadata.labels:type_name -> io.oxia.proto.v1.DataServerMetadata.LabelsEntry
-	0,  // 1: io.oxia.proto.v1.DataServerInfo.dataServer:type_name -> io.oxia.proto.v1.DataServer
-	1,  // 2: io.oxia.proto.v1.DataServerInfo.metadata:type_name -> io.oxia.proto.v1.DataServerMetadata
+	0,  // 1: io.oxia.proto.v1.DataServer.identity:type_name -> io.oxia.proto.v1.DataServerIdentity
+	1,  // 2: io.oxia.proto.v1.DataServer.metadata:type_name -> io.oxia.proto.v1.DataServerMetadata
 	3,  // 3: io.oxia.proto.v1.HierarchyPolicies.antiAffinities:type_name -> io.oxia.proto.v1.AntiAffinity
 	4,  // 4: io.oxia.proto.v1.Namespace.policy:type_name -> io.oxia.proto.v1.HierarchyPolicies
 	5,  // 5: io.oxia.proto.v1.ClusterConfiguration.namespaces:type_name -> io.oxia.proto.v1.Namespace
-	0,  // 6: io.oxia.proto.v1.ClusterConfiguration.servers:type_name -> io.oxia.proto.v1.DataServer
+	0,  // 6: io.oxia.proto.v1.ClusterConfiguration.servers:type_name -> io.oxia.proto.v1.DataServerIdentity
 	14, // 7: io.oxia.proto.v1.ClusterConfiguration.serverMetadata:type_name -> io.oxia.proto.v1.ClusterConfiguration.ServerMetadataEntry
 	6,  // 8: io.oxia.proto.v1.ClusterConfiguration.loadBalancer:type_name -> io.oxia.proto.v1.LoadBalancer
 	15, // 9: io.oxia.proto.v1.SplitMetadata.childLeadersAtBootstrap:type_name -> io.oxia.proto.v1.SplitMetadata.ChildLeadersAtBootstrapEntry
-	0,  // 10: io.oxia.proto.v1.ShardMetadata.leader:type_name -> io.oxia.proto.v1.DataServer
-	0,  // 11: io.oxia.proto.v1.ShardMetadata.ensemble:type_name -> io.oxia.proto.v1.DataServer
-	0,  // 12: io.oxia.proto.v1.ShardMetadata.removedNodes:type_name -> io.oxia.proto.v1.DataServer
-	0,  // 13: io.oxia.proto.v1.ShardMetadata.pendingDeleteShardNodes:type_name -> io.oxia.proto.v1.DataServer
+	0,  // 10: io.oxia.proto.v1.ShardMetadata.leader:type_name -> io.oxia.proto.v1.DataServerIdentity
+	0,  // 11: io.oxia.proto.v1.ShardMetadata.ensemble:type_name -> io.oxia.proto.v1.DataServerIdentity
+	0,  // 12: io.oxia.proto.v1.ShardMetadata.removedNodes:type_name -> io.oxia.proto.v1.DataServerIdentity
+	0,  // 13: io.oxia.proto.v1.ShardMetadata.pendingDeleteShardNodes:type_name -> io.oxia.proto.v1.DataServerIdentity
 	8,  // 14: io.oxia.proto.v1.ShardMetadata.int32HashRange:type_name -> io.oxia.proto.v1.HashRange
 	9,  // 15: io.oxia.proto.v1.ShardMetadata.split:type_name -> io.oxia.proto.v1.SplitMetadata
 	16, // 16: io.oxia.proto.v1.NamespaceStatus.shards:type_name -> io.oxia.proto.v1.NamespaceStatus.ShardsEntry

--- a/common/proto/metadata.proto
+++ b/common/proto/metadata.proto
@@ -18,7 +18,7 @@ package io.oxia.proto.v1;
 
 option go_package = "github.com/oxia-db/oxia/common/proto";
 
-message DataServer {
+message DataServerIdentity {
   optional string name = 1;
   string public = 2;
   string internal = 3;
@@ -28,8 +28,8 @@ message DataServerMetadata {
   map<string, string> labels = 1;
 }
 
-message DataServerInfo {
-  DataServer dataServer = 1;
+message DataServer {
+  DataServerIdentity identity = 1;
   DataServerMetadata metadata = 2;
 }
 
@@ -58,7 +58,7 @@ message LoadBalancer {
 
 message ClusterConfiguration {
   repeated Namespace namespaces = 1;
-  repeated DataServer servers = 2;
+  repeated DataServerIdentity servers = 2;
   repeated string allowExtraAuthorities = 3;
   map<string, DataServerMetadata> serverMetadata = 4;
   LoadBalancer loadBalancer = 5;
@@ -82,10 +82,10 @@ message SplitMetadata {
 message ShardMetadata {
   string status = 1;
   int64 term = 2;
-  DataServer leader = 3;
-  repeated DataServer ensemble = 4;
-  repeated DataServer removedNodes = 5;
-  repeated DataServer pendingDeleteShardNodes = 6;
+  DataServerIdentity leader = 3;
+  repeated DataServerIdentity ensemble = 4;
+  repeated DataServerIdentity removedNodes = 5;
+  repeated DataServerIdentity pendingDeleteShardNodes = 6;
   HashRange int32HashRange = 7;
   SplitMetadata split = 8;
 }

--- a/common/proto/metadata_ext.go
+++ b/common/proto/metadata_ext.go
@@ -43,7 +43,7 @@ const (
 	SplitPhaseCutover   = "Cutover"
 )
 
-func (ds *DataServer) GetNameOrDefault() string {
+func (ds *DataServerIdentity) GetNameOrDefault() string {
 	if ds == nil {
 		return ""
 	}
@@ -51,6 +51,13 @@ func (ds *DataServer) GetNameOrDefault() string {
 		return ds.GetName()
 	}
 	return ds.GetInternal()
+}
+
+func (ds *DataServer) GetNameOrDefault() string {
+	if ds == nil {
+		return ""
+	}
+	return ds.GetIdentity().GetNameOrDefault()
 }
 
 func NewClusterStatus() *ClusterStatus {
@@ -156,7 +163,7 @@ func (a *AntiAffinity) SetModeOrDefault(value string) {
 	a.Mode = ParseAntiAffinityMode(value)
 }
 
-func (cc *ClusterConfiguration) GetDataServerInfo(id string) (*DataServerInfo, bool) {
+func (cc *ClusterConfiguration) GetDataServer(id string) (*DataServer, bool) {
 	if cc == nil {
 		return nil, false
 	}
@@ -166,24 +173,23 @@ func (cc *ClusterConfiguration) GetDataServerInfo(id string) (*DataServerInfo, b
 			continue
 		}
 
-		dataServer := server
+		identity := server
 		if server.GetName() == "" {
-			name := server.GetNameOrDefault()
-			dataServer = &DataServer{
-				Name:     &name,
+			identity = &DataServerIdentity{
+				Name:     new(server.GetNameOrDefault()),
 				Public:   server.GetPublic(),
 				Internal: server.GetInternal(),
 			}
 		}
 
-		info := &DataServerInfo{
-			DataServer: dataServer,
-			Metadata:   &DataServerMetadata{},
+		dataServer := &DataServer{
+			Identity: identity,
+			Metadata: &DataServerMetadata{},
 		}
 		if metadata, found := cc.GetServerMetadata()[id]; found {
-			info.Metadata = metadata
+			dataServer.Metadata = metadata
 		}
-		return info, true
+		return dataServer, true
 	}
 
 	return nil, false

--- a/common/proto/metadata_ext.go
+++ b/common/proto/metadata_ext.go
@@ -175,8 +175,9 @@ func (cc *ClusterConfiguration) GetDataServer(id string) (*DataServer, bool) {
 
 		identity := server
 		if server.GetName() == "" {
+			name := server.GetNameOrDefault()
 			identity = &DataServerIdentity{
-				Name:     new(server.GetNameOrDefault()),
+				Name:     &name,
 				Public:   server.GetPublic(),
 				Internal: server.GetInternal(),
 			}

--- a/common/proto/metadata_ext_test.go
+++ b/common/proto/metadata_ext_test.go
@@ -161,7 +161,7 @@ func TestEncodeYAMLRoundTrip(t *testing.T) {
 				},
 			},
 		},
-		Servers: []*DataServer{
+		Servers: []*DataServerIdentity{
 			{
 				Name:     &name,
 				Public:   "localhost:6648",
@@ -342,12 +342,12 @@ func TestEncodeClusterStatusYAMLRoundTrip(t *testing.T) {
 					1: {
 						Status: ShardStatusSteadyState,
 						Term:   3,
-						Leader: &DataServer{
+						Leader: &DataServerIdentity{
 							Name:     &name,
 							Public:   "localhost:6648",
 							Internal: "localhost:6649",
 						},
-						Ensemble: []*DataServer{
+						Ensemble: []*DataServerIdentity{
 							{
 								Name:     &name,
 								Public:   "localhost:6648",

--- a/common/proto/metadata_vtproto.pb.go
+++ b/common/proto/metadata_vtproto.pb.go
@@ -20,11 +20,11 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-func (m *DataServer) CloneVT() *DataServer {
+func (m *DataServerIdentity) CloneVT() *DataServerIdentity {
 	if m == nil {
-		return (*DataServer)(nil)
+		return (*DataServerIdentity)(nil)
 	}
-	r := new(DataServer)
+	r := new(DataServerIdentity)
 	r.Public = m.Public
 	r.Internal = m.Internal
 	if rhs := m.Name; rhs != nil {
@@ -38,7 +38,7 @@ func (m *DataServer) CloneVT() *DataServer {
 	return r
 }
 
-func (m *DataServer) CloneMessageVT() proto.Message {
+func (m *DataServerIdentity) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -65,12 +65,12 @@ func (m *DataServerMetadata) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
-func (m *DataServerInfo) CloneVT() *DataServerInfo {
+func (m *DataServer) CloneVT() *DataServer {
 	if m == nil {
-		return (*DataServerInfo)(nil)
+		return (*DataServer)(nil)
 	}
-	r := new(DataServerInfo)
-	r.DataServer = m.DataServer.CloneVT()
+	r := new(DataServer)
+	r.Identity = m.Identity.CloneVT()
 	r.Metadata = m.Metadata.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -79,7 +79,7 @@ func (m *DataServerInfo) CloneVT() *DataServerInfo {
 	return r
 }
 
-func (m *DataServerInfo) CloneMessageVT() proto.Message {
+func (m *DataServer) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -185,7 +185,7 @@ func (m *ClusterConfiguration) CloneVT() *ClusterConfiguration {
 		r.Namespaces = tmpContainer
 	}
 	if rhs := m.Servers; rhs != nil {
-		tmpContainer := make([]*DataServer, len(rhs))
+		tmpContainer := make([]*DataServerIdentity, len(rhs))
 		for k, v := range rhs {
 			tmpContainer[k] = v.CloneVT()
 		}
@@ -276,21 +276,21 @@ func (m *ShardMetadata) CloneVT() *ShardMetadata {
 	r.Int32HashRange = m.Int32HashRange.CloneVT()
 	r.Split = m.Split.CloneVT()
 	if rhs := m.Ensemble; rhs != nil {
-		tmpContainer := make([]*DataServer, len(rhs))
+		tmpContainer := make([]*DataServerIdentity, len(rhs))
 		for k, v := range rhs {
 			tmpContainer[k] = v.CloneVT()
 		}
 		r.Ensemble = tmpContainer
 	}
 	if rhs := m.RemovedNodes; rhs != nil {
-		tmpContainer := make([]*DataServer, len(rhs))
+		tmpContainer := make([]*DataServerIdentity, len(rhs))
 		for k, v := range rhs {
 			tmpContainer[k] = v.CloneVT()
 		}
 		r.RemovedNodes = tmpContainer
 	}
 	if rhs := m.PendingDeleteShardNodes; rhs != nil {
-		tmpContainer := make([]*DataServer, len(rhs))
+		tmpContainer := make([]*DataServerIdentity, len(rhs))
 		for k, v := range rhs {
 			tmpContainer[k] = v.CloneVT()
 		}
@@ -357,7 +357,7 @@ func (m *ClusterStatus) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
-func (this *DataServer) EqualVT(that *DataServer) bool {
+func (this *DataServerIdentity) EqualVT(that *DataServerIdentity) bool {
 	if this == that {
 		return true
 	} else if this == nil || that == nil {
@@ -375,8 +375,8 @@ func (this *DataServer) EqualVT(that *DataServer) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
-func (this *DataServer) EqualMessageVT(thatMsg proto.Message) bool {
-	that, ok := thatMsg.(*DataServer)
+func (this *DataServerIdentity) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DataServerIdentity)
 	if !ok {
 		return false
 	}
@@ -410,13 +410,13 @@ func (this *DataServerMetadata) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
-func (this *DataServerInfo) EqualVT(that *DataServerInfo) bool {
+func (this *DataServer) EqualVT(that *DataServer) bool {
 	if this == that {
 		return true
 	} else if this == nil || that == nil {
 		return false
 	}
-	if !this.DataServer.EqualVT(that.DataServer) {
+	if !this.Identity.EqualVT(that.Identity) {
 		return false
 	}
 	if !this.Metadata.EqualVT(that.Metadata) {
@@ -425,8 +425,8 @@ func (this *DataServerInfo) EqualVT(that *DataServerInfo) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
-func (this *DataServerInfo) EqualMessageVT(thatMsg proto.Message) bool {
-	that, ok := thatMsg.(*DataServerInfo)
+func (this *DataServer) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DataServer)
 	if !ok {
 		return false
 	}
@@ -579,10 +579,10 @@ func (this *ClusterConfiguration) EqualVT(that *ClusterConfiguration) bool {
 		vy := that.Servers[i]
 		if p, q := vx, vy; p != q {
 			if p == nil {
-				p = &DataServer{}
+				p = &DataServerIdentity{}
 			}
 			if q == nil {
-				q = &DataServer{}
+				q = &DataServerIdentity{}
 			}
 			if !p.EqualVT(q) {
 				return false
@@ -727,10 +727,10 @@ func (this *ShardMetadata) EqualVT(that *ShardMetadata) bool {
 		vy := that.Ensemble[i]
 		if p, q := vx, vy; p != q {
 			if p == nil {
-				p = &DataServer{}
+				p = &DataServerIdentity{}
 			}
 			if q == nil {
-				q = &DataServer{}
+				q = &DataServerIdentity{}
 			}
 			if !p.EqualVT(q) {
 				return false
@@ -744,10 +744,10 @@ func (this *ShardMetadata) EqualVT(that *ShardMetadata) bool {
 		vy := that.RemovedNodes[i]
 		if p, q := vx, vy; p != q {
 			if p == nil {
-				p = &DataServer{}
+				p = &DataServerIdentity{}
 			}
 			if q == nil {
-				q = &DataServer{}
+				q = &DataServerIdentity{}
 			}
 			if !p.EqualVT(q) {
 				return false
@@ -761,10 +761,10 @@ func (this *ShardMetadata) EqualVT(that *ShardMetadata) bool {
 		vy := that.PendingDeleteShardNodes[i]
 		if p, q := vx, vy; p != q {
 			if p == nil {
-				p = &DataServer{}
+				p = &DataServerIdentity{}
 			}
 			if q == nil {
-				q = &DataServer{}
+				q = &DataServerIdentity{}
 			}
 			if !p.EqualVT(q) {
 				return false
@@ -871,7 +871,7 @@ func (this *ClusterStatus) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
-func (m *DataServer) MarshalVT() (dAtA []byte, err error) {
+func (m *DataServerIdentity) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -884,12 +884,12 @@ func (m *DataServer) MarshalVT() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *DataServer) MarshalToVT(dAtA []byte) (int, error) {
+func (m *DataServerIdentity) MarshalToVT(dAtA []byte) (int, error) {
 	size := m.SizeVT()
 	return m.MarshalToSizedBufferVT(dAtA[:size])
 }
 
-func (m *DataServer) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+func (m *DataServerIdentity) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m == nil {
 		return 0, nil
 	}
@@ -977,7 +977,7 @@ func (m *DataServerMetadata) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *DataServerInfo) MarshalVT() (dAtA []byte, err error) {
+func (m *DataServer) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -990,12 +990,12 @@ func (m *DataServerInfo) MarshalVT() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *DataServerInfo) MarshalToVT(dAtA []byte) (int, error) {
+func (m *DataServer) MarshalToVT(dAtA []byte) (int, error) {
 	size := m.SizeVT()
 	return m.MarshalToSizedBufferVT(dAtA[:size])
 }
 
-func (m *DataServerInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+func (m *DataServer) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m == nil {
 		return 0, nil
 	}
@@ -1017,8 +1017,8 @@ func (m *DataServerInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x12
 	}
-	if m.DataServer != nil {
-		size, err := m.DataServer.MarshalToSizedBufferVT(dAtA[:i])
+	if m.Identity != nil {
+		size, err := m.Identity.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
 			return 0, err
 		}
@@ -1728,7 +1728,7 @@ func (m *ClusterStatus) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *DataServer) SizeVT() (n int) {
+func (m *DataServerIdentity) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1768,14 +1768,14 @@ func (m *DataServerMetadata) SizeVT() (n int) {
 	return n
 }
 
-func (m *DataServerInfo) SizeVT() (n int) {
+func (m *DataServer) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
 	var l int
 	_ = l
-	if m.DataServer != nil {
-		l = m.DataServer.SizeVT()
+	if m.Identity != nil {
+		l = m.Identity.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if m.Metadata != nil {
@@ -2079,7 +2079,7 @@ func (m *ClusterStatus) SizeVT() (n int) {
 	return n
 }
 
-func (m *DataServer) UnmarshalVT(dAtA []byte) error {
+func (m *DataServerIdentity) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2102,10 +2102,10 @@ func (m *DataServer) UnmarshalVT(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: DataServer: wiretype end group for non-group")
+			return fmt.Errorf("proto: DataServerIdentity: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: DataServer: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: DataServerIdentity: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -2405,7 +2405,7 @@ func (m *DataServerMetadata) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *DataServerInfo) UnmarshalVT(dAtA []byte) error {
+func (m *DataServer) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2428,15 +2428,15 @@ func (m *DataServerInfo) UnmarshalVT(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: DataServerInfo: wiretype end group for non-group")
+			return fmt.Errorf("proto: DataServer: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: DataServerInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: DataServer: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Identity", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2463,10 +2463,10 @@ func (m *DataServerInfo) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.DataServer == nil {
-				m.DataServer = &DataServer{}
+			if m.Identity == nil {
+				m.Identity = &DataServerIdentity{}
 			}
-			if err := m.DataServer.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+			if err := m.Identity.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -3145,7 +3145,7 @@ func (m *ClusterConfiguration) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Servers = append(m.Servers, &DataServer{})
+			m.Servers = append(m.Servers, &DataServerIdentity{})
 			if err := m.Servers[len(m.Servers)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -3916,7 +3916,7 @@ func (m *ShardMetadata) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Leader == nil {
-				m.Leader = &DataServer{}
+				m.Leader = &DataServerIdentity{}
 			}
 			if err := m.Leader.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -3951,7 +3951,7 @@ func (m *ShardMetadata) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Ensemble = append(m.Ensemble, &DataServer{})
+			m.Ensemble = append(m.Ensemble, &DataServerIdentity{})
 			if err := m.Ensemble[len(m.Ensemble)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -3985,7 +3985,7 @@ func (m *ShardMetadata) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.RemovedNodes = append(m.RemovedNodes, &DataServer{})
+			m.RemovedNodes = append(m.RemovedNodes, &DataServerIdentity{})
 			if err := m.RemovedNodes[len(m.RemovedNodes)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -4019,7 +4019,7 @@ func (m *ShardMetadata) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.PendingDeleteShardNodes = append(m.PendingDeleteShardNodes, &DataServer{})
+			m.PendingDeleteShardNodes = append(m.PendingDeleteShardNodes, &DataServerIdentity{})
 			if err := m.PendingDeleteShardNodes[len(m.PendingDeleteShardNodes)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -4553,7 +4553,7 @@ func (m *ClusterStatus) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *DataServer) UnmarshalVTUnsafe(dAtA []byte) error {
+func (m *DataServerIdentity) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -4576,10 +4576,10 @@ func (m *DataServer) UnmarshalVTUnsafe(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: DataServer: wiretype end group for non-group")
+			return fmt.Errorf("proto: DataServerIdentity: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: DataServer: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: DataServerIdentity: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -4899,7 +4899,7 @@ func (m *DataServerMetadata) UnmarshalVTUnsafe(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *DataServerInfo) UnmarshalVTUnsafe(dAtA []byte) error {
+func (m *DataServer) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -4922,15 +4922,15 @@ func (m *DataServerInfo) UnmarshalVTUnsafe(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: DataServerInfo: wiretype end group for non-group")
+			return fmt.Errorf("proto: DataServer: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: DataServerInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: DataServer: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Identity", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -4957,10 +4957,10 @@ func (m *DataServerInfo) UnmarshalVTUnsafe(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.DataServer == nil {
-				m.DataServer = &DataServer{}
+			if m.Identity == nil {
+				m.Identity = &DataServerIdentity{}
 			}
-			if err := m.DataServer.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+			if err := m.Identity.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -5663,7 +5663,7 @@ func (m *ClusterConfiguration) UnmarshalVTUnsafe(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Servers = append(m.Servers, &DataServer{})
+			m.Servers = append(m.Servers, &DataServerIdentity{})
 			if err := m.Servers[len(m.Servers)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -6454,7 +6454,7 @@ func (m *ShardMetadata) UnmarshalVTUnsafe(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Leader == nil {
-				m.Leader = &DataServer{}
+				m.Leader = &DataServerIdentity{}
 			}
 			if err := m.Leader.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -6489,7 +6489,7 @@ func (m *ShardMetadata) UnmarshalVTUnsafe(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Ensemble = append(m.Ensemble, &DataServer{})
+			m.Ensemble = append(m.Ensemble, &DataServerIdentity{})
 			if err := m.Ensemble[len(m.Ensemble)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -6523,7 +6523,7 @@ func (m *ShardMetadata) UnmarshalVTUnsafe(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.RemovedNodes = append(m.RemovedNodes, &DataServer{})
+			m.RemovedNodes = append(m.RemovedNodes, &DataServerIdentity{})
 			if err := m.RemovedNodes[len(m.RemovedNodes)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -6557,7 +6557,7 @@ func (m *ShardMetadata) UnmarshalVTUnsafe(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.PendingDeleteShardNodes = append(m.PendingDeleteShardNodes, &DataServer{})
+			m.PendingDeleteShardNodes = append(m.PendingDeleteShardNodes, &DataServerIdentity{})
 			if err := m.PendingDeleteShardNodes[len(m.PendingDeleteShardNodes)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}

--- a/oxia/admin.go
+++ b/oxia/admin.go
@@ -24,7 +24,7 @@ type AdminClient interface {
 	io.Closer
 
 	ListDataServers() ([]*proto.DataServer, error)
-	GetDataServer(dataServer string) (*proto.DataServerInfo, error)
+	GetDataServer(dataServer string) (*proto.DataServer, error)
 
 	ListNamespaces() *ListNamespacesResult
 

--- a/oxia/admin_client_impl.go
+++ b/oxia/admin_client_impl.go
@@ -50,7 +50,7 @@ func (admin *adminClientImpl) ListDataServers() ([]*proto.DataServer, error) {
 	return response.DataServers, nil
 }
 
-func (admin *adminClientImpl) GetDataServer(dataServer string) (*proto.DataServerInfo, error) {
+func (admin *adminClientImpl) GetDataServer(dataServer string) (*proto.DataServer, error) {
 	client, err := admin.clientPool.GetAminRpc(admin.adminAddr)
 	if err != nil {
 		return nil, mapAdminError(err)
@@ -64,7 +64,7 @@ func (admin *adminClientImpl) GetDataServer(dataServer string) (*proto.DataServe
 	if err != nil {
 		return nil, mapAdminError(err)
 	}
-	return response.DataServerInfo, nil
+	return response.DataServer, nil
 }
 
 func (admin *adminClientImpl) ListNodes() *ListNodesResult {

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -157,9 +157,11 @@ func TestAdminClientListDataServersReturnsResponse(t *testing.T) {
 				listDataServersResponse: &proto.ListDataServersResponse{
 					DataServers: []*proto.DataServer{
 						{
-							Name:     &serverName,
-							Public:   "public-1",
-							Internal: "internal-1",
+							Identity: &proto.DataServerIdentity{
+								Name:     &serverName,
+								Public:   "public-1",
+								Internal: "internal-1",
+							},
 						},
 					},
 				},
@@ -170,10 +172,11 @@ func TestAdminClientListDataServersReturnsResponse(t *testing.T) {
 	dataServers, err := admin.ListDataServers()
 	require.NoError(t, err)
 	require.Len(t, dataServers, 1)
-	require.NotNil(t, dataServers[0].Name)
-	assert.Equal(t, serverName, *dataServers[0].Name)
-	assert.Equal(t, "public-1", dataServers[0].GetPublic())
-	assert.Equal(t, "internal-1", dataServers[0].GetInternal())
+	require.NotNil(t, dataServers[0].Identity)
+	require.NotNil(t, dataServers[0].Identity.Name)
+	assert.Equal(t, serverName, *dataServers[0].Identity.Name)
+	assert.Equal(t, "public-1", dataServers[0].Identity.GetPublic())
+	assert.Equal(t, "internal-1", dataServers[0].Identity.GetInternal())
 }
 
 func TestAdminClientGetDataServerReturnsResponse(t *testing.T) {
@@ -183,8 +186,8 @@ func TestAdminClientGetDataServerReturnsResponse(t *testing.T) {
 		clientPool: &mockAdminClientPool{
 			adminClient: &mockAdminRpcClient{
 				getDataServerResponse: &proto.GetDataServerResponse{
-					DataServerInfo: &proto.DataServerInfo{
-						DataServer: &proto.DataServer{
+					DataServer: &proto.DataServer{
+						Identity: &proto.DataServerIdentity{
 							Name:     &serverName,
 							Public:   "public-1",
 							Internal: "internal-1",
@@ -201,11 +204,11 @@ func TestAdminClientGetDataServerReturnsResponse(t *testing.T) {
 	dataServer, err := admin.GetDataServer(serverName)
 	require.NoError(t, err)
 	require.NotNil(t, dataServer)
-	require.NotNil(t, dataServer.DataServer)
-	require.NotNil(t, dataServer.DataServer.Name)
-	assert.Equal(t, serverName, *dataServer.DataServer.Name)
-	assert.Equal(t, "public-1", dataServer.DataServer.GetPublic())
-	assert.Equal(t, "internal-1", dataServer.DataServer.GetInternal())
+	require.NotNil(t, dataServer.Identity)
+	require.NotNil(t, dataServer.Identity.Name)
+	assert.Equal(t, serverName, *dataServer.Identity.Name)
+	assert.Equal(t, "public-1", dataServer.Identity.GetPublic())
+	assert.Equal(t, "internal-1", dataServer.Identity.GetInternal())
 	assert.Equal(t, map[string]string{"rack": "rack-1"}, dataServer.Metadata.GetLabels())
 }
 

--- a/oxiad/coordinator/action/change_ensemble.go
+++ b/oxiad/coordinator/action/change_ensemble.go
@@ -28,8 +28,8 @@ type ChangeEnsembleAction struct {
 	sync.WaitGroup
 
 	Shard int64
-	From  *commonproto.DataServer
-	To    *commonproto.DataServer
+	From  *commonproto.DataServerIdentity
+	To    *commonproto.DataServerIdentity
 
 	finished     atomic.Bool
 	executeError error
@@ -66,11 +66,11 @@ func (*ChangeEnsembleAction) Type() Type {
 	return SwapNode
 }
 
-func NewChangeEnsembleAction(shard int64, from *commonproto.DataServer, to *commonproto.DataServer) *ChangeEnsembleAction {
+func NewChangeEnsembleAction(shard int64, from *commonproto.DataServerIdentity, to *commonproto.DataServerIdentity) *ChangeEnsembleAction {
 	return NewChangeEnsembleActionWithCallback(shard, from, to, nil)
 }
 
-func NewChangeEnsembleActionWithCallback(shard int64, from *commonproto.DataServer, to *commonproto.DataServer, callback concurrent.Callback[any]) *ChangeEnsembleAction {
+func NewChangeEnsembleActionWithCallback(shard int64, from *commonproto.DataServerIdentity, to *commonproto.DataServerIdentity, callback concurrent.Callback[any]) *ChangeEnsembleAction {
 	action := ChangeEnsembleAction{
 		WaitGroup:    sync.WaitGroup{},
 		Shard:        shard,

--- a/oxiad/coordinator/action/change_ensemble_test.go
+++ b/oxiad/coordinator/action/change_ensemble_test.go
@@ -29,7 +29,7 @@ func TestChangeEnsembleAction_WithCallback(t *testing.T) {
 	var finishedErr error
 
 	// success
-	action := NewChangeEnsembleActionWithCallback(0, &proto.DataServer{}, &proto.DataServer{}, concurrent.NewOnce(func(t any) {
+	action := NewChangeEnsembleActionWithCallback(0, &proto.DataServerIdentity{}, &proto.DataServerIdentity{}, concurrent.NewOnce(func(t any) {
 		finished = true
 	}, func(err error) {
 		finished = true
@@ -40,7 +40,7 @@ func TestChangeEnsembleAction_WithCallback(t *testing.T) {
 	assert.Nil(t, finishedErr)
 
 	// failure
-	action = NewChangeEnsembleActionWithCallback(0, &proto.DataServer{}, &proto.DataServer{}, concurrent.NewOnce(func(t any) {
+	action = NewChangeEnsembleActionWithCallback(0, &proto.DataServerIdentity{}, &proto.DataServerIdentity{}, concurrent.NewOnce(func(t any) {
 		finished = true
 	}, func(err error) {
 		finished = true
@@ -53,7 +53,7 @@ func TestChangeEnsembleAction_WithCallback(t *testing.T) {
 
 func TestChangeEnsembleAction_WithoutCallback(t *testing.T) {
 	// success
-	action := NewChangeEnsembleAction(0, &proto.DataServer{}, &proto.DataServer{})
+	action := NewChangeEnsembleAction(0, &proto.DataServerIdentity{}, &proto.DataServerIdentity{})
 	go func() {
 		action.Done(nil)
 	}()
@@ -61,7 +61,7 @@ func TestChangeEnsembleAction_WithoutCallback(t *testing.T) {
 	assert.Nil(t, err)
 
 	// failure
-	action = NewChangeEnsembleAction(0, &proto.DataServer{}, &proto.DataServer{})
+	action = NewChangeEnsembleAction(0, &proto.DataServerIdentity{}, &proto.DataServerIdentity{})
 	go func() {
 		action.Error(errors.New("error"))
 	}()

--- a/oxiad/coordinator/admin_server.go
+++ b/oxiad/coordinator/admin_server.go
@@ -47,11 +47,23 @@ func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServer
 	dataServers := make([]*proto.DataServer, 0, len(cnf.GetServers()))
 	for _, server := range cnf.GetServers() {
 		id := server.GetNameOrDefault()
-		dataServer, found := cnf.GetDataServer(id)
-		if !found {
-			continue
+		identity := server
+		if server.GetName() == "" {
+			name := id
+			identity = &proto.DataServerIdentity{
+				Name:     &name,
+				Public:   server.GetPublic(),
+				Internal: server.GetInternal(),
+			}
 		}
-		dataServers = append(dataServers, dataServer)
+		metadata := &proto.DataServerMetadata{}
+		if value, found := cnf.GetServerMetadata()[id]; found {
+			metadata = value
+		}
+		dataServers = append(dataServers, &proto.DataServer{
+			Identity: identity,
+			Metadata: metadata,
+		})
 	}
 
 	return &proto.ListDataServersResponse{DataServers: dataServers}, nil

--- a/oxiad/coordinator/admin_server.go
+++ b/oxiad/coordinator/admin_server.go
@@ -46,11 +46,12 @@ func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServer
 
 	dataServers := make([]*proto.DataServer, 0, len(cnf.GetServers()))
 	for _, server := range cnf.GetServers() {
-		dataServers = append(dataServers, &proto.DataServer{
-			Name:     new(server.GetNameOrDefault()),
-			Public:   server.GetPublic(),
-			Internal: server.GetInternal(),
-		})
+		id := server.GetNameOrDefault()
+		dataServer, found := cnf.GetDataServer(id)
+		if !found {
+			continue
+		}
+		dataServers = append(dataServers, dataServer)
 	}
 
 	return &proto.ListDataServersResponse{DataServers: dataServers}, nil
@@ -61,13 +62,13 @@ func (admin *adminServer) GetDataServer(_ context.Context, req *proto.GetDataSer
 		return nil, grpcstatus.Error(codes.InvalidArgument, "data server must not be empty")
 	}
 
-	dataServerInfo, found := admin.metadata.GetDataServerInfo(req.DataServer)
+	dataServer, found := admin.metadata.GetDataServer(req.DataServer)
 	if !found {
 		return nil, grpcstatus.Errorf(codes.NotFound, "data server %q not found", req.DataServer)
 	}
 
 	return &proto.GetDataServerResponse{
-		DataServerInfo: dataServerInfo,
+		DataServer: dataServer,
 	}, nil
 }
 

--- a/oxiad/coordinator/admin_server_test.go
+++ b/oxiad/coordinator/admin_server_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 )
 
-func dataServer(name *string, public, internal string) *proto.DataServer {
-	return &proto.DataServer{
+func dataServer(name *string, public, internal string) *proto.DataServerIdentity {
+	return &proto.DataServerIdentity{
 		Name:     name,
 		Public:   public,
 		Internal: internal,
@@ -59,7 +59,7 @@ func TestAdminServerListDataServers(t *testing.T) {
 
 	admin := newAdminServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{
-			Servers: []*proto.DataServer{
+			Servers: []*proto.DataServerIdentity{
 				dataServer(&serverName1, "public-1", "internal-1"),
 				dataServer(&serverName2, "public-2", "internal-2"),
 				dataServer(nil, "public-3", "internal-3"),
@@ -77,20 +77,26 @@ func TestAdminServerListDataServers(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, res.DataServers, 3)
 
-	require.NotNil(t, res.DataServers[0].Name)
-	assert.Equal(t, serverName1, *res.DataServers[0].Name)
-	assert.Equal(t, "public-1", res.DataServers[0].GetPublic())
-	assert.Equal(t, "internal-1", res.DataServers[0].GetInternal())
+	require.NotNil(t, res.DataServers[0].Identity)
+	require.NotNil(t, res.DataServers[0].Identity.Name)
+	assert.Equal(t, serverName1, *res.DataServers[0].Identity.Name)
+	assert.Equal(t, "public-1", res.DataServers[0].Identity.GetPublic())
+	assert.Equal(t, "internal-1", res.DataServers[0].Identity.GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-1"}, res.DataServers[0].Metadata.GetLabels())
 
-	require.NotNil(t, res.DataServers[1].Name)
-	assert.Equal(t, serverName2, *res.DataServers[1].Name)
-	assert.Equal(t, "public-2", res.DataServers[1].GetPublic())
-	assert.Equal(t, "internal-2", res.DataServers[1].GetInternal())
+	require.NotNil(t, res.DataServers[1].Identity)
+	require.NotNil(t, res.DataServers[1].Identity.Name)
+	assert.Equal(t, serverName2, *res.DataServers[1].Identity.Name)
+	assert.Equal(t, "public-2", res.DataServers[1].Identity.GetPublic())
+	assert.Equal(t, "internal-2", res.DataServers[1].Identity.GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-2"}, res.DataServers[1].Metadata.GetLabels())
 
-	require.NotNil(t, res.DataServers[2].Name)
-	assert.Equal(t, "internal-3", *res.DataServers[2].Name)
-	assert.Equal(t, "public-3", res.DataServers[2].GetPublic())
-	assert.Equal(t, "internal-3", res.DataServers[2].GetInternal())
+	require.NotNil(t, res.DataServers[2].Identity)
+	require.NotNil(t, res.DataServers[2].Identity.Name)
+	assert.Equal(t, "internal-3", *res.DataServers[2].Identity.Name)
+	assert.Equal(t, "public-3", res.DataServers[2].Identity.GetPublic())
+	assert.Equal(t, "internal-3", res.DataServers[2].Identity.GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-3"}, res.DataServers[2].Metadata.GetLabels())
 }
 
 func TestAdminServerListNodesUsesInternalAddressWhenNameIsUnset(t *testing.T) {
@@ -98,7 +104,7 @@ func TestAdminServerListNodesUsesInternalAddressWhenNameIsUnset(t *testing.T) {
 
 	admin := newAdminServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{
-			Servers: []*proto.DataServer{
+			Servers: []*proto.DataServerIdentity{
 				dataServer(&serverName1, "public-1", "internal-1"),
 				dataServer(nil, "public-2", "internal-2"),
 			},
@@ -130,7 +136,7 @@ func TestAdminServerGetDataServerByName(t *testing.T) {
 
 	admin := newAdminServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{
-			Servers: []*proto.DataServer{
+			Servers: []*proto.DataServerIdentity{
 				dataServer(&serverName, "public-2", "internal-2"),
 			},
 			ServerMetadata: map[string]*proto.DataServerMetadata{
@@ -143,13 +149,13 @@ func TestAdminServerGetDataServerByName(t *testing.T) {
 	res, err := admin.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: serverName})
 	require.NoError(t, err)
 	require.NotNil(t, res)
-	require.NotNil(t, res.DataServerInfo)
-	require.NotNil(t, res.DataServerInfo.DataServer)
-	require.NotNil(t, res.DataServerInfo.DataServer.Name)
-	assert.Equal(t, serverName, *res.DataServerInfo.DataServer.Name)
-	assert.Equal(t, "public-2", res.DataServerInfo.DataServer.GetPublic())
-	assert.Equal(t, "internal-2", res.DataServerInfo.DataServer.GetInternal())
-	assert.Equal(t, map[string]string{"zone": "zone-2"}, res.DataServerInfo.Metadata.GetLabels())
+	require.NotNil(t, res.DataServer)
+	require.NotNil(t, res.DataServer.Identity)
+	require.NotNil(t, res.DataServer.Identity.Name)
+	assert.Equal(t, serverName, *res.DataServer.Identity.Name)
+	assert.Equal(t, "public-2", res.DataServer.Identity.GetPublic())
+	assert.Equal(t, "internal-2", res.DataServer.Identity.GetInternal())
+	assert.Equal(t, map[string]string{"zone": "zone-2"}, res.DataServer.Metadata.GetLabels())
 }
 
 func TestAdminServerGetDataServerByIdentifierFallback(t *testing.T) {
@@ -157,7 +163,7 @@ func TestAdminServerGetDataServerByIdentifierFallback(t *testing.T) {
 
 	admin := newAdminServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{
-			Servers: []*proto.DataServer{
+			Servers: []*proto.DataServerIdentity{
 				dataServer(&serverName, "public-2", "internal-2"),
 				dataServer(nil, "public-3", "internal-3"),
 			},
@@ -172,13 +178,13 @@ func TestAdminServerGetDataServerByIdentifierFallback(t *testing.T) {
 	res, err := admin.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: "internal-3"})
 	require.NoError(t, err)
 	require.NotNil(t, res)
-	require.NotNil(t, res.DataServerInfo)
-	require.NotNil(t, res.DataServerInfo.DataServer)
-	require.NotNil(t, res.DataServerInfo.DataServer.Name)
-	assert.Equal(t, "internal-3", *res.DataServerInfo.DataServer.Name)
-	assert.Equal(t, "public-3", res.DataServerInfo.DataServer.GetPublic())
-	assert.Equal(t, "internal-3", res.DataServerInfo.DataServer.GetInternal())
-	assert.Equal(t, map[string]string{"role": "fallback"}, res.DataServerInfo.Metadata.GetLabels())
+	require.NotNil(t, res.DataServer)
+	require.NotNil(t, res.DataServer.Identity)
+	require.NotNil(t, res.DataServer.Identity.Name)
+	assert.Equal(t, "internal-3", *res.DataServer.Identity.Name)
+	assert.Equal(t, "public-3", res.DataServer.Identity.GetPublic())
+	assert.Equal(t, "internal-3", res.DataServer.Identity.GetInternal())
+	assert.Equal(t, map[string]string{"role": "fallback"}, res.DataServer.Metadata.GetLabels())
 
 	_, err = admin.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: "internal-2"})
 	require.Error(t, err)
@@ -188,7 +194,7 @@ func TestAdminServerGetDataServerByIdentifierFallback(t *testing.T) {
 func TestAdminServerGetDataServerNotFound(t *testing.T) {
 	admin := newAdminServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{
-			Servers: []*proto.DataServer{
+			Servers: []*proto.DataServerIdentity{
 				dataServer(nil, "public-1", "internal-1"),
 			},
 		}),

--- a/oxiad/coordinator/balancer/model/load_ratio.go
+++ b/oxiad/coordinator/balancer/model/load_ratio.go
@@ -27,11 +27,11 @@ import (
 type ShardInfo struct {
 	Namespace string
 	ShardID   int64
-	Ensemble  []*commonproto.DataServer
+	Ensemble  []*commonproto.DataServerIdentity
 }
 
 type RatioParams struct {
-	HistoryNodes    map[string]*commonproto.DataServer
+	HistoryNodes    map[string]*commonproto.DataServerIdentity
 	NodeShardsInfos map[string][]ShardInfo
 	QuarantineNodes *linkedhashset.Set[string]
 }
@@ -122,7 +122,7 @@ func NewRatio(maxNodeLoadRatio float64, minNodeLoadRatio float64, avgShardLoadRa
 
 type NodeLoadRatio struct {
 	NodeID      string
-	Node        *commonproto.DataServer
+	Node        *commonproto.DataServerIdentity
 	Ratio       float64
 	ShardRatios *arraylist.List[*ShardLoadRatio]
 }

--- a/oxiad/coordinator/balancer/scheduler.go
+++ b/oxiad/coordinator/balancer/scheduler.go
@@ -213,7 +213,7 @@ func (r *nodeBasedBalancer) cleanDeletedNode(loadRatios *model.Ratio,
 
 func (r *nodeBasedBalancer) swapShard(
 	candidateShard *model.ShardLoadRatio,
-	fromNode *commonproto.DataServer,
+	fromNode *commonproto.DataServerIdentity,
 	swapGroup *sync.WaitGroup,
 	loadRatios *model.Ratio,
 	candidates *linkedhashset.Set[string],
@@ -260,7 +260,7 @@ func (r *nodeBasedBalancer) swapShard(
 	if targetNodeID == fromNodeID {
 		return false, nil
 	}
-	var targetNode *commonproto.DataServer
+	var targetNode *commonproto.DataServerIdentity
 	if targetNode, exist = r.metadata.Node(targetNodeID); !exist {
 		return false, errors.New("target node does not exist")
 	}

--- a/oxiad/coordinator/balancer/scheduler_test.go
+++ b/oxiad/coordinator/balancer/scheduler_test.go
@@ -36,12 +36,12 @@ type mockMetadata struct {
 	nodes     *linkedhashset.Set[string]
 	metadata  map[string]*proto.DataServerMetadata
 	nsConfigs map[string]*proto.Namespace
-	nodeMap   map[string]*proto.DataServer
+	nodeMap   map[string]*proto.DataServerIdentity
 	lbConfig  *proto.LoadBalancer
 }
 
-func dataServer(id string) *proto.DataServer {
-	return &proto.DataServer{
+func dataServer(id string) *proto.DataServerIdentity {
+	return &proto.DataServerIdentity{
 		Internal: id,
 	}
 }
@@ -93,12 +93,12 @@ func (m *mockMetadata) Namespace(namespace string) (*proto.Namespace, bool) {
 	return nc, ok
 }
 
-func (m *mockMetadata) Node(id string) (*proto.DataServer, bool) {
+func (m *mockMetadata) Node(id string) (*proto.DataServerIdentity, bool) {
 	n, ok := m.nodeMap[id]
 	return n, ok
 }
 
-func (m *mockMetadata) GetDataServerInfo(id string) (*proto.DataServerInfo, bool) {
+func (m *mockMetadata) GetDataServer(id string) (*proto.DataServer, bool) {
 	n, ok := m.nodeMap[id]
 	if !ok {
 		return nil, false
@@ -107,9 +107,9 @@ func (m *mockMetadata) GetDataServerInfo(id string) (*proto.DataServerInfo, bool
 	if !ok {
 		metadata = &proto.DataServerMetadata{}
 	}
-	return &proto.DataServerInfo{
-		DataServer: n,
-		Metadata:   metadata,
+	return &proto.DataServer{
+		Identity: n,
+		Metadata: metadata,
 	}, true
 }
 
@@ -165,9 +165,9 @@ func TestSwapShardSkipsRF1Namespace(t *testing.T) {
 			"rf1ns": {
 				ReplicationFactor: 1,
 				Shards: map[int64]*proto.ShardMetadata{
-					0: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServer{sv1}},
-					1: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServer{sv1}},
-					2: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServer{sv1}},
+					0: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServerIdentity{sv1}},
+					1: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServerIdentity{sv1}},
+					2: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServerIdentity{sv1}},
 				},
 			},
 		},
@@ -182,7 +182,7 @@ func TestSwapShardSkipsRF1Namespace(t *testing.T) {
 		nsConfigs: map[string]*proto.Namespace{
 			"rf1ns": {Name: "rf1ns", ReplicationFactor: 1},
 		},
-		nodeMap: map[string]*proto.DataServer{
+		nodeMap: map[string]*proto.DataServerIdentity{
 			"sv-1": sv1,
 			"sv-2": sv2,
 		},
@@ -217,13 +217,13 @@ func TestBalanceHighestNodeDoesNotHangOnSelectorError(t *testing.T) {
 			"ns": {
 				ReplicationFactor: 3,
 				Shards: map[int64]*proto.ShardMetadata{
-					0: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServer{sv1, sv2, sv3}},
-					1: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServer{sv1, sv2, sv3}},
-					2: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServer{sv1, sv2, sv3}},
-					3: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServer{sv1, sv2, sv3}},
-					4: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServer{sv1, sv2, sv3}},
-					5: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServer{sv2, sv3}},
-					6: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServer{sv3}},
+					0: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServerIdentity{sv1, sv2, sv3}},
+					1: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServerIdentity{sv1, sv2, sv3}},
+					2: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServerIdentity{sv1, sv2, sv3}},
+					3: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServerIdentity{sv1, sv2, sv3}},
+					4: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServerIdentity{sv1, sv2, sv3}},
+					5: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServerIdentity{sv2, sv3}},
+					6: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServerIdentity{sv3}},
 				},
 			},
 		},
@@ -237,7 +237,7 @@ func TestBalanceHighestNodeDoesNotHangOnSelectorError(t *testing.T) {
 		nsConfigs: map[string]*proto.Namespace{
 			"ns": {Name: "ns", ReplicationFactor: 3},
 		},
-		nodeMap: map[string]*proto.DataServer{
+		nodeMap: map[string]*proto.DataServerIdentity{
 			"sv-1": sv1,
 			"sv-2": sv2,
 			"sv-3": sv3,

--- a/oxiad/coordinator/balancer/selector/leader/context.go
+++ b/oxiad/coordinator/balancer/selector/leader/context.go
@@ -17,6 +17,6 @@ package leader
 import commonproto "github.com/oxia-db/oxia/common/proto"
 
 type Context struct {
-	Candidates []*commonproto.DataServer
+	Candidates []*commonproto.DataServerIdentity
 	Status     *commonproto.ClusterStatus
 }

--- a/oxiad/coordinator/balancer/selector/leader/lowerest_leaders_selector.go
+++ b/oxiad/coordinator/balancer/selector/leader/lowerest_leaders_selector.go
@@ -24,11 +24,11 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/util"
 )
 
-var _ selector.Selector[*Context, *commonproto.DataServer] = &leader{}
+var _ selector.Selector[*Context, *commonproto.DataServerIdentity] = &leader{}
 
 type leader struct{}
 
-func (*leader) Select(context *Context) (*commonproto.DataServer, error) {
+func (*leader) Select(context *Context) (*commonproto.DataServerIdentity, error) {
 	if len(context.Candidates) == 0 {
 		return nil, selector.ErrNoCandidates
 	}
@@ -41,7 +41,7 @@ func (*leader) Select(context *Context) (*commonproto.DataServer, error) {
 	_, _, leaders := util.NodeShardLeaders(candidates, status)
 
 	minLeaders := -1
-	var minLeadersNode *commonproto.DataServer
+	var minLeadersNode *commonproto.DataServerIdentity
 
 	for idx, candidate := range context.Candidates {
 		if shards, exist := leaders[candidate.GetNameOrDefault()]; exist {
@@ -58,6 +58,6 @@ func (*leader) Select(context *Context) (*commonproto.DataServer, error) {
 	return minLeadersNode, nil
 }
 
-func NewSelector() selector.Selector[*Context, *commonproto.DataServer] {
+func NewSelector() selector.Selector[*Context, *commonproto.DataServerIdentity] {
 	return &leader{}
 }

--- a/oxiad/coordinator/balancer/selector/leader/lowerest_leaders_selector_test.go
+++ b/oxiad/coordinator/balancer/selector/leader/lowerest_leaders_selector_test.go
@@ -27,7 +27,7 @@ func TestSelect_NoCandidates(t *testing.T) {
 	s := NewSelector()
 
 	_, err := s.Select(&Context{
-		Candidates: []*proto.DataServer{},
+		Candidates: []*proto.DataServerIdentity{},
 		Status:     proto.NewClusterStatus(),
 	})
 	assert.ErrorIs(t, err, selector.ErrNoCandidates)
@@ -47,7 +47,7 @@ func TestSelect_SingleCandidate(t *testing.T) {
 	s := NewSelector()
 
 	server, err := s.Select(&Context{
-		Candidates: []*proto.DataServer{
+		Candidates: []*proto.DataServerIdentity{
 			{Internal: "127.0.0.1:6601", Public: "127.0.0.1:6611"},
 		},
 		Status: proto.NewClusterStatus(),

--- a/oxiad/coordinator/balancer/selector/single/load_ratio_algorithms_test.go
+++ b/oxiad/coordinator/balancer/selector/single/load_ratio_algorithms_test.go
@@ -24,36 +24,36 @@ import (
 )
 
 func TestDefaultShardsRank(t *testing.T) {
-	ds := func(id string) *proto.DataServer {
-		return &proto.DataServer{Internal: id}
+	ds := func(id string) *proto.DataServerIdentity {
+		return &proto.DataServerIdentity{Internal: id}
 	}
 
 	params := &model.RatioParams{
 		NodeShardsInfos: map[string][]model.ShardInfo{
 			"sv-1": {
-				{Namespace: "ns-1", ShardID: 1, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-2", ShardID: 2, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-3", ShardID: 3, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-4", ShardID: 4, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-3"), ds("sv-4")}},
-				{Namespace: "ns-5", ShardID: 5, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-4"), ds("sv-5")}},
+				{Namespace: "ns-1", ShardID: 1, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-2", ShardID: 2, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-3", ShardID: 3, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-4", ShardID: 4, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-3"), ds("sv-4")}},
+				{Namespace: "ns-5", ShardID: 5, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-4"), ds("sv-5")}},
 			},
 			"sv-2": {
-				{Namespace: "ns-1", ShardID: 1, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-2", ShardID: 2, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-3", ShardID: 3, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-1", ShardID: 1, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-2", ShardID: 2, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-3", ShardID: 3, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
 			},
 			"sv-3": {
-				{Namespace: "ns-1", ShardID: 1, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-2", ShardID: 2, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-3", ShardID: 3, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-4", ShardID: 4, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-3"), ds("sv-4")}},
+				{Namespace: "ns-1", ShardID: 1, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-2", ShardID: 2, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-3", ShardID: 3, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-4", ShardID: 4, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-3"), ds("sv-4")}},
 			},
 			"sv-4": {
-				{Namespace: "ns-4", ShardID: 4, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-3"), ds("sv-4")}},
-				{Namespace: "ns-5", ShardID: 5, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-4"), ds("sv-5")}},
+				{Namespace: "ns-4", ShardID: 4, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-3"), ds("sv-4")}},
+				{Namespace: "ns-5", ShardID: 5, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-4"), ds("sv-5")}},
 			},
 			"sv-5": {
-				{Namespace: "ns-5", ShardID: 5, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-4"), ds("sv-5")}},
+				{Namespace: "ns-5", ShardID: 5, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-4"), ds("sv-5")}},
 			},
 		},
 	}

--- a/oxiad/coordinator/balancer/selector/single/lowerest_load_selector_test.go
+++ b/oxiad/coordinator/balancer/selector/single/lowerest_load_selector_test.go
@@ -27,8 +27,8 @@ import (
 
 func TestSelectLowerestLoadSelector(t *testing.T) {
 	llSelector := &lowerestLoadSelector{}
-	ds := func(id string) *proto.DataServer {
-		return &proto.DataServer{Internal: id}
+	ds := func(id string) *proto.DataServerIdentity {
+		return &proto.DataServerIdentity{Internal: id}
 	}
 	_, err := llSelector.Select(&Context{
 		LoadRatioSupplier: nil,
@@ -37,29 +37,29 @@ func TestSelectLowerestLoadSelector(t *testing.T) {
 	ratioSnapshot := DefaultShardsRank(&model.RatioParams{
 		NodeShardsInfos: map[string][]model.ShardInfo{
 			"sv-1": {
-				{Namespace: "ns-1", ShardID: 1, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-2", ShardID: 2, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-3", ShardID: 3, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-4", ShardID: 4, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-3"), ds("sv-4")}},
-				{Namespace: "ns-5", ShardID: 5, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-4"), ds("sv-5")}},
+				{Namespace: "ns-1", ShardID: 1, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-2", ShardID: 2, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-3", ShardID: 3, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-4", ShardID: 4, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-3"), ds("sv-4")}},
+				{Namespace: "ns-5", ShardID: 5, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-4"), ds("sv-5")}},
 			},
 			"sv-2": {
-				{Namespace: "ns-1", ShardID: 1, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-2", ShardID: 2, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-3", ShardID: 3, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-1", ShardID: 1, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-2", ShardID: 2, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-3", ShardID: 3, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
 			},
 			"sv-3": {
-				{Namespace: "ns-1", ShardID: 1, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-2", ShardID: 2, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-3", ShardID: 3, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
-				{Namespace: "ns-4", ShardID: 4, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-3"), ds("sv-4")}},
+				{Namespace: "ns-1", ShardID: 1, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-2", ShardID: 2, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-3", ShardID: 3, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-2"), ds("sv-3")}},
+				{Namespace: "ns-4", ShardID: 4, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-3"), ds("sv-4")}},
 			},
 			"sv-4": {
-				{Namespace: "ns-4", ShardID: 4, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-3"), ds("sv-4")}},
-				{Namespace: "ns-5", ShardID: 5, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-4"), ds("sv-5")}},
+				{Namespace: "ns-4", ShardID: 4, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-3"), ds("sv-4")}},
+				{Namespace: "ns-5", ShardID: 5, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-4"), ds("sv-5")}},
 			},
 			"sv-5": {
-				{Namespace: "ns-5", ShardID: 5, Ensemble: []*proto.DataServer{ds("sv-1"), ds("sv-4"), ds("sv-5")}},
+				{Namespace: "ns-5", ShardID: 5, Ensemble: []*proto.DataServerIdentity{ds("sv-1"), ds("sv-4"), ds("sv-5")}},
 			},
 		},
 	})
@@ -148,7 +148,7 @@ func makeShardInfos(nodeID string, count int, startID int) []model.ShardInfo {
 		shards[i] = model.ShardInfo{
 			Namespace: "ns",
 			ShardID:   int64(startID + i),
-			Ensemble:  []*proto.DataServer{{Internal: nodeID}},
+			Ensemble:  []*proto.DataServerIdentity{{Internal: nodeID}},
 		}
 	}
 	return shards

--- a/oxiad/coordinator/controller/dataserver_controller.go
+++ b/oxiad/coordinator/controller/dataserver_controller.go
@@ -76,7 +76,7 @@ type dataServerController struct {
 
 	ctx        context.Context
 	cancel     context.CancelFunc
-	dataServer *proto.DataServer
+	dataServer *proto.DataServerIdentity
 	rpc        rpc.Provider
 	insID      string
 	closed     atomic.Bool
@@ -347,7 +347,7 @@ func (n *dataServerController) healthCheckHandler(response *grpc_health_v1.Healt
 	return nil
 }
 
-func NewDataServerController(ctx context.Context, dataServer *proto.DataServer,
+func NewDataServerController(ctx context.Context, dataServer *proto.DataServerIdentity,
 	shardAssignmentsProvider ShardAssignmentsProvider,
 	dataServerEventListener DataServerEventListener,
 	rpcProvider rpc.Provider,
@@ -355,7 +355,7 @@ func NewDataServerController(ctx context.Context, dataServer *proto.DataServer,
 	return newDataServerController(ctx, dataServer, shardAssignmentsProvider, dataServerEventListener, rpcProvider, insID, defaultInitialRetryBackoff)
 }
 
-func newDataServerController(ctx context.Context, dataServer *proto.DataServer,
+func newDataServerController(ctx context.Context, dataServer *proto.DataServerIdentity,
 	shardAssignmentsProvider ShardAssignmentsProvider,
 	dataServerEventListener DataServerEventListener,
 	rpcProvider rpc.Provider,

--- a/oxiad/coordinator/controller/dataserver_controller_test.go
+++ b/oxiad/coordinator/controller/dataserver_controller_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestDataServerController_HealthCheck(t *testing.T) {
-	addr := &proto.DataServer{
+	addr := &proto.DataServerIdentity{
 		Public:   "my-server:9190",
 		Internal: "my-server:8190",
 	}
@@ -69,7 +69,7 @@ func TestDataServerController_HealthCheck(t *testing.T) {
 }
 
 func TestDataServerController_HandshakeOnlyCalledOnStateTransition(t *testing.T) {
-	addr := &proto.DataServer{
+	addr := &proto.DataServerIdentity{
 		Public:   "my-server:9190",
 		Internal: "my-server:8190",
 	}
@@ -129,7 +129,7 @@ func TestDataServerController_HandshakeOnlyCalledOnStateTransition(t *testing.T)
 }
 
 func TestDataServerController_ShardsAssignments(t *testing.T) {
-	addr := &proto.DataServer{
+	addr := &proto.DataServerIdentity{
 		Public:   "my-server:9190",
 		Internal: "my-server:8190",
 	}

--- a/oxiad/coordinator/controller/dataserver_event_listener.go
+++ b/oxiad/coordinator/controller/dataserver_event_listener.go
@@ -17,5 +17,5 @@ package controller
 import commonproto "github.com/oxia-db/oxia/common/proto"
 
 type DataServerEventListener interface {
-	BecameUnavailable(dataServer *commonproto.DataServer)
+	BecameUnavailable(dataServer *commonproto.DataServerIdentity)
 }

--- a/oxiad/coordinator/controller/mock_test.go
+++ b/oxiad/coordinator/controller/mock_test.go
@@ -82,16 +82,16 @@ func (sap *mockShardAssignmentsProvider) WaitForNextUpdate(ctx context.Context, 
 }
 
 type mockNodeAvailabilityListener struct {
-	events chan *proto.DataServer
+	events chan *proto.DataServerIdentity
 }
 
 func newMockNodeAvailabilityListener() *mockNodeAvailabilityListener {
 	return &mockNodeAvailabilityListener{
-		events: make(chan *proto.DataServer, 100),
+		events: make(chan *proto.DataServerIdentity, 100),
 	}
 }
 
-func (nal *mockNodeAvailabilityListener) BecameUnavailable(node *proto.DataServer) {
+func (nal *mockNodeAvailabilityListener) BecameUnavailable(node *proto.DataServerIdentity) {
 	nal.events <- node
 }
 
@@ -374,7 +374,7 @@ func (r *mockRpcProvider) Close() error {
 	return nil
 }
 
-func (r *mockRpcProvider) ClearPooledConnections(node *proto.DataServer) {
+func (r *mockRpcProvider) ClearPooledConnections(node *proto.DataServerIdentity) {
 }
 
 func newMockRpcProvider() *mockRpcProvider {
@@ -383,14 +383,14 @@ func newMockRpcProvider() *mockRpcProvider {
 	}
 }
 
-func (r *mockRpcProvider) FailNode(node *proto.DataServer, err error) {
+func (r *mockRpcProvider) FailNode(node *proto.DataServerIdentity, err error) {
 	r.Lock()
 	defer r.Unlock()
 
 	n := r.getNode(node)
 	n.err = err
 }
-func (r *mockRpcProvider) GetInfo(_ context.Context, node *proto.DataServer, _ *proto.GetInfoRequest) (*proto.GetInfoResponse, error) {
+func (r *mockRpcProvider) GetInfo(_ context.Context, node *proto.DataServerIdentity, _ *proto.GetInfoRequest) (*proto.GetInfoResponse, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -404,7 +404,7 @@ func (r *mockRpcProvider) GetInfo(_ context.Context, node *proto.DataServer, _ *
 	}, nil
 }
 
-func (r *mockRpcProvider) Handshake(_ context.Context, node *proto.DataServer, _ *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+func (r *mockRpcProvider) Handshake(_ context.Context, node *proto.DataServerIdentity, _ *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -419,7 +419,7 @@ func (r *mockRpcProvider) Handshake(_ context.Context, node *proto.DataServer, _
 	}, nil
 }
 
-func (r *mockRpcProvider) RecoverNode(node *proto.DataServer) {
+func (r *mockRpcProvider) RecoverNode(node *proto.DataServerIdentity) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -427,14 +427,14 @@ func (r *mockRpcProvider) RecoverNode(node *proto.DataServer) {
 	n.err = nil
 }
 
-func (r *mockRpcProvider) GetNode(node *proto.DataServer) *mockPerNodeChannels {
+func (r *mockRpcProvider) GetNode(node *proto.DataServerIdentity) *mockPerNodeChannels {
 	r.Lock()
 	defer r.Unlock()
 
 	return r.getNode(node)
 }
 
-func (r *mockRpcProvider) getNode(node *proto.DataServer) *mockPerNodeChannels {
+func (r *mockRpcProvider) getNode(node *proto.DataServerIdentity) *mockPerNodeChannels {
 	res, ok := r.channels[node.GetInternal()]
 	if ok {
 		return res
@@ -445,7 +445,7 @@ func (r *mockRpcProvider) getNode(node *proto.DataServer) *mockPerNodeChannels {
 	return res
 }
 
-func (r *mockRpcProvider) PushShardAssignments(ctx context.Context, node *proto.DataServer) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
+func (r *mockRpcProvider) PushShardAssignments(ctx context.Context, node *proto.DataServerIdentity) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -457,7 +457,7 @@ func (r *mockRpcProvider) PushShardAssignments(ctx context.Context, node *proto.
 	return n.shardAssignmentsStream, nil
 }
 
-func (r *mockRpcProvider) NewTerm(ctx context.Context, node *proto.DataServer, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
+func (r *mockRpcProvider) NewTerm(ctx context.Context, node *proto.DataServerIdentity, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
 	r.Lock()
 
 	s := r.getNode(node)
@@ -480,7 +480,7 @@ func (r *mockRpcProvider) NewTerm(ctx context.Context, node *proto.DataServer, r
 	}
 }
 
-func (r *mockRpcProvider) BecomeLeader(ctx context.Context, node *proto.DataServer, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
+func (r *mockRpcProvider) BecomeLeader(ctx context.Context, node *proto.DataServerIdentity, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
 	r.Lock()
 
 	s := r.getNode(node)
@@ -503,7 +503,7 @@ func (r *mockRpcProvider) BecomeLeader(ctx context.Context, node *proto.DataServ
 	}
 }
 
-func (r *mockRpcProvider) GetStatus(ctx context.Context, node *proto.DataServer, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
+func (r *mockRpcProvider) GetStatus(ctx context.Context, node *proto.DataServerIdentity, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
 	r.Lock()
 
 	s := r.getNode(node)
@@ -526,7 +526,7 @@ func (r *mockRpcProvider) GetStatus(ctx context.Context, node *proto.DataServer,
 	}
 }
 
-func (r *mockRpcProvider) DeleteShard(ctx context.Context, node *proto.DataServer, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
+func (r *mockRpcProvider) DeleteShard(ctx context.Context, node *proto.DataServerIdentity, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
 	r.Lock()
 
 	s := r.getNode(node)
@@ -549,7 +549,7 @@ func (r *mockRpcProvider) DeleteShard(ctx context.Context, node *proto.DataServe
 	}
 }
 
-func (r *mockRpcProvider) AddFollower(ctx context.Context, node *proto.DataServer, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error) {
+func (r *mockRpcProvider) AddFollower(ctx context.Context, node *proto.DataServerIdentity, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error) {
 	r.Lock()
 
 	s := r.getNode(node)
@@ -572,7 +572,7 @@ func (r *mockRpcProvider) AddFollower(ctx context.Context, node *proto.DataServe
 	}
 }
 
-func (r *mockRpcProvider) RemoveObserver(ctx context.Context, node *proto.DataServer, req *proto.RemoveObserverRequest) (*proto.RemoveObserverResponse, error) {
+func (r *mockRpcProvider) RemoveObserver(ctx context.Context, node *proto.DataServerIdentity, req *proto.RemoveObserverRequest) (*proto.RemoveObserverResponse, error) {
 	r.Lock()
 
 	s := r.getNode(node)
@@ -595,7 +595,7 @@ func (r *mockRpcProvider) RemoveObserver(ctx context.Context, node *proto.DataSe
 	}
 }
 
-func (r *mockRpcProvider) GetHealthClient(node *proto.DataServer) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (r *mockRpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, io.Closer, error) {
 	c := r.GetNode(node).healthClient
 	return c, c, nil
 }

--- a/oxiad/coordinator/controller/shard_controller.go
+++ b/oxiad/coordinator/controller/shard_controller.go
@@ -66,9 +66,9 @@ type ShardController interface {
 	ChangeEnsemble(changeEnsembleAction *action.ChangeEnsembleAction)
 }
 
-type DataServerSupportedFeaturesSupplier = func(dataServers []*proto.DataServer) map[string][]proto.Feature
+type DataServerSupportedFeaturesSupplier = func(dataServers []*proto.DataServerIdentity) map[string][]proto.Feature
 
-func NoOpSupportedFeaturesSupplier([]*proto.DataServer) map[string][]proto.Feature {
+func NoOpSupportedFeaturesSupplier([]*proto.DataServerIdentity) map[string][]proto.Feature {
 	return map[string][]proto.Feature{}
 }
 
@@ -79,7 +79,7 @@ type shardController struct {
 	rpc             rpc.Provider
 	metadata        Metadata
 
-	leaderSelector selector.Selector[*leaderselector.Context, *proto.DataServer]
+	leaderSelector selector.Selector[*leaderselector.Context, *proto.DataServerIdentity]
 
 	eventListener                       ShardEventListener
 	metadataStore                       coordmetadata.Metadata
@@ -87,7 +87,7 @@ type shardController struct {
 
 	electionOp          chan *action.ElectionAction
 	deleteOp            chan any
-	dataServerFailureOp chan *proto.DataServer
+	dataServerFailureOp chan *proto.DataServerIdentity
 	changeEnsembleOp    chan *action.ChangeEnsembleAction
 
 	ctx                   context.Context
@@ -109,7 +109,7 @@ func (s *shardController) Metadata() *Metadata {
 	return &s.metadata
 }
 
-func (s *shardController) BecameUnavailable(dataServer *proto.DataServer) {
+func (s *shardController) BecameUnavailable(dataServer *proto.DataServerIdentity) {
 	s.dataServerFailureOp <- dataServer
 }
 
@@ -137,7 +137,7 @@ func NewShardController(
 		leaderSelector:                      leaderselector.NewSelector(),
 		electionOp:                          make(chan *action.ElectionAction, chanBufferSize),
 		deleteOp:                            make(chan any, chanBufferSize),
-		dataServerFailureOp:                 make(chan *proto.DataServer, chanBufferSize),
+		dataServerFailureOp:                 make(chan *proto.DataServerIdentity, chanBufferSize),
 		changeEnsembleOp:                    make(chan *action.ChangeEnsembleAction, chanBufferSize),
 
 		periodicTasksInterval: periodTasksInterval,
@@ -279,7 +279,7 @@ func (s *shardController) waitForSplitComplete() {
 	}
 }
 
-func (s *shardController) handleDataServerFailure(failedDataServer *proto.DataServer) {
+func (s *shardController) handleDataServerFailure(failedDataServer *proto.DataServerIdentity) {
 	shardMeta := s.metadata.Load()
 	s.log.Debug(
 		"Received notification of failed data server",
@@ -348,7 +348,7 @@ func (s *shardController) verifyCurrentEnsemble(initShardMeta *proto.ShardMetada
 	return true
 }
 
-func (s *shardController) onElectLeader(changeEnsembleAction *action.ChangeEnsembleAction) *proto.DataServer {
+func (s *shardController) onElectLeader(changeEnsembleAction *action.ChangeEnsembleAction) *proto.DataServerIdentity {
 	// stop the current term election
 	if s.currentElection != nil {
 		s.currentElection.Stop()
@@ -375,7 +375,7 @@ func (s *shardController) onElectLeader(changeEnsembleAction *action.ChangeEnsem
 	return leaderDataServer
 }
 
-func (s *shardController) deleteShardRpc(ctx context.Context, dataServer *proto.DataServer) error {
+func (s *shardController) deleteShardRpc(ctx context.Context, dataServer *proto.DataServerIdentity) error {
 	_, err := s.rpc.DeleteShard(ctx, dataServer, &proto.DeleteShardRequest{
 		Namespace: s.namespace,
 		Shard:     s.shard,
@@ -474,7 +474,7 @@ func (s *shardController) SyncServerAddress() {
 	needSync := false
 	for _, candidate := range shardMeta.Ensemble {
 		if newInfo, ok := s.metadataStore.Node(candidate.GetNameOrDefault()); ok {
-			if newInfo.GetPublic() != candidate.Public || newInfo.GetInternal() != candidate.Internal {
+			if newInfo.GetPublic() != candidate.GetPublic() || newInfo.GetInternal() != candidate.GetInternal() {
 				needSync = true
 				break
 			}

--- a/oxiad/coordinator/controller/shard_controller_election.go
+++ b/oxiad/coordinator/controller/shard_controller_election.go
@@ -61,7 +61,7 @@ type ShardElection struct {
 	// borrowed resource
 	metadataStore                       coordmetadata.Metadata
 	dataServerSupportedFeaturesSupplier DataServerSupportedFeaturesSupplier
-	leaderSelector                      selector.Selector[*leaderselector.Context, *proto.DataServer]
+	leaderSelector                      selector.Selector[*leaderselector.Context, *proto.DataServerIdentity]
 	eventListener                       ShardEventListener
 	provider                            rpc.Provider
 	meta                                *Metadata
@@ -75,8 +75,8 @@ type ShardElection struct {
 	started atomic.Bool
 }
 
-func (e *ShardElection) refreshedEnsemble(ensemble []*proto.DataServer) []*proto.DataServer {
-	refreshedEnsembleDataServerAddress := make([]*proto.DataServer, len(ensemble))
+func (e *ShardElection) refreshedEnsemble(ensemble []*proto.DataServerIdentity) []*proto.DataServerIdentity {
+	refreshedEnsembleDataServerAddress := make([]*proto.DataServerIdentity, len(ensemble))
 	for idx, candidate := range ensemble {
 		if refreshedAddress, exist := e.metadataStore.Node(candidate.GetNameOrDefault()); exist {
 			refreshedEnsembleDataServerAddress[idx] = refreshedAddress
@@ -93,7 +93,7 @@ func (e *ShardElection) refreshedEnsemble(ensemble []*proto.DataServer) []*proto
 	return refreshedEnsembleDataServerAddress
 }
 
-func (e *ShardElection) fenceNewTerm(ctx context.Context, term int64, dataServer *proto.DataServer) (*proto.EntryId, error) {
+func (e *ShardElection) fenceNewTerm(ctx context.Context, term int64, dataServer *proto.DataServerIdentity) (*proto.EntryId, error) {
 	res, err := e.provider.NewTerm(ctx, dataServer, &proto.NewTermRequest{
 		Namespace: e.namespace,
 		Shard:     e.shard,
@@ -109,7 +109,7 @@ func (e *ShardElection) fenceNewTerm(ctx context.Context, term int64, dataServer
 
 // Send NewTerm to all the ensemble members in parallel and wait for
 // a majority of them to reply successfully.
-func (e *ShardElection) fenceNewTermQuorum(term int64, ensemble []*proto.DataServer, removedCandidates []*proto.DataServer) (map[*proto.DataServer]*proto.EntryId, error) {
+func (e *ShardElection) fenceNewTermQuorum(term int64, ensemble []*proto.DataServerIdentity, removedCandidates []*proto.DataServerIdentity) (map[*proto.DataServerIdentity]*proto.EntryId, error) {
 	fenceQuorumTimer := e.newTermQuorumLatency.Timer()
 
 	fencingDataServers := slices.Concat(ensemble, removedCandidates)
@@ -127,7 +127,7 @@ func (e *ShardElection) fenceNewTermQuorum(term int64, ensemble []*proto.DataSer
 
 	// Channel to receive responses or errors from each server
 	ch := make(chan struct {
-		DataServer *proto.DataServer
+		DataServer *proto.DataServerIdentity
 		EntryID    *proto.EntryId
 		Err        error
 	}, fencingQuorumSize)
@@ -150,7 +150,7 @@ func (e *ShardElection) fenceNewTermQuorum(term int64, ensemble []*proto.DataSer
 						e.Info("Processed fenceNewTerm response", slog.Any("data-server", pinedServer), slog.Any("entry-id", entryId))
 					}
 					ch <- struct {
-						DataServer *proto.DataServer
+						DataServer *proto.DataServerIdentity
 						EntryID    *proto.EntryId
 						Err        error
 					}{DataServer: pinedServer, EntryID: entryId, Err: err}
@@ -167,10 +167,10 @@ func (e *ShardElection) fenceNewTermQuorum(term int64, ensemble []*proto.DataSer
 }
 
 func (*ShardElection) waitForGracePeriod(ch chan struct {
-	DataServer *proto.DataServer
+	DataServer *proto.DataServerIdentity
 	EntryID    *proto.EntryId
 	Err        error
-}, fencingQuorumSize int, ensemble []*proto.DataServer, totalResponses int, candidatesResponse map[*proto.DataServer]*proto.EntryId) {
+}, fencingQuorumSize int, ensemble []*proto.DataServerIdentity, totalResponses int, candidatesResponse map[*proto.DataServerIdentity]*proto.EntryId) {
 	// If we have already reached a quorum of successful responses, we can wait a
 	// tiny bit more, to allow time for all the "healthy" data servers to respond.
 	for totalResponses < fencingQuorumSize {
@@ -191,11 +191,11 @@ func (*ShardElection) waitForGracePeriod(ch chan struct {
 }
 
 func (*ShardElection) waitForMajority(ch chan struct {
-	DataServer *proto.DataServer
+	DataServer *proto.DataServerIdentity
 	EntryID    *proto.EntryId
 	Err        error
-}, fencingQuorumSize int, majority int, ensemble []*proto.DataServer) (map[*proto.DataServer]*proto.EntryId, int, error) {
-	res := make(map[*proto.DataServer]*proto.EntryId)
+}, fencingQuorumSize int, majority int, ensemble []*proto.DataServerIdentity) (map[*proto.DataServerIdentity]*proto.EntryId, int, error) {
+	res := make(map[*proto.DataServerIdentity]*proto.EntryId)
 	successResponses := 0
 	totalResponses := 0
 	var err error
@@ -220,8 +220,8 @@ func (*ShardElection) waitForMajority(ch chan struct {
 	return res, totalResponses, nil
 }
 
-func (e *ShardElection) selectNewLeader(candidatesStatus map[*proto.DataServer]*proto.EntryId) (
-	leader *proto.DataServer, followers map[*proto.DataServer]*proto.EntryId, err error) {
+func (e *ShardElection) selectNewLeader(candidatesStatus map[*proto.DataServerIdentity]*proto.EntryId) (
+	leader *proto.DataServerIdentity, followers map[*proto.DataServerIdentity]*proto.EntryId, err error) {
 	candidates := chooseCandidates(candidatesStatus)
 	server, err := e.leaderSelector.Select(&leaderselector.Context{
 		Candidates: candidates,
@@ -231,7 +231,7 @@ func (e *ShardElection) selectNewLeader(candidatesStatus map[*proto.DataServer]*
 		return nil, nil, err
 	}
 	leader = server
-	followers = make(map[*proto.DataServer]*proto.EntryId)
+	followers = make(map[*proto.DataServerIdentity]*proto.EntryId)
 	for a, e := range candidatesStatus {
 		if a.GetNameOrDefault() != leader.GetNameOrDefault() {
 			followers[a] = e
@@ -240,7 +240,7 @@ func (e *ShardElection) selectNewLeader(candidatesStatus map[*proto.DataServer]*
 	return leader, followers, nil
 }
 
-func (e *ShardElection) becomeLeader(term int64, leader *proto.DataServer, followers map[*proto.DataServer]*proto.EntryId,
+func (e *ShardElection) becomeLeader(term int64, leader *proto.DataServerIdentity, followers map[*proto.DataServerIdentity]*proto.EntryId,
 	replicationFactor uint32, negotiateFeatures []proto.Feature) error {
 	becomeLeaderTimer := e.becomeLeaderLatency.Timer()
 
@@ -264,7 +264,7 @@ func (e *ShardElection) becomeLeader(term int64, leader *proto.DataServer, follo
 }
 
 // ensureFollowerCaught Must be called before we change ensemble to avoid any potential data lost.
-func (e *ShardElection) ensureFollowerCaught(ensemble []*proto.DataServer, leader *proto.DataServer, leaderEntry *proto.EntryId) {
+func (e *ShardElection) ensureFollowerCaught(ensemble []*proto.DataServerIdentity, leader *proto.DataServerIdentity, leaderEntry *proto.EntryId) {
 	waitGroup := sync.WaitGroup{}
 	for _, server := range ensemble {
 		if server.GetNameOrDefault() == leader.GetNameOrDefault() {
@@ -326,7 +326,7 @@ func (e *ShardElection) ensureFollowerCaught(ensemble []*proto.DataServer, leade
 	waitGroup.Wait()
 }
 
-func (e *ShardElection) fenceNewTermAndAddFollower(ctx context.Context, term int64, leader *proto.DataServer, follower *proto.DataServer) error {
+func (e *ShardElection) fenceNewTermAndAddFollower(ctx context.Context, term int64, leader *proto.DataServerIdentity, follower *proto.DataServerIdentity) error {
 	fr, err := e.fenceNewTerm(ctx, term, follower)
 	if err != nil {
 		return err
@@ -353,8 +353,8 @@ func (e *ShardElection) fenceNewTermAndAddFollower(ctx context.Context, term int
 	return nil
 }
 
-func (e *ShardElection) fencingFailedFollowers(term int64, ensemble []*proto.DataServer, leader *proto.DataServer,
-	successfulFollowers map[*proto.DataServer]*proto.EntryId) {
+func (e *ShardElection) fencingFailedFollowers(term int64, ensemble []*proto.DataServerIdentity, leader *proto.DataServerIdentity,
+	successfulFollowers map[*proto.DataServerIdentity]*proto.EntryId) {
 	if len(successfulFollowers) == len(ensemble)-1 {
 		e.Debug(
 			"All the member of the ensemble were successfully added",
@@ -415,17 +415,17 @@ func (e *ShardElection) fencingFailedFollowers(term int64, ensemble []*proto.Dat
 func (e *ShardElection) prepareIfChangeEnsemble(mutShardMeta *proto.ShardMetadata) {
 	from := e.changeEnsembleAction.From
 	to := e.changeEnsembleAction.To
-	if !slices.ContainsFunc(mutShardMeta.RemovedNodes, func(server *proto.DataServer) bool {
+	if !slices.ContainsFunc(mutShardMeta.RemovedNodes, func(server *proto.DataServerIdentity) bool {
 		return server.GetNameOrDefault() == from.GetNameOrDefault()
 	}) {
 		mutShardMeta.RemovedNodes = append(mutShardMeta.RemovedNodes, from)
 	}
 	// A dataServer might get re-added to the ensemble after it was swapped out and be in
 	// pending delete state. We don't want a background task to attempt deletion anymore
-	mutShardMeta.PendingDeleteShardNodes = slices.DeleteFunc(mutShardMeta.PendingDeleteShardNodes, func(dataServer *proto.DataServer) bool {
+	mutShardMeta.PendingDeleteShardNodes = slices.DeleteFunc(mutShardMeta.PendingDeleteShardNodes, func(dataServer *proto.DataServerIdentity) bool {
 		return dataServer.GetNameOrDefault() == to.GetNameOrDefault()
 	})
-	mutShardMeta.Ensemble = append(slices.DeleteFunc(mutShardMeta.Ensemble, func(dataServer *proto.DataServer) bool {
+	mutShardMeta.Ensemble = append(slices.DeleteFunc(mutShardMeta.Ensemble, func(dataServer *proto.DataServerIdentity) bool {
 		return dataServer.GetNameOrDefault() == from.GetNameOrDefault()
 	}), to)
 	e.Info(
@@ -437,7 +437,7 @@ func (e *ShardElection) prepareIfChangeEnsemble(mutShardMeta *proto.ShardMetadat
 	)
 }
 
-func (e *ShardElection) start() (*proto.DataServer, error) {
+func (e *ShardElection) start() (*proto.DataServerIdentity, error) {
 	e.Info("Starting a new election")
 	timer := e.leaderElectionLatency.Timer()
 
@@ -464,13 +464,13 @@ func (e *ShardElection) start() (*proto.DataServer, error) {
 	}
 	if e.Enabled(context.Background(), slog.LevelInfo) {
 		f := make([]struct {
-			ServerAddress *proto.DataServer `json:"server-address"`
-			EntryId       *proto.EntryId    `json:"entry-id"`
+			ServerAddress *proto.DataServerIdentity `json:"server-address"`
+			EntryId       *proto.EntryId            `json:"entry-id"`
 		}, 0)
 		for sa, entryId := range followers {
 			f = append(f, struct {
-				ServerAddress *proto.DataServer `json:"server-address"`
-				EntryId       *proto.EntryId    `json:"entry-id"`
+				ServerAddress *proto.DataServerIdentity `json:"server-address"`
+				EntryId       *proto.EntryId            `json:"entry-id"`
 			}{ServerAddress: sa, EntryId: entryId})
 		}
 		e.Info(
@@ -576,11 +576,11 @@ func (e *ShardElection) IsReadyForChangeEnsemble() bool {
 	return e.followerCaughtUp.Load()
 }
 
-func (e *ShardElection) Start() *proto.DataServer {
+func (e *ShardElection) Start() *proto.DataServerIdentity {
 	if swapped := e.started.CompareAndSwap(false, true); !swapped {
 		panic("bug! the election has been started")
 	}
-	newLeader, _ := backoff.RetryNotifyWithData[*proto.DataServer](func() (*proto.DataServer, error) {
+	newLeader, _ := backoff.RetryNotifyWithData[*proto.DataServerIdentity](func() (*proto.DataServerIdentity, error) {
 		return e.start()
 	}, oxiatime.NewBackOff(e.Context), func(err error, duration time.Duration) {
 		e.leaderElectionsFailed.Inc()
@@ -604,7 +604,7 @@ func (e *ShardElection) Stop() {
 func NewShardElection(ctx context.Context, logger *slog.Logger, eventListener ShardEventListener,
 	metadataStore coordmetadata.Metadata,
 	dataServerSupportedFeaturesSupplier DataServerSupportedFeaturesSupplier,
-	leaderSelector selector.Selector[*leaderselector.Context, *proto.DataServer],
+	leaderSelector selector.Selector[*leaderselector.Context, *proto.DataServerIdentity],
 	provider rpc.Provider, metadata *Metadata, namespace string, shard int64,
 	changeEnsembleAction *action.ChangeEnsembleAction, termOptions *proto.NewTermOptions,
 	leaderElectionLatency metric.LatencyHistogram, newTermQuorumLatency metric.LatencyHistogram,
@@ -632,23 +632,23 @@ func NewShardElection(ctx context.Context, logger *slog.Logger, eventListener Sh
 	}
 }
 
-func chooseCandidates(candidatesStatus map[*proto.DataServer]*proto.EntryId) []*proto.DataServer {
+func chooseCandidates(candidatesStatus map[*proto.DataServerIdentity]*proto.EntryId) []*proto.DataServerIdentity {
 	// Select all the data servers that have the highest term first
 	var currentMaxTerm int64 = -1
 	// Select all the data servers that have the highest entry in the wal
 	var currentMax int64 = -1
-	var candidates []*proto.DataServer
+	var candidates []*proto.DataServerIdentity
 	for addr, headEntryId := range candidatesStatus {
 		if headEntryId.Term > currentMaxTerm {
 			// the new max
 			currentMaxTerm = headEntryId.Term
 			currentMax = headEntryId.Offset
-			candidates = []*proto.DataServer{addr}
+			candidates = []*proto.DataServerIdentity{addr}
 		} else if headEntryId.Term == currentMaxTerm {
 			if headEntryId.Offset > currentMax {
 				// the new max
 				currentMax = headEntryId.Offset
-				candidates = []*proto.DataServer{addr}
+				candidates = []*proto.DataServerIdentity{addr}
 			} else if headEntryId.Offset == currentMax {
 				candidates = append(candidates, addr)
 			}

--- a/oxiad/coordinator/controller/shard_controller_election_test.go
+++ b/oxiad/coordinator/controller/shard_controller_election_test.go
@@ -24,12 +24,12 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 )
 
-func testDataServer(id string) *proto.DataServer {
-	return &proto.DataServer{Internal: id, Public: id}
+func testDataServer(id string) *proto.DataServerIdentity {
+	return &proto.DataServerIdentity{Internal: id, Public: id}
 }
 
 type electionResponse = struct {
-	DataServer *proto.DataServer
+	DataServer *proto.DataServerIdentity
 	EntryID    *proto.EntryId
 	Err        error
 }
@@ -143,7 +143,7 @@ func TestWaitForMajority_Success(t *testing.T) {
 	server1 := testDataServer("server1")
 	server2 := testDataServer("server2")
 	server3 := testDataServer("server3")
-	ensemble := []*proto.DataServer{server1, server2, server3}
+	ensemble := []*proto.DataServerIdentity{server1, server2, server3}
 
 	ch := make(chan electionResponse, 3)
 	ch <- electionResponse{DataServer: server1, EntryID: &proto.EntryId{Term: 1, Offset: 100}}
@@ -163,7 +163,7 @@ func TestWaitForMajority_FailureNoQuorum(t *testing.T) {
 	server1 := testDataServer("server1")
 	server2 := testDataServer("server2")
 	server3 := testDataServer("server3")
-	ensemble := []*proto.DataServer{server1, server2, server3}
+	ensemble := []*proto.DataServerIdentity{server1, server2, server3}
 
 	ch := make(chan electionResponse, 3)
 	ch <- electionResponse{DataServer: server1, EntryID: &proto.EntryId{Term: 1, Offset: 100}}
@@ -183,7 +183,7 @@ func TestWaitForMajority_MixedSuccessAndFailure(t *testing.T) {
 	server1 := testDataServer("server1")
 	server2 := testDataServer("server2")
 	server3 := testDataServer("server3")
-	ensemble := []*proto.DataServer{server1, server2, server3}
+	ensemble := []*proto.DataServerIdentity{server1, server2, server3}
 
 	ch := make(chan electionResponse, 3)
 	ch <- electionResponse{DataServer: server1, EntryID: &proto.EntryId{Term: 1, Offset: 100}}
@@ -205,7 +205,7 @@ func TestWaitForMajority_ExcludesRemovedServers(t *testing.T) {
 	server2 := testDataServer("server2")
 	server3 := testDataServer("server3")
 	removedServer := testDataServer("removed")
-	ensemble := []*proto.DataServer{server1, server2, server3}
+	ensemble := []*proto.DataServerIdentity{server1, server2, server3}
 
 	ch := make(chan electionResponse, 4)
 	ch <- electionResponse{DataServer: server1, EntryID: &proto.EntryId{Term: 1, Offset: 100}}
@@ -227,7 +227,7 @@ func TestWaitForMajority_EarlyReturn(t *testing.T) {
 	server1 := testDataServer("server1")
 	server2 := testDataServer("server2")
 	server3 := testDataServer("server3")
-	ensemble := []*proto.DataServer{server1, server2, server3}
+	ensemble := []*proto.DataServerIdentity{server1, server2, server3}
 
 	ch := make(chan electionResponse, 3)
 	ch <- electionResponse{DataServer: server1, EntryID: &proto.EntryId{Term: 1, Offset: 100}}
@@ -245,9 +245,9 @@ func TestWaitForGracePeriod_AllResponsesReceived(t *testing.T) {
 	server1 := testDataServer("server1")
 	server2 := testDataServer("server2")
 	server3 := testDataServer("server3")
-	ensemble := []*proto.DataServer{server1, server2, server3}
+	ensemble := []*proto.DataServerIdentity{server1, server2, server3}
 
-	candidatesResponse := map[*proto.DataServer]*proto.EntryId{
+	candidatesResponse := map[*proto.DataServerIdentity]*proto.EntryId{
 		server1: {Term: 1, Offset: 100},
 	}
 
@@ -267,9 +267,9 @@ func TestWaitForGracePeriod_Timeout(t *testing.T) {
 	e := &ShardElection{}
 	server1 := testDataServer("server1")
 	server2 := testDataServer("server2")
-	ensemble := []*proto.DataServer{server1, server2}
+	ensemble := []*proto.DataServerIdentity{server1, server2}
 
-	candidatesResponse := map[*proto.DataServer]*proto.EntryId{
+	candidatesResponse := map[*proto.DataServerIdentity]*proto.EntryId{
 		server1: {Term: 1, Offset: 100},
 	}
 
@@ -289,9 +289,9 @@ func TestWaitForGracePeriod_IgnoresErrors(t *testing.T) {
 	server1 := testDataServer("server1")
 	server2 := testDataServer("server2")
 	server3 := testDataServer("server3")
-	ensemble := []*proto.DataServer{server1, server2, server3}
+	ensemble := []*proto.DataServerIdentity{server1, server2, server3}
 
-	candidatesResponse := map[*proto.DataServer]*proto.EntryId{
+	candidatesResponse := map[*proto.DataServerIdentity]*proto.EntryId{
 		server1: {Term: 1, Offset: 100},
 	}
 
@@ -312,9 +312,9 @@ func TestWaitForGracePeriod_ExcludesRemovedServers(t *testing.T) {
 	server1 := testDataServer("server1")
 	server2 := testDataServer("server2")
 	removedServer := testDataServer("removed")
-	ensemble := []*proto.DataServer{server1, server2}
+	ensemble := []*proto.DataServerIdentity{server1, server2}
 
-	candidatesResponse := map[*proto.DataServer]*proto.EntryId{
+	candidatesResponse := map[*proto.DataServerIdentity]*proto.EntryId{
 		server1: {Term: 1, Offset: 100},
 	}
 
@@ -334,9 +334,9 @@ func TestWaitForGracePeriod_AlreadyComplete(t *testing.T) {
 	e := &ShardElection{}
 	server1 := testDataServer("server1")
 	server2 := testDataServer("server2")
-	ensemble := []*proto.DataServer{server1, server2}
+	ensemble := []*proto.DataServerIdentity{server1, server2}
 
-	candidatesResponse := map[*proto.DataServer]*proto.EntryId{
+	candidatesResponse := map[*proto.DataServerIdentity]*proto.EntryId{
 		server1: {Term: 1, Offset: 100},
 		server2: {Term: 1, Offset: 95},
 	}

--- a/oxiad/coordinator/controller/shard_controller_metadata.go
+++ b/oxiad/coordinator/controller/shard_controller_metadata.go
@@ -52,7 +52,7 @@ func (s *Metadata) Status() string {
 	return s.shardMetadata.GetStatusOrDefault()
 }
 
-func (s *Metadata) Leader() *commonproto.DataServer {
+func (s *Metadata) Leader() *commonproto.DataServerIdentity {
 	s.RLock()
 	defer s.RUnlock()
 	return s.shardMetadata.GetLeader()

--- a/oxiad/coordinator/controller/shard_controller_test.go
+++ b/oxiad/coordinator/controller/shard_controller_test.go
@@ -58,42 +58,42 @@ func newTestMetadata(t *testing.T, metadataProvider provider.Provider, clusterCo
 func TestLeaderElection_ShouldChooseHighestTerm(t *testing.T) {
 	tests := []struct {
 		name           string
-		candidates     map[*proto.DataServer]*proto.EntryId
-		expectedLeader *proto.DataServer
+		candidates     map[*proto.DataServerIdentity]*proto.EntryId
+		expectedLeader *proto.DataServerIdentity
 	}{
 		{
 			name: "Choose highest term",
-			candidates: map[*proto.DataServer]*proto.EntryId{
+			candidates: map[*proto.DataServerIdentity]*proto.EntryId{
 				{Public: "1", Internal: "1"}: {Term: 200, Offset: 2480},
 				{Public: "2", Internal: "2"}: {Term: 200, Offset: 2500},
 				{Public: "3", Internal: "3"}: {Term: 198, Offset: 3000},
 			},
-			expectedLeader: &proto.DataServer{Public: "2", Internal: "2"},
+			expectedLeader: &proto.DataServerIdentity{Public: "2", Internal: "2"},
 		},
 		{
 			name: "Same term, different offsets",
-			candidates: map[*proto.DataServer]*proto.EntryId{
+			candidates: map[*proto.DataServerIdentity]*proto.EntryId{
 				{Public: "1", Internal: "1"}: {Term: 200, Offset: 1000},
 				{Public: "2", Internal: "2"}: {Term: 200, Offset: 2000},
 				{Public: "3", Internal: "3"}: {Term: 200, Offset: 1500},
 			},
-			expectedLeader: &proto.DataServer{Public: "2", Internal: "2"},
+			expectedLeader: &proto.DataServerIdentity{Public: "2", Internal: "2"},
 		},
 		{
 			name: "Different terms, same offsets",
-			candidates: map[*proto.DataServer]*proto.EntryId{
+			candidates: map[*proto.DataServerIdentity]*proto.EntryId{
 				{Public: "1", Internal: "1"}: {Term: 200, Offset: 1500},
 				{Public: "2", Internal: "2"}: {Term: 198, Offset: 1500},
 				{Public: "3", Internal: "3"}: {Term: 199, Offset: 1500},
 			},
-			expectedLeader: &proto.DataServer{Public: "1", Internal: "1"},
+			expectedLeader: &proto.DataServerIdentity{Public: "1", Internal: "1"},
 		},
 		{
 			name: "Single candidate",
-			candidates: map[*proto.DataServer]*proto.EntryId{
+			candidates: map[*proto.DataServerIdentity]*proto.EntryId{
 				{Public: "1", Internal: "1"}: {Term: 200, Offset: 1500},
 			},
-			expectedLeader: &proto.DataServer{Public: "1", Internal: "1"},
+			expectedLeader: &proto.DataServerIdentity{Public: "1", Internal: "1"},
 		},
 	}
 
@@ -114,9 +114,9 @@ func TestShardController(t *testing.T) {
 	var shard int64 = 5
 	rpc := newMockRpcProvider()
 
-	s1 := &proto.DataServer{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := &proto.DataServer{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := &proto.DataServer{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
 
 	metadata := newTestMetadata(t, memory.NewProvider(), &proto.ClusterConfiguration{})
 
@@ -124,7 +124,7 @@ func TestShardController(t *testing.T) {
 		Status:   proto.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []*proto.DataServer{s1, s2, s3},
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
 	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
 
 	// Shard controller should initiate a leader election
@@ -189,9 +189,9 @@ func TestShardController_StartingWithLeaderAlreadyPresent(t *testing.T) {
 	var shard int64 = 5
 	rpc := newMockRpcProvider()
 
-	s1 := &proto.DataServer{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := &proto.DataServer{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := &proto.DataServer{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
 	n1 := rpc.GetNode(s1)
 	n2 := rpc.GetNode(s2)
 	n3 := rpc.GetNode(s3)
@@ -202,7 +202,7 @@ func TestShardController_StartingWithLeaderAlreadyPresent(t *testing.T) {
 		Status:   proto.ShardStatusSteadyState,
 		Term:     1,
 		Leader:   s1,
-		Ensemble: []*proto.DataServer{s1, s2, s3},
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
 	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
 
 	n1.expectGetStatusRequest(t, shard)
@@ -223,9 +223,9 @@ func TestShardController_NewTermWithNonRespondingServer(t *testing.T) {
 	var shard int64 = 5
 	rpc := newMockRpcProvider()
 
-	s1 := &proto.DataServer{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := &proto.DataServer{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := &proto.DataServer{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
 
 	metadata := newTestMetadata(t, memory.NewProvider(), &proto.ClusterConfiguration{})
 
@@ -233,7 +233,7 @@ func TestShardController_NewTermWithNonRespondingServer(t *testing.T) {
 		Status:   proto.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []*proto.DataServer{s1, s2, s3},
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
 	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
 
 	timeStart := time.Now()
@@ -270,9 +270,9 @@ func TestShardController_NewTermFollowerUntilItRecovers(t *testing.T) {
 	var shard int64 = 5
 	rpc := newMockRpcProvider()
 
-	s1 := &proto.DataServer{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := &proto.DataServer{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := &proto.DataServer{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
 
 	metadata := newTestMetadata(t, memory.NewProvider(), &proto.ClusterConfiguration{})
 
@@ -280,7 +280,7 @@ func TestShardController_NewTermFollowerUntilItRecovers(t *testing.T) {
 		Status:   proto.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []*proto.DataServer{s1, s2, s3},
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
 	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
 
 	// s3 is failing, though we can still elect a leader
@@ -322,9 +322,9 @@ func TestShardController_VerifyFollowersWereAllFenced(t *testing.T) {
 	var shard int64 = 5
 	rpc := newMockRpcProvider()
 
-	s1 := &proto.DataServer{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := &proto.DataServer{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := &proto.DataServer{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
 	n1 := rpc.GetNode(s1)
 	n2 := rpc.GetNode(s2)
 	n3 := rpc.GetNode(s3)
@@ -335,7 +335,7 @@ func TestShardController_VerifyFollowersWereAllFenced(t *testing.T) {
 		Status:   proto.ShardStatusSteadyState,
 		Term:     4,
 		Leader:   s1,
-		Ensemble: []*proto.DataServer{s1, s2, s3},
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
 	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
 
 	n1.expectGetStatusRequest(t, 5)
@@ -361,9 +361,9 @@ func TestShardController_NotificationsDisabled(t *testing.T) {
 	var shard int64 = 5
 	rpc := newMockRpcProvider()
 
-	s1 := &proto.DataServer{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := &proto.DataServer{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := &proto.DataServer{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
 
 	notificationsEnabled := false
 	metadata := newTestMetadata(t, memory.NewProvider(), &proto.ClusterConfiguration{
@@ -381,7 +381,7 @@ func TestShardController_NotificationsDisabled(t *testing.T) {
 		Status:   proto.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []*proto.DataServer{s1, s2, s3},
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
 	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
 
 	// Shard controller should initiate a leader election
@@ -403,10 +403,10 @@ func TestShardController_SwapNodeWithLeaderElectionFailure(t *testing.T) {
 	var shard int64 = 5
 	rpc := newMockRpcProvider()
 
-	s1 := &proto.DataServer{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := &proto.DataServer{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := &proto.DataServer{Public: "s3:9091", Internal: "s3:8191"}
-	s4 := &proto.DataServer{Public: "s4:9091", Internal: "s4:8191"}
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
+	s4 := &proto.DataServerIdentity{Public: "s4:9091", Internal: "s4:8191"}
 
 	metadata := newTestMetadata(t, memory.NewProvider(), &proto.ClusterConfiguration{})
 
@@ -414,7 +414,7 @@ func TestShardController_SwapNodeWithLeaderElectionFailure(t *testing.T) {
 		Status:   proto.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []*proto.DataServer{s1, s2, s3},
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
 	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
 
 	// Do initial election
@@ -501,10 +501,10 @@ func TestShardController_LeaderElectionShouldNotFailIfRemoveFails(t *testing.T) 
 	var shard int64 = 5
 	rpc := newMockRpcProvider()
 
-	s1 := &proto.DataServer{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := &proto.DataServer{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := &proto.DataServer{Public: "s3:9091", Internal: "s3:8191"}
-	s4 := &proto.DataServer{Public: "s4:9091", Internal: "s4:8191"}
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
+	s4 := &proto.DataServerIdentity{Public: "s4:9091", Internal: "s4:8191"}
 
 	metadata := newTestMetadata(t, memory.NewProvider(), &proto.ClusterConfiguration{})
 
@@ -512,7 +512,7 @@ func TestShardController_LeaderElectionShouldNotFailIfRemoveFails(t *testing.T) 
 		Status:   proto.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []*proto.DataServer{s1, s2, s3},
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
 	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, 1*time.Second)
 
 	// Do initial election
@@ -619,19 +619,19 @@ func TestShardController_ShardsDataLostWithChangeEnsemble(t *testing.T) {
 	var shardId = rand.Int63()
 	rpc := newMockRpcProvider()
 
-	s1 := &proto.DataServer{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := &proto.DataServer{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := &proto.DataServer{Public: "s3:9091", Internal: "s3:8191"}
-	s4 := &proto.DataServer{Public: "s4:9091", Internal: "s4:8191"}
-	s5 := &proto.DataServer{Public: "s5:9091", Internal: "s5:8191"}
-	s6 := &proto.DataServer{Public: "s6:9091", Internal: "s6:8191"}
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
+	s4 := &proto.DataServerIdentity{Public: "s4:9091", Internal: "s4:8191"}
+	s5 := &proto.DataServerIdentity{Public: "s5:9091", Internal: "s5:8191"}
+	s6 := &proto.DataServerIdentity{Public: "s6:9091", Internal: "s6:8191"}
 
 	metadata := newTestMetadata(t, memory.NewProvider(), &proto.ClusterConfiguration{})
 	sc := NewShardController(constant.DefaultNamespace, shardId, namespaceConfig, &proto.ShardMetadata{
 		Status:   proto.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []*proto.DataServer{s1, s2, s3},
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
 	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, 1*time.Second)
 
 	// Do initial election
@@ -663,7 +663,7 @@ func TestShardController_ShardsDataLostWithChangeEnsemble(t *testing.T) {
 	assert.Error(t, err)
 
 	metaSnap := sc.Metadata().Load()
-	assert.EqualValues(t, metaSnap.Ensemble, []*proto.DataServer{s1, s2, s3})
+	assert.EqualValues(t, metaSnap.Ensemble, []*proto.DataServerIdentity{s1, s2, s3})
 
 	// test become leader would not change metadata ensemble
 	wait := sync.WaitGroup{}
@@ -707,7 +707,7 @@ func TestShardController_ShardsDataLostWithChangeEnsemble(t *testing.T) {
 	wait.Wait()
 
 	metaSnap = sc.Metadata().Load()
-	assert.EqualValues(t, metaSnap.Ensemble, []*proto.DataServer{s1, s2, s3})
+	assert.EqualValues(t, metaSnap.Ensemble, []*proto.DataServerIdentity{s1, s2, s3})
 }
 
 // Test feature negotiation with all nodes supporting the same features.
@@ -715,9 +715,9 @@ func TestShardController_FeatureNegotiation_AllNodesSupport(t *testing.T) {
 	var shard int64 = 5
 	rpc := newMockRpcProvider()
 
-	s1 := &proto.DataServer{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := &proto.DataServer{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := &proto.DataServer{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
 
 	// All nodes support FINGERPRINT feature
 	rpc.GetNode(s1).SetNodeFeatures(feature.SupportedFeatures())
@@ -727,7 +727,7 @@ func TestShardController_FeatureNegotiation_AllNodesSupport(t *testing.T) {
 	metadata := newTestMetadata(t, memory.NewProvider(), &proto.ClusterConfiguration{})
 
 	// Create a feature supplier that queries the mock RPC
-	featureSupplier := func(servers []*proto.DataServer) map[string][]proto.Feature {
+	featureSupplier := func(servers []*proto.DataServerIdentity) map[string][]proto.Feature {
 		result := make(map[string][]proto.Feature)
 		for _, server := range servers {
 			info, err := rpc.GetInfo(context.Background(), server, &proto.GetInfoRequest{})
@@ -742,7 +742,7 @@ func TestShardController_FeatureNegotiation_AllNodesSupport(t *testing.T) {
 		Status:   proto.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []*proto.DataServer{s1, s2, s3},
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
 	}, metadata, featureSupplier, nil, rpc, DefaultPeriodicTasksInterval)
 
 	rpc.GetNode(s1).NewTermResponse(1, 0, nil)
@@ -770,9 +770,9 @@ func TestShardController_FeatureNegotiation_MixedVersions(t *testing.T) {
 	var shard int64 = 5
 	rpc := newMockRpcProvider()
 
-	s1 := &proto.DataServer{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := &proto.DataServer{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := &proto.DataServer{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
 
 	// s1 and s2 are new nodes with DB checksum support
 	rpc.GetNode(s1).SetNodeFeatures([]proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM})
@@ -782,7 +782,7 @@ func TestShardController_FeatureNegotiation_MixedVersions(t *testing.T) {
 
 	metadata := newTestMetadata(t, memory.NewProvider(), &proto.ClusterConfiguration{})
 
-	featureSupplier := func(servers []*proto.DataServer) map[string][]proto.Feature {
+	featureSupplier := func(servers []*proto.DataServerIdentity) map[string][]proto.Feature {
 		result := make(map[string][]proto.Feature)
 		for _, server := range servers {
 			info, err := rpc.GetInfo(context.Background(), server, &proto.GetInfoRequest{})
@@ -797,7 +797,7 @@ func TestShardController_FeatureNegotiation_MixedVersions(t *testing.T) {
 		Status:   proto.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []*proto.DataServer{s1, s2, s3},
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
 	}, metadata, featureSupplier, nil, rpc, DefaultPeriodicTasksInterval)
 
 	rpc.GetNode(s1).NewTermResponse(1, 0, nil)

--- a/oxiad/coordinator/controller/shard_event_listener.go
+++ b/oxiad/coordinator/controller/shard_event_listener.go
@@ -17,7 +17,7 @@ package controller
 import commonproto "github.com/oxia-db/oxia/common/proto"
 
 type ShardEventListener interface {
-	LeaderElected(shard int64, leader *commonproto.DataServer, followers []*commonproto.DataServer)
+	LeaderElected(shard int64, leader *commonproto.DataServerIdentity, followers []*commonproto.DataServerIdentity)
 
 	ShardDeleted(shard int64)
 }

--- a/oxiad/coordinator/controller/split_controller.go
+++ b/oxiad/coordinator/controller/split_controller.go
@@ -61,7 +61,7 @@ type SplitController struct {
 	eventListener SplitEventListener
 
 	// ensembleSelector selects server ensembles for new shards.
-	ensembleSelector func(namespace string) ([]*proto.DataServer, error)
+	ensembleSelector func(namespace string) ([]*proto.DataServerIdentity, error)
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -78,7 +78,7 @@ type SplitControllerConfig struct {
 	Metadata         coordmetadata.Metadata
 	RpcProvider      rpc.Provider
 	EventListener    SplitEventListener
-	EnsembleSelector func(namespace string) ([]*proto.DataServer, error)
+	EnsembleSelector func(namespace string) ([]*proto.DataServerIdentity, error)
 
 	// SplitTimeout is the maximum duration for the entire split operation.
 	// If the split does not complete within this time, it is aborted.
@@ -352,7 +352,7 @@ func (sc *SplitController) fenceAndElectChild(childId int64) error {
 
 // addChildObserver adds a child's leader as an observer follower on the parent
 // leader so the parent streams snapshots and WAL entries to it.
-func (sc *SplitController) addChildObserver(childId int64, parentLeader *proto.DataServer, parentTerm int64) error {
+func (sc *SplitController) addChildObserver(childId int64, parentLeader *proto.DataServerIdentity, parentTerm int64) error {
 	childMeta := sc.loadShardMeta(childId)
 	if childMeta == nil || childMeta.Leader == nil {
 		return errors.Errorf("child shard %d has no leader", childId)
@@ -704,10 +704,10 @@ func (sc *SplitController) updateShardMeta(shardId int64, fn func(meta *proto.Sh
 func (sc *SplitController) fenceEnsemble(
 	shardId int64,
 	term int64,
-	ensemble []*proto.DataServer,
-) (map[*proto.DataServer]*proto.EntryId, error) {
+	ensemble []*proto.DataServerIdentity,
+) (map[*proto.DataServerIdentity]*proto.EntryId, error) {
 	type fenceResult struct {
-		server *proto.DataServer
+		server *proto.DataServerIdentity
 		entry  *proto.EntryId
 		err    error
 	}
@@ -736,7 +736,7 @@ func (sc *SplitController) fenceEnsemble(
 		close(ch)
 	}()
 
-	results := make(map[*proto.DataServer]*proto.EntryId)
+	results := make(map[*proto.DataServerIdentity]*proto.EntryId)
 	var lastErr error
 	for r := range ch {
 		if r.err != nil {
@@ -763,8 +763,8 @@ func (sc *SplitController) fenceEnsemble(
 
 // pickLeader chooses the server with the highest term/offset from the
 // fencing results.
-func (*SplitController) pickLeader(entries map[*proto.DataServer]*proto.EntryId) *proto.DataServer {
-	var best *proto.DataServer
+func (*SplitController) pickLeader(entries map[*proto.DataServerIdentity]*proto.EntryId) *proto.DataServerIdentity {
+	var best *proto.DataServerIdentity
 	var bestEntry *proto.EntryId
 
 	for server, entry := range entries {

--- a/oxiad/coordinator/controller/split_controller_test.go
+++ b/oxiad/coordinator/controller/split_controller_test.go
@@ -58,15 +58,15 @@ func (m *mockSplitEventListener) SplitAborted(parentShard int64, leftChild int64
 }
 
 var (
-	ps1 = &proto.DataServer{Public: "ps1:9091", Internal: "ps1:8191"}
-	ps2 = &proto.DataServer{Public: "ps2:9091", Internal: "ps2:8191"}
-	ps3 = &proto.DataServer{Public: "ps3:9091", Internal: "ps3:8191"}
-	ls1 = &proto.DataServer{Public: "ls1:9091", Internal: "ls1:8191"}
-	ls2 = &proto.DataServer{Public: "ls2:9091", Internal: "ls2:8191"}
-	ls3 = &proto.DataServer{Public: "ls3:9091", Internal: "ls3:8191"}
-	rs1 = &proto.DataServer{Public: "rs1:9091", Internal: "rs1:8191"}
-	rs2 = &proto.DataServer{Public: "rs2:9091", Internal: "rs2:8191"}
-	rs3 = &proto.DataServer{Public: "rs3:9091", Internal: "rs3:8191"}
+	ps1 = &proto.DataServerIdentity{Public: "ps1:9091", Internal: "ps1:8191"}
+	ps2 = &proto.DataServerIdentity{Public: "ps2:9091", Internal: "ps2:8191"}
+	ps3 = &proto.DataServerIdentity{Public: "ps3:9091", Internal: "ps3:8191"}
+	ls1 = &proto.DataServerIdentity{Public: "ls1:9091", Internal: "ls1:8191"}
+	ls2 = &proto.DataServerIdentity{Public: "ls2:9091", Internal: "ls2:8191"}
+	ls3 = &proto.DataServerIdentity{Public: "ls3:9091", Internal: "ls3:8191"}
+	rs1 = &proto.DataServerIdentity{Public: "rs1:9091", Internal: "rs1:8191"}
+	rs2 = &proto.DataServerIdentity{Public: "rs2:9091", Internal: "rs2:8191"}
+	rs3 = &proto.DataServerIdentity{Public: "rs3:9091", Internal: "rs3:8191"}
 )
 
 // setupSplitTest creates a cluster status with a parent shard in SteadyState,
@@ -94,7 +94,7 @@ func setupSplitTest(t *testing.T, phase string) (
 						Status:   proto.ShardStatusSteadyState,
 						Term:     5,
 						Leader:   ps1,
-						Ensemble: []*proto.DataServer{ps1, ps2, ps3},
+						Ensemble: []*proto.DataServerIdentity{ps1, ps2, ps3},
 						Int32HashRange: &proto.HashRange{
 							Min: 0,
 							Max: 1000,
@@ -108,7 +108,7 @@ func setupSplitTest(t *testing.T, phase string) (
 					1: {
 						Status:   proto.ShardStatusSteadyState,
 						Term:     0,
-						Ensemble: []*proto.DataServer{ls1, ls2, ls3},
+						Ensemble: []*proto.DataServerIdentity{ls1, ls2, ls3},
 						Int32HashRange: &proto.HashRange{
 							Min: 0,
 							Max: 500,
@@ -122,7 +122,7 @@ func setupSplitTest(t *testing.T, phase string) (
 					2: {
 						Status:   proto.ShardStatusSteadyState,
 						Term:     0,
-						Ensemble: []*proto.DataServer{rs1, rs2, rs3},
+						Ensemble: []*proto.DataServerIdentity{rs1, rs2, rs3},
 						Int32HashRange: &proto.HashRange{
 							Min: 501,
 							Max: 1000,

--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -86,7 +86,7 @@ type coordinator struct {
 	rpc rpc.Provider
 }
 
-func (c *coordinator) LeaderElected(int64, *proto.DataServer, []*proto.DataServer) {
+func (c *coordinator) LeaderElected(int64, *proto.DataServerIdentity, []*proto.DataServerIdentity) {
 	c.Lock()
 	defer c.Unlock()
 	c.computeNewAssignments()
@@ -182,7 +182,7 @@ func (c *coordinator) ConfigChanged(newConfig *proto.ClusterConfiguration) {
 	c.loadBalancer.Trigger()
 }
 
-func (c *coordinator) findDataServerFeatures(dataServers []*proto.DataServer) map[string][]proto.Feature {
+func (c *coordinator) findDataServerFeatures(dataServers []*proto.DataServerIdentity) map[string][]proto.Feature {
 	features := make(map[string][]proto.Feature)
 	for _, dataServer := range dataServers {
 		dataServerID := dataServer.GetNameOrDefault()
@@ -201,7 +201,7 @@ func (c *coordinator) findDataServerFeatures(dataServers []*proto.DataServer) ma
 
 // selectNewEnsemble select a new server ensemble based on namespace policy and current cluster status.
 // It uses the ensemble selector to choose appropriate servers and returns the selected server metadata or an error.
-func (c *coordinator) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.ClusterStatus) ([]*proto.DataServer, error) {
+func (c *coordinator) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
 	nodes, nodesMetadata := c.metadata.NodesWithMetadata()
 	ensembleContext := &ensemble.Context{
 		Candidates:         nodes,
@@ -219,9 +219,9 @@ func (c *coordinator) selectNewEnsemble(ns *proto.Namespace, editingStatus *prot
 	if ensembles, err = c.ensembleSelector.Select(ensembleContext); err != nil {
 		return nil, err
 	}
-	esm := make([]*proto.DataServer, 0)
+	esm := make([]*proto.DataServerIdentity, 0)
 	for _, id := range ensembles {
-		var node *proto.DataServer
+		var node *proto.DataServerIdentity
 		var exist bool
 		if node, exist = c.metadata.Node(id); !exist {
 			return nil, fmt.Errorf("failed to find node %s", id)
@@ -254,7 +254,7 @@ func (c *coordinator) Close() error {
 	return err
 }
 
-func (c *coordinator) BecameUnavailable(node *proto.DataServer) {
+func (c *coordinator) BecameUnavailable(node *proto.DataServerIdentity) {
 	c.Lock()
 	if nc, ok := c.drainingNodes[node.GetNameOrDefault()]; ok {
 		// The draining node became unavailable. Let's remove it
@@ -418,7 +418,7 @@ func (c *coordinator) computeNewAssignments() {
 	c.assignmentsChanged.Broadcast()
 }
 
-func mergedAuthorities(status *proto.ClusterStatus, servers []*proto.DataServer, extraAuthorities []string) []string {
+func mergedAuthorities(status *proto.ClusterStatus, servers []*proto.DataServerIdentity, extraAuthorities []string) []string {
 	authorities := linkedhashset.New[string]()
 	addServerAuthorities := func(public string, internal string) {
 		authorities.Add(public)
@@ -586,7 +586,7 @@ func (c *coordinator) InitiateSplit(namespace string, parentShardId int64, split
 		Metadata:      c.metadata,
 		RpcProvider:   c.rpc,
 		EventListener: c,
-		EnsembleSelector: func(ns string) ([]*proto.DataServer, error) {
+		EnsembleSelector: func(ns string) ([]*proto.DataServerIdentity, error) {
 			return c.selectNewEnsemble(c.namespaceConfigForSplit(ns), c.metadata.LoadStatus())
 		},
 	})
@@ -702,7 +702,7 @@ func (c *coordinator) restartInProgressSplits(clusterStatus *proto.ClusterStatus
 				Metadata:      c.metadata,
 				RpcProvider:   c.rpc,
 				EventListener: c,
-				EnsembleSelector: func(namespace string) ([]*proto.DataServer, error) {
+				EnsembleSelector: func(namespace string) ([]*proto.DataServerIdentity, error) {
 					return c.selectNewEnsemble(c.namespaceConfigForSplit(namespace), c.metadata.LoadStatus())
 				},
 			})

--- a/oxiad/coordinator/coordinator_authority_test.go
+++ b/oxiad/coordinator/coordinator_authority_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
-	leader := &proto.DataServer{
+	leader := &proto.DataServerIdentity{
 		Public:   "leader-public:6648",
 		Internal: "leader-internal:6649",
 	}
@@ -40,7 +40,7 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 			InitialShardCount: 1,
 			ReplicationFactor: 1,
 		}},
-		Servers: []*proto.DataServer{{
+		Servers: []*proto.DataServerIdentity{{
 			Public:   leader.Public,
 			Internal: leader.Internal,
 		}},
@@ -66,7 +66,7 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 					0: {
 						Status:   proto.ShardStatusUnknown,
 						Leader:   leader,
-						Ensemble: []*proto.DataServer{leader},
+						Ensemble: []*proto.DataServerIdentity{leader},
 						Int32HashRange: &proto.HashRange{
 							Min: 0,
 							Max: 100,
@@ -94,11 +94,11 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 }
 
 func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
-	active := &proto.DataServer{
+	active := &proto.DataServerIdentity{
 		Public:   "active-public:6648",
 		Internal: "active-internal:6649",
 	}
-	removed := &proto.DataServer{
+	removed := &proto.DataServerIdentity{
 		Public:   "removed-public:6648",
 		Internal: "removed-internal:6649",
 	}
@@ -109,7 +109,7 @@ func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
 			InitialShardCount: 1,
 			ReplicationFactor: 1,
 		}},
-		Servers: []*proto.DataServer{{
+		Servers: []*proto.DataServerIdentity{{
 			Public:   active.Public,
 			Internal: active.Internal,
 		}},
@@ -131,8 +131,8 @@ func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
 					0: {
 						Status:       proto.ShardStatusUnknown,
 						Leader:       removed,
-						Ensemble:     []*proto.DataServer{removed},
-						RemovedNodes: []*proto.DataServer{removed},
+						Ensemble:     []*proto.DataServerIdentity{removed},
+						RemovedNodes: []*proto.DataServerIdentity{removed},
 						Int32HashRange: &proto.HashRange{
 							Min: 0,
 							Max: 100,

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -51,11 +51,11 @@ type Metadata interface {
 	Nodes() *linkedhashset.Set[string]
 	NodesWithMetadata() (*linkedhashset.Set[string], map[string]*commonproto.DataServerMetadata)
 	Namespace(namespace string) (*commonproto.Namespace, bool)
-	Node(id string) (*commonproto.DataServer, bool)
-	GetDataServerInfo(name string) (*commonproto.DataServerInfo, bool)
+	Node(id string) (*commonproto.DataServerIdentity, bool)
+	GetDataServer(name string) (*commonproto.DataServer, bool)
 }
 
-type EnsembleSupplier func(namespaceConfig *commonproto.Namespace, status *commonproto.ClusterStatus) ([]*commonproto.DataServer, error)
+type EnsembleSupplier func(namespaceConfig *commonproto.Namespace, status *commonproto.ClusterStatus) ([]*commonproto.DataServerIdentity, error)
 
 type coordinatorMetadata struct {
 	*slog.Logger
@@ -77,7 +77,7 @@ type coordinatorMetadata struct {
 	clusterConfigLock     sync.RWMutex
 	currentClusterConfig  *commonproto.ClusterConfiguration
 	clusterConfigWatch    *commonoption.Watch[*commonproto.ClusterConfiguration]
-	nodesIndex            *redblacktree.Tree[string, *commonproto.DataServer]
+	nodesIndex            *redblacktree.Tree[string, *commonproto.DataServerIdentity]
 	namespaceConfigsIndex *redblacktree.Tree[string, *commonproto.Namespace]
 }
 
@@ -288,7 +288,7 @@ func (m *coordinatorMetadata) loadClusterConfigWithInitSlow() {
 }
 
 func (m *coordinatorMetadata) rebuildConfigIndexesLocked() {
-	nodes := redblacktree.New[string, *commonproto.DataServer]()
+	nodes := redblacktree.New[string, *commonproto.DataServerIdentity]()
 	for _, server := range m.currentClusterConfig.GetServers() {
 		nodes.Put(server.GetNameOrDefault(), server)
 	}
@@ -399,7 +399,7 @@ func (m *coordinatorMetadata) Namespace(namespace string) (*commonproto.Namespac
 	return m.namespaceConfigsIndex.Get(namespace)
 }
 
-func (m *coordinatorMetadata) Node(id string) (*commonproto.DataServer, bool) {
+func (m *coordinatorMetadata) Node(id string) (*commonproto.DataServerIdentity, bool) {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -410,7 +410,7 @@ func (m *coordinatorMetadata) Node(id string) (*commonproto.DataServer, bool) {
 	return m.nodesIndex.Get(id)
 }
 
-func (m *coordinatorMetadata) GetDataServerInfo(id string) (*commonproto.DataServerInfo, bool) {
+func (m *coordinatorMetadata) GetDataServer(id string) (*commonproto.DataServer, bool) {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -419,7 +419,7 @@ func (m *coordinatorMetadata) GetDataServerInfo(id string) (*commonproto.DataSer
 		m.clusterConfigLock.RLock()
 	}
 
-	return m.currentClusterConfig.GetDataServerInfo(id)
+	return m.currentClusterConfig.GetDataServer(id)
 }
 
 func WaitForCondition(ctx context.Context, metadata Metadata, triggerFn func(), condition func(*commonproto.ClusterStatus) bool) error {

--- a/oxiad/coordinator/rpc/rpc_provider.go
+++ b/oxiad/coordinator/rpc/rpc_provider.go
@@ -36,18 +36,18 @@ const rpcTimeout = 30 * time.Second
 type Provider interface {
 	io.Closer
 
-	PushShardAssignments(ctx context.Context, node *proto.DataServer) (proto.OxiaCoordination_PushShardAssignmentsClient, error)
-	NewTerm(ctx context.Context, node *proto.DataServer, req *proto.NewTermRequest) (*proto.NewTermResponse, error)
-	BecomeLeader(ctx context.Context, node *proto.DataServer, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error)
-	AddFollower(ctx context.Context, node *proto.DataServer, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error)
-	GetStatus(ctx context.Context, node *proto.DataServer, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error)
-	DeleteShard(ctx context.Context, node *proto.DataServer, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error)
-	Handshake(ctx context.Context, node *proto.DataServer, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error)
-	RemoveObserver(ctx context.Context, node *proto.DataServer, req *proto.RemoveObserverRequest) (*proto.RemoveObserverResponse, error)
+	PushShardAssignments(ctx context.Context, node *proto.DataServerIdentity) (proto.OxiaCoordination_PushShardAssignmentsClient, error)
+	NewTerm(ctx context.Context, node *proto.DataServerIdentity, req *proto.NewTermRequest) (*proto.NewTermResponse, error)
+	BecomeLeader(ctx context.Context, node *proto.DataServerIdentity, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error)
+	AddFollower(ctx context.Context, node *proto.DataServerIdentity, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error)
+	GetStatus(ctx context.Context, node *proto.DataServerIdentity, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error)
+	DeleteShard(ctx context.Context, node *proto.DataServerIdentity, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error)
+	Handshake(ctx context.Context, node *proto.DataServerIdentity, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error)
+	RemoveObserver(ctx context.Context, node *proto.DataServerIdentity, req *proto.RemoveObserverRequest) (*proto.RemoveObserverResponse, error)
 
-	GetHealthClient(node *proto.DataServer) (grpc_health_v1.HealthClient, io.Closer, error)
+	GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, io.Closer, error)
 
-	ClearPooledConnections(node *proto.DataServer)
+	ClearPooledConnections(node *proto.DataServerIdentity)
 }
 
 type rpcProvider struct {
@@ -68,7 +68,7 @@ func (r *rpcProvider) Close() error {
 	return r.pool.Close()
 }
 
-func (r *rpcProvider) PushShardAssignments(ctx context.Context, node *proto.DataServer) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
+func (r *rpcProvider) PushShardAssignments(ctx context.Context, node *proto.DataServerIdentity) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
 	client, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func (r *rpcProvider) PushShardAssignments(ctx context.Context, node *proto.Data
 	return client.PushShardAssignments(ctx)
 }
 
-func (r *rpcProvider) NewTerm(ctx context.Context, node *proto.DataServer, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
+func (r *rpcProvider) NewTerm(ctx context.Context, node *proto.DataServerIdentity, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
 	client, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -89,7 +89,7 @@ func (r *rpcProvider) NewTerm(ctx context.Context, node *proto.DataServer, req *
 	return client.NewTerm(ctx, req)
 }
 
-func (r *rpcProvider) BecomeLeader(ctx context.Context, node *proto.DataServer, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
+func (r *rpcProvider) BecomeLeader(ctx context.Context, node *proto.DataServerIdentity, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
 	client, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func (r *rpcProvider) BecomeLeader(ctx context.Context, node *proto.DataServer, 
 	return client.BecomeLeader(ctx, req)
 }
 
-func (r *rpcProvider) AddFollower(ctx context.Context, node *proto.DataServer, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error) {
+func (r *rpcProvider) AddFollower(ctx context.Context, node *proto.DataServerIdentity, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error) {
 	client, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func (r *rpcProvider) AddFollower(ctx context.Context, node *proto.DataServer, r
 	return client.AddFollower(ctx, req)
 }
 
-func (r *rpcProvider) GetStatus(ctx context.Context, node *proto.DataServer, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
+func (r *rpcProvider) GetStatus(ctx context.Context, node *proto.DataServerIdentity, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
 	client, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -125,7 +125,7 @@ func (r *rpcProvider) GetStatus(ctx context.Context, node *proto.DataServer, req
 	return client.GetStatus(ctx, req)
 }
 
-func (r *rpcProvider) Handshake(ctx context.Context, node *proto.DataServer, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+func (r *rpcProvider) Handshake(ctx context.Context, node *proto.DataServerIdentity, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
 	client, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -154,7 +154,7 @@ func (r *rpcProvider) Handshake(ctx context.Context, node *proto.DataServer, req
 	}, nil
 }
 
-func (r *rpcProvider) DeleteShard(ctx context.Context, node *proto.DataServer, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
+func (r *rpcProvider) DeleteShard(ctx context.Context, node *proto.DataServerIdentity, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
 	client, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -166,7 +166,7 @@ func (r *rpcProvider) DeleteShard(ctx context.Context, node *proto.DataServer, r
 	return client.DeleteShard(ctx, req)
 }
 
-func (r *rpcProvider) RemoveObserver(ctx context.Context, node *proto.DataServer, req *proto.RemoveObserverRequest) (*proto.RemoveObserverResponse, error) {
+func (r *rpcProvider) RemoveObserver(ctx context.Context, node *proto.DataServerIdentity, req *proto.RemoveObserverRequest) (*proto.RemoveObserverResponse, error) {
 	client, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -178,10 +178,10 @@ func (r *rpcProvider) RemoveObserver(ctx context.Context, node *proto.DataServer
 	return client.RemoveObserver(ctx, req)
 }
 
-func (r *rpcProvider) GetHealthClient(node *proto.DataServer) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (r *rpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, io.Closer, error) {
 	return r.pool.GetHealthRpc(node.Internal)
 }
 
-func (r *rpcProvider) ClearPooledConnections(node *proto.DataServer) {
+func (r *rpcProvider) ClearPooledConnections(node *proto.DataServerIdentity) {
 	r.pool.Clear(node.Internal)
 }

--- a/oxiad/coordinator/util/cluster_updates.go
+++ b/oxiad/coordinator/util/cluster_updates.go
@@ -31,7 +31,7 @@ func findNamespaceConfig(config *commonproto.ClusterConfiguration, ns string) *c
 	return nil
 }
 
-func ApplyClusterChanges(config *commonproto.ClusterConfiguration, status *commonproto.ClusterStatus, ensembleSupplier func(namespaceConfig *commonproto.Namespace, status *commonproto.ClusterStatus) ([]*commonproto.DataServer, error)) (
+func ApplyClusterChanges(config *commonproto.ClusterConfiguration, status *commonproto.ClusterStatus, ensembleSupplier func(namespaceConfig *commonproto.Namespace, status *commonproto.ClusterStatus) ([]*commonproto.DataServerIdentity, error)) (
 	shardsToAdd map[int64]string,
 	shardsToDelete []int64) {
 	shardsToAdd = map[int64]string{}
@@ -60,7 +60,7 @@ func ApplyClusterChanges(config *commonproto.ClusterConfiguration, status *commo
 		status.Namespaces[nc.GetName()] = nss
 
 		for _, shard := range sharding.GenerateShards(status.ShardIdGenerator, nc.GetInitialShardCount()) {
-			var esm []*commonproto.DataServer
+			var esm []*commonproto.DataServerIdentity
 			if esm, err = ensembleSupplier(nc, status); err != nil {
 				slog.Error("failed to select new ensembles.", slog.Any("shard", shard), slog.Any("error", err))
 				continue

--- a/oxiad/coordinator/util/cluster_updates_test.go
+++ b/oxiad/coordinator/util/cluster_updates_test.go
@@ -30,7 +30,7 @@ func hashRange(start, end uint32) *proto.HashRange {
 	return &proto.HashRange{Min: start, Max: end}
 }
 
-func shardMetadata(status string, ensemble []*proto.DataServer, start, end uint32) *proto.ShardMetadata {
+func shardMetadata(status string, ensemble []*proto.DataServerIdentity, start, end uint32) *proto.ShardMetadata {
 	return &proto.ShardMetadata{
 		Status:         status,
 		Term:           -1,
@@ -39,8 +39,8 @@ func shardMetadata(status string, ensemble []*proto.DataServer, start, end uint3
 	}
 }
 
-func loadAwareEnsembleSupplier(servers []*proto.DataServer) func(*proto.Namespace, *proto.ClusterStatus) ([]*proto.DataServer, error) {
-	return func(nc *proto.Namespace, cs *proto.ClusterStatus) ([]*proto.DataServer, error) {
+func loadAwareEnsembleSupplier(servers []*proto.DataServerIdentity) func(*proto.Namespace, *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
+	return func(nc *proto.Namespace, cs *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
 		load := make(map[string]int, len(servers))
 		for _, s := range servers {
 			load[s.GetInternal()] = 0
@@ -52,7 +52,7 @@ func loadAwareEnsembleSupplier(servers []*proto.DataServer) func(*proto.Namespac
 				}
 			}
 		}
-		ranked := make([]*proto.DataServer, len(servers))
+		ranked := make([]*proto.DataServerIdentity, len(servers))
 		copy(ranked, servers)
 		sort.SliceStable(ranked, func(i, j int) bool {
 			return load[ranked[i].GetInternal()] < load[ranked[j].GetInternal()]
@@ -75,7 +75,7 @@ func assertStatusEqual(t *testing.T, expected, actual *proto.ClusterStatus) {
 // pseudo-random initial placement that immediately tripped the count-based
 // load-balancer once the cluster came up.
 func TestClientUpdates_InitialPlacementSeesPriorShards(t *testing.T) {
-	servers := []*proto.DataServer{s1, s2, s3, s4}
+	servers := []*proto.DataServerIdentity{s1, s2, s3, s4}
 	const shardCount = 16
 	const rf = 3
 
@@ -108,14 +108,14 @@ func TestClientUpdates_InitialPlacementSeesPriorShards(t *testing.T) {
 }
 
 var (
-	s1 = &proto.DataServer{Public: "s1:6648", Internal: "s1:6649"}
-	s2 = &proto.DataServer{Public: "s2:6648", Internal: "s2:6649"}
-	s3 = &proto.DataServer{Public: "s3:6648", Internal: "s3:6649"}
-	s4 = &proto.DataServer{Public: "s4:6648", Internal: "s4:6649"}
+	s1 = &proto.DataServerIdentity{Public: "s1:6648", Internal: "s1:6649"}
+	s2 = &proto.DataServerIdentity{Public: "s2:6648", Internal: "s2:6649"}
+	s3 = &proto.DataServerIdentity{Public: "s3:6648", Internal: "s3:6649"}
+	s4 = &proto.DataServerIdentity{Public: "s4:6648", Internal: "s4:6649"}
 )
 
 func TestClientUpdates_ClusterInit(t *testing.T) {
-	servers := []*proto.DataServer{s1, s2, s3, s4}
+	servers := []*proto.DataServerIdentity{s1, s2, s3, s4}
 	status := proto.NewClusterStatus()
 	shardsAdded, shardsToRemove := ApplyClusterChanges(&proto.ClusterConfiguration{
 		Namespaces: []*proto.Namespace{{
@@ -128,7 +128,7 @@ func TestClientUpdates_ClusterInit(t *testing.T) {
 			ReplicationFactor: 3,
 		}},
 		Servers: servers,
-	}, status, func(namespaceConfig *proto.Namespace, status *proto.ClusterStatus) ([]*proto.DataServer, error) {
+	}, status, func(namespaceConfig *proto.Namespace, status *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
 		return SimpleEnsembleSupplier(servers, namespaceConfig, status), nil
 	})
 
@@ -137,14 +137,14 @@ func TestClientUpdates_ClusterInit(t *testing.T) {
 			"ns-1": {
 				ReplicationFactor: 3,
 				Shards: map[int64]*proto.ShardMetadata{
-					0: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServer{s1, s2, s3}, 0, math.MaxUint32),
+					0: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s1, s2, s3}, 0, math.MaxUint32),
 				},
 			},
 			"ns-2": {
 				ReplicationFactor: 3,
 				Shards: map[int64]*proto.ShardMetadata{
-					1: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServer{s4, s1, s2}, 0, math.MaxUint32/2),
-					2: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServer{s3, s4, s1}, math.MaxUint32/2+1, math.MaxUint32),
+					1: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s4, s1, s2}, 0, math.MaxUint32/2),
+					2: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s3, s4, s1}, math.MaxUint32/2+1, math.MaxUint32),
 				},
 			},
 		},
@@ -161,13 +161,13 @@ func TestClientUpdates_ClusterInit(t *testing.T) {
 }
 
 func TestClientUpdates_NamespaceAdded(t *testing.T) {
-	servers := []*proto.DataServer{s1, s2, s3, s4}
+	servers := []*proto.DataServerIdentity{s1, s2, s3, s4}
 	status := &proto.ClusterStatus{
 		Namespaces: map[string]*proto.NamespaceStatus{
 			"ns-1": {
 				ReplicationFactor: 3,
 				Shards: map[int64]*proto.ShardMetadata{
-					0: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServer{s1, s2, s3}, 0, math.MaxUint32),
+					0: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s1, s2, s3}, 0, math.MaxUint32),
 				},
 			},
 		},
@@ -185,7 +185,7 @@ func TestClientUpdates_NamespaceAdded(t *testing.T) {
 			ReplicationFactor: 3,
 		}},
 		Servers: servers,
-	}, status, func(namespaceConfig *proto.Namespace, status *proto.ClusterStatus) ([]*proto.DataServer, error) {
+	}, status, func(namespaceConfig *proto.Namespace, status *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
 		return SimpleEnsembleSupplier(servers, namespaceConfig, status), nil
 	})
 
@@ -194,14 +194,14 @@ func TestClientUpdates_NamespaceAdded(t *testing.T) {
 			"ns-1": {
 				ReplicationFactor: 3,
 				Shards: map[int64]*proto.ShardMetadata{
-					0: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServer{s1, s2, s3}, 0, math.MaxUint32),
+					0: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s1, s2, s3}, 0, math.MaxUint32),
 				},
 			},
 			"ns-2": {
 				ReplicationFactor: 3,
 				Shards: map[int64]*proto.ShardMetadata{
-					1: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServer{s4, s1, s2}, 0, math.MaxUint32/2),
-					2: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServer{s3, s4, s1}, math.MaxUint32/2+1, math.MaxUint32),
+					1: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s4, s1, s2}, 0, math.MaxUint32/2),
+					2: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s3, s4, s1}, math.MaxUint32/2+1, math.MaxUint32),
 				},
 			},
 		},
@@ -217,20 +217,20 @@ func TestClientUpdates_NamespaceAdded(t *testing.T) {
 }
 
 func TestClientUpdates_NamespaceRemoved(t *testing.T) {
-	servers := []*proto.DataServer{s1, s2, s3, s4}
+	servers := []*proto.DataServerIdentity{s1, s2, s3, s4}
 	status := &proto.ClusterStatus{
 		Namespaces: map[string]*proto.NamespaceStatus{
 			"ns-1": {
 				ReplicationFactor: 3,
 				Shards: map[int64]*proto.ShardMetadata{
-					0: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServer{s1, s2, s3}, 0, math.MaxUint32),
+					0: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s1, s2, s3}, 0, math.MaxUint32),
 				},
 			},
 			"ns-2": {
 				ReplicationFactor: 3,
 				Shards: map[int64]*proto.ShardMetadata{
-					1: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServer{s4, s1, s2}, 0, math.MaxUint32/2),
-					2: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServer{s3, s4, s1}, math.MaxUint32/2+1, math.MaxUint32),
+					1: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s4, s1, s2}, 0, math.MaxUint32/2),
+					2: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s3, s4, s1}, math.MaxUint32/2+1, math.MaxUint32),
 				},
 			},
 		},
@@ -244,7 +244,7 @@ func TestClientUpdates_NamespaceRemoved(t *testing.T) {
 			ReplicationFactor: 3,
 		}},
 		Servers: servers,
-	}, status, func(namespaceConfig *proto.Namespace, status *proto.ClusterStatus) ([]*proto.DataServer, error) {
+	}, status, func(namespaceConfig *proto.Namespace, status *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
 		return SimpleEnsembleSupplier(servers, namespaceConfig, status), nil
 	})
 
@@ -253,14 +253,14 @@ func TestClientUpdates_NamespaceRemoved(t *testing.T) {
 			"ns-1": {
 				ReplicationFactor: 3,
 				Shards: map[int64]*proto.ShardMetadata{
-					0: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServer{s1, s2, s3}, 0, math.MaxUint32),
+					0: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s1, s2, s3}, 0, math.MaxUint32),
 				},
 			},
 			"ns-2": {
 				ReplicationFactor: 3,
 				Shards: map[int64]*proto.ShardMetadata{
-					1: shardMetadata(proto.ShardStatusDeleting, []*proto.DataServer{s4, s1, s2}, 0, math.MaxUint32/2),
-					2: shardMetadata(proto.ShardStatusDeleting, []*proto.DataServer{s3, s4, s1}, math.MaxUint32/2+1, math.MaxUint32),
+					1: shardMetadata(proto.ShardStatusDeleting, []*proto.DataServerIdentity{s4, s1, s2}, 0, math.MaxUint32/2),
+					2: shardMetadata(proto.ShardStatusDeleting, []*proto.DataServerIdentity{s3, s4, s1}, math.MaxUint32/2+1, math.MaxUint32),
 				},
 			},
 		},

--- a/oxiad/coordinator/util/grouping.go
+++ b/oxiad/coordinator/util/grouping.go
@@ -66,9 +66,9 @@ func NodeShardLeaders(candidates *linkedhashset.Set[string], status *commonproto
 	return totalShards, electedShards, result
 }
 
-func GroupingShardsNodeByStatus(candidates *linkedhashset.Set[string], status *commonproto.ClusterStatus) (map[string][]model.ShardInfo, map[string]*commonproto.DataServer) {
+func GroupingShardsNodeByStatus(candidates *linkedhashset.Set[string], status *commonproto.ClusterStatus) (map[string][]model.ShardInfo, map[string]*commonproto.DataServerIdentity) {
 	groupingShardByNode := make(map[string][]model.ShardInfo)
-	historyNodes := make(map[string]*commonproto.DataServer)
+	historyNodes := make(map[string]*commonproto.DataServerIdentity)
 	if status != nil {
 		for namespace, namespaceStatus := range status.Namespaces {
 			for shard, shardStatus := range namespaceStatus.Shards {

--- a/oxiad/coordinator/util/mock_utils.go
+++ b/oxiad/coordinator/util/mock_utils.go
@@ -19,9 +19,9 @@ import (
 	commonproto "github.com/oxia-db/oxia/common/proto"
 )
 
-func SimpleEnsembleSupplier(candidates []*commonproto.DataServer, nc *commonproto.Namespace, cs *commonproto.ClusterStatus) []*commonproto.DataServer {
+func SimpleEnsembleSupplier(candidates []*commonproto.DataServerIdentity, nc *commonproto.Namespace, cs *commonproto.ClusterStatus) []*commonproto.DataServerIdentity {
 	n := len(candidates)
-	res := make([]*commonproto.DataServer, nc.GetReplicationFactor())
+	res := make([]*commonproto.DataServerIdentity, nc.GetReplicationFactor())
 	for i := uint32(0); i < nc.GetReplicationFactor(); i++ {
 		res[i] = candidates[int(cs.ServerIdx+i)%n]
 	}

--- a/oxiad/maelstrom/coordinator_rpc_client.go
+++ b/oxiad/maelstrom/coordinator_rpc_client.go
@@ -49,7 +49,7 @@ func (m *maelstromCoordinatorRpcProvider) Close() error {
 	return nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) ClearPooledConnections(node *proto.DataServer) {
+func (m *maelstromCoordinatorRpcProvider) ClearPooledConnections(node *proto.DataServerIdentity) {
 }
 
 func newRpcProvider(dispatcher *dispatcher) rpc.Provider {
@@ -59,12 +59,12 @@ func newRpcProvider(dispatcher *dispatcher) rpc.Provider {
 	}
 }
 
-func (m *maelstromCoordinatorRpcProvider) PushShardAssignments(ctx context.Context, node *proto.DataServer) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
-	return newShardAssignmentClient(ctx, m, node.Internal), nil
+func (m *maelstromCoordinatorRpcProvider) PushShardAssignments(ctx context.Context, node *proto.DataServerIdentity) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
+	return newShardAssignmentClient(ctx, m, node.GetInternal()), nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) NewTerm(ctx context.Context, node *proto.DataServer, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
-	res, err := m.dispatcher.RpcRequest(ctx, node.Internal, MsgTypeNewTermRequest, req)
+func (m *maelstromCoordinatorRpcProvider) NewTerm(ctx context.Context, node *proto.DataServerIdentity, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
+	res, err := m.dispatcher.RpcRequest(ctx, node.GetInternal(), MsgTypeNewTermRequest, req)
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +72,8 @@ func (m *maelstromCoordinatorRpcProvider) NewTerm(ctx context.Context, node *pro
 	return res.(*proto.NewTermResponse), nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) BecomeLeader(ctx context.Context, node *proto.DataServer, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
-	res, err := m.dispatcher.RpcRequest(ctx, node.Internal, MsgTypeBecomeLeaderRequest, req)
+func (m *maelstromCoordinatorRpcProvider) BecomeLeader(ctx context.Context, node *proto.DataServerIdentity, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
+	res, err := m.dispatcher.RpcRequest(ctx, node.GetInternal(), MsgTypeBecomeLeaderRequest, req)
 	if err != nil {
 		return nil, err
 	}
@@ -81,8 +81,8 @@ func (m *maelstromCoordinatorRpcProvider) BecomeLeader(ctx context.Context, node
 	return res.(*proto.BecomeLeaderResponse), nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) AddFollower(ctx context.Context, node *proto.DataServer, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error) {
-	res, err := m.dispatcher.RpcRequest(ctx, node.Internal, MsgTypeAddFollowerRequest, req)
+func (m *maelstromCoordinatorRpcProvider) AddFollower(ctx context.Context, node *proto.DataServerIdentity, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error) {
+	res, err := m.dispatcher.RpcRequest(ctx, node.GetInternal(), MsgTypeAddFollowerRequest, req)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +90,8 @@ func (m *maelstromCoordinatorRpcProvider) AddFollower(ctx context.Context, node 
 	return res.(*proto.AddFollowerResponse), nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) GetStatus(ctx context.Context, node *proto.DataServer, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
-	res, err := m.dispatcher.RpcRequest(ctx, node.Internal, MsgTypeGetStatusRequest, req)
+func (m *maelstromCoordinatorRpcProvider) GetStatus(ctx context.Context, node *proto.DataServerIdentity, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
+	res, err := m.dispatcher.RpcRequest(ctx, node.GetInternal(), MsgTypeGetStatusRequest, req)
 	if err != nil {
 		return nil, err
 	}
@@ -99,29 +99,29 @@ func (m *maelstromCoordinatorRpcProvider) GetStatus(ctx context.Context, node *p
 	return res.(*proto.GetStatusResponse), nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) DeleteShard(ctx context.Context, node *proto.DataServer, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
-	res, err := m.dispatcher.RpcRequest(ctx, node.Internal, MsgTypeDeleteShardRequest, req)
+func (m *maelstromCoordinatorRpcProvider) DeleteShard(ctx context.Context, node *proto.DataServerIdentity, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
+	res, err := m.dispatcher.RpcRequest(ctx, node.GetInternal(), MsgTypeDeleteShardRequest, req)
 	if err != nil {
 		return nil, err
 	}
 
 	return res.(*proto.DeleteShardResponse), nil
 }
-func (m *maelstromCoordinatorRpcProvider) RemoveObserver(ctx context.Context, node *proto.DataServer, req *proto.RemoveObserverRequest) (*proto.RemoveObserverResponse, error) {
+func (m *maelstromCoordinatorRpcProvider) RemoveObserver(ctx context.Context, node *proto.DataServerIdentity, req *proto.RemoveObserverRequest) (*proto.RemoveObserverResponse, error) {
 	return &proto.RemoveObserverResponse{}, nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) Handshake(ctx context.Context, node *proto.DataServer, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+func (m *maelstromCoordinatorRpcProvider) Handshake(ctx context.Context, node *proto.DataServerIdentity, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
 	return &proto.HandshakeResponse{
 		Status:            proto.HandshakeStatus_HANDSHAKE_STATUS_ALREADY_BOUND,
 		FeaturesSupported: make([]proto.Feature, 0),
 	}, nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) GetHealthClient(node *proto.DataServer) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (m *maelstromCoordinatorRpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, io.Closer, error) {
 	c := &maelstromHealthCheckClient{
 		provider: m,
-		node:     node.Internal,
+		node:     node.GetInternal(),
 	}
 
 	return c, c, nil

--- a/oxiad/maelstrom/main.go
+++ b/oxiad/maelstrom/main.go
@@ -153,10 +153,10 @@ func main() {
 	replicationGrpcProvider := newMaelstromReplicationRpcProvider()
 	dispatcher := newDispatcher(grpcProvider, replicationGrpcProvider)
 
-	var servers []*commonproto.DataServer
+	var servers []*commonproto.DataServerIdentity
 	for _, node := range allNodes {
 		if node != thisNode {
-			servers = append(servers, &commonproto.DataServer{
+			servers = append(servers, &commonproto.DataServerIdentity{
 				Public:   node,
 				Internal: node,
 			})

--- a/tests/assignments/helpers_test.go
+++ b/tests/assignments/helpers_test.go
@@ -46,7 +46,7 @@ func newCoordinatorInstance(
 	return coordinatorInstance
 }
 
-func newDefaultClusterConfig(servers ...*proto.DataServer) *proto.ClusterConfiguration {
+func newDefaultClusterConfig(servers ...*proto.DataServerIdentity) *proto.ClusterConfiguration {
 	return &proto.ClusterConfiguration{
 		Namespaces: []*proto.Namespace{{
 			Name:              constant.DefaultNamespace,

--- a/tests/balancer/leader_balancer_test.go
+++ b/tests/balancer/leader_balancer_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/oxia-db/oxia/tests/mock"
 )
 
-func dataServers(servers ...*proto.DataServer) []*proto.DataServer {
+func dataServers(servers ...*proto.DataServerIdentity) []*proto.DataServerIdentity {
 	return servers
 }
 
@@ -95,7 +95,7 @@ func TestLeaderBalanced(t *testing.T) {
 				ReplicationFactor: 3,
 			},
 		},
-		Servers: []*proto.DataServer{s1ad, s2ad, s3ad},
+		Servers: []*proto.DataServerIdentity{s1ad, s2ad, s3ad},
 		LoadBalancer: &proto.LoadBalancer{
 			QuarantineTime: "1ms",
 		},

--- a/tests/balancer/shard_balancer_test.go
+++ b/tests/balancer/shard_balancer_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/oxia-db/oxia/tests/mock"
 )
 
-func shardBalancerDataServers(servers ...*proto.DataServer) []*proto.DataServer {
+func shardBalancerDataServers(servers ...*proto.DataServerIdentity) []*proto.DataServerIdentity {
 	return servers
 }
 

--- a/tests/control/helpers_test.go
+++ b/tests/control/helpers_test.go
@@ -46,7 +46,7 @@ func newCoordinatorInstance(
 	return coordinatorInstance
 }
 
-func newDefaultClusterConfig(servers ...*proto.DataServer) *proto.ClusterConfiguration {
+func newDefaultClusterConfig(servers ...*proto.DataServerIdentity) *proto.ClusterConfiguration {
 	return &proto.ClusterConfiguration{
 		Namespaces: []*proto.Namespace{{
 			Name:              constant.DefaultNamespace,

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/oxia-db/oxia/oxia"
 )
 
-func newServer(t *testing.T) (s *dataserver.Server, addr *proto.DataServer) {
+func newServer(t *testing.T) (s *dataserver.Server, addr *proto.DataServerIdentity) {
 	t.Helper()
 
 	options := option.NewDefaultOptions()
@@ -55,7 +55,7 @@ func newServer(t *testing.T) (s *dataserver.Server, addr *proto.DataServer) {
 
 	assert.NoError(t, err)
 
-	addr = &proto.DataServer{
+	addr = &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s.InternalPort()),
 	}
@@ -73,7 +73,7 @@ func TestCoordinatorE2E(t *testing.T) {
 		Name:              constant.DefaultNamespace,
 		ReplicationFactor: 3,
 		InitialShardCount: 1,
-	}}, []*proto.DataServer{sa1, sa2, sa3})
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 
@@ -107,7 +107,7 @@ func TestCoordinatorE2E_ShardsRanges(t *testing.T) {
 		Name:              constant.DefaultNamespace,
 		ReplicationFactor: 3,
 		InitialShardCount: 4,
-	}}, []*proto.DataServer{sa1, sa2, sa3})
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 
@@ -155,7 +155,7 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 		Name:              constant.DefaultNamespace,
 		ReplicationFactor: 3,
 		InitialShardCount: 1,
-	}}, []*proto.DataServer{sa1, sa2, sa3})
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 
@@ -174,8 +174,8 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 	nsStatus = metadata.LoadStatus().Namespaces[constant.DefaultNamespace]
 
 	leader := nsStatus.Shards[0].Leader
-	var follower *proto.DataServer
-	for _, addr := range []*proto.DataServer{sa1, sa2, sa3} {
+	var follower *proto.DataServerIdentity
+	for _, addr := range []*proto.DataServerIdentity{sa1, sa2, sa3} {
 		if addr.GetNameOrDefault() != leader.GetNameOrDefault() {
 			follower = addr
 			break
@@ -255,7 +255,7 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 		Name:              "my-ns-2",
 		ReplicationFactor: 2,
 		InitialShardCount: 3,
-	}}, []*proto.DataServer{sa1, sa2, sa3})
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 
@@ -342,7 +342,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 		Name:              "my-ns-1",
 		ReplicationFactor: 1,
 		InitialShardCount: 2,
-	}}, []*proto.DataServer{sa1, sa2, sa3})
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 
@@ -385,7 +385,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	// Restart the coordinator and remove the namespace
 	assert.NoError(t, coordinatorInstance.Close())
 
-	newClusterConfig := newClusterConfig([]*proto.Namespace{}, []*proto.DataServer{sa1, sa2, sa3})
+	newClusterConfig := newClusterConfig([]*proto.Namespace{}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	slog.Info("Restarting coordinator")
 	newMetadata := createCoordinatorMetadata(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return newClusterConfig, nil }, nil)
@@ -426,7 +426,7 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 		Name:              "my-ns-1",
 		ReplicationFactor: 1,
 		InitialShardCount: 2,
-	}}, []*proto.DataServer{sa1, sa2, sa3})
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	configChangesCh := make(chan any)
 	configProvider := func() (*proto.ClusterConfiguration, error) {
@@ -512,7 +512,7 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 		Name:              "my-ns-1",
 		ReplicationFactor: 1,
 		InitialShardCount: 2,
-	}}, []*proto.DataServer{sa1, sa2, sa3})
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	configProvider := func() (*proto.ClusterConfiguration, error) {
 		return clusterConfig, nil
@@ -525,8 +525,8 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 
 	// Add s4, s5
 	clusterConfig.Servers = append(clusterConfig.Servers,
-		&proto.DataServer{Name: sa4.Name, Public: sa4.Public, Internal: sa4.Internal},
-		&proto.DataServer{Name: sa5.Name, Public: sa5.Public, Internal: sa5.Internal},
+		&proto.DataServerIdentity{Name: sa4.Name, Public: sa4.Public, Internal: sa4.Internal},
+		&proto.DataServerIdentity{Name: sa5.Name, Public: sa5.Public, Internal: sa5.Internal},
 	)
 	// Remove s1
 	clusterConfig.Servers = clusterConfig.Servers[1:]
@@ -571,7 +571,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 		Name:              "my-ns-1",
 		ReplicationFactor: 1,
 		InitialShardCount: 1,
-	}}, []*proto.DataServer{sa1, sa2, sa3, sa4})
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3, sa4})
 
 	configProvider := func() (*proto.ClusterConfiguration, error) {
 		return clusterConfig, nil
@@ -598,7 +598,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 
 	// Remove leader dataserver
 	leaderID := metadata.LoadStatus().Namespaces["my-ns-1"].Shards[0].Leader.GetNameOrDefault()
-	d := make([]*proto.DataServer, 0)
+	d := make([]*proto.DataServerIdentity, 0)
 	for _, sv := range clusterConfig.Servers {
 		if sv.GetNameOrDefault() != leaderID {
 			d = append(d, sv)
@@ -645,7 +645,7 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 		Name:              "my-ns-1",
 		ReplicationFactor: 3,
 		InitialShardCount: 1,
-	}}, []*proto.DataServer{sa1, sa2, sa3})
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 	configChangesCh := make(chan any)
 	c := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) {
 		return clusterConfig, nil
@@ -666,9 +666,9 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	}, 10*time.Second, 10*time.Millisecond)
 
 	// change the localhost to 127.0.0.1
-	clusterServer := make([]*proto.DataServer, 0, len(clusterConfig.Servers))
+	clusterServer := make([]*proto.DataServerIdentity, 0, len(clusterConfig.Servers))
 	for _, sv := range clusterConfig.Servers {
-		clusterServer = append(clusterServer, &proto.DataServer{
+		clusterServer = append(clusterServer, &proto.DataServerIdentity{
 			Name:     sv.Name,
 			Public:   strings.ReplaceAll(sv.GetPublic(), "localhost", "127.0.0.1"),
 			Internal: sv.GetInternal(),

--- a/tests/coordinator/coordinator_test.go
+++ b/tests/coordinator/coordinator_test.go
@@ -40,7 +40,7 @@ func TestCoordinatorInitiateLeaderElection(t *testing.T) {
 		Name:              "default",
 		ReplicationFactor: 1,
 		InitialShardCount: 2,
-	}}, []*proto.DataServer{sa1, sa2, sa3})
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	metadata := createCoordinatorMetadata(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil)
 	defer func() {
@@ -57,9 +57,9 @@ func TestCoordinatorInitiateLeaderElection(t *testing.T) {
 		Status:                  proto.ShardStatusSteadyState,
 		Term:                    999,
 		Leader:                  nil,
-		Ensemble:                []*proto.DataServer{},
-		RemovedNodes:            []*proto.DataServer{},
-		PendingDeleteShardNodes: make([]*proto.DataServer, 0),
+		Ensemble:                []*proto.DataServerIdentity{},
+		RemovedNodes:            []*proto.DataServerIdentity{},
+		PendingDeleteShardNodes: make([]*proto.DataServerIdentity, 0),
 		Int32HashRange:          &proto.HashRange{Min: 2000, Max: 100000},
 	}
 	metadataView := coordinatorInstance.Metadata()

--- a/tests/coordinator/helpers_test.go
+++ b/tests/coordinator/helpers_test.go
@@ -56,7 +56,7 @@ func newCoordinatorInstance(
 	return coordinatorInstance
 }
 
-func newClusterConfig(namespaces []*proto.Namespace, servers []*proto.DataServer) *proto.ClusterConfiguration {
+func newClusterConfig(namespaces []*proto.Namespace, servers []*proto.DataServerIdentity) *proto.ClusterConfiguration {
 	return &proto.ClusterConfiguration{
 		Namespaces: namespaces,
 		Servers:    servers,

--- a/tests/coordinator/split_e2e_test.go
+++ b/tests/coordinator/split_e2e_test.go
@@ -59,7 +59,7 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 		Name:              constant.DefaultNamespace,
 		ReplicationFactor: 3,
 		InitialShardCount: 1,
-	}}, []*proto.DataServer{sa1, sa2, sa3})
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	coordinatorInstance := newCoordinatorInstance(
 		t,
@@ -296,8 +296,8 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 // coordinator, used by the shard-split integration tests.
 type splitTestCluster struct {
 	servers             map[string]*dataserver.Server
-	addresses           []*proto.DataServer
-	sa1                 *proto.DataServer
+	addresses           []*proto.DataServerIdentity
+	sa1                 *proto.DataServerIdentity
 	coordinator         coordinator.Coordinator
 	metadata            coordmetadata.Metadata
 	leftChild           int64
@@ -324,7 +324,7 @@ func setupSplitCluster(t *testing.T) *splitTestCluster {
 		Name:              constant.DefaultNamespace,
 		ReplicationFactor: 3,
 		InitialShardCount: 1,
-	}}, []*proto.DataServer{sa1, sa2, sa3})
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	coordinatorInstance := newCoordinatorInstance(
 		t,
@@ -343,7 +343,7 @@ func setupSplitCluster(t *testing.T) *splitTestCluster {
 
 	return &splitTestCluster{
 		servers:     servers,
-		addresses:   []*proto.DataServer{sa1, sa2, sa3},
+		addresses:   []*proto.DataServerIdentity{sa1, sa2, sa3},
 		sa1:         sa1,
 		coordinator: coordinatorInstance,
 		metadata:    metadata,
@@ -423,7 +423,7 @@ func (c *splitTestCluster) close(t *testing.T) {
 	}
 }
 
-func (c *splitTestCluster) liveAddressExcluding(excludedIDs ...string) *proto.DataServer {
+func (c *splitTestCluster) liveAddressExcluding(excludedIDs ...string) *proto.DataServerIdentity {
 	excluded := make(map[string]struct{}, len(excludedIDs))
 	for _, id := range excludedIDs {
 		excluded[id] = struct{}{}
@@ -854,7 +854,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 			s1, err := dataserver.New(t.Context(), commonoption.NewWatch(dataServerOption))
 			assert.NoError(t, err)
 
-			sa1 := &proto.DataServer{
+			sa1 := &proto.DataServerIdentity{
 				Public:   fmt.Sprintf("localhost:%d", s1.PublicPort()),
 				Internal: fmt.Sprintf("localhost:%d", s1.InternalPort()),
 			}
@@ -875,7 +875,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 				ReplicationFactor: 1,
 				InitialShardCount: 1,
 				KeySorting:        keySortingValue,
-			}}, []*proto.DataServer{sa1})
+			}}, []*proto.DataServerIdentity{sa1})
 
 			coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 

--- a/tests/mock/server.go
+++ b/tests/mock/server.go
@@ -29,7 +29,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/dataserver"
 )
 
-func NewServerWithOptions(t *testing.T, name string, optionsConsumer func(options *option.Options)) (s *dataserver.Server, addr *commonproto.DataServer) {
+func NewServerWithOptions(t *testing.T, name string, optionsConsumer func(options *option.Options)) (s *dataserver.Server, addr *commonproto.DataServerIdentity) {
 	t.Helper()
 	dataServerOption := option.NewDefaultOptions()
 	dataServerOption.Server.Public.BindAddress = "localhost:0"
@@ -44,7 +44,7 @@ func NewServerWithOptions(t *testing.T, name string, optionsConsumer func(option
 	assert.NoError(t, err)
 
 	tmp := &name
-	addr = &commonproto.DataServer{
+	addr = &commonproto.DataServerIdentity{
 		Name:     tmp,
 		Public:   fmt.Sprintf("localhost:%d", s.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s.InternalPort()),
@@ -53,13 +53,13 @@ func NewServerWithOptions(t *testing.T, name string, optionsConsumer func(option
 	return s, addr
 }
 
-func NewServer(t *testing.T, name string) (s *dataserver.Server, addr *commonproto.DataServer) {
+func NewServer(t *testing.T, name string) (s *dataserver.Server, addr *commonproto.DataServerIdentity) {
 	t.Helper()
 	return NewServerWithOptions(t, name, func(_ *option.Options) {
 	})
 }
 
-func NewServerWithAddress(t *testing.T, name string, publicAddress string, internalAddress string) (s *dataserver.Server, addr *commonproto.DataServer) {
+func NewServerWithAddress(t *testing.T, name string, publicAddress string, internalAddress string) (s *dataserver.Server, addr *commonproto.DataServerIdentity) {
 	t.Helper()
 	dataServerOption := option.NewDefaultOptions()
 	dataServerOption.Server.Public.BindAddress = publicAddress
@@ -74,7 +74,7 @@ func NewServerWithAddress(t *testing.T, name string, publicAddress string, inter
 	assert.NoError(t, err)
 
 	tmp := &name
-	addr = &commonproto.DataServer{
+	addr = &commonproto.DataServerIdentity{
 		Name:     tmp,
 		Public:   publicAddress,
 		Internal: internalAddress,

--- a/tests/resolver/target_ip_flip_test.go
+++ b/tests/resolver/target_ip_flip_test.go
@@ -40,7 +40,7 @@ type testCluster struct {
 	authority   string
 	coordinator coordinator.Coordinator
 	servers     map[string]*dataserver.Server
-	addresses   []*proto.DataServer
+	addresses   []*proto.DataServerIdentity
 }
 
 const integrationRequestTimeout = 30 * time.Second
@@ -53,7 +53,7 @@ func newCoordinatorCluster(t *testing.T, prefix string, serverCount int) *testCl
 		name:      prefix,
 		authority: fmt.Sprintf("%s-bootstrap:6648", prefix),
 		servers:   make(map[string]*dataserver.Server, serverCount),
-		addresses: make([]*proto.DataServer, 0, serverCount),
+		addresses: make([]*proto.DataServerIdentity, 0, serverCount),
 	}
 
 	for i := 0; i < serverCount; i++ {
@@ -74,7 +74,7 @@ func newCoordinatorCluster(t *testing.T, prefix string, serverCount int) *testCl
 					ReplicationFactor: 1,
 					InitialShardCount: 3,
 				}},
-				Servers: func() []*proto.DataServer {
+				Servers: func() []*proto.DataServerIdentity {
 					return cluster.addresses
 				}(),
 				AllowExtraAuthorities: []string{cluster.authority},
@@ -110,11 +110,11 @@ func (c *testCluster) stopAllServers(t *testing.T) {
 	}
 }
 
-func (c *testCluster) leader() *proto.DataServer {
+func (c *testCluster) leader() *proto.DataServerIdentity {
 	return c.coordinator.Metadata().LoadStatus().Namespaces[constant.DefaultNamespace].Shards[0].Leader
 }
 
-func (c *testCluster) bootstrapTargetExcluding(excluded *proto.DataServer) *proto.DataServer {
+func (c *testCluster) bootstrapTargetExcluding(excluded *proto.DataServerIdentity) *proto.DataServerIdentity {
 	for _, addr := range c.addresses {
 		if addr.GetNameOrDefault() != excluded.GetNameOrDefault() {
 			return addr

--- a/tests/security/auth/auth_oidc_test.go
+++ b/tests/security/auth/auth_oidc_test.go
@@ -71,7 +71,7 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 	dataServerOption1.Storage.WAL.Dir = t.TempDir()
 	s1, err := dataserver.New(t.Context(), commonoption.NewWatch(dataServerOption1))
 	assert.NoError(t, err)
-	s1Addr := &proto.DataServer{
+	s1Addr := &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s1.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s1.InternalPort()),
 	}
@@ -85,7 +85,7 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 
 	s2, err := dataserver.New(t.Context(), commonoption.NewWatch(dataServerOption2))
 	assert.NoError(t, err)
-	s2Addr := &proto.DataServer{
+	s2Addr := &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s2.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s2.InternalPort()),
 	}
@@ -99,7 +99,7 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 
 	s3, err := dataserver.New(t.Context(), commonoption.NewWatch(dataServerOption3))
 	assert.NoError(t, err)
-	s3Addr := &proto.DataServer{
+	s3Addr := &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s3.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s3.InternalPort()),
 	}
@@ -255,7 +255,7 @@ func TestOIDCWithPerIssuerConfig(t *testing.T) {
 	assert.NoError(t, err)
 	defer s1.Close()
 
-	s1Addr := &proto.DataServer{
+	s1Addr := &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s1.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s1.InternalPort()),
 	}
@@ -271,7 +271,7 @@ func TestOIDCWithPerIssuerConfig(t *testing.T) {
 	assert.NoError(t, err)
 	defer s2.Close()
 
-	s2Addr := &proto.DataServer{
+	s2Addr := &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s2.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s2.InternalPort()),
 	}
@@ -287,7 +287,7 @@ func TestOIDCWithPerIssuerConfig(t *testing.T) {
 	assert.NoError(t, err)
 	defer s3.Close()
 
-	s3Addr := &proto.DataServer{
+	s3Addr := &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s3.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s3.InternalPort()),
 	}
@@ -405,7 +405,7 @@ func TestOIDCWithStaticKeyFile(t *testing.T) {
 	assert.NoError(t, err)
 	defer s1.Close()
 
-	s1Addr := &proto.DataServer{
+	s1Addr := &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s1.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s1.InternalPort()),
 	}
@@ -421,7 +421,7 @@ func TestOIDCWithStaticKeyFile(t *testing.T) {
 	assert.NoError(t, err)
 	defer s2.Close()
 
-	s2Addr := &proto.DataServer{
+	s2Addr := &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s2.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s2.InternalPort()),
 	}
@@ -437,7 +437,7 @@ func TestOIDCWithStaticKeyFile(t *testing.T) {
 	assert.NoError(t, err)
 	defer s3.Close()
 
-	s3Addr := &proto.DataServer{
+	s3Addr := &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s3.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s3.InternalPort()),
 	}

--- a/tests/security/auth/helpers_test.go
+++ b/tests/security/auth/helpers_test.go
@@ -46,7 +46,7 @@ func newCoordinatorInstance(
 	return coordinatorInstance
 }
 
-func newDefaultClusterConfig(servers ...*proto.DataServer) *proto.ClusterConfiguration {
+func newDefaultClusterConfig(servers ...*proto.DataServerIdentity) *proto.ClusterConfiguration {
 	return &proto.ClusterConfiguration{
 		Namespaces: []*proto.Namespace{{
 			Name:              constant.DefaultNamespace,

--- a/tests/security/tls/helpers_test.go
+++ b/tests/security/tls/helpers_test.go
@@ -46,7 +46,7 @@ func newCoordinatorInstance(
 	return coordinatorInstance
 }
 
-func newDefaultClusterConfig(servers ...*proto.DataServer) *proto.ClusterConfiguration {
+func newDefaultClusterConfig(servers ...*proto.DataServerIdentity) *proto.ClusterConfiguration {
 	return &proto.ClusterConfiguration{
 		Namespaces: []*proto.Namespace{{
 			Name:              constant.DefaultNamespace,

--- a/tests/security/tls/tls_encryption_test.go
+++ b/tests/security/tls/tls_encryption_test.go
@@ -75,13 +75,13 @@ func getClientTLSOption() (*security.TLSOptions, error) {
 	return &clientOption, nil
 }
 
-func newTLSServer(t *testing.T) (s *dataserver.Server, addr *proto.DataServer) {
+func newTLSServer(t *testing.T) (s *dataserver.Server, addr *proto.DataServerIdentity) {
 	t.Helper()
 	return newTLSServerWithInterceptor(t, func(config *dataserveroption.Options) {
 	})
 }
 
-func newTLSServerWithInterceptor(t *testing.T, interceptor func(config *dataserveroption.Options)) (s *dataserver.Server, addr *proto.DataServer) {
+func newTLSServerWithInterceptor(t *testing.T, interceptor func(config *dataserveroption.Options)) (s *dataserver.Server, addr *proto.DataServerIdentity) {
 	t.Helper()
 	option, err := getPeerTLSOption()
 	assert.NoError(t, err)
@@ -102,7 +102,7 @@ func newTLSServerWithInterceptor(t *testing.T, interceptor func(config *dataserv
 
 	assert.NoError(t, err)
 
-	addr = &proto.DataServer{
+	addr = &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s.InternalPort()),
 	}


### PR DESCRIPTION
## Motivation
- Make `DataServer` represent the managed data-server resource.
- Rename the embedded endpoint/name payload so the protobuf model is clearer before adding coordinator domain APIs.

## Modifications
- Rename the embedded protobuf message from `DataServer` to `DataServerIdentity`.
- Rename `DataServerInfo` to `DataServer` and the nested `dataServer` field to `identity`.
- Update coordinator, admin client, tests, codecs, and generated protobuf call sites to use the new names.

## Testing
- `go test ./cmd/admin/dataserver ./cmd/admin/dataserver/get ./cmd/admin/dataserver/list ./common/proto ./oxia ./oxiad/coordinator -count=1`
- `make lint`
- `make license-check`