### PR TITLE
refactor: rename coordinator management server

### DIFF
--- a/oxiad/coordinator/grpc_server.go
+++ b/oxiad/coordinator/grpc_server.go
@@ -47,12 +47,12 @@ type GrpcServer struct {
 	logger           *slog.Logger
 	watchableOptions *commonwatch.Watch[*option.Options]
 
-	grpcServer   rpc2.GrpcServer
-	adminServer  rpc2.GrpcServer
-	healthServer *health.Server
-	runtime      coordruntime.Runtime
-	metadata     coordmetadata.Metadata
-	metrics      *metric.PrometheusMetrics
+	grpcServer       rpc2.GrpcServer
+	managementServer rpc2.GrpcServer
+	healthServer     *health.Server
+	runtime          coordruntime.Runtime
+	metadata         coordmetadata.Metadata
+	metrics          *metric.PrometheusMetrics
 }
 
 func NewGrpcServer(parent context.Context, watchableOptions *commonwatch.Watch[*option.Options]) (*GrpcServer, error) {
@@ -88,18 +88,18 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonwatch.Watch[*
 		return nil, err
 	}
 
-	adminSv := options.Server.Admin
-	adminSvTLS, err := adminSv.TLS.TryIntoServerTLSConf()
+	managementSv := options.Server.Admin
+	managementSvTLS, err := managementSv.TLS.TryIntoServerTLSConf()
 	if err != nil {
 		return nil, err
 	}
-	admin := newAdminServer(
+	management := newManagementServer(
 		runtime.Metadata(),
 		runtime,
 	)
-	adminGrpcServer, err := rpc2.Default.StartGrpcServer("admin", adminSv.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
-		proto.RegisterOxiaAdminServer(registrar, admin)
-	}, adminSvTLS, &adminSv.Auth, nil)
+	managementGrpcServer, err := rpc2.Default.StartGrpcServer("admin", managementSv.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
+		proto.RegisterOxiaAdminServer(registrar, management)
+	}, managementSvTLS, &managementSv.Auth, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonwatch.Watch[*
 		logger:           slog.With(slog.String("component", "grpc-server")),
 		watchableOptions: watchableOptions,
 		grpcServer:       grpcServer,
-		adminServer:      adminGrpcServer,
+		managementServer: managementGrpcServer,
 		healthServer:     healthServer,
 		runtime:          runtime,
 		metadata:         metadata,
@@ -184,7 +184,7 @@ func (s *GrpcServer) Close() error {
 	s.healthServer.Shutdown()
 	err = multierr.Combine(
 		s.grpcServer.Close(),
-		s.adminServer.Close(),
+		s.managementServer.Close(),
 		s.runtime.Close(),
 		s.metadata.Close(),
 	)

--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -32,17 +32,17 @@ type ShardSplitter interface {
 	InitiateSplit(namespace string, parentShardId int64, splitPoint *uint32) (leftChild, rightChild int64, err error)
 }
 
-var _ proto.OxiaAdminServer = (*adminServer)(nil)
+var _ proto.OxiaAdminServer = (*managementServer)(nil)
 
-type adminServer struct {
+type managementServer struct {
 	proto.UnimplementedOxiaAdminServer
 
 	metadata      coordmetadata.Metadata
 	shardSplitter ShardSplitter
 }
 
-func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServersRequest) (*proto.ListDataServersResponse, error) {
-	cnf := admin.metadata.LoadConfig()
+func (management *managementServer) ListDataServers(context.Context, *proto.ListDataServersRequest) (*proto.ListDataServersResponse, error) {
+	cnf := management.metadata.LoadConfig()
 
 	dataServers := make([]*proto.DataServer, 0, len(cnf.GetServers()))
 	for _, server := range cnf.GetServers() {
@@ -69,12 +69,12 @@ func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServer
 	return &proto.ListDataServersResponse{DataServers: dataServers}, nil
 }
 
-func (admin *adminServer) GetDataServer(_ context.Context, req *proto.GetDataServerRequest) (*proto.GetDataServerResponse, error) {
+func (management *managementServer) GetDataServer(_ context.Context, req *proto.GetDataServerRequest) (*proto.GetDataServerResponse, error) {
 	if req == nil || req.DataServer == "" {
 		return nil, grpcstatus.Error(codes.InvalidArgument, "data server must not be empty")
 	}
 
-	dataServer, found := admin.metadata.GetDataServer(req.DataServer)
+	dataServer, found := management.metadata.GetDataServer(req.DataServer)
 	if !found {
 		return nil, grpcstatus.Errorf(codes.NotFound, "data server %q not found", req.DataServer)
 	}
@@ -84,8 +84,8 @@ func (admin *adminServer) GetDataServer(_ context.Context, req *proto.GetDataSer
 	}, nil
 }
 
-func (admin *adminServer) ListNamespaces(context.Context, *proto.ListNamespacesRequest) (*proto.ListNamespacesResponse, error) {
-	cnf := admin.metadata.LoadConfig()
+func (management *managementServer) ListNamespaces(context.Context, *proto.ListNamespacesRequest) (*proto.ListNamespacesResponse, error) {
+	cnf := management.metadata.LoadConfig()
 
 	namespaceNames := hashset.New[string]()
 	for _, nsConfig := range cnf.GetNamespaces() {
@@ -96,8 +96,8 @@ func (admin *adminServer) ListNamespaces(context.Context, *proto.ListNamespacesR
 	}, nil
 }
 
-func (admin *adminServer) ListNodes(context.Context, *proto.ListNodesRequest) (*proto.ListNodesResponse, error) {
-	cnf := admin.metadata.LoadConfig()
+func (management *managementServer) ListNodes(context.Context, *proto.ListNodesRequest) (*proto.ListNodesResponse, error) {
+	cnf := management.metadata.LoadConfig()
 
 	cnfNodes := cnf.GetServers()
 	cnfMeta := cnf.GetServerMetadata()
@@ -117,8 +117,8 @@ func (admin *adminServer) ListNodes(context.Context, *proto.ListNodesRequest) (*
 	return &proto.ListNodesResponse{Nodes: nodes}, nil
 }
 
-func (admin *adminServer) SplitShard(_ context.Context, req *proto.SplitShardRequest) (*proto.SplitShardResponse, error) {
-	if admin.shardSplitter == nil {
+func (management *managementServer) SplitShard(_ context.Context, req *proto.SplitShardRequest) (*proto.SplitShardResponse, error) {
+	if management.shardSplitter == nil {
 		return nil, errors.New("split shard not supported")
 	}
 
@@ -128,7 +128,7 @@ func (admin *adminServer) SplitShard(_ context.Context, req *proto.SplitShardReq
 		slog.Any("split-point", req.SplitPoint),
 	)
 
-	left, right, err := admin.shardSplitter.InitiateSplit(req.Namespace, req.Shard, req.SplitPoint)
+	left, right, err := management.shardSplitter.InitiateSplit(req.Namespace, req.Shard, req.SplitPoint)
 	if err != nil {
 		return nil, err
 	}
@@ -139,11 +139,11 @@ func (admin *adminServer) SplitShard(_ context.Context, req *proto.SplitShardReq
 	}, nil
 }
 
-func newAdminServer(
+func newManagementServer(
 	metadata coordmetadata.Metadata,
 	shardSplitter ShardSplitter,
-) *adminServer {
-	return &adminServer{
+) *managementServer {
+	return &managementServer{
 		metadata:      metadata,
 		shardSplitter: shardSplitter,
 	}

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -54,11 +54,11 @@ func newTestMetadata(t *testing.T, config *proto.ClusterConfiguration) coordmeta
 	return metadata
 }
 
-func TestAdminServerListDataServers(t *testing.T) {
+func TestManagementServerListDataServers(t *testing.T) {
 	serverName1 := "server-1"
 	serverName2 := "server-2"
 
-	admin := newAdminServer(
+	management := newManagementServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{
 			Servers: []*proto.DataServerIdentity{
 				dataServer(&serverName1, "public-1", "internal-1"),
@@ -74,7 +74,7 @@ func TestAdminServerListDataServers(t *testing.T) {
 		nil,
 	)
 
-	res, err := admin.ListDataServers(context.Background(), &proto.ListDataServersRequest{})
+	res, err := management.ListDataServers(context.Background(), &proto.ListDataServersRequest{})
 	require.NoError(t, err)
 	require.Len(t, res.DataServers, 3)
 
@@ -100,10 +100,10 @@ func TestAdminServerListDataServers(t *testing.T) {
 	assert.Equal(t, map[string]string{"rack": "rack-3"}, res.DataServers[2].Metadata.GetLabels())
 }
 
-func TestAdminServerListNodesUsesInternalAddressWhenNameIsUnset(t *testing.T) {
+func TestManagementServerListNodesUsesInternalAddressWhenNameIsUnset(t *testing.T) {
 	serverName1 := "server-1"
 
-	admin := newAdminServer(
+	management := newManagementServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{
 			Servers: []*proto.DataServerIdentity{
 				dataServer(&serverName1, "public-1", "internal-1"),
@@ -117,7 +117,7 @@ func TestAdminServerListNodesUsesInternalAddressWhenNameIsUnset(t *testing.T) {
 		nil,
 	)
 
-	res, err := admin.ListNodes(context.Background(), &proto.ListNodesRequest{})
+	res, err := management.ListNodes(context.Background(), &proto.ListNodesRequest{})
 	require.NoError(t, err)
 	require.Len(t, res.Nodes, 2)
 
@@ -132,10 +132,10 @@ func TestAdminServerListNodesUsesInternalAddressWhenNameIsUnset(t *testing.T) {
 	assert.Equal(t, map[string]string{"role": "fallback"}, res.Nodes[1].Metadata)
 }
 
-func TestAdminServerGetDataServerByName(t *testing.T) {
+func TestManagementServerGetDataServerByName(t *testing.T) {
 	serverName := "server-2"
 
-	admin := newAdminServer(
+	management := newManagementServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{
 			Servers: []*proto.DataServerIdentity{
 				dataServer(&serverName, "public-2", "internal-2"),
@@ -147,7 +147,7 @@ func TestAdminServerGetDataServerByName(t *testing.T) {
 		nil,
 	)
 
-	res, err := admin.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: serverName})
+	res, err := management.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: serverName})
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.NotNil(t, res.DataServer)
@@ -159,10 +159,10 @@ func TestAdminServerGetDataServerByName(t *testing.T) {
 	assert.Equal(t, map[string]string{"zone": "zone-2"}, res.DataServer.Metadata.GetLabels())
 }
 
-func TestAdminServerGetDataServerByIdentifierFallback(t *testing.T) {
+func TestManagementServerGetDataServerByIdentifierFallback(t *testing.T) {
 	serverName := "server-2"
 
-	admin := newAdminServer(
+	management := newManagementServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{
 			Servers: []*proto.DataServerIdentity{
 				dataServer(&serverName, "public-2", "internal-2"),
@@ -176,7 +176,7 @@ func TestAdminServerGetDataServerByIdentifierFallback(t *testing.T) {
 		nil,
 	)
 
-	res, err := admin.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: "internal-3"})
+	res, err := management.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: "internal-3"})
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.NotNil(t, res.DataServer)
@@ -187,13 +187,13 @@ func TestAdminServerGetDataServerByIdentifierFallback(t *testing.T) {
 	assert.Equal(t, "internal-3", res.DataServer.Identity.GetInternal())
 	assert.Equal(t, map[string]string{"role": "fallback"}, res.DataServer.Metadata.GetLabels())
 
-	_, err = admin.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: "internal-2"})
+	_, err = management.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: "internal-2"})
 	require.Error(t, err)
 	assert.Equal(t, codes.NotFound, grpcstatus.Code(err))
 }
 
-func TestAdminServerGetDataServerNotFound(t *testing.T) {
-	admin := newAdminServer(
+func TestManagementServerGetDataServerNotFound(t *testing.T) {
+	management := newManagementServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{
 			Servers: []*proto.DataServerIdentity{
 				dataServer(nil, "public-1", "internal-1"),
@@ -202,18 +202,18 @@ func TestAdminServerGetDataServerNotFound(t *testing.T) {
 		nil,
 	)
 
-	_, err := admin.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: "missing"})
+	_, err := management.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: "missing"})
 	require.Error(t, err)
 	assert.Equal(t, codes.NotFound, grpcstatus.Code(err))
 }
 
-func TestAdminServerGetDataServerRejectsEmptyLookup(t *testing.T) {
-	admin := newAdminServer(
+func TestManagementServerGetDataServerRejectsEmptyLookup(t *testing.T) {
+	management := newManagementServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{}),
 		nil,
 	)
 
-	_, err := admin.GetDataServer(context.Background(), &proto.GetDataServerRequest{})
+	_, err := management.GetDataServer(context.Background(), &proto.GetDataServerRequest{})
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, grpcstatus.Code(err))
 }


### PR DESCRIPTION
## Motivation
- align the internal server naming with its role as the management API surface instead of the legacy admin naming
- keep the coordinator file and symbol names consistent with the surrounding runtime and gRPC server cleanup

## Modifications
- renamed `oxiad/coordinator/admin_server.go` to `oxiad/coordinator/management_server.go`
- renamed the internal server type, constructor, tests, and gRPC server field from `admin` to `management`
- kept the public gRPC API registration as `OxiaAdminServer`

## Testing
- `go test ./oxiad/coordinator -run '^TestManagementServer|^TestGrpcServer|^TestAdminServer'`
- `make lint`
