### PR TITLE
refactor: make coordinator lifecycle fields explicit

### DIFF
--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -68,11 +68,10 @@ type Metadata interface {
 type EnsembleSupplier func(namespaceConfig *commonproto.Namespace, status *commonproto.ClusterStatus) ([]*commonproto.DataServerIdentity, error)
 
 type coordinatorMetadata struct {
-	*slog.Logger
-
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     *sync.WaitGroup
+	logger    *slog.Logger
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+	wg        sync.WaitGroup
 
 	statusProvider provider.Provider[*commonproto.ClusterStatus]
 	configProvider provider.Provider[*commonproto.ClusterConfiguration]
@@ -179,10 +178,10 @@ func newCoordinatorMetadata(ctx context.Context, statusProvider provider.Provide
 func newCoordinatorMetadataWithCloser(ctx context.Context, statusProvider provider.Provider[*commonproto.ClusterStatus], configProvider provider.Provider[*commonproto.ClusterConfiguration], backendCloser io.Closer) Metadata {
 	metadataCtx, cancel := context.WithCancel(ctx)
 	m := &coordinatorMetadata{
-		Logger:             slog.With(slog.String("component", "coordinator-metadata")),
+		logger:             slog.With(slog.String("component", "coordinator-metadata")),
 		ctx:                metadataCtx,
-		cancel:             cancel,
-		wg:                 &sync.WaitGroup{},
+		ctxCancel:          cancel,
+		wg:                 sync.WaitGroup{},
 		statusProvider:     statusProvider,
 		configProvider:     configProvider,
 		backendCloser:      backendCloser,
@@ -194,7 +193,7 @@ func newCoordinatorMetadataWithCloser(ctx context.Context, statusProvider provid
 	m.doStatusRecovery()
 
 	if configWatch, err := configProvider.Watch(); err != nil && !errors.Is(err, provider.ErrWatchUnsupported) {
-		m.Warn("failed to watch cluster config provider", slog.Any("error", err))
+		m.logger.Warn("failed to watch cluster config provider", slog.Any("error", err))
 	} else if configWatch != nil {
 		m.wg.Go(func() {
 			process.DoWithLabels(metadataCtx, map[string]string{
@@ -210,7 +209,7 @@ func newCoordinatorMetadataWithCloser(ctx context.Context, statusProvider provid
 
 type callbackConfigProvider struct {
 	ctx           context.Context
-	cancel        context.CancelFunc
+	ctxCancel     context.CancelFunc
 	wg            sync.WaitGroup
 	load          func() (*commonproto.ClusterConfiguration, error)
 	notifications <-chan any
@@ -225,7 +224,7 @@ func newCallbackConfigProvider(
 	watchCtx, cancel := context.WithCancel(ctx)
 	p := &callbackConfigProvider{
 		ctx:           watchCtx,
-		cancel:        cancel,
+		ctxCancel:     cancel,
 		load:          load,
 		notifications: notifications,
 	}
@@ -297,7 +296,7 @@ func (p *callbackConfigProvider) publishCurrentValue() {
 }
 
 func (p *callbackConfigProvider) Close() error {
-	p.cancel()
+	p.ctxCancel()
 	p.wg.Wait()
 	if p.watcher != nil {
 		p.watcher.Close()
@@ -306,7 +305,7 @@ func (p *callbackConfigProvider) Close() error {
 }
 
 func (m *coordinatorMetadata) Close() error {
-	m.cancel()
+	m.ctxCancel()
 	m.wg.Wait()
 	return multierr.Combine(m.statusProvider.Close(), m.configProvider.Close(), closeIfNotNil(m.backendCloser))
 }
@@ -341,7 +340,7 @@ func (m *coordinatorMetadata) doStatusRecovery() {
 		m.currentVersionID = version
 		return nil
 	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
-		m.Warn(
+		m.logger.Warn(
 			"failed to load status, retrying later",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
@@ -369,7 +368,7 @@ func (m *coordinatorMetadata) persistStatusLocked(newStatus *commonproto.Cluster
 		m.currentVersionID = versionID
 		return nil
 	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
-		m.Warn(
+		m.logger.Warn(
 			warnMessage,
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
@@ -482,7 +481,7 @@ func (m *coordinatorMetadata) loadClusterConfigWithInitSlow() {
 		}
 		return nil
 	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
-		m.Warn(
+		m.logger.Warn(
 			"failed to load cluster configuration, retrying later",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
@@ -554,7 +553,7 @@ func (m *coordinatorMetadata) waitForConfigUpdates(configWatch *commonwatch.Rece
 			if !ok {
 				return
 			}
-			m.Info("Received cluster config change event")
+			m.logger.Info("Received cluster config change event")
 			m.applyConfigWatchValue(configWatch)
 		}
 	}
@@ -567,7 +566,7 @@ func (m *coordinatorMetadata) applyConfigWatchValue(configWatch *commonwatch.Rec
 	}
 	if !m.usesCallbackConfigProvider() {
 		if err := validateClusterConfig(config); err != nil {
-			m.Warn("received invalid cluster config watch value", slog.Any("error", err))
+			m.logger.Warn("received invalid cluster config watch value", slog.Any("error", err))
 			return
 		}
 	}
@@ -580,7 +579,7 @@ func (m *coordinatorMetadata) applyConfigWatchValue(configWatch *commonwatch.Rec
 	m.clusterConfigLock.Unlock()
 
 	if gproto.Equal(oldClusterConfig, clonedConfig) {
-		m.Info("No cluster config changes detected")
+		m.logger.Info("No cluster config changes detected")
 		return
 	}
 	m.clusterConfigWatch.Publish(clonedConfig)

--- a/oxiad/coordinator/metadata/provider/file/file.go
+++ b/oxiad/coordinator/metadata/provider/file/file.go
@@ -45,11 +45,12 @@ type Provider[T gproto.Message] struct {
 	watchEnabled provider.WatchMode
 	version      provider.Version
 
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+	wg        sync.WaitGroup
 
 	watcher *commonwatch.Watch[T]
+	logger  *slog.Logger
 }
 
 func NewProvider[T gproto.Message](ctx context.Context, path string, codec provider.Codec[T], watchEnabled provider.WatchMode) (provider.Provider[T], error) {
@@ -59,8 +60,9 @@ func NewProvider[T gproto.Message](ctx context.Context, path string, codec provi
 		fileLock:     fslock.New(path),
 		watchEnabled: watchEnabled,
 		version:      provider.NotExists,
+		logger:       slog.With(slog.String("component", "metadata-file-provider"), slog.String("path", path)),
 	}
-	p.ctx, p.cancel = context.WithCancel(ctx)
+	p.ctx, p.ctxCancel = context.WithCancel(ctx)
 	if err := p.ensureParentDirectoryExists(); err != nil {
 		return nil, err
 	}
@@ -81,7 +83,7 @@ func NewProvider[T gproto.Message](ctx context.Context, path string, codec provi
 }
 
 func (m *Provider[T]) Close() error {
-	m.cancel()
+	m.ctxCancel()
 	m.wg.Wait()
 	if m.watcher != nil {
 		m.watcher.Close()
@@ -90,7 +92,7 @@ func (m *Provider[T]) Close() error {
 		return nil
 	}
 	if err := m.fileLock.Unlock(); err != nil {
-		slog.Warn(
+		m.logger.Warn(
 			"Failed to release file lock on metadata",
 			slog.Any("error", err),
 		)
@@ -166,7 +168,7 @@ func (m *Provider[T]) watchLoop() {
 		m.watcher.Publish(value)
 		return m.watchOnce()
 	}, backoff.WithContext(retry, m.ctx), func(err error, duration time.Duration) {
-		slog.Warn("File metadata watch failed, reconnecting",
+		m.logger.Warn("File metadata watch failed, reconnecting",
 			slog.String("path", m.path),
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration))
@@ -180,7 +182,7 @@ func (m *Provider[T]) watchOnce() error {
 	}
 	defer func() {
 		if err := watcher.Close(); err != nil {
-			slog.Warn("Failed to close file metadata watcher", slog.Any("error", err))
+			m.logger.Warn("Failed to close file metadata watcher", slog.Any("error", err))
 		}
 	}()
 

--- a/oxiad/coordinator/metadata/provider/kubernetes/configmap.go
+++ b/oxiad/coordinator/metadata/provider/kubernetes/configmap.go
@@ -69,13 +69,13 @@ type Provider[T gproto.Message] struct {
 	storeLatencyHisto metric.LatencyHistogram
 	metadataSizeGauge metric.Gauge
 
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+	wg        sync.WaitGroup
 
 	watcher *commonwatch.Watch[T]
 
-	log *slog.Logger
+	logger *slog.Logger
 }
 
 func NewConfigMapProvider[T gproto.Message](
@@ -91,7 +91,7 @@ func NewConfigMapProvider[T gproto.Message](
 		name:         name,
 		codec:        codec,
 		watchEnabled: watchEnabled,
-		log:          slog.With("component", "metadata-config-map"),
+		logger:       slog.With("component", "metadata-config-map"),
 
 		getLatencyHisto: metric.NewLatencyHistogram("oxia_coordinator_metadata_get_latency",
 			"Latency for reading coordinator metadata", nil),
@@ -99,7 +99,7 @@ func NewConfigMapProvider[T gproto.Message](
 			"Latency for storing coordinator metadata", nil),
 	}
 
-	m.ctx, m.cancel = context.WithCancel(ctx)
+	m.ctx, m.ctxCancel = context.WithCancel(ctx)
 	if watchEnabled.Enabled() {
 		initialValue, _, err := m.getWithoutLock() //nolint:contextcheck // Constructor seeds the watch from the provider-owned context.
 		if err != nil {
@@ -119,8 +119,8 @@ func NewConfigMapProvider[T gproto.Message](
 			return m.metadataSize.Load()
 		})
 
-	logger := logr.FromSlogHandler(m.log.With(slog.String("sub-component", "k8s-client")).Handler())
-	klog.SetLogger(logger)
+	clientLogger := logr.FromSlogHandler(m.logger.With(slog.String("sub-component", "k8s-client")).Handler())
+	klog.SetLogger(clientLogger)
 	return m, nil
 }
 
@@ -223,7 +223,7 @@ func (m *Provider[T]) WaitToBecomeLeader() error {
 		},
 	}
 
-	log := m.log.With(slog.String("identity", myIdentity))
+	logger := m.logger.With(slog.String("identity", myIdentity))
 	wg := concurrent.NewWaitGroup(1)
 
 	// Configure leader election
@@ -235,18 +235,18 @@ func (m *Provider[T]) WaitToBecomeLeader() error {
 		RetryPeriod:     retryPeriod,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(_ context.Context) {
-				log.Info("Started leading - lease acquired")
+				logger.Info("Started leading - lease acquired")
 				wg.Done()
 			},
 			OnStoppedLeading: func() {
-				log.Warn("Stopped leading - lease lost!")
+				logger.Warn("Stopped leading - lease lost!")
 			},
 			OnNewLeader: func(newLeader string) {
 				if newLeader == myIdentity {
 					return
 				}
 
-				log.Info("New leader elected", slog.String("leader", newLeader))
+				logger.Info("New leader elected", slog.String("leader", newLeader))
 			},
 		},
 	}
@@ -270,12 +270,12 @@ func (m *Provider[T]) WaitToBecomeLeader() error {
 }
 
 func (m *Provider[T]) Close() error {
-	m.cancel()
+	m.ctxCancel()
 	m.wg.Wait()
 	if m.watcher != nil {
 		m.watcher.Close()
 	}
-	m.log.Info("Closed metadata provider")
+	m.logger.Info("Closed metadata provider")
 	return nil
 }
 
@@ -297,7 +297,7 @@ func (m *Provider[T]) watchLoop() {
 		m.watcher.Publish(value)
 		return m.watch()
 	}, backoff.WithContext(retry, m.ctx), func(err error, duration time.Duration) {
-		m.log.Warn("K8S config map watch failed, reconnecting",
+		m.logger.Warn("K8S config map watch failed, reconnecting",
 			slog.String("k8s-namespace", m.namespace),
 			slog.String("k8s-config-map", m.name),
 			slog.Any("error", err),

--- a/oxiad/coordinator/metadata/provider/raft/raft.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft.go
@@ -47,10 +47,10 @@ type Provider[T gproto.Message] struct {
 
 type Raft struct {
 	sync.Mutex
-	sc    *stateContainer
-	node  *hashicorpraft.Raft
-	store *kvRaftStore
-	log   *slog.Logger
+	sc     *stateContainer
+	node   *hashicorpraft.Raft
+	store  *kvRaftStore
+	logger *slog.Logger
 
 	closeOnce sync.Once
 	closeErr  error
@@ -105,8 +105,8 @@ func NewRaft(
 	raftDataDir string,
 ) (*Raft, error) {
 	metadataRaft := &Raft{
-		sc:  newStateContainer(slog.With(slog.String("component", "metadata-provider-raft-state-container"))),
-		log: slog.With(slog.String("component", "metadata-provider-raft")),
+		sc:     newStateContainer(slog.With(slog.String("component", "metadata-provider-raft-state-container"))),
+		logger: slog.With(slog.String("component", "metadata-provider-raft")),
 	}
 
 	// Ensure data dir per node
@@ -124,7 +124,7 @@ func NewRaft(
 	config.LogLevel = "INFO"
 	levelVar := &slog.LevelVar{}
 	levelVar.Set(slog.LevelInfo)
-	config.Logger = slog2hclog.New(metadataRaft.log, levelVar)
+	config.Logger = slog2hclog.New(metadataRaft.logger, levelVar)
 
 	// Create TCP transport for Raft
 	addr, err := net.ResolveTCPAddr("tcp", raftAddress)
@@ -209,7 +209,7 @@ func (mpr *Provider[T]) Get() (value T, version provider.Version, err error) {
 
 	document := mpr.raft.sc.document(mpr.resourceType)
 
-	mpr.raft.log.Debug("Get metadata",
+	mpr.raft.logger.Debug("Get metadata",
 		slog.String("resource-type", string(mpr.resourceType)),
 		slog.Any("metadata", document.State),
 		slog.Any("current-version", document.CurrentVersion))
@@ -233,7 +233,7 @@ func (mpr *Provider[T]) Store(value T, expectedVersion provider.Version) (newVer
 		return provider.NotExists, err
 	}
 
-	mpr.raft.log.Debug("Store into raft",
+	mpr.raft.logger.Debug("Store into raft",
 		slog.String("resource-type", string(mpr.resourceType)),
 		slog.Any("metadata", data),
 		slog.Any("expected-version", expectedVersion),

--- a/oxiad/coordinator/metadata/provider/raft/raft_fsm.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft_fsm.go
@@ -33,13 +33,13 @@ type raftOpCmd struct {
 
 type stateContainer struct {
 	Documents map[provider.ResourceType]*documentContainer `json:"-"`
-	log       *slog.Logger
+	logger    *slog.Logger
 }
 
-func newStateContainer(log *slog.Logger) *stateContainer {
+func newStateContainer(logger *slog.Logger) *stateContainer {
 	return &stateContainer{
 		Documents: map[provider.ResourceType]*documentContainer{},
-		log:       log,
+		logger:    logger,
 	}
 }
 
@@ -49,7 +49,7 @@ func (sc *stateContainer) Apply(logEntry *raft.Log) any {
 	opCmd := raftOpCmd{}
 	err := json.Unmarshal(logEntry.Data, &opCmd)
 	if err != nil {
-		sc.log.Error("failed to deserialize state",
+		sc.logger.Error("failed to deserialize state",
 			slog.Any("error", err))
 		return &applyResult{changeApplied: false}
 	}
@@ -59,7 +59,7 @@ func (sc *stateContainer) Apply(logEntry *raft.Log) any {
 
 	document := sc.document(opCmd.ResourceType)
 	if opCmd.ExpectedVersion != document.CurrentVersion {
-		sc.log.Warn("Failed to apply raft state",
+		sc.logger.Warn("Failed to apply raft state",
 			slog.String("resource-type", string(opCmd.ResourceType)),
 			slog.Int64("expected-version", opCmd.ExpectedVersion),
 			slog.Int64("current-version", document.CurrentVersion),
@@ -71,7 +71,7 @@ func (sc *stateContainer) Apply(logEntry *raft.Log) any {
 	document.State = cloneBytes(opCmd.NewState)
 	document.CurrentVersion++
 
-	sc.log.Info("Applied raft log entry",
+	sc.logger.Info("Applied raft log entry",
 		slog.String("resource-type", string(opCmd.ResourceType)),
 		slog.Int64("new-version", document.CurrentVersion))
 	return &applyResult{changeApplied: true, newVersion: document.CurrentVersion}
@@ -88,7 +88,7 @@ func (sc *stateContainer) Snapshot() (raft.FSMSnapshot, error) {
 func (sc *stateContainer) Restore(rc io.ReadCloser) error {
 	dec := json.NewDecoder(rc)
 	persisted := &persistedStateContainer{}
-	sc.log.Info("Restored metadata state from snapshot",
+	sc.logger.Info("Restored metadata state from snapshot",
 		slog.Any("cluster-status", sc))
 
 	if err := dec.Decode(persisted); err != nil {

--- a/oxiad/coordinator/runtime/balancer/scheduler.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler.go
@@ -44,11 +44,10 @@ const defaultThreshElectedThreshold = 0.75
 var _ LoadBalancer = &nodeBasedBalancer{}
 
 type nodeBasedBalancer struct {
-	*slog.Logger
-	*sync.WaitGroup
-
-	ctx    context.Context
-	cancel context.CancelFunc
+	logger    *slog.Logger
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+	wg        sync.WaitGroup
 
 	loadBalancerConf    *commonproto.LoadBalancer
 	metadata            coordmetadata.Metadata
@@ -71,8 +70,8 @@ func (r *nodeBasedBalancer) Action() <-chan action.Action {
 
 func (r *nodeBasedBalancer) Close() error {
 	close(r.triggerCh)
-	r.cancel()
-	r.Wait()
+	r.ctxCancel()
+	r.wg.Wait()
 	return nil
 }
 
@@ -103,8 +102,8 @@ func (r *nodeBasedBalancer) rebalanceEnsemble() bool {
 	groupedStatus, historyNodes := state.GroupingShardsNodeByStatus(candidates, currentStatus)
 	loadRatios := r.loadRatioAlgorithm(&model.RatioParams{NodeShardsInfos: groupedStatus, HistoryNodes: historyNodes})
 
-	if r.Enabled(r.ctx, slog.LevelDebug) {
-		r.Debug("start shard rebalance",
+	if r.logger.Enabled(r.ctx, slog.LevelDebug) {
+		r.logger.Debug("start shard rebalance",
 			slog.Float64("max-node-load-ratio", loadRatios.MaxNodeLoadRatio()),
 			slog.Float64("min-node-load-ratio", loadRatios.MinNodeLoadRatio()),
 			slog.Any("quarantine-nodes", r.quarantineNodes()),
@@ -114,8 +113,8 @@ func (r *nodeBasedBalancer) rebalanceEnsemble() bool {
 
 	defer func() {
 		swapGroup.Wait()
-		if r.Enabled(r.ctx, slog.LevelDebug) {
-			r.Debug("end shard rebalance",
+		if r.logger.Enabled(r.ctx, slog.LevelDebug) {
+			r.logger.Debug("end shard rebalance",
 				slog.Float64("max-node-load-ratio", loadRatios.MaxNodeLoadRatio()),
 				slog.Float64("min-node-load-ratio", loadRatios.MinNodeLoadRatio()),
 				slog.Float64("avg-shard-ratio", loadRatios.AvgShardLoadRatio()),
@@ -162,7 +161,7 @@ func (r *nodeBasedBalancer) balanceHighestNode(loadRatios *model.Ratio, candidat
 		fromNodeID := highestLoadRatioNode.NodeID
 		fromNode := highestLoadRatioNode.Node
 		if _, err := r.swapShard(highestLoadRatioShard, fromNode, swapGroup, loadRatios, candidates, metadata, currentStatus); err != nil {
-			r.Error("failed to select server when swap the node",
+			r.logger.Error("failed to select server when swap the node",
 				slog.String("namespace", highestLoadRatioShard.Namespace),
 				slog.Int64("shard", highestLoadRatioShard.ShardID),
 				slog.String("from-node", fromNodeID),
@@ -175,7 +174,7 @@ func (r *nodeBasedBalancer) balanceHighestNode(loadRatios *model.Ratio, candidat
 	}
 	if highestLoadRatioNode.Ratio-loadRatios.MinNodeLoadRatio() > loadRatios.AvgShardLoadRatio() {
 		r.nodeQuarantineNodeMap.Store(highestLoadRatioNode.NodeID, time.Now())
-		r.Info("can't rebalance the current node, quarantine it.",
+		r.logger.Info("can't rebalance the current node, quarantine it.",
 			slog.Float64("highest-load-node-ratio", highestLoadRatioNode.Ratio),
 			slog.String("highest-load-node", highestLoadRatioNode.NodeID))
 	}
@@ -196,7 +195,7 @@ func (r *nodeBasedBalancer) cleanDeletedNode(loadRatios *model.Ratio,
 		for shardIter := nodeLoadRatio.ShardIterator(); shardIter.Next(); {
 			var shardRatio = shardIter.Value()
 			if swapped, err := r.swapShard(shardRatio, deletedNode, swapGroup, loadRatios, candidates, metadata, currentStatus); err != nil || !swapped {
-				r.Error("failed to select server when move ensemble out of deleted node",
+				r.logger.Error("failed to select server when move ensemble out of deleted node",
 					slog.String("namespace", shardRatio.Namespace),
 					slog.Int64("shard", shardRatio.ShardID),
 					slog.String("from-node", deletedNodeID),
@@ -206,7 +205,7 @@ func (r *nodeBasedBalancer) cleanDeletedNode(loadRatios *model.Ratio,
 			}
 		}
 		if err := loadRatios.RemoveDeletedNode(nodeLoadRatio.NodeID); err != nil {
-			r.Error("failed to remove deleted node from ratio snapshot", slog.Any("error", err))
+			r.logger.Error("failed to remove deleted node from ratio snapshot", slog.Any("error", err))
 		}
 	}
 }
@@ -265,7 +264,7 @@ func (r *nodeBasedBalancer) swapShard(
 		return false, errors.New("target node does not exist")
 	}
 
-	r.Info("propose to swap the shard", slog.Int64("shard", candidateShard.ShardID), slog.Any("from", fromNode), slog.Any("to", targetNodeID))
+	r.logger.Info("propose to swap the shard", slog.Int64("shard", candidateShard.ShardID), slog.Any("from", fromNode), slog.Any("to", targetNodeID))
 	swapGroup.Add(1)
 	r.actionCh <- action.NewChangeEnsembleActionWithCallback(candidateShard.ShardID, fromNode, targetNode,
 		concurrent.NewOnce(func(_ any) {
@@ -325,7 +324,7 @@ func (r *nodeBasedBalancer) IsBalanced() bool {
 }
 
 func (r *nodeBasedBalancer) Trigger() {
-	r.Info("manually trigger balance")
+	r.logger.Info("manually trigger balance")
 	channel.PushNoBlock(r.triggerCh, nil)
 }
 
@@ -334,46 +333,46 @@ func (r *nodeBasedBalancer) LoadRatioAlgorithm() selector.LoadRatioAlgorithm {
 }
 
 func (r *nodeBasedBalancer) startBackgroundScheduler() {
-	r.Add(1)
-	go process.DoWithLabels(r.ctx, map[string]string{
-		"component": "load-balancer-scheduler",
-	}, func() {
-		timer := time.NewTicker(r.loadBalancerConf.GetScheduleIntervalDurationOrDefault())
-		defer timer.Stop()
-		defer r.Done()
-		for {
-			select {
-			case _, more := <-timer.C:
-				if !more {
+	r.wg.Go(func() {
+		process.DoWithLabels(r.ctx, map[string]string{
+			"component": "load-balancer-scheduler",
+		}, func() {
+			timer := time.NewTicker(r.loadBalancerConf.GetScheduleIntervalDurationOrDefault())
+			defer timer.Stop()
+			for {
+				select {
+				case _, more := <-timer.C:
+					if !more {
+						return
+					}
+					channel.PushNoBlock(r.triggerCh, nil)
+				case <-r.ctx.Done():
 					return
 				}
-				channel.PushNoBlock(r.triggerCh, nil)
-			case <-r.ctx.Done():
-				return
 			}
-		}
+		})
 	})
 }
 
 func (r *nodeBasedBalancer) startBackgroundNotifier() {
-	r.Add(1)
-	go process.DoWithLabels(r.ctx, map[string]string{
-		"component": "load-balancer-notifier",
-	}, func() {
-		defer r.Done()
-		for {
-			select {
-			case _, more := <-r.triggerCh:
-				if !more {
+	r.wg.Go(func() {
+		process.DoWithLabels(r.ctx, map[string]string{
+			"component": "load-balancer-notifier",
+		}, func() {
+			for {
+				select {
+				case _, more := <-r.triggerCh:
+					if !more {
+						return
+					}
+					if r.rebalanceEnsemble() { // if shard is balanced
+						r.rebalanceLeader()
+					}
+				case <-r.ctx.Done():
 					return
 				}
-				if r.rebalanceEnsemble() { // if shard is balanced
-					r.rebalanceLeader()
-				}
-			case <-r.ctx.Done():
-				return
 			}
-		}
+		})
 	})
 }
 
@@ -390,13 +389,13 @@ func (r *nodeBasedBalancer) rebalanceLeader() {
 		return
 	}
 
-	if r.Enabled(r.ctx, slog.LevelDebug) {
-		r.Debug("start leader rebalance",
+	if r.logger.Enabled(r.ctx, slog.LevelDebug) {
+		r.logger.Debug("start leader rebalance",
 			slog.Any("node-leaders", nodeLeaders),
 			slog.Any("quarantine-shards", r.quarantineShards()),
 		)
 		defer func() {
-			r.Debug("end leader rebalance")
+			r.logger.Debug("end leader rebalance")
 		}()
 	}
 
@@ -433,7 +432,7 @@ func (r *nodeBasedBalancer) rebalanceLeader() {
 			}
 		}
 		if minCandidateLeaders == maxLeaders || minCandidateLeaders+1 == maxLeaders {
-			r.Info("quarantine the shard due to no valid candidates", slog.Int64("shard", shard), slog.Any("leader", maxLeadersNodeID))
+			r.logger.Info("quarantine the shard due to no valid candidates", slog.Int64("shard", shard), slog.Any("leader", maxLeadersNodeID))
 			r.shardQuarantineShardMap.Store(shard, time.Now())
 			continue
 		}
@@ -447,9 +446,9 @@ func (r *nodeBasedBalancer) rebalanceLeader() {
 		r.actionCh <- ac
 		latch.Wait()
 		leader := ac.NewLeader
-		r.Info("triggered new election", slog.Int64("shard", shard), slog.Any("old-leader", maxLeadersNodeID), slog.Any("new-leader", leader))
+		r.logger.Info("triggered new election", slog.Int64("shard", shard), slog.Any("old-leader", maxLeadersNodeID), slog.Any("new-leader", leader))
 		if leader == maxLeadersNodeID { // no changes
-			r.Info("quarantine the shard due to no leader changed", slog.Int64("shard", shard), slog.Any("old-leader", maxLeadersNodeID), slog.Any("new-leader", leader))
+			r.logger.Info("quarantine the shard due to no leader changed", slog.Int64("shard", shard), slog.Any("old-leader", maxLeadersNodeID), slog.Any("new-leader", leader))
 			r.shardQuarantineShardMap.Store(shard, time.Now())
 		}
 		break
@@ -500,10 +499,10 @@ func NewLoadBalancer(options Options) LoadBalancer {
 		slog.String("component", "load-balancer"))
 
 	return &nodeBasedBalancer{
-		WaitGroup:               &sync.WaitGroup{},
-		Logger:                  logger,
+		logger:                  logger,
 		ctx:                     ctx,
-		cancel:                  cancelFunc,
+		ctxCancel:               cancelFunc,
+		wg:                      sync.WaitGroup{},
 		loadBalancerConf:        options.Metadata.LoadLoadBalancer(),
 		actionCh:                make(chan action.Action, 1000),
 		nodeAvailableJudger:     options.NodeAvailableJudger,

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -127,10 +127,10 @@ func newTestBalancer(
 	sel selector.Selector[*single.Context, string],
 ) *nodeBasedBalancer {
 	return &nodeBasedBalancer{
-		Logger:                  slog.Default(),
-		WaitGroup:               &sync.WaitGroup{},
+		logger:                  slog.Default(),
 		ctx:                     ctx,
-		cancel:                  cancel,
+		ctxCancel:               cancel,
+		wg:                      sync.WaitGroup{},
 		loadBalancerConf:        metadata.LoadLoadBalancer(),
 		metadata:                metadata,
 		selector:                sel,

--- a/oxiad/coordinator/runtime/controller/dataserver_controller.go
+++ b/oxiad/coordinator/runtime/controller/dataserver_controller.go
@@ -69,13 +69,13 @@ type DataServerController interface {
 }
 
 type dataServerController struct {
-	*slog.Logger
-	sync.WaitGroup
+	logger *slog.Logger
+	wg     sync.WaitGroup
 	ShardAssignmentsProvider
 	DataServerEventListener
 
 	ctx        context.Context
-	cancel     context.CancelFunc
+	ctxCancel  context.CancelFunc
 	dataServer *proto.DataServerIdentity
 	rpc        rpc.Provider
 	insID      string
@@ -111,7 +111,7 @@ func (n *dataServerController) SetStatus(status DataServerStatus) {
 	defer n.statusLock.Unlock()
 	previous := n.status
 	n.status = status
-	n.Info("Changed status", slog.Any("from", previous), slog.Any("to", status))
+	n.logger.Info("Changed status", slog.Any("from", previous), slog.Any("to", status))
 }
 
 func (n *dataServerController) maybeInitHealthClient() {
@@ -125,7 +125,7 @@ func (n *dataServerController) maybeInitHealthClient() {
 			n.healthClientCloser = closer
 			return nil
 		}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
-			n.Warn(
+			n.logger.Warn(
 				"Failed to create health client to storage data server",
 				slog.Duration("retry-after", duration),
 				slog.Any("error", err),
@@ -139,25 +139,24 @@ func (n *dataServerController) Close() error {
 		return nil
 	}
 	n.dataServerRunningGauge.Unregister()
-	n.cancel()
-	n.Wait()
+	n.ctxCancel()
+	n.wg.Wait()
 
 	var err error
 	if err = n.healthClientCloser.Close(); err != nil {
-		n.Warn("close data server controller health client failed", slog.Any("error", err))
+		n.logger.Warn("close data server controller health client failed", slog.Any("error", err))
 	}
-	n.Info("Closed data server controller")
+	n.logger.Info("Closed data server controller")
 	return err
 }
 
 func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
-	defer n.Done()
 	_ = backoff.RetryNotify(func() error {
-		n.Debug("Ready to send assignments")
+		n.logger.Debug("Ready to send assignments")
 
 		stream, err := n.rpc.PushShardAssignments(n.ctx, n.dataServer)
 		if err != nil {
-			n.Debug("Failed to create shard assignments stream", slog.Any("error", err))
+			n.logger.Debug("Failed to create shard assignments stream", slog.Any("error", err))
 			return err
 		}
 		streamCtx := stream.Context()
@@ -169,30 +168,30 @@ func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
 			case <-streamCtx.Done():
 				return streamCtx.Err()
 			default:
-				n.Debug(
+				n.logger.Debug(
 					"Waiting for next assignments update",
 					slog.Any("current-assignments", assignments),
 				)
 				if assignments, err = n.WaitForNextUpdate(streamCtx, assignments); err != nil {
-					n.Debug("Failed to send assignments", slog.Any("error", err))
+					n.logger.Debug("Failed to send assignments", slog.Any("error", err))
 					return err
 				}
 				if assignments == nil {
 					continue
 				}
 
-				n.Debug("Sending assignments", slog.Any("assignments", assignments))
+				n.logger.Debug("Sending assignments", slog.Any("assignments", assignments))
 				if err := stream.Send(assignments); err != nil {
-					n.Debug("Failed to send assignments", slog.Any("error", err))
+					n.logger.Debug("Failed to send assignments", slog.Any("error", err))
 					return err
 				}
-				n.Debug("Send assignments completed successfully")
+				n.logger.Debug("Send assignments completed successfully")
 				n.dispatchAssignmentsBackoff.Reset()
 			}
 		}
 	}, n.dispatchAssignmentsBackoff, func(err error, duration time.Duration) {
 		if !errors.Is(err, context.Canceled) {
-			n.Warn(
+			n.logger.Warn(
 				"Failed to send assignments updates to storage data server",
 				slog.Duration("retry-after", duration),
 				slog.Any("error", err),
@@ -209,7 +208,6 @@ func (n *dataServerController) doHealthPing() error {
 }
 
 func (n *dataServerController) healthPingWithRetries() {
-	defer n.Done()
 	_ = backoff.RetryNotify(func() error {
 		n.maybeInitHealthClient()
 		// Immediate check on startup instead of waiting for first tick
@@ -224,13 +222,13 @@ func (n *dataServerController) healthPingWithRetries() {
 				return nil
 			case <-ticker.C:
 				if err := n.doHealthPing(); err != nil {
-					n.Warn("Data server stopped responding to ping")
+					n.logger.Warn("Data server stopped responding to ping")
 					return err
 				}
 			}
 		}
 	}, n.healthCheckBackoff, func(err error, duration time.Duration) {
-		n.Warn(
+		n.logger.Warn(
 			"Failed to check storage data server health by ping-pong",
 			slog.Duration("retry-after", duration),
 			slog.Any("error", err),
@@ -240,9 +238,8 @@ func (n *dataServerController) healthPingWithRetries() {
 }
 
 func (n *dataServerController) healthWatchWithRetries() {
-	defer n.Done()
 	_ = backoff.RetryNotify(func() error {
-		n.Debug("Start new health watch cycle")
+		n.logger.Debug("Start new health watch cycle")
 		n.maybeInitHealthClient()
 
 		watchStream, err := n.healthClient.Watch(n.ctx, &grpc_health_v1.HealthCheckRequest{Service: ""})
@@ -260,7 +257,7 @@ func (n *dataServerController) healthWatchWithRetries() {
 			}
 		}
 	}, n.healthCheckBackoff, func(err error, duration time.Duration) {
-		n.Warn("Failed to check storage data server health by watch",
+		n.logger.Warn("Failed to check storage data server health by watch",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
 		)
@@ -292,7 +289,7 @@ func (n *dataServerController) becomeAvailable() {
 		return
 	}
 
-	n.Info("Storage data server is back online")
+	n.logger.Info("Storage data server is back online")
 
 	// To avoid the send assignments stream to miss the notification about the current
 	// dataServer went down, we interrupt the current stream when the ping on the dataServer fails
@@ -318,7 +315,7 @@ func (n *dataServerController) becomeAvailable() {
 			return errors.Errorf("unexpected handshake status: %s", handshake.Status.String())
 		}
 	}, bo, func(err error, duration time.Duration) {
-		n.Warn("Failed to handshake with data server",
+		n.logger.Warn("Failed to handshake with data server",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
 		)
@@ -336,7 +333,7 @@ func (n *dataServerController) becomeAvailable() {
 func (n *dataServerController) healthCheckHandler(response *grpc_health_v1.HealthCheckResponse, err error) error {
 	if err != nil {
 		if !errors.Is(err, context.Canceled) && grpcstatus.Code(err) != codes.Canceled {
-			n.Warn("Data server health check failed", slog.Any("error", err))
+			n.logger.Warn("Data server health check failed", slog.Any("error", err))
 		}
 		return err
 	}
@@ -370,7 +367,7 @@ func newDataServerController(ctx context.Context, dataServer *proto.DataServerId
 
 	nc := &dataServerController{
 		ctx:                      dataServerCtx,
-		cancel:                   cancel,
+		ctxCancel:                cancel,
 		dataServer:               dataServer,
 		ShardAssignmentsProvider: shardAssignmentsProvider,
 		DataServerEventListener:  dataServerEventListener,
@@ -379,7 +376,7 @@ func newDataServerController(ctx context.Context, dataServer *proto.DataServerId
 		statusLock:               sync.RWMutex{},
 		status:                   NotRunning,
 		supportedFeatures:        supportedFeatures,
-		Logger: slog.With(
+		logger: slog.With(
 			slog.String("component", "data-server-controller"),
 			slog.Any("data-server", dataServerID),
 		),
@@ -399,36 +396,39 @@ func newDataServerController(ctx context.Context, dataServer *proto.DataServerId
 			return 0
 		})
 
-	nc.Add(1)
-	go process.DoWithLabels(
-		nc.ctx,
-		map[string]string{
-			"component":  "data-server-controller-health-watch",
-			"dataServer": dataServerID,
-		},
-		nc.healthWatchWithRetries,
-	)
+	nc.wg.Go(func() {
+		process.DoWithLabels(
+			nc.ctx,
+			map[string]string{
+				"component":  "data-server-controller-health-watch",
+				"dataServer": dataServerID,
+			},
+			nc.healthWatchWithRetries,
+		)
+	})
 
-	nc.Add(1)
-	go process.DoWithLabels(
-		nc.ctx,
-		map[string]string{
-			"component":  "data-server-controller-health-ping",
-			"dataServer": dataServerID,
-		},
-		nc.healthPingWithRetries,
-	)
+	nc.wg.Go(func() {
+		process.DoWithLabels(
+			nc.ctx,
+			map[string]string{
+				"component":  "data-server-controller-health-ping",
+				"dataServer": dataServerID,
+			},
+			nc.healthPingWithRetries,
+		)
+	})
 
-	nc.Add(1)
-	go process.DoWithLabels(
-		nc.ctx,
-		map[string]string{
-			"component":  "data-server-controller-assignment-dispatcher",
-			"dataServer": dataServerID,
-		},
-		nc.sendAssignmentsDispatchWithRetries,
-	)
+	nc.wg.Go(func() {
+		process.DoWithLabels(
+			nc.ctx,
+			map[string]string{
+				"component":  "data-server-controller-assignment-dispatcher",
+				"dataServer": dataServerID,
+			},
+			nc.sendAssignmentsDispatchWithRetries,
+		)
+	})
 
-	nc.Info("Started data server controller")
+	nc.logger.Info("Started data server controller")
 	return nc
 }

--- a/oxiad/coordinator/runtime/controller/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller.go
@@ -91,10 +91,10 @@ type shardController struct {
 	changeEnsembleOp    chan *action.ChangeEnsembleAction
 
 	ctx                   context.Context
-	cancel                context.CancelFunc
-	wg                    *sync.WaitGroup
+	ctxCancel             context.CancelFunc
+	wg                    sync.WaitGroup
 	periodicTasksInterval time.Duration
-	log                   *slog.Logger
+	logger                *slog.Logger
 
 	currentElection *ShardElection
 
@@ -141,12 +141,12 @@ func NewShardController(
 		changeEnsembleOp:                    make(chan *action.ChangeEnsembleAction, chanBufferSize),
 
 		periodicTasksInterval: periodTasksInterval,
-		log: slog.With(
+		logger: slog.With(
 			slog.String("component", "shard-controller"),
 			slog.String("namespace", namespace),
 			slog.Int64("shard", shard),
 		),
-		wg: &sync.WaitGroup{},
+		wg: sync.WaitGroup{},
 
 		leaderElectionLatency: metric.NewLatencyHistogram("oxia_coordinator_leader_election_latency",
 			"The time it takes to elect a leader for the shard", labels),
@@ -163,10 +163,10 @@ func NewShardController(
 			return s.metadata.Term()
 		})
 
-	s.ctx, s.cancel = context.WithCancel(context.Background())
+	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
 
 	shardMeta := s.metadata.Load()
-	s.log.Info("Started shard controller", slog.Any("shard-metadata", shardMeta))
+	s.logger.Info("Started shard controller", slog.Any("shard-metadata", shardMeta))
 
 	s.wg.Go(func() {
 		process.DoWithLabels(
@@ -202,12 +202,12 @@ func (s *shardController) run(initShardMeta *proto.ShardMetadata) {
 		// Wait until the split is complete (Split metadata cleared) before
 		// entering the normal event loop, to prevent the load balancer from
 		// triggering elections that would interfere with the split controller.
-		s.log.Info("Child shard during split, waiting for split to complete")
+		s.logger.Info("Child shard during split, waiting for split to complete")
 		s.waitForSplitComplete()
 	case initShardMeta.Leader == nil || initShardMeta.GetStatusOrDefault() != proto.ShardStatusSteadyState:
 		s.onElectLeader(nil)
 	default:
-		s.log.Info(
+		s.logger.Info(
 			"There is already a data server marked as leader on the shard, verifying",
 			slog.Any("current-leader", initShardMeta.Leader),
 		)
@@ -219,7 +219,7 @@ func (s *shardController) run(initShardMeta *proto.ShardMetadata) {
 		}
 	}
 
-	s.log.Info("Shard is ready", slog.Any("leader", initShardMeta.Leader))
+	s.logger.Info("Shard is ready", slog.Any("leader", initShardMeta.Leader))
 
 	periodicTasksTimer := time.NewTicker(s.periodicTasksInterval)
 
@@ -268,7 +268,7 @@ func (s *shardController) waitForSplitComplete() {
 				continue
 			}
 			if meta.Split == nil {
-				s.log.Info("Split complete, child shard entering normal operation",
+				s.logger.Info("Split complete, child shard entering normal operation",
 					slog.Any("leader", meta.Leader),
 				)
 				// Update local metadata to match the status resource
@@ -281,7 +281,7 @@ func (s *shardController) waitForSplitComplete() {
 
 func (s *shardController) handleDataServerFailure(failedDataServer *proto.DataServerIdentity) {
 	shardMeta := s.metadata.Load()
-	s.log.Debug(
+	s.logger.Debug(
 		"Received notification of failed data server",
 		slog.Any("failed-data-server", failedDataServer.GetNameOrDefault()),
 		slog.Any("current-leader", shardMeta.Leader),
@@ -289,7 +289,7 @@ func (s *shardController) handleDataServerFailure(failedDataServer *proto.DataSe
 
 	if shardMeta.Leader != nil &&
 		shardMeta.Leader.GetNameOrDefault() == failedDataServer.GetNameOrDefault() {
-		s.log.Info(
+		s.logger.Info(
 			"Detected failure on shard leader",
 			slog.Any("leader", failedDataServer.GetNameOrDefault()),
 		)
@@ -306,7 +306,7 @@ func (s *shardController) verifyCurrentEnsemble(initShardMeta *proto.ShardMetada
 
 		switch {
 		case err != nil:
-			s.log.Warn(
+			s.logger.Warn(
 				"Failed to verify status for shard. Start a new election",
 				slog.Any("error", err),
 				slog.Any("data-server", dataServer),
@@ -314,7 +314,7 @@ func (s *shardController) verifyCurrentEnsemble(initShardMeta *proto.ShardMetada
 			return false
 		case dataServer.GetNameOrDefault() == initShardMeta.Leader.GetNameOrDefault() &&
 			dataServerStatus.Status != proto.ServingStatus_LEADER:
-			s.log.Warn(
+			s.logger.Warn(
 				"Expected leader is not in leader status. Start a new election",
 				slog.Any("data-server", dataServer),
 				slog.Any("status", dataServerStatus.Status),
@@ -322,14 +322,14 @@ func (s *shardController) verifyCurrentEnsemble(initShardMeta *proto.ShardMetada
 			return false
 		case dataServer.GetNameOrDefault() != initShardMeta.Leader.GetNameOrDefault() &&
 			dataServerStatus.Status != proto.ServingStatus_FOLLOWER:
-			s.log.Warn(
+			s.logger.Warn(
 				"Expected follower is not in follower status. Start a new election",
 				slog.Any("data-server", dataServer),
 				slog.Any("status", dataServerStatus.Status),
 			)
 			return false
 		case dataServerStatus.Term != initShardMeta.Term:
-			s.log.Warn(
+			s.logger.Warn(
 				"Node has a wrong term. Start a new election",
 				slog.Any("data-server", dataServer),
 				slog.Any("data-server-term", dataServerStatus.Term),
@@ -337,14 +337,14 @@ func (s *shardController) verifyCurrentEnsemble(initShardMeta *proto.ShardMetada
 			)
 			return false
 		default:
-			s.log.Info(
+			s.logger.Info(
 				"Data Server looks ok",
 				slog.Any("data-server", dataServer),
 			)
 		}
 	}
 
-	s.log.Info("All data servers look good. No need to trigger new leader election")
+	s.logger.Info("All data servers look good. No need to trigger new leader election")
 	return true
 }
 
@@ -363,7 +363,7 @@ func (s *shardController) onElectLeader(changeEnsembleAction *action.ChangeEnsem
 		termOptions.EnableNotifications = nsConfig.NotificationsEnabledOrDefault()
 		termOptions.KeySorting, _ = nsConfig.GetKeySortingType()
 	}
-	s.currentElection = NewShardElection(s.ctx, s.log, s.eventListener,
+	s.currentElection = NewShardElection(s.ctx, s.logger, s.eventListener,
 		s.metadataStore, s.dataServerSupportedFeaturesSupplier, s.leaderSelector,
 		s.rpc, &s.metadata, s.namespace, s.shard, changeEnsembleAction,
 		termOptions,
@@ -390,18 +390,18 @@ func (s *shardController) DeleteShard() {
 }
 
 func (s *shardController) deleteShardWithRetries() {
-	s.log.Info("Deleting shard")
+	s.logger.Info("Deleting shard")
 
 	_ = backoff.RetryNotify(s.deleteShard, oxiatime.NewBackOff(s.ctx),
 		func(err error, duration time.Duration) {
-			s.log.Warn(
+			s.logger.Warn(
 				"Delete shard failed, retrying later",
 				slog.Duration("retry-after", duration),
 				slog.Any("error", err),
 			)
 		})
 
-	s.cancel()
+	s.ctxCancel()
 }
 
 func (s *shardController) deleteShard() error {
@@ -409,7 +409,7 @@ func (s *shardController) deleteShard() error {
 	for _, server := range shardMeta.Ensemble {
 		// We need to save the address because it gets modified in the loop
 		if err := s.deleteShardRpc(s.ctx, server); err != nil {
-			s.log.Warn(
+			s.logger.Warn(
 				"Failed to delete shard",
 				slog.Any("error", err),
 				slog.Any("data-server", server),
@@ -417,7 +417,7 @@ func (s *shardController) deleteShard() error {
 			return err
 		}
 
-		s.log.Info(
+		s.logger.Info(
 			"Successfully deleted shard from data server",
 			slog.Any("server-address", server),
 		)
@@ -441,7 +441,7 @@ func (s *shardController) Close() error {
 }
 
 func (s *shardController) close() error {
-	s.cancel()
+	s.ctxCancel()
 	s.termGauge.Unregister()
 	return nil
 }
@@ -461,7 +461,7 @@ func (s *shardController) onChangeEnsemble(changeEnsembleAction *action.ChangeEn
 	}()
 	if s.currentElection != nil {
 		if ready := s.currentElection.IsReadyForChangeEnsemble(); !ready {
-			s.log.Warn("Change ensemble rejected: shard is not ready (follower catch-up still in progress)")
+			s.logger.Warn("Change ensemble rejected: shard is not ready (follower catch-up still in progress)")
 			err = ErrNotReadyForChangeEnsemble
 			return
 		}
@@ -483,7 +483,7 @@ func (s *shardController) SyncServerAddress() {
 	if !needSync {
 		return
 	}
-	s.log.Info("server address changed, start a new leader election")
+	s.logger.Info("server address changed, start a new leader election")
 	group := &sync.WaitGroup{}
 	group.Add(1)
 	s.electionOp <- &action.ElectionAction{
@@ -498,7 +498,7 @@ func (s *shardController) handlePeriodicTasks() {
 	if len(mutShardMeta.PendingDeleteShardNodes) > 0 {
 		var err error
 		if err = s.handlePendingDeleteShard(mutShardMeta); err != nil {
-			s.log.Warn("Failed to handle pending delete shard", "error", err)
+			s.logger.Warn("Failed to handle pending delete shard", "error", err)
 			return
 		}
 	}
@@ -510,18 +510,18 @@ func (s *shardController) handlePeriodicTasks() {
 
 func (s *shardController) handlePendingDeleteShard(mutShardMeta *proto.ShardMetadata) error {
 	for _, ds := range mutShardMeta.PendingDeleteShardNodes {
-		s.log.Info("Deleting shard from removed data server", slog.Any("data-server", ds))
+		s.logger.Info("Deleting shard from removed data server", slog.Any("data-server", ds))
 
 		if _, err := s.rpc.DeleteShard(s.ctx, ds, &proto.DeleteShardRequest{
 			Namespace: s.namespace,
 			Shard:     s.shard,
 			Term:      mutShardMeta.Term,
 		}); err != nil {
-			s.log.Warn("Failed to delete shard from removed data server", slog.Any("data-server", ds), slog.Any("error", err))
+			s.logger.Warn("Failed to delete shard from removed data server", slog.Any("data-server", ds), slog.Any("error", err))
 			return err
 		}
 
-		s.log.Info("Successfully deleted shard from data server", slog.Any("data-server", ds))
+		s.logger.Info("Successfully deleted shard from data server", slog.Any("data-server", ds))
 	}
 
 	mutShardMeta.PendingDeleteShardNodes = nil

--- a/oxiad/coordinator/runtime/controller/shard_controller_election.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller_election.go
@@ -49,10 +49,10 @@ var (
 )
 
 type ShardElection struct {
-	*slog.Logger
-	sync.WaitGroup
-	context.Context
-	context.CancelFunc
+	logger    *slog.Logger
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+	wg        sync.WaitGroup
 	// metrics
 	leaderElectionLatency metric.LatencyHistogram
 	newTermQuorumLatency  metric.LatencyHistogram
@@ -84,9 +84,9 @@ func (e *ShardElection) refreshedEnsemble(ensemble []*proto.DataServerIdentity) 
 		}
 		refreshedEnsembleDataServerAddress[idx] = candidate
 	}
-	if e.Enabled(e.Context, slog.LevelDebug) {
+	if e.logger.Enabled(e.ctx, slog.LevelDebug) {
 		if !reflect.DeepEqual(ensemble, refreshedEnsembleDataServerAddress) {
-			e.Info("refresh the shard ensemble dataServer address", slog.Any("current-ensemble", ensemble),
+			e.logger.Info("refresh the shard ensemble dataServer address", slog.Any("current-ensemble", ensemble),
 				slog.Any("new-ensemble", refreshedEnsembleDataServerAddress))
 		}
 	}
@@ -117,7 +117,7 @@ func (e *ShardElection) fenceNewTermQuorum(term int64, ensemble []*proto.DataSer
 	majority := fencingQuorumSize/2 + 1
 
 	// Use a new context, so we can cancel the pending requests
-	fencingContext, fencingContextCancel := context.WithCancel(e.Context)
+	fencingContext, fencingContextCancel := context.WithCancel(e.ctx)
 	latch := sync.WaitGroup{}
 	defer func() {
 		fencingContextCancel()
@@ -145,9 +145,9 @@ func (e *ShardElection) fenceNewTermQuorum(term int64, ensemble []*proto.DataSer
 				}, func() {
 					entryId, err := e.fenceNewTerm(fencingContext, term, pinedServer)
 					if err != nil {
-						e.Warn("FenceNewTerm failed", slog.Any("error", err), slog.Any("data-server", pinedServer))
+						e.logger.Warn("FenceNewTerm failed", slog.Any("error", err), slog.Any("data-server", pinedServer))
 					} else {
-						e.Info("Processed fenceNewTerm response", slog.Any("data-server", pinedServer), slog.Any("entry-id", entryId))
+						e.logger.Info("Processed fenceNewTerm response", slog.Any("data-server", pinedServer), slog.Any("entry-id", entryId))
 					}
 					ch <- struct {
 						DataServer *proto.DataServerIdentity
@@ -248,7 +248,7 @@ func (e *ShardElection) becomeLeader(term int64, leader *proto.DataServerIdentit
 	for server, e := range followers {
 		followersMap[server.GetInternal()] = e
 	}
-	if _, err := e.provider.BecomeLeader(e.Context, leader, &proto.BecomeLeaderRequest{
+	if _, err := e.provider.BecomeLeader(e.ctx, leader, &proto.BecomeLeaderRequest{
 		Namespace:         e.namespace,
 		Shard:             e.shard,
 		Term:              term,
@@ -272,7 +272,7 @@ func (e *ShardElection) ensureFollowerCaught(ensemble []*proto.DataServerIdentit
 		}
 		waitGroup.Add(1)
 		go process.DoWithLabels(
-			e.Context,
+			e.ctx,
 			map[string]string{
 				"oxia":        "shard-caught-up-monitor",
 				"namespace":   e.namespace,
@@ -281,36 +281,36 @@ func (e *ShardElection) ensureFollowerCaught(ensemble []*proto.DataServerIdentit
 			}, func() {
 				defer waitGroup.Done()
 				err := backoff.RetryNotify(func() error {
-					fs, err := e.provider.GetStatus(e.Context, server, &proto.GetStatusRequest{Shard: e.shard})
+					fs, err := e.provider.GetStatus(e.ctx, server, &proto.GetStatusRequest{Shard: e.shard})
 					if err != nil {
 						return err
 					}
 					followerHeadOffset := fs.HeadOffset
 					if followerHeadOffset >= leaderEntry.Offset {
-						e.Info(
+						e.logger.Info(
 							"Follower is caught-up with the leader after election",
 							slog.Any("server", server),
 						)
 						return nil
 					}
-					e.Info(
+					e.logger.Info(
 						"Follower is *not* caught-up yet with the leader",
 						slog.Any("server", server),
 						slog.Int64("leader-head-offset", leaderEntry.Offset),
 						slog.Int64("follower-head-offset", followerHeadOffset),
 					)
 					return ErrFollowerNotCaughtUp
-				}, oxiatime.NewBackOff(e.Context), func(err error, duration time.Duration) {
+				}, oxiatime.NewBackOff(e.ctx), func(err error, duration time.Duration) {
 					switch {
 					case errors.Is(err, ErrFollowerNotCaughtUp):
 					case status.Code(err) == constant.CodeNodeIsNotMember:
-						e.Info("Follower has not been added by leader yet",
+						e.logger.Info("Follower has not been added by leader yet",
 							slog.Any("server", server),
 							slog.Int64("shard", e.shard),
 							slog.Duration("retry-after", duration),
 						)
 					default:
-						e.Warn("Failed to get the follower status",
+						e.logger.Warn("Failed to get the follower status",
 							slog.Any("server", server),
 							slog.Any("error", err),
 							slog.Duration("retry-after", duration),
@@ -318,7 +318,7 @@ func (e *ShardElection) ensureFollowerCaught(ensemble []*proto.DataServerIdentit
 					}
 				})
 				if err != nil {
-					e.Info("Abort data server swap follower status validation due to context canceled", slog.Any("error", err))
+					e.logger.Info("Abort data server swap follower status validation due to context canceled", slog.Any("error", err))
 					return
 				}
 			})
@@ -345,7 +345,7 @@ func (e *ShardElection) fenceNewTermAndAddFollower(ctx context.Context, term int
 		return err
 	}
 
-	e.Info(
+	e.logger.Info(
 		"Successfully rejoined the quorum",
 		slog.Any("follower", follower),
 		slog.Int64("term", fr.Term),
@@ -356,7 +356,7 @@ func (e *ShardElection) fenceNewTermAndAddFollower(ctx context.Context, term int
 func (e *ShardElection) fencingFailedFollowers(term int64, ensemble []*proto.DataServerIdentity, leader *proto.DataServerIdentity,
 	successfulFollowers map[*proto.DataServerIdentity]*proto.EntryId) {
 	if len(successfulFollowers) == len(ensemble)-1 {
-		e.Debug(
+		e.logger.Debug(
 			"All the member of the ensemble were successfully added",
 			slog.Int64("term", term),
 		)
@@ -372,24 +372,24 @@ func (e *ShardElection) fencingFailedFollowers(term int64, ensemble []*proto.Dat
 		if _, found := successfulFollowers[follower]; found {
 			continue
 		}
-		e.Info("Data server has failed in leader election, retrying", slog.Any("follower", follower))
+		e.logger.Info("Data server has failed in leader election, retrying", slog.Any("follower", follower))
 		group.Go(func() {
 			process.DoWithLabels(
-				e.Context,
+				e.ctx,
 				map[string]string{
 					"oxia":     "election-retry-failed-follower",
 					"shard":    fmt.Sprintf("%d", e.shard),
 					"follower": follower.GetNameOrDefault(),
 				},
 				func() {
-					bo := oxiatime.NewBackOffWithInitialInterval(e.Context, 1*time.Second)
+					bo := oxiatime.NewBackOffWithInitialInterval(e.ctx, 1*time.Second)
 					_ = backoff.RetryNotify(func() error {
 						var err error
-						if err = e.fenceNewTermAndAddFollower(e.Context, term, leader, follower); status.Code(err) == constant.CodeInvalidTerm {
+						if err = e.fenceNewTermAndAddFollower(e.ctx, term, leader, follower); status.Code(err) == constant.CodeInvalidTerm {
 							// If we're receiving invalid term error, it would mean
 							// there's already a new term generated, and we don't have
 							// to keep trying with this old term
-							e.Warn(
+							e.logger.Warn(
 								"Failed to fenceNewTermAndAddFollower, invalid term. Stop trying",
 								slog.Any("follower", follower),
 								slog.Int64("term", term),
@@ -398,7 +398,7 @@ func (e *ShardElection) fencingFailedFollowers(term int64, ensemble []*proto.Dat
 						}
 						return err
 					}, bo, func(err error, duration time.Duration) {
-						e.Warn(
+						e.logger.Warn(
 							"Failed to fenceNewTermAndAddFollower, retrying later",
 							slog.Any("error", err),
 							slog.Any("follower", follower),
@@ -428,7 +428,7 @@ func (e *ShardElection) prepareIfChangeEnsemble(mutShardMeta *proto.ShardMetadat
 	mutShardMeta.Ensemble = append(slices.DeleteFunc(mutShardMeta.Ensemble, func(dataServer *proto.DataServerIdentity) bool {
 		return dataServer.GetNameOrDefault() == from.GetNameOrDefault()
 	}), to)
-	e.Info(
+	e.logger.Info(
 		"Changing ensemble",
 		slog.Any("removed-data-servers", mutShardMeta.RemovedNodes),
 		slog.Any("new-ensemble", mutShardMeta.Ensemble),
@@ -438,7 +438,7 @@ func (e *ShardElection) prepareIfChangeEnsemble(mutShardMeta *proto.ShardMetadat
 }
 
 func (e *ShardElection) start() (*proto.DataServerIdentity, error) {
-	e.Info("Starting a new election")
+	e.logger.Info("Starting a new election")
 	timer := e.leaderElectionLatency.Timer()
 
 	mutShardMeta := e.meta.Compute(func(metadata *proto.ShardMetadata) {
@@ -462,7 +462,7 @@ func (e *ShardElection) start() (*proto.DataServerIdentity, error) {
 	if err != nil {
 		return nil, err
 	}
-	if e.Enabled(context.Background(), slog.LevelInfo) {
+	if e.logger.Enabled(e.ctx, slog.LevelInfo) {
 		f := make([]struct {
 			ServerAddress *proto.DataServerIdentity `json:"server-address"`
 			EntryId       *proto.EntryId            `json:"entry-id"`
@@ -473,7 +473,7 @@ func (e *ShardElection) start() (*proto.DataServerIdentity, error) {
 				EntryId       *proto.EntryId            `json:"entry-id"`
 			}{ServerAddress: sa, EntryId: entryId})
 		}
-		e.Info(
+		e.logger.Info(
 			"Successfully moved ensemble to a new term",
 			slog.Int64("term", mutShardMeta.Term),
 			slog.Any("new-leader", newLeader),
@@ -503,7 +503,7 @@ func (e *ShardElection) start() (*proto.DataServerIdentity, error) {
 		e.eventListener.LeaderElected(e.shard, newLeader, maps.Keys(followers))
 	}
 
-	e.Info(
+	e.logger.Info(
 		"Elected new leader",
 		slog.Int64("term", mutShardMeta.Term),
 		slog.Any("leader", mutShardMeta.Leader),
@@ -511,9 +511,9 @@ func (e *ShardElection) start() (*proto.DataServerIdentity, error) {
 	)
 	timer.Done()
 
-	e.Go(func() {
+	e.wg.Go(func() {
 		process.DoWithLabels(
-			e.Context,
+			e.ctx,
 			map[string]string{
 				"oxia":  "election-fencing-failed-followers",
 				"shard": fmt.Sprintf("%d", e.shard),
@@ -522,9 +522,9 @@ func (e *ShardElection) start() (*proto.DataServerIdentity, error) {
 			},
 		)
 	})
-	e.Go(func() {
+	e.wg.Go(func() {
 		process.DoWithLabels(
-			e.Context,
+			e.ctx,
 			map[string]string{
 				"oxia":  "election-monitor-followers-caught-up",
 				"shard": fmt.Sprintf("%d", e.shard),
@@ -582,9 +582,9 @@ func (e *ShardElection) Start() *proto.DataServerIdentity {
 	}
 	newLeader, _ := backoff.RetryNotifyWithData[*proto.DataServerIdentity](func() (*proto.DataServerIdentity, error) {
 		return e.start()
-	}, oxiatime.NewBackOff(e.Context), func(err error, duration time.Duration) {
+	}, oxiatime.NewBackOff(e.ctx), func(err error, duration time.Duration) {
 		e.leaderElectionsFailed.Inc()
-		e.Warn(
+		e.logger.Warn(
 			"Leader election has failed, retrying later",
 			slog.Int64("term", e.meta.Term()),
 			slog.Any("error", err),
@@ -595,9 +595,9 @@ func (e *ShardElection) Start() *proto.DataServerIdentity {
 }
 
 func (e *ShardElection) Stop() {
-	e.CancelFunc()
-	e.Wait()
-	e.Info("stopped the election", slog.Any("term", e.meta.Term()))
+	e.ctxCancel()
+	e.wg.Wait()
+	e.logger.Info("stopped the election", slog.Any("term", e.meta.Term()))
 }
 
 //nolint:revive
@@ -611,10 +611,10 @@ func NewShardElection(ctx context.Context, logger *slog.Logger, eventListener Sh
 	becomeLeaderLatency metric.LatencyHistogram, leaderElectionsFailed metric.Counter) *ShardElection {
 	current, cancelFunc := context.WithCancel(ctx)
 	return &ShardElection{
-		Logger:                              logger,
-		WaitGroup:                           sync.WaitGroup{},
-		Context:                             current,
-		CancelFunc:                          cancelFunc,
+		logger:                              logger,
+		ctx:                                 current,
+		ctxCancel:                           cancelFunc,
+		wg:                                  sync.WaitGroup{},
 		metadataStore:                       metadataStore,
 		dataServerSupportedFeaturesSupplier: dataServerSupportedFeaturesSupplier,
 		eventListener:                       eventListener,

--- a/oxiad/coordinator/runtime/controller/split_controller.go
+++ b/oxiad/coordinator/runtime/controller/split_controller.go
@@ -63,10 +63,10 @@ type SplitController struct {
 	// ensembleSelector selects server ensembles for new shards.
 	ensembleSelector func(namespace string) ([]*proto.DataServerIdentity, error)
 
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
-	log    *slog.Logger
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+	wg        sync.WaitGroup
+	logger    *slog.Logger
 }
 
 const DefaultSplitTimeout = 5 * time.Minute
@@ -97,7 +97,7 @@ func NewSplitController(cfg SplitControllerConfig) *SplitController {
 		rpcProvider:      cfg.RpcProvider,
 		eventListener:    cfg.EventListener,
 		ensembleSelector: cfg.EnsembleSelector,
-		log: slog.With(
+		logger: slog.With(
 			slog.String("component", "split-controller"),
 			slog.String("namespace", cfg.Namespace),
 			slog.Int64("parent-shard", cfg.ParentShardId),
@@ -108,18 +108,18 @@ func NewSplitController(cfg SplitControllerConfig) *SplitController {
 	if splitTimeout == 0 {
 		splitTimeout = DefaultSplitTimeout
 	}
-	sc.ctx, sc.cancel = context.WithTimeout(context.Background(), splitTimeout)
+	sc.ctx, sc.ctxCancel = context.WithTimeout(context.Background(), splitTimeout)
 
 	// Load the current split metadata from cluster status
 	status := sc.metadata.LoadStatus()
 	ns, exists := status.Namespaces[sc.namespace]
 	if !exists {
-		sc.log.Error("Namespace not found in cluster status")
+		sc.logger.Error("Namespace not found in cluster status")
 		return sc
 	}
 	parentMeta, exists := ns.Shards[sc.parentShardId]
 	if !exists || parentMeta.Split == nil {
-		sc.log.Error("Parent shard or split metadata not found")
+		sc.logger.Error("Parent shard or split metadata not found")
 		return sc
 	}
 
@@ -143,7 +143,7 @@ func NewSplitController(cfg SplitControllerConfig) *SplitController {
 }
 
 func (sc *SplitController) Close() {
-	sc.cancel()
+	sc.ctxCancel()
 	sc.wg.Wait()
 }
 
@@ -151,7 +151,7 @@ func (sc *SplitController) run() {
 	_ = backoff.RetryNotify(func() error {
 		return sc.driveStateMachine()
 	}, oxiatime.NewBackOff(sc.ctx), func(err error, duration time.Duration) {
-		sc.log.Warn(
+		sc.logger.Warn(
 			"Split state machine step failed, retrying",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
@@ -180,7 +180,7 @@ func (sc *SplitController) driveStateMachine() error {
 			return nil
 		}
 
-		sc.log.Info("Running split phase", slog.String("phase", phase))
+		sc.logger.Info("Running split phase", slog.String("phase", phase))
 
 		var err error
 		switch phase {
@@ -191,7 +191,7 @@ func (sc *SplitController) driveStateMachine() error {
 		case proto.SplitPhaseCutover:
 			err = sc.runCutover()
 		default:
-			sc.log.Error("Unknown split phase", slog.Any("phase", phase))
+			sc.logger.Error("Unknown split phase", slog.Any("phase", phase))
 			return nil
 		}
 
@@ -240,7 +240,7 @@ func (sc *SplitController) updatePhase(newPhase string) {
 // child leaders (so they start replicating to their followers immediately),
 // and adds children as observer followers on the parent leader.
 func (sc *SplitController) runBootstrap() error {
-	sc.log.Info("Phase Bootstrap: fencing children and adding as observers")
+	sc.logger.Info("Phase Bootstrap: fencing children and adding as observers")
 
 	parentMeta := sc.loadParentMeta()
 	if parentMeta == nil || parentMeta.Leader == nil {
@@ -301,7 +301,7 @@ func (sc *SplitController) fenceAndElectChild(childId int64) error {
 	}
 
 	if childMeta.Leader != nil {
-		sc.log.Info("Child already has leader, skipping fence/elect",
+		sc.logger.Info("Child already has leader, skipping fence/elect",
 			slog.Int64("child-shard", childId),
 			slog.Any("leader", childMeta.Leader),
 		)
@@ -342,7 +342,7 @@ func (sc *SplitController) fenceAndElectChild(childId int64) error {
 		return errors.Wrapf(err, "BecomeLeader failed for child %d", childId)
 	}
 
-	sc.log.Info("Child leader elected",
+	sc.logger.Info("Child leader elected",
 		slog.Int64("child-shard", childId),
 		slog.Any("child-leader", childLeader),
 		slog.Int64("term", childTerm),
@@ -379,7 +379,7 @@ func (sc *SplitController) addChildObserver(childId int64, parentLeader *proto.D
 		return errors.Wrapf(err, "failed to add child %d as observer on parent", childId)
 	}
 
-	sc.log.Info("Added child as observer on parent",
+	sc.logger.Info("Added child as observer on parent",
 		slog.Int64("child-shard", childId),
 		slog.Any("child-leader", childLeader),
 	)
@@ -400,7 +400,7 @@ const CatchUpRoundTimeout = 10 * time.Second
 // leader during Bootstrap and are actively replicating to their followers.
 // commitOffset advancing means a quorum of child followers have the data.
 func (sc *SplitController) runCatchUp() error {
-	sc.log.Info("Phase CatchUp: monitoring observer progress")
+	sc.logger.Info("Phase CatchUp: monitoring observer progress")
 
 	for {
 		if err := sc.ctx.Err(); err != nil {
@@ -418,7 +418,7 @@ func (sc *SplitController) runCatchUp() error {
 			return err
 		}
 		if caughtUp {
-			sc.log.Info("All children caught up")
+			sc.logger.Info("All children caught up")
 			sc.updatePhase(proto.SplitPhaseCutover)
 			return nil
 		}
@@ -437,7 +437,7 @@ func (sc *SplitController) checkObserverCursorsStale() (bool, error) {
 	// Parent leader election: observer cursors are closed when the old leader
 	// is fenced, so they need to be re-added on the new leader.
 	if parentMeta.Split.ParentTermAtBootstrap > 0 && parentMeta.Term != parentMeta.Split.ParentTermAtBootstrap {
-		sc.log.Warn("Parent term changed since bootstrap, resetting to Bootstrap",
+		sc.logger.Warn("Parent term changed since bootstrap, resetting to Bootstrap",
 			slog.Int64("bootstrap-term", parentMeta.Split.ParentTermAtBootstrap),
 			slog.Int64("current-term", parentMeta.Term),
 		)
@@ -471,7 +471,7 @@ func (sc *SplitController) removeStaleChildObservers(parentMeta *proto.ShardMeta
 			continue
 		}
 
-		sc.log.Warn("Child leader changed since bootstrap, removing stale observer and resetting to Bootstrap",
+		sc.logger.Warn("Child leader changed since bootstrap, removing stale observer and resetting to Bootstrap",
 			slog.Int64("child-shard", childId),
 			slog.String("old-leader", bootstrapLeader),
 			slog.String("new-leader", childMeta.Leader.GetInternal()),
@@ -505,7 +505,7 @@ func (sc *SplitController) runCatchUpRound() (bool, error) {
 	}
 	target := parentStatus.CommitOffset
 
-	sc.log.Info("CatchUp round: waiting for children to reach target",
+	sc.logger.Info("CatchUp round: waiting for children to reach target",
 		slog.Int64("target-commit-offset", target),
 	)
 
@@ -515,7 +515,7 @@ func (sc *SplitController) runCatchUpRound() (bool, error) {
 	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
 		if err := sc.waitForChildCommitOffset(roundCtx, childId, target); err != nil {
 			if roundCtx.Err() != nil {
-				sc.log.Info("CatchUp round timed out, retrying",
+				sc.logger.Info("CatchUp round timed out, retrying",
 					slog.Int64("child-shard", childId),
 					slog.Int64("target", target),
 				)
@@ -531,7 +531,7 @@ func (sc *SplitController) runCatchUpRound() (bool, error) {
 // data, re-elects child leaders in a clean term, updates shard assignments,
 // and marks the parent for deletion.
 func (sc *SplitController) runCutover() error {
-	sc.log.Info("Phase Cutover: fencing parent and completing split")
+	sc.logger.Info("Phase Cutover: fencing parent and completing split")
 
 	parentMeta := sc.loadParentMeta()
 	if parentMeta == nil {
@@ -554,7 +554,7 @@ func (sc *SplitController) runCutover() error {
 		}
 	}
 
-	sc.log.Info("Parent fenced",
+	sc.logger.Info("Parent fenced",
 		slog.Int64("new-term", newParentTerm),
 		slog.Int64("final-offset", parentFinalOffset),
 	)
@@ -612,7 +612,7 @@ func (sc *SplitController) runCutover() error {
 // It removes observer cursors from the parent, deletes child shards from
 // status, clears the parent's split metadata, and notifies the coordinator.
 func (sc *SplitController) abort() {
-	sc.log.Warn("Aborting split due to timeout or cancellation")
+	sc.logger.Warn("Aborting split due to timeout or cancellation")
 
 	// Use a fresh context since the split context is cancelled.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -636,7 +636,7 @@ func (sc *SplitController) abort() {
 						TargetShard:  childId,
 					})
 					if err != nil {
-						sc.log.Warn("Failed to remove observer during abort",
+						sc.logger.Warn("Failed to remove observer during abort",
 							slog.Int64("child-shard", childId),
 							slog.Any("error", err),
 						)
@@ -656,7 +656,7 @@ func (sc *SplitController) abort() {
 		meta.Split = nil
 	})
 
-	sc.log.Info("Split aborted, parent restored")
+	sc.logger.Info("Split aborted, parent restored")
 
 	// Notify coordinator to clean up child controllers and recompute assignments.
 	sc.eventListener.SplitAborted(sc.parentShardId, sc.leftChildId, sc.rightChildId)
@@ -740,7 +740,7 @@ func (sc *SplitController) fenceEnsemble(
 	var lastErr error
 	for r := range ch {
 		if r.err != nil {
-			sc.log.Warn("NewTerm failed for server",
+			sc.logger.Warn("NewTerm failed for server",
 				slog.Int64("shard", shardId),
 				slog.Any("server", r.server),
 				slog.Any("error", r.err),
@@ -797,7 +797,7 @@ func (sc *SplitController) waitForChildCommitOffset(ctx context.Context, childId
 		}
 
 		if resp.CommitOffset >= targetOffset {
-			sc.log.Info("Child reached target commit offset",
+			sc.logger.Info("Child reached target commit offset",
 				slog.Int64("child-shard", childId),
 				slog.Int64("target", targetOffset),
 				slog.Int64("commit-offset", resp.CommitOffset),
@@ -807,7 +807,7 @@ func (sc *SplitController) waitForChildCommitOffset(ctx context.Context, childId
 
 		return errors.Errorf("child %d commit offset %d, target %d", childId, resp.CommitOffset, targetOffset)
 	}, oxiatime.NewBackOff(ctx), func(err error, duration time.Duration) {
-		sc.log.Debug("Waiting for child commit offset",
+		sc.logger.Debug("Waiting for child commit offset",
 			slog.Int64("child-shard", childId),
 			slog.Int64("target-offset", targetOffset),
 			slog.Any("error", err),
@@ -862,7 +862,7 @@ func (sc *SplitController) reelectChild(childId int64) error {
 		meta.Status = proto.ShardStatusSteadyState
 	})
 
-	sc.log.Info("Child re-elected in clean term",
+	sc.logger.Info("Child re-elected in clean term",
 		slog.Int64("child-shard", childId),
 		slog.Any("leader", newLeader),
 		slog.Int64("term", newTerm),

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -42,13 +42,13 @@ import (
 )
 
 type runtime struct {
-	*slog.Logger
-	sync.WaitGroup
 	sync.RWMutex
 
-	ctx    context.Context
-	cancel context.CancelFunc
-	insID  string
+	logger    *slog.Logger
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+	wg        sync.WaitGroup
+	insID     string
 
 	metadata coordmetadata.Metadata
 
@@ -103,7 +103,7 @@ func (c *runtime) ConfigChanged(newConfig *proto.ClusterConfiguration) {
 	c.Lock()
 	defer c.Unlock()
 
-	c.Info("Detected change in cluster config", slog.Any("newClusterConfig", newConfig))
+	c.logger.Info("Detected change in cluster config", slog.Any("newClusterConfig", newConfig))
 
 	// Check for nodes to add
 	for _, sa := range newConfig.GetServers() {
@@ -112,7 +112,7 @@ func (c *runtime) ConfigChanged(newConfig *proto.ClusterConfiguration) {
 		}
 		// The node is present in the config, though we don't know it yet,
 		// therefore it must be a newly added node
-		c.Info("Detected new node", slog.Any("server", sa))
+		c.logger.Info("Detected new node", slog.Any("server", sa))
 		if nc, ok := c.drainingNodes[sa.GetNameOrDefault()]; ok {
 			// If there were any controller for a draining node, close it
 			// and recreate it as a new node
@@ -134,7 +134,7 @@ func (c *runtime) ConfigChanged(newConfig *proto.ClusterConfiguration) {
 		if _, exist := c.metadata.Node(serverID); exist {
 			continue
 		}
-		c.Info("Detected a removed node", slog.Any("server", serverID))
+		c.logger.Info("Detected a removed node", slog.Any("server", serverID))
 		// Moved the node
 		delete(c.nodeControllers, serverID)
 		nc.SetStatus(controller.Draining)
@@ -215,8 +215,8 @@ func (c *runtime) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.Cl
 }
 
 func (c *runtime) Close() error {
-	c.cancel()
-	c.Wait()
+	c.ctxCancel()
+	c.wg.Wait()
 
 	var err error
 	for _, sc := range c.splitControllers {
@@ -246,7 +246,7 @@ func (c *runtime) BecameUnavailable(node *proto.DataServerIdentity) {
 			// the callback will come from the node controller internal health check goroutine,
 			// we should close it in the background goroutines to avoid any unexpected deadlock here
 			if err := nc.Close(); err != nil {
-				c.Error("Failed to close node controller", slog.String("node", node.GetNameOrDefault()), slog.Any("error", err))
+				c.logger.Error("Failed to close node controller", slog.String("node", node.GetNameOrDefault()), slog.Any("error", err))
 			}
 		}()
 	}
@@ -299,7 +299,7 @@ func (c *runtime) startBackgroundConfigWatcher() {
 	configWatch := c.metadata.ConfigWatch()
 	receiver, err := configWatch.Subscribe()
 	if err != nil {
-		c.Warn("failed to subscribe to cluster config watch", slog.Any("error", err))
+		c.logger.Warn("failed to subscribe to cluster config watch", slog.Any("error", err))
 		return
 	}
 	defer func() {
@@ -334,13 +334,13 @@ func (c *runtime) handleActionElection(ac action.Action) {
 	if electionAc, ok = ac.(*action.ElectionAction); !ok {
 		panic("unexpected action type")
 	}
-	c.Info("Applying swap action", slog.Any("swap-action", ac))
+	c.logger.Info("Applying swap action", slog.Any("swap-action", ac))
 
 	c.RLock()
 	sc, ok := c.shardControllers[electionAc.Shard]
 	c.RUnlock()
 	if !ok {
-		c.Warn("Shard controller not found", slog.Int64("shard", electionAc.Shard))
+		c.logger.Warn("Shard controller not found", slog.Int64("shard", electionAc.Shard))
 		electionAc.Done(nil)
 		return
 	}
@@ -353,13 +353,13 @@ func (c *runtime) handleActionChangeEnsemble(ac action.Action) {
 	if changeEnsembleAction, ok = ac.(*action.ChangeEnsembleAction); !ok {
 		panic("unexpected action type")
 	}
-	c.Info("Applying swap action", slog.Any("swap-action", ac))
+	c.logger.Info("Applying swap action", slog.Any("swap-action", ac))
 
 	c.RLock()
 	sc, ok := c.shardControllers[changeEnsembleAction.Shard]
 	c.RUnlock()
 	if !ok {
-		c.Warn("Shard controller not found", slog.Int64("shard", changeEnsembleAction.Shard))
+		c.logger.Warn("Shard controller not found", slog.Int64("shard", changeEnsembleAction.Shard))
 		return
 	}
 
@@ -561,7 +561,7 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 	// Persist
 	c.metadata.UpdateStatus(cloned)
 
-	c.Info("Split initiated",
+	c.logger.Info("Split initiated",
 		slog.Int64("parent-shard", parentShardId),
 		slog.Int64("left-child", leftChildId),
 		slog.Int64("right-child", rightChildId),
@@ -606,7 +606,7 @@ func (c *runtime) SplitComplete(parentShard int64, leftChild int64, rightChild i
 	c.Lock()
 	defer c.Unlock()
 
-	c.Info("Split complete, triggering parent shard deletion",
+	c.logger.Info("Split complete, triggering parent shard deletion",
 		slog.Int64("parent-shard", parentShard),
 		slog.Int64("left-child", leftChild),
 		slog.Int64("right-child", rightChild),
@@ -646,7 +646,7 @@ func (c *runtime) SplitAborted(parentShard int64, leftChild int64, rightChild in
 	c.Lock()
 	defer c.Unlock()
 
-	c.Warn("Split aborted",
+	c.logger.Warn("Split aborted",
 		slog.Int64("parent-shard", parentShard),
 		slog.Int64("left-child", leftChild),
 		slog.Int64("right-child", rightChild),
@@ -687,7 +687,7 @@ func (c *runtime) restartInProgressSplits(clusterStatus *proto.ClusterStatus) {
 				continue
 			}
 
-			c.Info("Resuming in-progress split",
+			c.logger.Info("Resuming in-progress split",
 				slog.String("namespace", ns),
 				slog.Int64("parent-shard", shardId),
 				slog.String("phase", meta.Split.GetPhaseOrDefault()),
@@ -713,10 +713,9 @@ func New(
 	rpcProvider rpc.ProviderFactory,
 ) (Runtime, error) {
 	c := &runtime{
-		Logger: slog.With(
+		logger: slog.With(
 			slog.String("component", "coordinator"),
 		),
-		WaitGroup:        sync.WaitGroup{},
 		ensembleSelector: ensemble.NewSelector(),
 		shardControllers: make(map[int64]controller.ShardController),
 		splitControllers: make(map[int64]*controller.SplitController),
@@ -725,7 +724,7 @@ func New(
 		metadata:         metadata,
 	}
 
-	c.ctx, c.cancel = context.WithCancel(context.Background())
+	c.ctx, c.ctxCancel = context.WithCancel(context.Background())
 	c.assignmentsChanged = concurrent.NewConditionContext(c)
 
 	c.loadBalancer = balancer.NewLoadBalancer(balancer.Options{
@@ -756,7 +755,7 @@ func New(
 			c.insID,
 		)
 	}
-	c.Info("Checking cluster config", slog.Any("clusterConfig", clusterConfig))
+	c.logger.Info("Checking cluster config", slog.Any("clusterConfig", clusterConfig))
 	clusterStatus, _, _ = c.metadata.ApplyStatusChanges(clusterConfig, c.selectNewEnsemble)
 
 	// init shard controller
@@ -777,12 +776,12 @@ func New(
 	// Restart any in-progress splits from persisted state
 	c.restartInProgressSplits(clusterStatus)
 
-	c.Go(func() {
+	c.wg.Go(func() {
 		process.DoWithLabels(c.ctx, map[string]string{
 			"component": "coordinator-action-worker",
 		}, c.startBackgroundActionWorker)
 	})
-	c.Go(func() {
+	c.wg.Go(func() {
 		process.DoWithLabels(c.ctx, map[string]string{
 			"component": "coordinator-config-watcher",
 		}, c.startBackgroundConfigWatcher)


### PR DESCRIPTION
## Motivation
- make coordinator lifecycle ownership explicit instead of relying on embedded logger, context, and waitgroup fields
- standardize coordinator runtime and metadata components on the same private field shape

## Modifications
- replaced embedded lifecycle helpers in runtime, metadata, balancer, and controller structs with explicit `ctx`, `ctxCancel`, `wg`, and `logger` fields
- updated the touched background workers to use `wg.Go(...)` consistently
- aligned the file, configmap, and raft metadata providers with the same naming pattern

## Testing
- `go test ./oxiad/coordinator/... -run '^$'`
- `make lint`
