### PR TITLE
refactor: rename options watch variables

### DIFF
--- a/cmd/coordinator/cmd.go
+++ b/cmd/coordinator/cmd.go
@@ -94,7 +94,7 @@ func init() {
 
 func exec(cmd *cobra.Command, _ []string) {
 	process.RunProcess(func() (io.Closer, error) {
-		watchableOptions := commonwatch.New(coordinatorOptions)
+		optionsWatch := commonwatch.New(coordinatorOptions)
 		// configure the options
 		if cmd.Flags().Changed("sconfig") {
 			// init options
@@ -110,11 +110,11 @@ func exec(cmd *cobra.Command, _ []string) {
 					slog.Warn("parse updated configuration file failed", slog.Any("err", err))
 					return
 				}
-				previous, _ := watchableOptions.Load()
+				previous, _ := optionsWatch.Load()
 				slog.Info("configuration file has changed.",
 					slog.Any("previous", previous),
 					slog.Any("current", temporaryOptions))
-				watchableOptions.Publish(temporaryOptions)
+				optionsWatch.Publish(temporaryOptions)
 			})
 			v.WatchConfig()
 		} else {
@@ -123,6 +123,6 @@ func exec(cmd *cobra.Command, _ []string) {
 				return nil, err
 			}
 		}
-		return coordinator.NewGrpcServer(context.Background(), watchableOptions)
+		return coordinator.NewGrpcServer(context.Background(), optionsWatch)
 	})
 }

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -117,7 +117,7 @@ func init() {
 
 func exec(cmd *cobra.Command, _ []string) {
 	process.RunProcess(func() (io.Closer, error) {
-		watchableOptions := commonwatch.New(dataServerOptions)
+		optionsWatch := commonwatch.New(dataServerOptions)
 		switch {
 		case cmd.Flags().Changed("sconfig"):
 			// init options
@@ -133,11 +133,11 @@ func exec(cmd *cobra.Command, _ []string) {
 					slog.Warn("parse updated configuration file failed", slog.Any("err", err))
 					return
 				}
-				previous, _ := watchableOptions.Load()
+				previous, _ := optionsWatch.Load()
 				slog.Info("configuration file has changed.",
 					slog.Any("previous", previous),
 					slog.Any("current", temporaryOptions))
-				watchableOptions.Publish(temporaryOptions)
+				optionsWatch.Publish(temporaryOptions)
 			})
 			v.WatchConfig()
 		default:
@@ -147,6 +147,6 @@ func exec(cmd *cobra.Command, _ []string) {
 			}
 		}
 
-		return dataserver.New(context.Background(), watchableOptions)
+		return dataserver.New(context.Background(), optionsWatch)
 	})
 }

--- a/oxiad/coordinator/grpc_server.go
+++ b/oxiad/coordinator/grpc_server.go
@@ -36,27 +36,27 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/option"
 
 	"github.com/oxia-db/oxia/oxiad/common/metric"
-	rpc2 "github.com/oxia-db/oxia/oxiad/common/rpc"
+	commonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
 )
 
 type GrpcServer struct {
 	// concurrent control
-	ctx              context.Context
-	ctxCancel        context.CancelFunc
-	wg               sync.WaitGroup
-	logger           *slog.Logger
-	watchableOptions *commonwatch.Watch[*option.Options]
+	ctx          context.Context
+	ctxCancel    context.CancelFunc
+	wg           sync.WaitGroup
+	logger       *slog.Logger
+	optionsWatch *commonwatch.Watch[*option.Options]
 
-	grpcServer       rpc2.GrpcServer
-	managementServer rpc2.GrpcServer
+	grpcServer       commonrpc.GrpcServer
+	managementServer commonrpc.GrpcServer
 	healthServer     *health.Server
 	runtime          coordruntime.Runtime
 	metadata         coordmetadata.Metadata
 	metrics          *metric.PrometheusMetrics
 }
 
