### PR TITLE
refactor: move shard splitter into controller

### DIFF
--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -25,12 +25,8 @@ import (
 
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
 )
-
-// ShardSplitter is implemented by the coordinator to initiate shard splits.
-type ShardSplitter interface {
-	InitiateSplit(namespace string, parentShardId int64, splitPoint *uint32) (leftChild, rightChild int64, err error)
-}
 
 var _ proto.OxiaAdminServer = (*managementServer)(nil)
 
@@ -38,7 +34,7 @@ type managementServer struct {
 	proto.UnimplementedOxiaAdminServer
 
 	metadata      coordmetadata.Metadata
-	shardSplitter ShardSplitter
+	shardSplitter controller.ShardSplitter
 }
 
 func (management *managementServer) ListDataServers(context.Context, *proto.ListDataServersRequest) (*proto.ListDataServersResponse, error) {
@@ -141,7 +137,7 @@ func (management *managementServer) SplitShard(_ context.Context, req *proto.Spl
 
 func newManagementServer(
 	metadata coordmetadata.Metadata,
-	shardSplitter ShardSplitter,
+	shardSplitter controller.ShardSplitter,
 ) *managementServer {
 	return &managementServer{
 		metadata:      metadata,

--- a/oxiad/coordinator/runtime/controller/shard_splitter.go
+++ b/oxiad/coordinator/runtime/controller/shard_splitter.go
@@ -12,26 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package runtime
+package controller
 
-import (
-	"io"
-
-	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
-	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer"
-	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
-)
-
-type Runtime interface {
-	io.Closer
-	controller.ShardSplitter
-	controller.ShardEventListener
-	controller.ShardAssignmentsProvider
-	controller.DataServerEventListener
-
-	NodeControllers() map[string]controller.DataServerController
-
-	LoadBalancer() balancer.LoadBalancer
-
-	Metadata() coordmetadata.Metadata
+type ShardSplitter interface {
+	InitiateSplit(namespace string, parentShardId int64, splitPoint *uint32) (leftChild, rightChild int64, err error)
 }


### PR DESCRIPTION
## Motivation
- remove the duplicate `ShardSplitter` interface definition from the management server path
- keep runtime-facing contracts grouped in the controller layer alongside the other controller interfaces used by `runtime.Runtime`

## Modifications
- added `controller.ShardSplitter` in `oxiad/coordinator/runtime/controller/shard_splitter.go`
- changed `runtime.Runtime` to embed `controller.ShardSplitter`
- updated `management_server.go` to depend on `controller.ShardSplitter` directly

## Testing
- `go test ./oxiad/coordinator -run '^TestManagementServer|^TestGrpcServer|^TestAdminServer'`
- `make lint`
