### PR TITLE
refactor: use watch for shard assignments

### DIFF
--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -36,9 +36,9 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/state"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
 
-	"github.com/oxia-db/oxia/common/concurrent"
 	"github.com/oxia-db/oxia/common/process"
 	"github.com/oxia-db/oxia/common/proto"
+	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 )
 
 type runtime struct {
@@ -63,8 +63,7 @@ type runtime struct {
 	loadBalancer     balancer.LoadBalancer
 	ensembleSelector selector.Selector[*ensemble.Context, []string]
 
-	assignmentsChanged concurrent.ConditionContext
-	assignments        *proto.ShardAssignments
+	assignmentsWatch *commonwatch.Watch[*proto.ShardAssignments]
 
 	rpc rpc.Provider
 }
@@ -263,17 +262,24 @@ func (c *runtime) BecameUnavailable(node *proto.DataServerIdentity) {
 }
 
 func (c *runtime) WaitForNextUpdate(ctx context.Context, currentValue *proto.ShardAssignments) (*proto.ShardAssignments, error) {
-	c.Lock()
-	defer c.Unlock()
-
-	for pb.Equal(currentValue, c.assignments) {
-		// Wait on the condition until the assignments get changed
-		if err := c.assignmentsChanged.Wait(ctx); err != nil {
-			return nil, err
-		}
+	receiver := c.assignmentsWatch.Subscribe()
+	latest := c.assignmentsWatch.Load()
+	if !pb.Equal(currentValue, latest) {
+		return latest, nil
 	}
 
-	return c.assignments, nil
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-receiver.Changed():
+		}
+
+		latest = receiver.Load()
+		if !pb.Equal(currentValue, latest) {
+			return latest, nil
+		}
+	}
 }
 
 func (c *runtime) startBackgroundActionWorker() {
@@ -356,7 +362,7 @@ func (c *runtime) handleActionChangeEnsemble(ac action.Action) {
 func (c *runtime) computeNewAssignments() {
 	config := c.metadata.LoadConfig()
 	status := c.metadata.LoadStatus()
-	c.assignments = &proto.ShardAssignments{
+	assignments := &proto.ShardAssignments{
 		Namespaces:         map[string]*proto.NamespaceShardsAssignment{},
 		AllowedAuthorities: mergedAuthorities(status, config.GetServers(), config.GetAllowExtraAuthorities()),
 	}
@@ -395,10 +401,10 @@ func (c *runtime) computeNewAssignments() {
 			)
 		}
 
-		c.assignments.Namespaces[name] = nsAssignments
+		assignments.Namespaces[name] = nsAssignments
 	}
 
-	c.assignmentsChanged.Broadcast()
+	c.assignmentsWatch.Publish(assignments)
 }
 
 func mergedAuthorities(status *proto.ClusterStatus, servers []*proto.DataServerIdentity, extraAuthorities []string) []string {
@@ -708,10 +714,10 @@ func New(
 		nodeControllers:  make(map[string]controller.DataServerController),
 		drainingNodes:    make(map[string]controller.DataServerController),
 		metadata:         metadata,
+		assignmentsWatch: commonwatch.New(&proto.ShardAssignments{}),
 	}
 
 	c.ctx, c.ctxCancel = context.WithCancel(context.Background())
-	c.assignmentsChanged = concurrent.NewConditionContext(c)
 
 	c.loadBalancer = balancer.NewLoadBalancer(balancer.Options{
 		Context:  c.ctx,

--- a/oxiad/coordinator/runtime/runtime_authority_test.go
+++ b/oxiad/coordinator/runtime/runtime_authority_test.go
@@ -22,11 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/common/proto"
+	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
-
-	"github.com/oxia-db/oxia/common/concurrent"
 )
 
 func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
@@ -78,19 +77,20 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 		},
 	})
 	c := &runtime{
-		RWMutex:            sync.RWMutex{},
-		metadata:           metadata,
-		assignmentsChanged: concurrent.NewConditionContext(&sync.Mutex{}),
+		RWMutex:          sync.RWMutex{},
+		metadata:         metadata,
+		assignmentsWatch: commonwatch.New(&proto.ShardAssignments{}),
 	}
 
 	c.computeNewAssignments()
+	assignments := c.assignmentsWatch.Load()
 
-	nsAssignments, ok := c.assignments.Namespaces["default"]
+	nsAssignments, ok := assignments.Namespaces["default"]
 	require.True(t, ok)
 	require.Len(t, nsAssignments.Assignments, 1)
 	assert.Equal(t,
 		[]string{"leader-public:6648", "leader-internal:6649", "bootstrap:6648"},
-		c.assignments.AllowedAuthorities,
+		assignments.AllowedAuthorities,
 	)
 }
 
@@ -144,12 +144,13 @@ func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
 		},
 	})
 	c := &runtime{
-		RWMutex:            sync.RWMutex{},
-		metadata:           metadata,
-		assignmentsChanged: concurrent.NewConditionContext(&sync.Mutex{}),
+		RWMutex:          sync.RWMutex{},
+		metadata:         metadata,
+		assignmentsWatch: commonwatch.New(&proto.ShardAssignments{}),
 	}
 
 	c.computeNewAssignments()
+	assignments := c.assignmentsWatch.Load()
 
 	assert.Equal(t,
 		[]string{
@@ -158,6 +159,6 @@ func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
 			"removed-public:6648",
 			"removed-internal:6649",
 		},
-		c.assignments.AllowedAuthorities,
+		assignments.AllowedAuthorities,
 	)
 }


### PR DESCRIPTION
## Motivation
- align runtime shard-assignment updates with the shared watch primitive used elsewhere
- remove the dedicated condition-variable based assignment notification path

## Modifications
- replaced runtime assignment waiting with a `common/watch`-backed stream
- updated assignment recomputation to publish snapshots through the watch
- adjusted runtime authority tests to read assignments from the watch-backed source

## Testing
- `go test ./oxiad/coordinator/runtime ./oxiad/coordinator/runtime/controller -run '^$|TestComputeNewAssignments'`
- `make lint`