-func NewGrpcServer(parent context.Context, watchableOptions *commonwatch.Watch[*option.Options]) (*GrpcServer, error) {
-	options, _ := watchableOptions.Load()
+func NewGrpcServer(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options]) (*GrpcServer, error) {
+	options, _ := optionsWatch.Load()
 	slog.Info("Starting Oxia coordinator", slog.Any("options", options))
 
 	healthServer := health.NewServer()
@@ -66,7 +66,7 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonwatch.Watch[*
 	if err != nil {
 		return nil, err
 	}
-	grpcServer, err := rpc2.Default.StartGrpcServer("coordinator", internalServer.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
+	grpcServer, err := commonrpc.Default.StartGrpcServer("coordinator", internalServer.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
 		grpc_health_v1.RegisterHealthServer(registrar, healthServer)
 	}, internalServerTLS, &internalServer.Auth, nil)
 	if err != nil {
@@ -97,7 +97,7 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonwatch.Watch[*
 		runtime.Metadata(),
 		runtime,
 	)
-	managementGrpcServer, err := rpc2.Default.StartGrpcServer("admin", managementSv.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
+	managementGrpcServer, err := commonrpc.Default.StartGrpcServer("admin", managementSv.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
 		proto.RegisterOxiaAdminServer(registrar, management)
 	}, managementSvTLS, &managementSv.Auth, nil)
 	if err != nil {
@@ -114,7 +114,7 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonwatch.Watch[*
 		ctxCancel:        cancel,
 		wg:               sync.WaitGroup{},
 		logger:           slog.With(slog.String("component", "grpc-server")),
-		watchableOptions: watchableOptions,
+		optionsWatch:     optionsWatch,
 		grpcServer:       grpcServer,
 		managementServer: managementGrpcServer,
 		healthServer:     healthServer,
@@ -143,7 +143,7 @@ func startMetricsServer(metrics commonoption.MetricOptions) (*metric.PrometheusM
 }
 
 func (s *GrpcServer) backgroundHandleConfChange() {
-	receiver, err := s.watchableOptions.Subscribe()
+	receiver, err := s.optionsWatch.Subscribe()
 	if err != nil {
 		s.logger.Warn("exit background configuration watch goroutine due to a subscription error", slog.Any("error", err))
 		return

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -28,7 +28,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/dataserver/option"
 
 	"github.com/oxia-db/oxia/oxiad/common/metric"
-	rpc2 "github.com/oxia-db/oxia/oxiad/common/rpc"
+	commonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/assignment"
 	"github.com/oxia-db/oxia/oxiad/dataserver/controller"
@@ -45,11 +45,11 @@ type Server struct {
 	*publicRpcServer
 
 	// concurrent control
-	ctx              context.Context
-	ctxCancel        context.CancelFunc
-	wg               sync.WaitGroup
-	logger           *slog.Logger
-	watchableOptions *commonwatch.Watch[*option.Options]
+	ctx          context.Context
+	ctxCancel    context.CancelFunc
+	wg           sync.WaitGroup
+	logger       *slog.Logger
+	optionsWatch *commonwatch.Watch[*option.Options]
 
 	replicationRpcProvider    rpc.ReplicationRpcProvider
 	shardAssignmentDispatcher assignment.ShardAssignmentsDispatcher
@@ -58,11 +58,11 @@ type Server struct {
 	walFactory                wal.Factory
 	kvFactory                 kvstore.Factory
 
-	healthServer rpc2.HealthServer
+	healthServer commonrpc.HealthServer
 }
 
-func New(parent context.Context, watchableOption *commonwatch.Watch[*option.Options]) (*Server, error) {
-	options, _ := watchableOption.Load()
+func New(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options]) (*Server, error) {
+	options, _ := optionsWatch.Load()
 	manifest, err := manifestpkg.NewManifest(options.Storage.Database.Dir)
 	if err != nil {
 		return nil, err
@@ -71,13 +71,13 @@ func New(parent context.Context, watchableOption *commonwatch.Watch[*option.Opti
 	if err != nil {
 		return nil, err
 	}
-	grpcProvider, err := NewWithGrpcProvider(parent, watchableOption, rpc2.Default, provider, manifest, false)
+	grpcProvider, err := NewWithGrpcProvider(parent, optionsWatch, commonrpc.Default, provider, manifest, false)
 	return grpcProvider, err
 }
 
-func NewWithGrpcProvider(parent context.Context, watchableOption *commonwatch.Watch[*option.Options], provider rpc2.GrpcProvider,
+func NewWithGrpcProvider(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options], provider commonrpc.GrpcProvider,
 	replicationRpcProvider rpc.ReplicationRpcProvider, manifest *manifestpkg.Manifest, disableAuthorityValidation bool) (*Server, error) {
-	options, _ := watchableOption.Load()
+	options, _ := optionsWatch.Load()
 	slog.Info("Starting Oxia dataServer", slog.Any("options", options))
 
 	storage := &options.Storage
@@ -97,7 +97,7 @@ func NewWithGrpcProvider(parent context.Context, watchableOption *commonwatch.Wa
 		ctxCancel:              cancel,
 		wg:                     sync.WaitGroup{},
 		logger:                 slog.With(slog.String("component", "grpc-server")),
-		watchableOptions:       watchableOption,
+		optionsWatch:           optionsWatch,
 		replicationRpcProvider: replicationRpcProvider,
 		walFactory: wal.NewWalFactory(&wal.FactoryOptions{
 			BaseWalDir:  storage.WAL.Dir,
@@ -106,7 +106,7 @@ func NewWithGrpcProvider(parent context.Context, watchableOption *commonwatch.Wa
 			SyncData:    storage.WAL.IsSyncEnabled(),
 		}),
 		kvFactory:    kvFactory,
-		healthServer: rpc2.NewClosableHealthServer(context.Background()),
+		healthServer: commonrpc.NewClosableHealthServer(context.Background()),
 	}
 
 	s.wg.Go(func() {
@@ -171,7 +171,7 @@ func (s *Server) InternalPort() int {
 }
 
 func (s *Server) backgroundHandleConfChange() {
-	receiver, err := s.watchableOptions.Subscribe()
+	receiver, err := s.optionsWatch.Subscribe()
 	if err != nil {
 		s.logger.Warn("exit background configuration watch goroutine due to a subscription error", slog.Any("error", err))
 		return


### PR DESCRIPTION
## Motivation
- make the option watch parameter names clearer in the coordinator and dataserver server constructors
- replace the temporary `rpc2` alias with a descriptive common RPC alias

## Modifications
- renamed `watchableOptions` and `watchableOption` to `optionsWatch` in the command entrypoints and server constructors
- renamed the `oxiad/common/rpc` import alias from `rpc2` to `commonrpc` in the touched files

## Testing
- `go test ./cmd/coordinator ./cmd/server ./oxiad/coordinator ./oxiad/dataserver -run '^$'`
- `make lint`
