### PR TITLE
refactor: simplify common watch semantics

### DIFF
--- a/cmd/coordinator/cmd.go
+++ b/cmd/coordinator/cmd.go
@@ -110,7 +110,7 @@ func exec(cmd *cobra.Command, _ []string) {
 					slog.Warn("parse updated configuration file failed", slog.Any("err", err))
 					return
 				}
-				previous, _ := optionsWatch.Load()
+				previous := optionsWatch.Load()
 				slog.Info("configuration file has changed.",
 					slog.Any("previous", previous),
 					slog.Any("current", temporaryOptions))

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -133,7 +133,7 @@ func exec(cmd *cobra.Command, _ []string) {
 					slog.Warn("parse updated configuration file failed", slog.Any("err", err))
 					return
 				}
-				previous, _ := optionsWatch.Load()
+				previous := optionsWatch.Load()
 				slog.Info("configuration file has changed.",
 					slog.Any("previous", previous),
 					slog.Any("current", temporaryOptions))

--- a/oxiad/common/watch/watch.go
+++ b/oxiad/common/watch/watch.go
@@ -78,16 +78,12 @@ func (w *Watch[T]) Close() {
 	close(w.changed)
 }
 
-func (w *Watch[T]) Load() (T, bool) {
-	if w.closed.Load() {
-		var zero T
-		return zero, false
-	}
+func (w *Watch[T]) Load() T {
 	value, ok := w.value.Load().(T)
 	if !ok {
 		panic("watch value type mismatch")
 	}
-	return value, true
+	return value
 }
 
 type Receiver[T any] struct {
@@ -107,7 +103,7 @@ func (r *Receiver[T]) Changed() <-chan struct{} {
 	return r.changed
 }
 
-func (r *Receiver[T]) Load() (T, bool) {
+func (r *Receiver[T]) Load() T {
 	r.watch.Lock()
 	r.changed = r.watch.changed
 	r.watch.Unlock()

--- a/oxiad/common/watch/watch.go
+++ b/oxiad/common/watch/watch.go
@@ -15,18 +15,14 @@
 package watch
 
 import (
-	"errors"
 	"sync"
 	"sync/atomic"
 )
-
-var ErrClosed = errors.New("watch closed")
 
 type Watch[T any] struct {
 	sync.Mutex
 
 	value   atomic.Value
-	closed  atomic.Bool
 	changed chan struct{}
 }
 
@@ -38,44 +34,24 @@ func New[T any](init T) *Watch[T] {
 	return w
 }
 
-func (w *Watch[T]) Subscribe() (*Receiver[T], error) {
+func (w *Watch[T]) Subscribe() *Receiver[T] {
 	w.Lock()
 	defer w.Unlock()
-
-	if w.closed.Load() {
-		return nil, ErrClosed
-	}
 
 	return &Receiver[T]{
 		watch:   w,
 		changed: w.changed,
-	}, nil
+	}
 }
 
 func (w *Watch[T]) Publish(value T) {
 	w.Lock()
 	defer w.Unlock()
 
-	if w.closed.Load() {
-		return
-	}
-
 	w.value.Store(value)
 	changed := w.changed
 	w.changed = make(chan struct{})
 	close(changed)
-}
-
-func (w *Watch[T]) Close() {
-	w.Lock()
-	defer w.Unlock()
-
-	if w.closed.Load() {
-		return
-	}
-
-	w.closed.Store(true)
-	close(w.changed)
 }
 
 func (w *Watch[T]) Load() T {

--- a/oxiad/common/watch/watch.go
+++ b/oxiad/common/watch/watch.go
@@ -16,84 +16,78 @@ package watch
 
 import (
 	"errors"
-	"io"
 	"sync"
+	"sync/atomic"
 )
 
 var ErrClosed = errors.New("watch closed")
 
-var _ io.Closer = (*Receiver[any])(nil)
-
 type Watch[T any] struct {
 	sync.Mutex
 
-	value     T
-	closed    bool
-	receivers map[*Receiver[T]]chan struct{}
+	value   atomic.Value
+	closed  atomic.Bool
+	changed chan struct{}
 }
 
 func New[T any](init T) *Watch[T] {
-	return &Watch[T]{
-		value:     init,
-		receivers: map[*Receiver[T]]chan struct{}{},
+	w := &Watch[T]{
+		changed: make(chan struct{}),
 	}
+	w.value.Store(init)
+	return w
 }
 
 func (w *Watch[T]) Subscribe() (*Receiver[T], error) {
 	w.Lock()
 	defer w.Unlock()
 
-	if w.closed {
+	if w.closed.Load() {
 		return nil, ErrClosed
 	}
 
-	ch := make(chan struct{}, 1)
-	r := &Receiver[T]{
+	return &Receiver[T]{
 		watch:   w,
-		changed: ch,
-	}
-	w.receivers[r] = ch
-	return r, nil
+		changed: w.changed,
+	}, nil
 }
 
 func (w *Watch[T]) Publish(value T) {
 	w.Lock()
 	defer w.Unlock()
 
-	if w.closed {
+	if w.closed.Load() {
 		return
 	}
 
-	w.value = value
-
-	for _, ch := range w.receivers {
-		select {
-		case ch <- struct{}{}:
-		default:
-		}
-	}
+	w.value.Store(value)
+	changed := w.changed
+	w.changed = make(chan struct{})
+	close(changed)
 }
 
 func (w *Watch[T]) Close() {
 	w.Lock()
 	defer w.Unlock()
 
-	if w.closed {
+	if w.closed.Load() {
 		return
 	}
 
-	w.closed = true
-	for r, ch := range w.receivers {
-		close(ch)
-		delete(w.receivers, r)
-	}
+	w.closed.Store(true)
+	close(w.changed)
 }
 
 func (w *Watch[T]) Load() (T, bool) {
-	w.Lock()
-	defer w.Unlock()
-
-	return w.value, true
+	if w.closed.Load() {
+		var zero T
+		return zero, false
+	}
+	value, ok := w.value.Load().(T)
+	if !ok {
+		panic("watch value type mismatch")
+	}
+	return value, true
 }
 
 type Receiver[T any] struct {
@@ -101,27 +95,22 @@ type Receiver[T any] struct {
 	changed chan struct{}
 }
 
+// Changed returns the receiver's current notification channel.
+//
+// Callers must pair every wake-up from Changed with a call to Load. Load both
+// returns the latest value and re-arms the receiver onto the latest watch
+// generation for future notifications.
 func (r *Receiver[T]) Changed() <-chan struct{} {
+	r.watch.Lock()
+	defer r.watch.Unlock()
+
 	return r.changed
 }
 
 func (r *Receiver[T]) Load() (T, bool) {
+	r.watch.Lock()
+	r.changed = r.watch.changed
+	r.watch.Unlock()
+
 	return r.watch.Load()
-}
-
-func (r *Receiver[T]) Close() error {
-	r.watch.closeReceiver(r)
-	return nil
-}
-
-func (w *Watch[T]) closeReceiver(r *Receiver[T]) {
-	w.Lock()
-	defer w.Unlock()
-
-	ch, ok := w.receivers[r]
-	if !ok {
-		return
-	}
-	delete(w.receivers, r)
-	close(ch)
 }

--- a/oxiad/common/watch/watch_test.go
+++ b/oxiad/common/watch/watch_test.go
@@ -27,9 +27,8 @@ import (
 func TestWatchLoad(t *testing.T) {
 	w := New("initial")
 
-	value, ok := w.Load()
+	value := w.Load()
 	assert.Equal(t, "initial", value)
-	assert.True(t, ok)
 }
 
 func TestSubscribePublish(t *testing.T) {
@@ -37,8 +36,7 @@ func TestSubscribePublish(t *testing.T) {
 	r, err := w.Subscribe()
 	require.NoError(t, err)
 
-	value, ok := r.Load()
-	assert.True(t, ok)
+	value := r.Load()
 	assert.NotNil(t, value)
 
 	config := &proto.ClusterConfiguration{
@@ -56,8 +54,7 @@ func TestSubscribePublish(t *testing.T) {
 		t.Fatal("timed out waiting for watch change")
 	}
 
-	value, ok = r.Load()
-	assert.True(t, ok)
+	value = r.Load()
 	assert.Same(t, config, value)
 }
 

--- a/oxiad/common/watch/watch_test.go
+++ b/oxiad/common/watch/watch_test.go
@@ -33,13 +33,13 @@ func TestWatchLoad(t *testing.T) {
 }
 
 func TestSubscribePublish(t *testing.T) {
-	w := New[*proto.ClusterConfiguration](nil)
+	w := New(&proto.ClusterConfiguration{})
 	r, err := w.Subscribe()
 	require.NoError(t, err)
 
 	value, ok := r.Load()
 	assert.True(t, ok)
-	assert.Nil(t, value)
+	assert.NotNil(t, value)
 
 	config := &proto.ClusterConfiguration{
 		Namespaces: []*proto.Namespace{{
@@ -62,7 +62,7 @@ func TestSubscribePublish(t *testing.T) {
 }
 
 func TestWatchClose(t *testing.T) {
-	w := New[*proto.ClusterConfiguration](nil)
+	w := New(&proto.ClusterConfiguration{})
 	r, err := w.Subscribe()
 	require.NoError(t, err)
 
@@ -70,18 +70,6 @@ func TestWatchClose(t *testing.T) {
 
 	_, err = w.Subscribe()
 	assert.ErrorIs(t, err, ErrClosed)
-
-	_, ok := <-r.Changed()
-	assert.False(t, ok)
-}
-
-func TestReceiverClose(t *testing.T) {
-	w := New[*proto.ClusterConfiguration](nil)
-	r, err := w.Subscribe()
-	require.NoError(t, err)
-
-	require.NoError(t, r.Close())
-	w.Publish(&proto.ClusterConfiguration{})
 
 	_, ok := <-r.Changed()
 	assert.False(t, ok)

--- a/oxiad/common/watch/watch_test.go
+++ b/oxiad/common/watch/watch_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/common/proto"
 )
@@ -33,8 +32,7 @@ func TestWatchLoad(t *testing.T) {
 
 func TestSubscribePublish(t *testing.T) {
 	w := New(&proto.ClusterConfiguration{})
-	r, err := w.Subscribe()
-	require.NoError(t, err)
+	r := w.Subscribe()
 
 	value := r.Load()
 	assert.NotNil(t, value)
@@ -56,18 +54,4 @@ func TestSubscribePublish(t *testing.T) {
 
 	value = r.Load()
 	assert.Same(t, config, value)
-}
-
-func TestWatchClose(t *testing.T) {
-	w := New(&proto.ClusterConfiguration{})
-	r, err := w.Subscribe()
-	require.NoError(t, err)
-
-	w.Close()
-
-	_, err = w.Subscribe()
-	assert.ErrorIs(t, err, ErrClosed)
-
-	_, ok := <-r.Changed()
-	assert.False(t, ok)
 }

--- a/oxiad/coordinator/grpc_server.go
+++ b/oxiad/coordinator/grpc_server.go
@@ -56,7 +56,7 @@ type GrpcServer struct {
 }
 
 func NewGrpcServer(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options]) (*GrpcServer, error) {
-	options, _ := optionsWatch.Load()
+	options := optionsWatch.Load()
 	slog.Info("Starting Oxia coordinator", slog.Any("options", options))
 
 	healthServer := health.NewServer()
@@ -156,8 +156,8 @@ func (s *GrpcServer) backgroundHandleConfChange() {
 		case <-receiver.Changed():
 		}
 
-		coordinatorOptions, ok := receiver.Load()
-		if !ok || coordinatorOptions == nil {
+		coordinatorOptions := receiver.Load()
+		if coordinatorOptions == nil {
 			return
 		}
 

--- a/oxiad/coordinator/grpc_server.go
+++ b/oxiad/coordinator/grpc_server.go
@@ -157,9 +157,6 @@ func (s *GrpcServer) backgroundHandleConfChange() {
 		}
 
 		coordinatorOptions := receiver.Load()
-		if coordinatorOptions == nil {
-			return
-		}
 
 		s.logger.Info("configuration options has changed. processing the dynamic updates.")
 		logOptions := &coordinatorOptions.Observability.Log

--- a/oxiad/coordinator/grpc_server.go
+++ b/oxiad/coordinator/grpc_server.go
@@ -143,11 +143,7 @@ func startMetricsServer(metrics commonoption.MetricOptions) (*metric.PrometheusM
 }
 
 func (s *GrpcServer) backgroundHandleConfChange() {
-	receiver, err := s.optionsWatch.Subscribe()
-	if err != nil {
-		s.logger.Warn("exit background configuration watch goroutine due to a subscription error", slog.Any("error", err))
-		return
-	}
+	receiver := s.optionsWatch.Subscribe()
 
 	for {
 		select {

--- a/oxiad/coordinator/grpc_server.go
+++ b/oxiad/coordinator/grpc_server.go
@@ -148,18 +148,12 @@ func (s *GrpcServer) backgroundHandleConfChange() {
 		s.logger.Warn("exit background configuration watch goroutine due to a subscription error", slog.Any("error", err))
 		return
 	}
-	defer func() {
-		_ = receiver.Close()
-	}()
 
 	for {
 		select {
 		case <-s.ctx.Done():
 			return
-		case _, ok := <-receiver.Changed():
-			if !ok {
-				return
-			}
+		case <-receiver.Changed():
 		}
 
 		coordinatorOptions, ok := receiver.Load()

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -267,12 +267,10 @@ func (p *callbackConfigProvider) Watch() (*commonwatch.Receiver[*commonproto.Clu
 	if p.watcher == nil {
 		return nil, provider.ErrWatchUnsupported
 	}
-	return p.watcher.Subscribe()
+	return p.watcher.Subscribe(), nil
 }
 
 func (p *callbackConfigProvider) watchLoop() {
-	defer p.watcher.Close()
-
 	for {
 		select {
 		case <-p.ctx.Done():
@@ -298,9 +296,6 @@ func (p *callbackConfigProvider) publishCurrentValue() {
 func (p *callbackConfigProvider) Close() error {
 	p.ctxCancel()
 	p.wg.Wait()
-	if p.watcher != nil {
-		p.watcher.Close()
-	}
 	return nil
 }
 

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -56,7 +56,7 @@ type Metadata interface {
 	StatusChangeNotify() <-chan struct{}
 
 	LoadConfig() *commonproto.ClusterConfiguration
-	ConfigWatch() *commonwatch.Watch[*commonproto.ClusterConfiguration]
+	ConfigWatch() (*commonwatch.Receiver[*commonproto.ClusterConfiguration], error)
 	LoadLoadBalancer() *commonproto.LoadBalancer
 	Nodes() *linkedhashset.Set[string]
 	NodesWithMetadata() (*linkedhashset.Set[string], map[string]*commonproto.DataServerMetadata)
@@ -84,7 +84,6 @@ type coordinatorMetadata struct {
 
 	clusterConfigLock     sync.RWMutex
 	currentClusterConfig  *commonproto.ClusterConfiguration
-	clusterConfigWatch    *commonwatch.Watch[*commonproto.ClusterConfiguration]
 	nodesIndex            *redblacktree.Tree[string, *commonproto.DataServerIdentity]
 	namespaceConfigsIndex *redblacktree.Tree[string, *commonproto.Namespace]
 }
@@ -178,16 +177,15 @@ func newCoordinatorMetadata(ctx context.Context, statusProvider provider.Provide
 func newCoordinatorMetadataWithCloser(ctx context.Context, statusProvider provider.Provider[*commonproto.ClusterStatus], configProvider provider.Provider[*commonproto.ClusterConfiguration], backendCloser io.Closer) Metadata {
 	metadataCtx, cancel := context.WithCancel(ctx)
 	m := &coordinatorMetadata{
-		logger:             slog.With(slog.String("component", "coordinator-metadata")),
-		ctx:                metadataCtx,
-		ctxCancel:          cancel,
-		wg:                 sync.WaitGroup{},
-		statusProvider:     statusProvider,
-		configProvider:     configProvider,
-		backendCloser:      backendCloser,
-		currentVersionID:   provider.NotExists,
-		changeCh:           make(chan struct{}),
-		clusterConfigWatch: commonwatch.New[*commonproto.ClusterConfiguration](nil),
+		logger:           slog.With(slog.String("component", "coordinator-metadata")),
+		ctx:              metadataCtx,
+		ctxCancel:        cancel,
+		wg:               sync.WaitGroup{},
+		statusProvider:   statusProvider,
+		configProvider:   configProvider,
+		backendCloser:    backendCloser,
+		currentVersionID: provider.NotExists,
+		changeCh:         make(chan struct{}),
 	}
 
 	m.doStatusRecovery()
@@ -469,16 +467,12 @@ func (m *coordinatorMetadata) loadClusterConfigWithInitSlow() {
 	}
 
 	_ = backoff.RetryNotify(func() error {
-		newConfig, err := m.loadConfigFromProvider()
+		newConfig, err := loadClusterConfigFromProvider(m.configProvider)
 		if err != nil {
 			return err
 		}
 		m.currentClusterConfig = gproto.Clone(newConfig).(*commonproto.ClusterConfiguration) //nolint:revive
 		m.rebuildConfigIndexesLocked()
-		watchedConfig, _ := m.clusterConfigWatch.Load()
-		if watchedConfig == nil {
-			m.clusterConfigWatch.Publish(m.currentClusterConfig)
-		}
 		return nil
 	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
 		m.logger.Warn(
@@ -489,14 +483,14 @@ func (m *coordinatorMetadata) loadClusterConfigWithInitSlow() {
 	})
 }
 
-func (m *coordinatorMetadata) loadConfigFromProvider() (*commonproto.ClusterConfiguration, error) {
-	if loader, ok := m.configProvider.(interface {
+func loadClusterConfigFromProvider(configProvider provider.Provider[*commonproto.ClusterConfiguration]) (*commonproto.ClusterConfiguration, error) {
+	if loader, ok := configProvider.(interface {
 		LoadConfig() (*commonproto.ClusterConfiguration, error)
 	}); ok {
 		return loader.LoadConfig()
 	}
 
-	config, _, err := m.configProvider.Get()
+	config, _, err := configProvider.Get()
 	if err != nil {
 		return nil, err
 	}
@@ -539,20 +533,13 @@ func (m *coordinatorMetadata) rebuildConfigIndexesLocked() {
 }
 
 func (m *coordinatorMetadata) waitForConfigUpdates(configWatch *commonwatch.Receiver[*commonproto.ClusterConfiguration]) {
-	defer func() {
-		_ = configWatch.Close()
-	}()
-
 	m.applyConfigWatchValue(configWatch)
 	for {
 		select {
 		case <-m.ctx.Done():
 			return
 
-		case _, ok := <-configWatch.Changed():
-			if !ok {
-				return
-			}
+		case <-configWatch.Changed():
 			m.logger.Info("Received cluster config change event")
 			m.applyConfigWatchValue(configWatch)
 		}
@@ -582,7 +569,6 @@ func (m *coordinatorMetadata) applyConfigWatchValue(configWatch *commonwatch.Rec
 		m.logger.Info("No cluster config changes detected")
 		return
 	}
-	m.clusterConfigWatch.Publish(clonedConfig)
 }
 
 func (m *coordinatorMetadata) usesCallbackConfigProvider() bool {
@@ -601,8 +587,8 @@ func (m *coordinatorMetadata) LoadConfig() *commonproto.ClusterConfiguration {
 	return m.currentClusterConfig
 }
 
-func (m *coordinatorMetadata) ConfigWatch() *commonwatch.Watch[*commonproto.ClusterConfiguration] {
-	return m.clusterConfigWatch
+func (m *coordinatorMetadata) ConfigWatch() (*commonwatch.Receiver[*commonproto.ClusterConfiguration], error) {
+	return m.configProvider.Watch()
 }
 
 func (m *coordinatorMetadata) LoadLoadBalancer() *commonproto.LoadBalancer {

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -550,10 +550,7 @@ func (m *coordinatorMetadata) waitForConfigUpdates(configWatch *commonwatch.Rece
 }
 
 func (m *coordinatorMetadata) applyConfigWatchValue(configWatch *commonwatch.Receiver[*commonproto.ClusterConfiguration]) {
-	config, ok := configWatch.Load()
-	if !ok {
-		return
-	}
+	config := configWatch.Load()
 	if !m.usesCallbackConfigProvider() {
 		if err := validateClusterConfig(config); err != nil {
 			m.logger.Warn("received invalid cluster config watch value", slog.Any("error", err))

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -56,7 +56,7 @@ type Metadata interface {
 	StatusChangeNotify() <-chan struct{}
 
 	LoadConfig() *commonproto.ClusterConfiguration
-	ConfigWatch() (*commonwatch.Receiver[*commonproto.ClusterConfiguration], error)
+	ConfigWatch() *commonwatch.Watch[*commonproto.ClusterConfiguration]
 	LoadLoadBalancer() *commonproto.LoadBalancer
 	Nodes() *linkedhashset.Set[string]
 	NodesWithMetadata() (*linkedhashset.Set[string], map[string]*commonproto.DataServerMetadata)
@@ -84,6 +84,7 @@ type coordinatorMetadata struct {
 
 	clusterConfigLock     sync.RWMutex
 	currentClusterConfig  *commonproto.ClusterConfiguration
+	clusterConfigWatch    *commonwatch.Watch[*commonproto.ClusterConfiguration]
 	nodesIndex            *redblacktree.Tree[string, *commonproto.DataServerIdentity]
 	namespaceConfigsIndex *redblacktree.Tree[string, *commonproto.Namespace]
 }
@@ -177,15 +178,16 @@ func newCoordinatorMetadata(ctx context.Context, statusProvider provider.Provide
 func newCoordinatorMetadataWithCloser(ctx context.Context, statusProvider provider.Provider[*commonproto.ClusterStatus], configProvider provider.Provider[*commonproto.ClusterConfiguration], backendCloser io.Closer) Metadata {
 	metadataCtx, cancel := context.WithCancel(ctx)
 	m := &coordinatorMetadata{
-		logger:           slog.With(slog.String("component", "coordinator-metadata")),
-		ctx:              metadataCtx,
-		ctxCancel:        cancel,
-		wg:               sync.WaitGroup{},
-		statusProvider:   statusProvider,
-		configProvider:   configProvider,
-		backendCloser:    backendCloser,
-		currentVersionID: provider.NotExists,
-		changeCh:         make(chan struct{}),
+		logger:             slog.With(slog.String("component", "coordinator-metadata")),
+		ctx:                metadataCtx,
+		ctxCancel:          cancel,
+		wg:                 sync.WaitGroup{},
+		statusProvider:     statusProvider,
+		configProvider:     configProvider,
+		backendCloser:      backendCloser,
+		currentVersionID:   provider.NotExists,
+		changeCh:           make(chan struct{}),
+		clusterConfigWatch: commonwatch.New(&commonproto.ClusterConfiguration{}),
 	}
 
 	m.doStatusRecovery()
@@ -473,6 +475,7 @@ func (m *coordinatorMetadata) loadClusterConfigWithInitSlow() {
 		}
 		m.currentClusterConfig = gproto.Clone(newConfig).(*commonproto.ClusterConfiguration) //nolint:revive
 		m.rebuildConfigIndexesLocked()
+		m.clusterConfigWatch.Publish(m.currentClusterConfig)
 		return nil
 	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
 		m.logger.Warn(
@@ -569,6 +572,7 @@ func (m *coordinatorMetadata) applyConfigWatchValue(configWatch *commonwatch.Rec
 		m.logger.Info("No cluster config changes detected")
 		return
 	}
+	m.clusterConfigWatch.Publish(clonedConfig)
 }
 
 func (m *coordinatorMetadata) usesCallbackConfigProvider() bool {
@@ -587,8 +591,8 @@ func (m *coordinatorMetadata) LoadConfig() *commonproto.ClusterConfiguration {
 	return m.currentClusterConfig
 }
 
-func (m *coordinatorMetadata) ConfigWatch() (*commonwatch.Receiver[*commonproto.ClusterConfiguration], error) {
-	return m.configProvider.Watch()
+func (m *coordinatorMetadata) ConfigWatch() *commonwatch.Watch[*commonproto.ClusterConfiguration] {
+	return m.clusterConfigWatch
 }
 
 func (m *coordinatorMetadata) LoadLoadBalancer() *commonproto.LoadBalancer {

--- a/oxiad/coordinator/metadata/provider/file/file.go
+++ b/oxiad/coordinator/metadata/provider/file/file.go
@@ -85,9 +85,6 @@ func NewProvider[T gproto.Message](ctx context.Context, path string, codec provi
 func (m *Provider[T]) Close() error {
 	m.ctxCancel()
 	m.wg.Wait()
-	if m.watcher != nil {
-		m.watcher.Close()
-	}
 	if !m.lockAcquired {
 		return nil
 	}
@@ -154,7 +151,7 @@ func (m *Provider[T]) Watch() (*commonwatch.Receiver[T], error) {
 	if !m.watchEnabled.Enabled() || m.watcher == nil {
 		return nil, provider.ErrWatchUnsupported
 	}
-	return m.watcher.Subscribe()
+	return m.watcher.Subscribe(), nil
 }
 
 func (m *Provider[T]) watchLoop() {

--- a/oxiad/coordinator/metadata/provider/kubernetes/configmap.go
+++ b/oxiad/coordinator/metadata/provider/kubernetes/configmap.go
@@ -272,9 +272,6 @@ func (m *Provider[T]) WaitToBecomeLeader() error {
 func (m *Provider[T]) Close() error {
 	m.ctxCancel()
 	m.wg.Wait()
-	if m.watcher != nil {
-		m.watcher.Close()
-	}
 	m.logger.Info("Closed metadata provider")
 	return nil
 }
@@ -283,7 +280,7 @@ func (m *Provider[T]) Watch() (*commonwatch.Receiver[T], error) {
 	if !m.watchEnabled.Enabled() || m.watcher == nil {
 		return nil, provider.ErrWatchUnsupported
 	}
-	return m.watcher.Subscribe()
+	return m.watcher.Subscribe(), nil
 }
 
 func (m *Provider[T]) watchLoop() {

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -68,8 +68,8 @@ func (*mockMetadata) StatusChangeNotify() <-chan struct{} { return make(chan str
 
 func (*mockMetadata) LoadConfig() *proto.ClusterConfiguration { return nil }
 
-func (*mockMetadata) ConfigWatch() *commonwatch.Watch[*proto.ClusterConfiguration] {
-	return commonwatch.New[*proto.ClusterConfiguration](nil)
+func (*mockMetadata) ConfigWatch() (*commonwatch.Receiver[*proto.ClusterConfiguration], error) {
+	return commonwatch.New(&proto.ClusterConfiguration{}).Subscribe()
 }
 
 func (m *mockMetadata) LoadLoadBalancer() *proto.LoadBalancer {

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -68,8 +68,8 @@ func (*mockMetadata) StatusChangeNotify() <-chan struct{} { return make(chan str
 
 func (*mockMetadata) LoadConfig() *proto.ClusterConfiguration { return nil }
 
-func (*mockMetadata) ConfigWatch() (*commonwatch.Receiver[*proto.ClusterConfiguration], error) {
-	return commonwatch.New(&proto.ClusterConfiguration{}).Subscribe()
+func (*mockMetadata) ConfigWatch() *commonwatch.Watch[*proto.ClusterConfiguration] {
+	return commonwatch.New(&proto.ClusterConfiguration{})
 }
 
 func (m *mockMetadata) LoadLoadBalancer() *proto.LoadBalancer {

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -296,28 +296,20 @@ func (c *runtime) startBackgroundActionWorker() {
 }
 
 func (c *runtime) startBackgroundConfigWatcher() {
-	configWatch := c.metadata.ConfigWatch()
-	receiver, err := configWatch.Subscribe()
+	receiver, err := c.metadata.ConfigWatch()
 	if err != nil {
 		c.logger.Warn("failed to subscribe to cluster config watch", slog.Any("error", err))
 		return
 	}
-	defer func() {
-		_ = receiver.Close()
-	}()
 
-	currentConfig, ok := configWatch.Load()
-	if ok && currentConfig != nil {
+	if currentConfig := c.metadata.LoadConfig(); currentConfig != nil {
 		c.ConfigChanged(currentConfig)
 	}
 	for {
 		select {
 		case <-c.ctx.Done():
 			return
-		case _, ok := <-receiver.Changed():
-			if !ok {
-				return
-			}
+		case <-receiver.Changed():
 		}
 
 		newConfig, ok := receiver.Load()

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -313,8 +313,8 @@ func (c *runtime) startBackgroundConfigWatcher() {
 		case <-receiver.Changed():
 		}
 
-		newConfig, ok := receiver.Load()
-		if !ok || newConfig == nil {
+		newConfig := receiver.Load()
+		if newConfig == nil {
 			continue
 		}
 		c.ConfigChanged(newConfig)

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -296,7 +296,8 @@ func (c *runtime) startBackgroundActionWorker() {
 }
 
 func (c *runtime) startBackgroundConfigWatcher() {
-	receiver, err := c.metadata.ConfigWatch()
+	configWatch := c.metadata.ConfigWatch()
+	receiver, err := configWatch.Subscribe()
 	if err != nil {
 		c.logger.Warn("failed to subscribe to cluster config watch", slog.Any("error", err))
 		return

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -310,9 +310,6 @@ func (c *runtime) startBackgroundConfigWatcher() {
 		}
 
 		newConfig := receiver.Load()
-		if newConfig == nil {
-			continue
-		}
 		c.ConfigChanged(newConfig)
 	}
 }

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -297,11 +297,7 @@ func (c *runtime) startBackgroundActionWorker() {
 
 func (c *runtime) startBackgroundConfigWatcher() {
 	configWatch := c.metadata.ConfigWatch()
-	receiver, err := configWatch.Subscribe()
-	if err != nil {
-		c.logger.Warn("failed to subscribe to cluster config watch", slog.Any("error", err))
-		return
-	}
+	receiver := configWatch.Subscribe()
 
 	if currentConfig := c.metadata.LoadConfig(); currentConfig != nil {
 		c.ConfigChanged(currentConfig)

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -176,18 +176,12 @@ func (s *Server) backgroundHandleConfChange() {
 		s.logger.Warn("exit background configuration watch goroutine due to a subscription error", slog.Any("error", err))
 		return
 	}
-	defer func() {
-		_ = receiver.Close()
-	}()
 
 	for {
 		select {
 		case <-s.ctx.Done():
 			return
-		case _, ok := <-receiver.Changed():
-			if !ok {
-				return
-			}
+		case <-receiver.Changed():
 		}
 
 		dataServerOptions, ok := receiver.Load()

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -62,7 +62,7 @@ type Server struct {
 }
 
 func New(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options]) (*Server, error) {
-	options, _ := optionsWatch.Load()
+	options := optionsWatch.Load()
 	manifest, err := manifestpkg.NewManifest(options.Storage.Database.Dir)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func New(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options
 
 func NewWithGrpcProvider(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options], provider commonrpc.GrpcProvider,
 	replicationRpcProvider rpc.ReplicationRpcProvider, manifest *manifestpkg.Manifest, disableAuthorityValidation bool) (*Server, error) {
-	options, _ := optionsWatch.Load()
+	options := optionsWatch.Load()
 	slog.Info("Starting Oxia dataServer", slog.Any("options", options))
 
 	storage := &options.Storage
@@ -184,8 +184,8 @@ func (s *Server) backgroundHandleConfChange() {
 		case <-receiver.Changed():
 		}
 
-		dataServerOptions, ok := receiver.Load()
-		if !ok || dataServerOptions == nil {
+		dataServerOptions := receiver.Load()
+		if dataServerOptions == nil {
 			return
 		}
 

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -171,11 +171,7 @@ func (s *Server) InternalPort() int {
 }
 
 func (s *Server) backgroundHandleConfChange() {
-	receiver, err := s.optionsWatch.Subscribe()
-	if err != nil {
-		s.logger.Warn("exit background configuration watch goroutine due to a subscription error", slog.Any("error", err))
-		return
-	}
+	receiver := s.optionsWatch.Subscribe()
 
 	for {
 		select {

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -185,9 +185,6 @@ func (s *Server) backgroundHandleConfChange() {
 		}
 
 		dataServerOptions := receiver.Load()
-		if dataServerOptions == nil {
-			return
-		}
 
 		s.logger.Info("configuration options has changed. processing the dynamic updates.")
 		logOptions := &dataServerOptions.Observability.Log


### PR DESCRIPTION
## Motivation
- simplify `oxiad/common/watch` around the actual contract used by callers
- make the receiver notification model explicit: wake up, then `Load()` the latest value
- keep metadata config watching scoped to metadata-owned state instead of mixing it into this PR

## Modifications
- reworked `common/watch` to use a shared change-generation channel with atomic value reads
- documented that `Receiver.Changed()` must be paired with `Receiver.Load()` to re-arm the receiver
- updated coordinator and dataserver option/config watcher loops to use the revised watch contract
- restored the metadata-owned config watch so metadata remains the canonical config watch layer

## Testing
- `go test ./oxiad/common/watch ./oxiad/coordinator/metadata ./oxiad/coordinator/runtime/... ./oxiad/coordinator/... -run '^$'`
- `make lint`
