### PR TITLE
refactor: rename metadata accessors

### DIFF
--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -38,7 +38,7 @@ type managementServer struct {
 }
 
 func (management *managementServer) ListDataServers(context.Context, *proto.ListDataServersRequest) (*proto.ListDataServersResponse, error) {
-	cnf := management.metadata.LoadConfig()
+	cnf := management.metadata.GetConfig()
 
 	dataServers := make([]*proto.DataServer, 0, len(cnf.GetServers()))
 	for _, server := range cnf.GetServers() {
@@ -81,7 +81,7 @@ func (management *managementServer) GetDataServer(_ context.Context, req *proto.
 }
 
 func (management *managementServer) ListNamespaces(context.Context, *proto.ListNamespacesRequest) (*proto.ListNamespacesResponse, error) {
-	cnf := management.metadata.LoadConfig()
+	cnf := management.metadata.GetConfig()
 
 	namespaceNames := hashset.New[string]()
 	for _, nsConfig := range cnf.GetNamespaces() {
@@ -93,7 +93,7 @@ func (management *managementServer) ListNamespaces(context.Context, *proto.ListN
 }
 
 func (management *managementServer) ListNodes(context.Context, *proto.ListNodesRequest) (*proto.ListNodesResponse, error) {
-	cnf := management.metadata.LoadConfig()
+	cnf := management.metadata.GetConfig()
 
 	cnfNodes := cnf.GetServers()
 	cnfMeta := cnf.GetServerMetadata()

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -47,22 +47,22 @@ import (
 type Metadata interface {
 	io.Closer
 
-	LoadStatus() *commonproto.ClusterStatus
+	GetStatus() *commonproto.ClusterStatus
+	PutStatus(newStatus *commonproto.ClusterStatus)
 	ApplyStatusChanges(config *commonproto.ClusterConfiguration, ensembleSupplier EnsembleSupplier) (*commonproto.ClusterStatus, map[int64]string, []int64)
-	UpdateStatus(newStatus *commonproto.ClusterStatus)
-	UpdateShardMetadata(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata)
-	DeleteShardMetadata(namespace string, shard int64)
-	IsReady(clusterConfig *commonproto.ClusterConfiguration) bool
-	StatusChangeNotify() <-chan struct{}
 
-	LoadConfig() *commonproto.ClusterConfiguration
+	PutShard(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata)
+	DeleteShard(namespace string, shard int64)
+
+	GetConfig() *commonproto.ClusterConfiguration
 	ConfigWatch() *commonwatch.Watch[*commonproto.ClusterConfiguration]
-	LoadLoadBalancer() *commonproto.LoadBalancer
-	Nodes() *linkedhashset.Set[string]
-	NodesWithMetadata() (*linkedhashset.Set[string], map[string]*commonproto.DataServerMetadata)
-	Namespace(namespace string) (*commonproto.Namespace, bool)
-	Node(id string) (*commonproto.DataServerIdentity, bool)
+	GetLoadBalancer() *commonproto.LoadBalancer
+
+	ListDataServers() *linkedhashset.Set[string]
+	ListDataServersWithMetadata() (*linkedhashset.Set[string], map[string]*commonproto.DataServerMetadata)
+	GetDataServerIdentity(id string) (*commonproto.DataServerIdentity, bool)
 	GetDataServer(name string) (*commonproto.DataServer, bool)
+	GetNamespace(namespace string) (*commonproto.Namespace, bool)
 }
 
 type EnsembleSupplier func(namespaceConfig *commonproto.Namespace, status *commonproto.ClusterStatus) ([]*commonproto.DataServerIdentity, error)
@@ -371,7 +371,7 @@ func (m *coordinatorMetadata) persistStatusLocked(newStatus *commonproto.Cluster
 	})
 }
 
-func (m *coordinatorMetadata) LoadStatus() *commonproto.ClusterStatus {
+func (m *coordinatorMetadata) GetStatus() *commonproto.ClusterStatus {
 	m.statusLock.RLock()
 	defer m.statusLock.RUnlock()
 	return m.currentStatus
@@ -392,7 +392,7 @@ func (m *coordinatorMetadata) ApplyStatusChanges(config *commonproto.ClusterConf
 	return newStatus, shardsToAdd, shardsToDelete
 }
 
-func (m *coordinatorMetadata) UpdateStatus(newStatus *commonproto.ClusterStatus) {
+func (m *coordinatorMetadata) PutStatus(newStatus *commonproto.ClusterStatus) {
 	m.statusLock.Lock()
 	defer m.statusLock.Unlock()
 
@@ -400,7 +400,7 @@ func (m *coordinatorMetadata) UpdateStatus(newStatus *commonproto.ClusterStatus)
 	m.notifyStatusChange()
 }
 
-func (m *coordinatorMetadata) UpdateShardMetadata(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata) {
+func (m *coordinatorMetadata) PutShard(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata) {
 	m.statusLock.Lock()
 	defer m.statusLock.Unlock()
 
@@ -414,7 +414,7 @@ func (m *coordinatorMetadata) UpdateShardMetadata(namespace string, shard int64,
 	m.notifyStatusChange()
 }
 
-func (m *coordinatorMetadata) DeleteShardMetadata(namespace string, shard int64) {
+func (m *coordinatorMetadata) DeleteShard(namespace string, shard int64) {
 	m.statusLock.Lock()
 	defer m.statusLock.Unlock()
 
@@ -431,26 +431,7 @@ func (m *coordinatorMetadata) DeleteShardMetadata(namespace string, shard int64)
 	m.notifyStatusChange()
 }
 
-func (m *coordinatorMetadata) IsReady(clusterConfig *commonproto.ClusterConfiguration) bool {
-	currentStatus := m.LoadStatus()
-	for _, namespace := range clusterConfig.Namespaces {
-		namespaceStatus, ok := currentStatus.Namespaces[namespace.Name]
-		if !ok {
-			return false
-		}
-		if len(namespaceStatus.Shards) != int(namespace.InitialShardCount) {
-			return false
-		}
-		for _, shard := range namespaceStatus.Shards {
-			if shard.GetStatusOrDefault() != commonproto.ShardStatusSteadyState {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func (m *coordinatorMetadata) StatusChangeNotify() <-chan struct{} {
+func (m *coordinatorMetadata) statusChangeNotify() <-chan struct{} {
 	m.statusLock.RLock()
 	defer m.statusLock.RUnlock()
 	return m.changeCh
@@ -572,7 +553,7 @@ func (m *coordinatorMetadata) usesCallbackConfigProvider() bool {
 	return ok
 }
 
-func (m *coordinatorMetadata) LoadConfig() *commonproto.ClusterConfiguration {
+func (m *coordinatorMetadata) GetConfig() *commonproto.ClusterConfiguration {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -587,11 +568,11 @@ func (m *coordinatorMetadata) ConfigWatch() *commonwatch.Watch[*commonproto.Clus
 	return m.clusterConfigWatch
 }
 
-func (m *coordinatorMetadata) LoadLoadBalancer() *commonproto.LoadBalancer {
-	return m.LoadConfig().GetLoadBalancerWithDefaults()
+func (m *coordinatorMetadata) GetLoadBalancer() *commonproto.LoadBalancer {
+	return m.GetConfig().GetLoadBalancerWithDefaults()
 }
 
-func (m *coordinatorMetadata) Nodes() *linkedhashset.Set[string] {
+func (m *coordinatorMetadata) ListDataServers() *linkedhashset.Set[string] {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -607,7 +588,7 @@ func (m *coordinatorMetadata) Nodes() *linkedhashset.Set[string] {
 	return nodes
 }
 
-func (m *coordinatorMetadata) NodesWithMetadata() (*linkedhashset.Set[string], map[string]*commonproto.DataServerMetadata) {
+func (m *coordinatorMetadata) ListDataServersWithMetadata() (*linkedhashset.Set[string], map[string]*commonproto.DataServerMetadata) {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -628,7 +609,7 @@ func (m *coordinatorMetadata) NodesWithMetadata() (*linkedhashset.Set[string], m
 	return nodes, metadata
 }
 
-func (m *coordinatorMetadata) Namespace(namespace string) (*commonproto.Namespace, bool) {
+func (m *coordinatorMetadata) GetNamespace(namespace string) (*commonproto.Namespace, bool) {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -639,7 +620,7 @@ func (m *coordinatorMetadata) Namespace(namespace string) (*commonproto.Namespac
 	return m.namespaceConfigsIndex.Get(namespace)
 }
 
-func (m *coordinatorMetadata) Node(id string) (*commonproto.DataServerIdentity, bool) {
+func (m *coordinatorMetadata) GetDataServerIdentity(id string) (*commonproto.DataServerIdentity, bool) {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -663,9 +644,13 @@ func (m *coordinatorMetadata) GetDataServer(id string) (*commonproto.DataServer,
 }
 
 func WaitForCondition(ctx context.Context, metadata Metadata, triggerFn func(), condition func(*commonproto.ClusterStatus) bool) error {
+	notifier, ok := metadata.(interface{ statusChangeNotify() <-chan struct{} })
+	if !ok {
+		return errors.New("metadata does not support status change notifications")
+	}
 	for {
-		ch := metadata.StatusChangeNotify()
-		if condition(metadata.LoadStatus()) {
+		ch := notifier.statusChangeNotify()
+		if condition(metadata.GetStatus()) {
 			return nil
 		}
 		if triggerFn != nil {

--- a/oxiad/coordinator/metadata/metadata_test.go
+++ b/oxiad/coordinator/metadata/metadata_test.go
@@ -44,7 +44,7 @@ func TestNewFromOptionsLoadsFileClusterConfig(t *testing.T) {
 		require.NoError(t, metadata.Close())
 	}()
 
-	config := metadata.LoadConfig()
+	config := metadata.GetConfig()
 	require.Len(t, config.GetNamespaces(), 1)
 	require.Equal(t, "default", config.GetNamespaces()[0].GetName())
 }
@@ -72,7 +72,7 @@ func TestNewFromOptionsMergesLegacyClusterConfigPath(t *testing.T) {
 		require.NoError(t, metadata.Close())
 	}()
 
-	config := metadata.LoadConfig()
+	config := metadata.GetConfig()
 	require.Len(t, config.GetNamespaces(), 1)
 	require.Equal(t, "default", config.GetNamespaces()[0].GetName())
 }

--- a/oxiad/coordinator/runtime/balancer/scheduler.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler.go
@@ -97,8 +97,8 @@ func (r *nodeBasedBalancer) rebalanceEnsemble() bool {
 	r.checkQuarantineNodes()
 
 	swapGroup := &sync.WaitGroup{}
-	currentStatus := r.metadata.LoadStatus()
-	candidates, metadata := r.metadata.NodesWithMetadata()
+	currentStatus := r.metadata.GetStatus()
+	candidates, metadata := r.metadata.ListDataServersWithMetadata()
 	groupedStatus, historyNodes := state.GroupingShardsNodeByStatus(candidates, currentStatus)
 	loadRatios := r.loadRatioAlgorithm(&model.RatioParams{NodeShardsInfos: groupedStatus, HistoryNodes: historyNodes})
 
@@ -222,7 +222,7 @@ func (r *nodeBasedBalancer) swapShard(
 	var exist bool
 	var err error
 
-	if nsc, exist = r.metadata.Namespace(candidateShard.Namespace); !exist {
+	if nsc, exist = r.metadata.GetNamespace(candidateShard.Namespace); !exist {
 		return false, nil
 	}
 
@@ -260,7 +260,7 @@ func (r *nodeBasedBalancer) swapShard(
 		return false, nil
 	}
 	var targetNode *commonproto.DataServerIdentity
-	if targetNode, exist = r.metadata.Node(targetNodeID); !exist {
+	if targetNode, exist = r.metadata.GetDataServerIdentity(targetNodeID); !exist {
 		return false, errors.New("target node does not exist")
 	}
 
@@ -311,8 +311,8 @@ func (r *nodeBasedBalancer) IsNodeQuarantined(highestLoadRatioNode *model.NodeLo
 }
 
 func (r *nodeBasedBalancer) IsBalanced() bool {
-	status := r.metadata.LoadStatus()
-	candidates := r.metadata.Nodes()
+	status := r.metadata.GetStatus()
+	candidates := r.metadata.ListDataServers()
 	groupedStatus, historyNodes := state.GroupingShardsNodeByStatus(candidates, status)
 	return r.loadRatioAlgorithm(
 		&model.RatioParams{
@@ -379,8 +379,8 @@ func (r *nodeBasedBalancer) startBackgroundNotifier() {
 func (r *nodeBasedBalancer) rebalanceLeader() {
 	r.checkQuarantineShards()
 
-	status := r.metadata.LoadStatus()
-	candidates := r.metadata.Nodes()
+	status := r.metadata.GetStatus()
+	candidates := r.metadata.ListDataServers()
 	totalShards, electedShards, nodeLeaders := state.NodeShardLeaders(candidates, status)
 
 	electedRate := float64(electedShards) / float64(totalShards)
@@ -503,7 +503,7 @@ func NewLoadBalancer(options Options) LoadBalancer {
 		ctx:                     ctx,
 		ctxCancel:               cancelFunc,
 		wg:                      sync.WaitGroup{},
-		loadBalancerConf:        options.Metadata.LoadLoadBalancer(),
+		loadBalancerConf:        options.Metadata.GetLoadBalancer(),
 		actionCh:                make(chan action.Action, 1000),
 		nodeAvailableJudger:     options.NodeAvailableJudger,
 		metadata:                options.Metadata,

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -50,29 +50,27 @@ var _ coordmetadata.Metadata = (*mockMetadata)(nil)
 
 func (*mockMetadata) Close() error { return nil }
 
-func (m *mockMetadata) LoadStatus() *proto.ClusterStatus { return m.status }
+func (m *mockMetadata) GetStatus() *proto.ClusterStatus { return m.status }
 
 func (m *mockMetadata) ApplyStatusChanges(*proto.ClusterConfiguration, coordmetadata.EnsembleSupplier) (*proto.ClusterStatus, map[int64]string, []int64) {
 	return m.status, nil, nil
 }
 
-func (m *mockMetadata) UpdateStatus(newStatus *proto.ClusterStatus) { m.status = newStatus }
+func (m *mockMetadata) PutStatus(newStatus *proto.ClusterStatus) { m.status = newStatus }
 
-func (*mockMetadata) UpdateShardMetadata(string, int64, *proto.ShardMetadata) {}
+func (*mockMetadata) PutShard(string, int64, *proto.ShardMetadata) {}
 
-func (*mockMetadata) DeleteShardMetadata(string, int64) {}
+func (*mockMetadata) DeleteShard(string, int64) {}
 
 func (*mockMetadata) IsReady(*proto.ClusterConfiguration) bool { return true }
 
-func (*mockMetadata) StatusChangeNotify() <-chan struct{} { return make(chan struct{}) }
-
-func (*mockMetadata) LoadConfig() *proto.ClusterConfiguration { return nil }
+func (*mockMetadata) GetConfig() *proto.ClusterConfiguration { return nil }
 
 func (*mockMetadata) ConfigWatch() *commonwatch.Watch[*proto.ClusterConfiguration] {
 	return commonwatch.New(&proto.ClusterConfiguration{})
 }
 
-func (m *mockMetadata) LoadLoadBalancer() *proto.LoadBalancer {
+func (m *mockMetadata) GetLoadBalancer() *proto.LoadBalancer {
 	if m.lbConfig != nil {
 		return m.lbConfig
 	}
@@ -82,18 +80,18 @@ func (m *mockMetadata) LoadLoadBalancer() *proto.LoadBalancer {
 	}
 }
 
-func (m *mockMetadata) Nodes() *linkedhashset.Set[string] { return m.nodes }
+func (m *mockMetadata) ListDataServers() *linkedhashset.Set[string] { return m.nodes }
 
-func (m *mockMetadata) NodesWithMetadata() (*linkedhashset.Set[string], map[string]*proto.DataServerMetadata) {
+func (m *mockMetadata) ListDataServersWithMetadata() (*linkedhashset.Set[string], map[string]*proto.DataServerMetadata) {
 	return m.nodes, m.metadata
 }
 
-func (m *mockMetadata) Namespace(namespace string) (*proto.Namespace, bool) {
+func (m *mockMetadata) GetNamespace(namespace string) (*proto.Namespace, bool) {
 	nc, ok := m.nsConfigs[namespace]
 	return nc, ok
 }
 
-func (m *mockMetadata) Node(id string) (*proto.DataServerIdentity, bool) {
+func (m *mockMetadata) GetDataServerIdentity(id string) (*proto.DataServerIdentity, bool) {
 	n, ok := m.nodeMap[id]
 	return n, ok
 }
@@ -131,7 +129,7 @@ func newTestBalancer(
 		ctx:                     ctx,
 		ctxCancel:               cancel,
 		wg:                      sync.WaitGroup{},
-		loadBalancerConf:        metadata.LoadLoadBalancer(),
+		loadBalancerConf:        metadata.GetLoadBalancer(),
 		metadata:                metadata,
 		selector:                sel,
 		loadRatioAlgorithm:      single.DefaultShardsRank,

--- a/oxiad/coordinator/runtime/controller/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller.go
@@ -258,7 +258,7 @@ func (s *shardController) waitForSplitComplete() {
 		case <-s.ctx.Done():
 			return
 		case <-ticker.C:
-			status := s.metadataStore.LoadStatus()
+			status := s.metadataStore.GetStatus()
 			ns, exists := status.Namespaces[s.namespace]
 			if !exists {
 				continue
@@ -358,7 +358,7 @@ func (s *shardController) onElectLeader(changeEnsembleAction *action.ChangeEnsem
 		EnableNotifications: true,
 		KeySorting:          proto.KeySortingType_UNKNOWN,
 	}
-	nsConfig, exist := s.metadataStore.Namespace(s.namespace)
+	nsConfig, exist := s.metadataStore.GetNamespace(s.namespace)
 	if exist {
 		termOptions.EnableNotifications = nsConfig.NotificationsEnabledOrDefault()
 		termOptions.KeySorting, _ = nsConfig.GetKeySortingType()
@@ -423,7 +423,7 @@ func (s *shardController) deleteShard() error {
 		)
 	}
 
-	s.metadataStore.DeleteShardMetadata(s.namespace, s.shard)
+	s.metadataStore.DeleteShard(s.namespace, s.shard)
 	s.eventListener.ShardDeleted(s.shard)
 	return s.close()
 }
@@ -473,7 +473,7 @@ func (s *shardController) SyncServerAddress() {
 	shardMeta := s.metadata.Load()
 	needSync := false
 	for _, candidate := range shardMeta.Ensemble {
-		if newInfo, ok := s.metadataStore.Node(candidate.GetNameOrDefault()); ok {
+		if newInfo, ok := s.metadataStore.GetDataServerIdentity(candidate.GetNameOrDefault()); ok {
 			if newInfo.GetPublic() != candidate.GetPublic() || newInfo.GetInternal() != candidate.GetInternal() {
 				needSync = true
 				break
@@ -504,7 +504,7 @@ func (s *shardController) handlePeriodicTasks() {
 	}
 
 	// Update the shard status
-	s.metadataStore.UpdateShardMetadata(s.namespace, s.shard, mutShardMeta)
+	s.metadataStore.PutShard(s.namespace, s.shard, mutShardMeta)
 	s.metadata.Store(mutShardMeta)
 }
 

--- a/oxiad/coordinator/runtime/controller/shard_controller_election.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller_election.go
@@ -78,7 +78,7 @@ type ShardElection struct {
 func (e *ShardElection) refreshedEnsemble(ensemble []*proto.DataServerIdentity) []*proto.DataServerIdentity {
 	refreshedEnsembleDataServerAddress := make([]*proto.DataServerIdentity, len(ensemble))
 	for idx, candidate := range ensemble {
-		if refreshedAddress, exist := e.metadataStore.Node(candidate.GetNameOrDefault()); exist {
+		if refreshedAddress, exist := e.metadataStore.GetDataServerIdentity(candidate.GetNameOrDefault()); exist {
 			refreshedEnsembleDataServerAddress[idx] = refreshedAddress
 			continue
 		}
@@ -225,7 +225,7 @@ func (e *ShardElection) selectNewLeader(candidatesStatus map[*proto.DataServerId
 	candidates := chooseCandidates(candidatesStatus)
 	server, err := e.leaderSelector.Select(&leaderselector.Context{
 		Candidates: candidates,
-		Status:     e.metadataStore.LoadStatus(),
+		Status:     e.metadataStore.GetStatus(),
 	})
 	if err != nil {
 		return nil, nil, err
@@ -447,7 +447,7 @@ func (e *ShardElection) start() (*proto.DataServerIdentity, error) {
 		metadata.Term++
 		metadata.Ensemble = e.refreshedEnsemble(metadata.Ensemble)
 	})
-	e.metadataStore.UpdateShardMetadata(e.namespace, e.shard, mutShardMeta)
+	e.metadataStore.PutShard(e.namespace, e.shard, mutShardMeta)
 
 	if e.changeEnsembleAction != nil {
 		e.prepareIfChangeEnsemble(mutShardMeta)
@@ -497,7 +497,7 @@ func (e *ShardElection) start() (*proto.DataServerIdentity, error) {
 	leader := mutShardMeta.Leader
 	leaderEntry := candidatesStatus[leader]
 
-	e.metadataStore.UpdateShardMetadata(e.namespace, e.shard, mutShardMeta)
+	e.metadataStore.PutShard(e.namespace, e.shard, mutShardMeta)
 	e.meta.Store(mutShardMeta)
 	if e.eventListener != nil {
 		e.eventListener.LeaderElected(e.shard, newLeader, maps.Keys(followers))

--- a/oxiad/coordinator/runtime/controller/split_controller.go
+++ b/oxiad/coordinator/runtime/controller/split_controller.go
@@ -111,7 +111,7 @@ func NewSplitController(cfg SplitControllerConfig) *SplitController {
 	sc.ctx, sc.ctxCancel = context.WithTimeout(context.Background(), splitTimeout)
 
 	// Load the current split metadata from cluster status
-	status := sc.metadata.LoadStatus()
+	status := sc.metadata.GetStatus()
 	ns, exists := status.Namespaces[sc.namespace]
 	if !exists {
 		sc.logger.Error("Namespace not found in cluster status")
@@ -202,7 +202,7 @@ func (sc *SplitController) driveStateMachine() error {
 }
 
 func (sc *SplitController) currentPhase() string {
-	status := sc.metadata.LoadStatus()
+	status := sc.metadata.GetStatus()
 	ns, exists := status.Namespaces[sc.namespace]
 	if !exists {
 		return ""
@@ -216,7 +216,7 @@ func (sc *SplitController) currentPhase() string {
 
 // updatePhase atomically updates the split phase on both parent and children.
 func (sc *SplitController) updatePhase(newPhase string) {
-	status := sc.metadata.LoadStatus()
+	status := sc.metadata.GetStatus()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus) //nolint:revive
 
 	ns := cloned.Namespaces[sc.namespace]
@@ -233,7 +233,7 @@ func (sc *SplitController) updatePhase(newPhase string) {
 		}
 	}
 
-	sc.metadata.UpdateStatus(cloned)
+	sc.metadata.PutStatus(cloned)
 }
 
 // runBootstrap validates preconditions, fences child ensemble members, elects
@@ -648,7 +648,7 @@ func (sc *SplitController) abort() {
 
 	// Delete child shards from status.
 	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		sc.metadata.DeleteShardMetadata(sc.namespace, childId)
+		sc.metadata.DeleteShard(sc.namespace, childId)
 	}
 
 	// Clear parent split metadata.
@@ -669,7 +669,7 @@ func (sc *SplitController) loadParentMeta() *proto.ShardMetadata {
 }
 
 func (sc *SplitController) loadShardMeta(shardId int64) *proto.ShardMetadata {
-	status := sc.metadata.LoadStatus()
+	status := sc.metadata.GetStatus()
 	ns, exists := status.Namespaces[sc.namespace]
 	if !exists {
 		return nil
@@ -690,12 +690,12 @@ func (sc *SplitController) updateChildMeta(childId int64, fn func(meta *proto.Sh
 }
 
 func (sc *SplitController) updateShardMeta(shardId int64, fn func(meta *proto.ShardMetadata)) {
-	status := sc.metadata.LoadStatus()
+	status := sc.metadata.GetStatus()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus) //nolint:revive
 	ns := cloned.Namespaces[sc.namespace]
 	if meta, exists := ns.Shards[shardId]; exists {
 		fn(meta)
-		sc.metadata.UpdateStatus(cloned)
+		sc.metadata.PutStatus(cloned)
 	}
 }
 

--- a/oxiad/coordinator/runtime/controller/split_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/split_controller_test.go
@@ -140,7 +140,7 @@ func setupSplitTest(t *testing.T, phase string) (
 		ShardIdGenerator: 3,
 	}
 
-	metadata.UpdateStatus(clusterStatus)
+	metadata.PutStatus(clusterStatus)
 	listener := newMockSplitEventListener()
 
 	return rpcMock, metadata, listener
@@ -228,7 +228,7 @@ func TestSplitController_FullLifecycle(t *testing.T) {
 	}
 
 	// Verify final state: parent is Deleting, children have no split metadata
-	status := statusRes.LoadStatus()
+	status := statusRes.GetStatus()
 	ns := status.Namespaces[constant.DefaultNamespace]
 
 	parentMeta, parentExists := ns.Shards[0]
@@ -276,7 +276,7 @@ func TestSplitController_ResumeFromCatchUp(t *testing.T) {
 
 	// For CatchUp, we need child leaders to already be set (they were set during bootstrap)
 	// Update child metadata to have leaders
-	status := statusRes.LoadStatus()
+	status := statusRes.GetStatus()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 	leftMeta := ns.Shards[1]
@@ -287,7 +287,7 @@ func TestSplitController_ResumeFromCatchUp(t *testing.T) {
 	rightMeta.Leader = rs1
 	rightMeta.Term = 1
 	ns.Shards[2] = rightMeta
-	statusRes.UpdateStatus(cloned)
+	statusRes.PutStatus(cloned)
 
 	queueCatchUpResponses(rpcMock)
 	queueCutoverResponses(rpcMock)
@@ -329,7 +329,7 @@ func TestSplitController_PhaseTransitions(t *testing.T) {
 	select {
 	case <-listener.completions:
 		// Verify final state: parent marked Deleting, children elected
-		status := statusRes.LoadStatus()
+		status := statusRes.GetStatus()
 		ns := status.Namespaces[constant.DefaultNamespace]
 
 		parentMeta := ns.Shards[0]
@@ -374,7 +374,7 @@ func TestSplitController_TimeoutDuringBootstrap(t *testing.T) {
 	}
 
 	// Verify: parent.Split cleared, children deleted
-	status := statusRes.LoadStatus()
+	status := statusRes.GetStatus()
 	ns := status.Namespaces[constant.DefaultNamespace]
 
 	parentMeta, parentExists := ns.Shards[0]
@@ -392,7 +392,7 @@ func TestSplitController_TimeoutDuringCatchUp(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders (as if Bootstrap completed) and ParentTermAtBootstrap
-	status := statusRes.LoadStatus()
+	status := statusRes.GetStatus()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -410,7 +410,7 @@ func TestSplitController_TimeoutDuringCatchUp(t *testing.T) {
 	parentMeta.Split.ParentTermAtBootstrap = 5
 	ns.Shards[0] = parentMeta
 
-	statusRes.UpdateStatus(cloned)
+	statusRes.PutStatus(cloned)
 
 	// Queue RemoveObserver responses (abort will call these)
 	rpcMock.GetNode(ps1).RemoveObserverResponse(nil)
@@ -437,7 +437,7 @@ func TestSplitController_TimeoutDuringCatchUp(t *testing.T) {
 	}
 
 	// Verify: parent restored, children deleted
-	finalStatus := statusRes.LoadStatus()
+	finalStatus := statusRes.GetStatus()
 	finalNs := finalStatus.Namespaces[constant.DefaultNamespace]
 
 	pm, exists := finalNs.Shards[0]
@@ -454,7 +454,7 @@ func TestSplitController_ParentTermChangeDuringCatchUp(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders and ParentTermAtBootstrap = 5
-	status := statusRes.LoadStatus()
+	status := statusRes.GetStatus()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -475,7 +475,7 @@ func TestSplitController_ParentTermChangeDuringCatchUp(t *testing.T) {
 	parentMeta.Split.ParentTermAtBootstrap = 5 // Was 5 during Bootstrap
 	ns.Shards[0] = parentMeta
 
-	statusRes.UpdateStatus(cloned)
+	statusRes.PutStatus(cloned)
 
 	// The controller should detect term change and reset to Bootstrap.
 	// Queue Bootstrap responses -- note: parent leader is now ps2 (after election)
@@ -662,7 +662,7 @@ func TestSplitController_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders (as if Bootstrap completed) and ParentTermAtBootstrap
-	status := statusRes.LoadStatus()
+	status := statusRes.GetStatus()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -680,7 +680,7 @@ func TestSplitController_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
 	parentMeta.Split.ParentTermAtBootstrap = 5
 	ns.Shards[0] = parentMeta
 
-	statusRes.UpdateStatus(cloned)
+	statusRes.PutStatus(cloned)
 
 	// Queue RemoveObserver responses (abort will call these)
 	rpcMock.GetNode(ps1).RemoveObserverResponse(nil)
@@ -711,7 +711,7 @@ func TestSplitController_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
 	}
 
 	// Verify: parent restored, children deleted
-	finalStatus := statusRes.LoadStatus()
+	finalStatus := statusRes.GetStatus()
 	finalNs := finalStatus.Namespaces[constant.DefaultNamespace]
 
 	pm, exists := finalNs.Shards[0]
@@ -728,7 +728,7 @@ func TestSplitController_ChildFollowersDeadCommitStalls(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders (as if Bootstrap completed) and ParentTermAtBootstrap
-	status := statusRes.LoadStatus()
+	status := statusRes.GetStatus()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -746,7 +746,7 @@ func TestSplitController_ChildFollowersDeadCommitStalls(t *testing.T) {
 	parentMeta.Split.ParentTermAtBootstrap = 5
 	ns.Shards[0] = parentMeta
 
-	statusRes.UpdateStatus(cloned)
+	statusRes.PutStatus(cloned)
 
 	// Queue RemoveObserver responses (abort will call these)
 	rpcMock.GetNode(ps1).RemoveObserverResponse(nil)
@@ -783,7 +783,7 @@ func TestSplitController_ChildFollowersDeadCommitStalls(t *testing.T) {
 	}
 
 	// Verify: parent restored, children deleted
-	finalStatus := statusRes.LoadStatus()
+	finalStatus := statusRes.GetStatus()
 	finalNs := finalStatus.Namespaces[constant.DefaultNamespace]
 
 	pm, exists := finalNs.Shards[0]
@@ -801,7 +801,7 @@ func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 
 	// Set child leaders and ParentTermAtBootstrap as if Bootstrap completed.
 	// Also set ChildLeadersAtBootstrap with the ORIGINAL leaders.
-	status := statusRes.LoadStatus()
+	status := statusRes.GetStatus()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -823,7 +823,7 @@ func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 	}
 	ns.Shards[0] = parentMeta
 
-	statusRes.UpdateStatus(cloned)
+	statusRes.PutStatus(cloned)
 
 	// CatchUp detects left child leader changed (ls1 -> ls2).
 	// It RemoveObserver(old leader) on parent, then falls back to Bootstrap.
@@ -878,7 +878,7 @@ func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 	}
 
 	// Verify parent is Deleting and children are healthy
-	finalStatus := statusRes.LoadStatus()
+	finalStatus := statusRes.GetStatus()
 	finalNs := finalStatus.Namespaces[constant.DefaultNamespace]
 
 	pm := finalNs.Shards[0]

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -130,7 +130,7 @@ func (c *runtime) ConfigChanged(newConfig *proto.ClusterConfiguration) {
 
 	// Check for nodes to remove
 	for serverID, nc := range c.nodeControllers {
-		if _, exist := c.metadata.Node(serverID); exist {
+		if _, exist := c.metadata.GetDataServerIdentity(serverID); exist {
 			continue
 		}
 		c.logger.Info("Detected a removed node", slog.Any("server", serverID))
@@ -146,7 +146,7 @@ func (c *runtime) ConfigChanged(newConfig *proto.ClusterConfiguration) {
 	clusterStatus, shardsToAdd, shardsToDelete := c.metadata.ApplyStatusChanges(newConfig, c.selectNewEnsemble)
 	for shard, namespace := range shardsToAdd {
 		shardMetadata := clusterStatus.Namespaces[namespace].Shards[shard]
-		if namespaceConfig, exist := c.metadata.Namespace(namespace); exist {
+		if namespaceConfig, exist := c.metadata.GetNamespace(namespace); exist {
 			c.shardControllers[shard] = controller.NewShardController(namespace, shard, namespaceConfig,
 				pb.Clone(shardMetadata).(*proto.ShardMetadata), c.metadata, c.findDataServerFeatures,
 				c, c.rpc, controller.DefaultPeriodicTasksInterval)
@@ -184,7 +184,7 @@ func (c *runtime) findDataServerFeatures(dataServers []*proto.DataServerIdentity
 // selectNewEnsemble select a new server ensemble based on namespace policy and current cluster status.
 // It uses the ensemble selector to choose appropriate servers and returns the selected server metadata or an error.
 func (c *runtime) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
-	nodes, nodesMetadata := c.metadata.NodesWithMetadata()
+	nodes, nodesMetadata := c.metadata.ListDataServersWithMetadata()
 	ensembleContext := &ensemble.Context{
 		Candidates:         nodes,
 		CandidatesMetadata: nodesMetadata,
@@ -205,7 +205,7 @@ func (c *runtime) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.Cl
 	for _, id := range ensembles {
 		var node *proto.DataServerIdentity
 		var exist bool
-		if node, exist = c.metadata.Node(id); !exist {
+		if node, exist = c.metadata.GetDataServerIdentity(id); !exist {
 			return nil, fmt.Errorf("failed to find node %s", id)
 		}
 		esm = append(esm, node)
@@ -305,7 +305,7 @@ func (c *runtime) startBackgroundConfigWatcher() {
 	configWatch := c.metadata.ConfigWatch()
 	receiver := configWatch.Subscribe()
 
-	if currentConfig := c.metadata.LoadConfig(); currentConfig != nil {
+	if currentConfig := c.metadata.GetConfig(); currentConfig != nil {
 		c.ConfigChanged(currentConfig)
 	}
 	for {
@@ -360,8 +360,8 @@ func (c *runtime) handleActionChangeEnsemble(ac action.Action) {
 
 // This is called while already holding the lock on the coordinator.
 func (c *runtime) computeNewAssignments() {
-	config := c.metadata.LoadConfig()
-	status := c.metadata.LoadStatus()
+	config := c.metadata.GetConfig()
+	status := c.metadata.GetStatus()
 	assignments := &proto.ShardAssignments{
 		Namespaces:         map[string]*proto.NamespaceShardsAssignment{},
 		AllowedAuthorities: mergedAuthorities(status, config.GetServers(), config.GetAllowExtraAuthorities()),
@@ -438,7 +438,7 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 	c.Lock()
 	defer c.Unlock()
 
-	status := c.metadata.LoadStatus()
+	status := c.metadata.GetStatus()
 
 	// Validate namespace
 	ns, exists := status.Namespaces[namespace]
@@ -551,7 +551,7 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 	}
 
 	// Persist
-	c.metadata.UpdateStatus(cloned)
+	c.metadata.PutStatus(cloned)
 
 	c.logger.Info("Split initiated",
 		slog.Int64("parent-shard", parentShardId),
@@ -576,7 +576,7 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 		RpcProvider:   c.rpc,
 		EventListener: c,
 		EnsembleSelector: func(ns string) ([]*proto.DataServerIdentity, error) {
-			return c.selectNewEnsemble(c.namespaceConfigForSplit(ns), c.metadata.LoadStatus())
+			return c.selectNewEnsemble(c.namespaceConfigForSplit(ns), c.metadata.GetStatus())
 		},
 	})
 	c.splitControllers[parentShardId] = sc
@@ -617,7 +617,7 @@ func (c *runtime) SplitComplete(parentShard int64, leftChild int64, rightChild i
 	// during Cutover.
 	if sc, exists := c.shardControllers[parentShard]; exists {
 		// Sync shard controller metadata from the status resource.
-		status := c.metadata.LoadStatus()
+		status := c.metadata.GetStatus()
 		for _, ns := range status.Namespaces {
 			if parentMeta, ok := ns.Shards[parentShard]; ok {
 				sc.Metadata().Store(parentMeta)
@@ -659,7 +659,7 @@ func (c *runtime) SplitAborted(parentShard int64, leftChild int64, rightChild in
 }
 
 func (c *runtime) namespaceConfigForSplit(namespace string) *proto.Namespace {
-	nsConfig, exist := c.metadata.Namespace(namespace)
+	nsConfig, exist := c.metadata.GetNamespace(namespace)
 	if !exist {
 		nsConfig = &proto.Namespace{}
 	}
@@ -692,7 +692,7 @@ func (c *runtime) restartInProgressSplits(clusterStatus *proto.ClusterStatus) {
 				RpcProvider:   c.rpc,
 				EventListener: c,
 				EnsembleSelector: func(namespace string) ([]*proto.DataServerIdentity, error) {
-					return c.selectNewEnsemble(c.namespaceConfigForSplit(namespace), c.metadata.LoadStatus())
+					return c.selectNewEnsemble(c.namespaceConfigForSplit(namespace), c.metadata.GetStatus())
 				},
 			})
 			c.splitControllers[shardId] = sc
@@ -730,8 +730,8 @@ func New(
 		},
 	})
 
-	clusterConfig := c.metadata.LoadConfig()
-	clusterStatus := c.metadata.LoadStatus()
+	clusterConfig := c.metadata.GetConfig()
+	clusterStatus := c.metadata.GetStatus()
 	c.insID = clusterStatus.InstanceId
 
 	c.rpc = rpcProvider(c.insID)
@@ -756,7 +756,7 @@ func New(
 			shardMetadata := shards.Shards[shard]
 			var nsConfig *proto.Namespace
 			var exist bool
-			if nsConfig, exist = c.metadata.Namespace(ns); !exist {
+			if nsConfig, exist = c.metadata.GetNamespace(ns); !exist {
 				nsConfig = &proto.Namespace{}
 			}
 			c.shardControllers[shard] = controller.NewShardController(ns, shard, nsConfig,

--- a/oxiad/coordinator/runtime/runtime_authority_test.go
+++ b/oxiad/coordinator/runtime/runtime_authority_test.go
@@ -58,7 +58,7 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, metadata.Close())
 	})
-	metadata.UpdateStatus(&proto.ClusterStatus{
+	metadata.PutStatus(&proto.ClusterStatus{
 		Namespaces: map[string]*proto.NamespaceStatus{
 			"default": {
 				ReplicationFactor: 1,
@@ -124,7 +124,7 @@ func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, metadata.Close())
 	})
-	metadata.UpdateStatus(&proto.ClusterStatus{
+	metadata.PutStatus(&proto.ClusterStatus{
 		Namespaces: map[string]*proto.NamespaceStatus{
 			"default": {
 				ReplicationFactor: 1,

--- a/tests/assignments/leader_hint_test.go
+++ b/tests/assignments/leader_hint_test.go
@@ -51,12 +51,12 @@ func TestLeaderHintWithoutClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().LoadStatus().Namespaces["default"].Shards[0]
+		shard := coordinatorInstance.Metadata().GetStatus().Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 20*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().LoadStatus()
+	status := coordinatorInstance.Metadata().GetStatus()
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -107,12 +107,12 @@ func TestLeaderHintListWithoutClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().LoadStatus().Namespaces["default"].Shards[0]
+		shard := coordinatorInstance.Metadata().GetStatus().Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().LoadStatus()
+	status := coordinatorInstance.Metadata().GetStatus()
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -163,12 +163,12 @@ func TestLeaderHintListWithClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().LoadStatus().Namespaces["default"].Shards[0]
+		shard := coordinatorInstance.Metadata().GetStatus().Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().LoadStatus()
+	status := coordinatorInstance.Metadata().GetStatus()
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -210,12 +210,12 @@ func TestLeaderHintRangeScanWithoutClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().LoadStatus().Namespaces["default"].Shards[0]
+		shard := coordinatorInstance.Metadata().GetStatus().Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().LoadStatus()
+	status := coordinatorInstance.Metadata().GetStatus()
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -266,12 +266,12 @@ func TestLeaderHintRangeScanWithClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().LoadStatus().Namespaces["default"].Shards[0]
+		shard := coordinatorInstance.Metadata().GetStatus().Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().LoadStatus()
+	status := coordinatorInstance.Metadata().GetStatus()
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -317,12 +317,12 @@ func TestLeaderHintWithClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().LoadStatus().Namespaces["default"].Shards[0]
+		shard := coordinatorInstance.Metadata().GetStatus().Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 20*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().LoadStatus()
+	status := coordinatorInstance.Metadata().GetStatus()
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public

--- a/tests/balancer/shard_balancer_test.go
+++ b/tests/balancer/shard_balancer_test.go
@@ -75,7 +75,7 @@ func TestNormalShardBalancer(t *testing.T) {
 	metadata := coordinator.Metadata()
 
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.LoadStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -89,7 +89,7 @@ func TestNormalShardBalancer(t *testing.T) {
 	ch <- struct{}{}
 
 	assert.Eventually(t, func() bool {
-		_, exist := metadata.Node(s4ad.GetNameOrDefault())
+		_, exist := metadata.GetDataServerIdentity(s4ad.GetNameOrDefault())
 		return exist
 	}, 10*time.Second, 50*time.Millisecond)
 	assert.Eventually(t, func() bool {
@@ -182,7 +182,7 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 	metadata := coordinator.Metadata()
 
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.LoadStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -196,7 +196,7 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 	ch <- struct{}{}
 
 	assert.Eventually(t, func() bool {
-		_, exist := metadata.Node(s4ad.GetNameOrDefault())
+		_, exist := metadata.GetDataServerIdentity(s4ad.GetNameOrDefault())
 		return exist
 	}, 10*time.Second, 50*time.Millisecond)
 	assert.Eventually(t, func() bool {
@@ -215,7 +215,7 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 	}, 30*time.Second, 50*time.Millisecond)
 
 	// check if follow the policy
-	for name, ns := range metadata.LoadStatus().Namespaces {
+	for name, ns := range metadata.GetStatus().Namespaces {
 		for _, shard := range ns.Shards {
 			nodeIDs := linkedhashset.New[string]()
 			nodeZones := linkedhashset.New[string]()
@@ -275,7 +275,23 @@ func TestBalanceWithoutDeadlock(t *testing.T) {
 
 	metadata := coordinator.Metadata()
 	assert.Eventually(t, func() bool {
-		return metadata.IsReady(metadata.LoadConfig())
+		config := metadata.GetConfig()
+		status := metadata.GetStatus()
+		for _, namespace := range config.Namespaces {
+			namespaceStatus, ok := status.Namespaces[namespace.Name]
+			if !ok {
+				return false
+			}
+			if len(namespaceStatus.Shards) != int(namespace.InitialShardCount) {
+				return false
+			}
+			for _, shard := range namespaceStatus.Shards {
+				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
+					return false
+				}
+			}
+		}
+		return true
 	}, 60*time.Second, 1*time.Second)
 
 	namespaces := []string{"ns-1", "ns-2", "ns-3"}
@@ -293,7 +309,7 @@ func TestBalanceWithoutDeadlock(t *testing.T) {
 	ch <- struct{}{}
 
 	assert.Eventually(t, func() bool {
-		_, exist := metadata.Node(s4ad.GetNameOrDefault())
+		_, exist := metadata.GetDataServerIdentity(s4ad.GetNameOrDefault())
 		return exist
 	}, 60*time.Second, 1*time.Second)
 

--- a/tests/control/control_request_test.go
+++ b/tests/control/control_request_test.go
@@ -61,7 +61,7 @@ func TestControlRequestFeatureEnabled(t *testing.T) {
 	assert.NoError(t, err)
 	defer client.Close()
 
-	resource := coordinatorInstance.Metadata().LoadStatus()
+	resource := coordinatorInstance.Metadata().GetStatus()
 	shardMetadata := resource.Namespaces["default"].Shards[0]
 	leader := shardMetadata.Leader
 

--- a/tests/control/record_checksum_test.go
+++ b/tests/control/record_checksum_test.go
@@ -87,7 +87,7 @@ func TestControlRequestRecordChecksum(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Wait for the checksum feature to be enabled on all replicas
-	resource := coordinatorInstance.Metadata().LoadStatus()
+	resource := coordinatorInstance.Metadata().GetStatus()
 	shardMetadata := resource.Namespaces["default"].Shards[0]
 	leader := shardMetadata.Leader
 	for _, dataServer := range shardMetadata.Ensemble {

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -79,7 +79,7 @@ func TestCoordinatorE2E(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.LoadStatus()
+	status := metadata.GetStatus()
 
 	assert.EqualValues(t, 1, len(status.Namespaces))
 	nsStatus := status.Namespaces[constant.DefaultNamespace]
@@ -87,7 +87,7 @@ func TestCoordinatorE2E(t *testing.T) {
 	assert.EqualValues(t, 3, nsStatus.ReplicationFactor)
 
 	assert.Eventually(t, func() bool {
-		shard := metadata.LoadStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := metadata.GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 10*time.Second, 10*time.Millisecond)
 
@@ -113,7 +113,7 @@ func TestCoordinatorE2E_ShardsRanges(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.LoadStatus()
+	status := metadata.GetStatus()
 	nsStatus := status.Namespaces[constant.DefaultNamespace]
 	assert.EqualValues(t, 4, len(nsStatus.Shards))
 	assert.EqualValues(t, 3, nsStatus.ReplicationFactor)
@@ -161,18 +161,18 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.LoadStatus()
+	status := metadata.GetStatus()
 
 	nsStatus := status.Namespaces[constant.DefaultNamespace]
 	assert.EqualValues(t, 1, len(nsStatus.Shards))
 	assert.EqualValues(t, 3, nsStatus.ReplicationFactor)
 
 	assert.Eventually(t, func() bool {
-		shard := metadata.LoadStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := metadata.GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 10*time.Second, 10*time.Millisecond)
 
-	nsStatus = metadata.LoadStatus().Namespaces[constant.DefaultNamespace]
+	nsStatus = metadata.GetStatus().Namespaces[constant.DefaultNamespace]
 
 	leader := nsStatus.Shards[0].Leader
 	var follower *proto.DataServerIdentity
@@ -209,7 +209,7 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 	delete(servers, leader.GetNameOrDefault())
 
 	assert.Eventually(t, func() bool {
-		shard := metadata.LoadStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := metadata.GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 10*time.Second, 10*time.Millisecond)
 
@@ -261,7 +261,7 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.LoadStatus()
+	status := metadata.GetStatus()
 	nsDefaultStatus := status.Namespaces[constant.DefaultNamespace]
 	assert.EqualValues(t, 1, len(nsDefaultStatus.Shards))
 	assert.EqualValues(t, 3, nsDefaultStatus.ReplicationFactor)
@@ -276,7 +276,7 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.LoadStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -348,14 +348,14 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.LoadStatus()
+	status := metadata.GetStatus()
 	ns1Status := status.Namespaces["my-ns-1"]
 	assert.EqualValues(t, 2, len(ns1Status.Shards))
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.LoadStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -366,12 +366,12 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	}, 10*time.Second, 10*time.Millisecond)
 
 	// Trigger new leader election in order to have a new term
-	ns1Status = metadata.LoadStatus().Namespaces["my-ns-1"]
+	ns1Status = metadata.GetStatus().Namespaces["my-ns-1"]
 	coordinatorInstance.BecameUnavailable(ns1Status.Shards[0].Leader)
 
 	// Wait (again) for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.LoadStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -400,7 +400,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	metadata = coordinatorInstance.Metadata()
 	// Wait for all shards to be deleted
 	assert.Eventually(t, func() bool {
-		load := metadata.LoadStatus()
+		load := metadata.GetStatus()
 		slog.Info("load", slog.Any("load", load))
 		return len(load.Namespaces) == 0
 	}, 10*time.Second, 10*time.Millisecond)
@@ -437,14 +437,14 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.LoadStatus()
+	status := metadata.GetStatus()
 	ns1Status := status.Namespaces["my-ns-1"]
 	assert.EqualValues(t, 2, len(ns1Status.Shards))
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.LoadStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -466,7 +466,7 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
 		foundNS2 := false
-		for name, ns := range metadata.LoadStatus().Namespaces {
+		for name, ns := range metadata.GetStatus().Namespaces {
 			if name == "my-ns-2" {
 				foundNS2 = true
 			}
@@ -479,11 +479,11 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 		return foundNS2
 	}, 10*time.Second, 10*time.Millisecond)
 
-	ns1Status = metadata.LoadStatus().Namespaces["my-ns-1"]
+	ns1Status = metadata.GetStatus().Namespaces["my-ns-1"]
 	assert.EqualValues(t, 2, len(ns1Status.Shards))
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
-	ns2Status := metadata.LoadStatus().Namespaces["my-ns-2"]
+	ns2Status := metadata.GetStatus().Namespaces["my-ns-2"]
 	assert.EqualValues(t, 2, len(ns2Status.Shards))
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
@@ -585,7 +585,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.LoadStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -598,7 +598,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	assert.Equal(t, 4, len(c.NodeControllers()))
 
 	// Remove leader dataserver
-	leaderID := metadata.LoadStatus().Namespaces["my-ns-1"].Shards[0].Leader.GetNameOrDefault()
+	leaderID := metadata.GetStatus().Namespaces["my-ns-1"].Shards[0].Leader.GetNameOrDefault()
 	d := make([]*proto.DataServerIdentity, 0)
 	for _, sv := range clusterConfig.Servers {
 		if sv.GetNameOrDefault() != leaderID {
@@ -614,7 +614,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.LoadStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().Namespaces {
 			for _, shard := range ns.Shards {
 				return shard.Term > 0 && shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 			}
@@ -656,7 +656,7 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	metadata := c.Metadata()
 	// wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.LoadStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -680,7 +680,7 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	configChangesCh <- nil
 
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.LoadStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false

--- a/tests/coordinator/coordinator_test.go
+++ b/tests/coordinator/coordinator_test.go
@@ -64,8 +64,8 @@ func TestCoordinatorInitiateLeaderElection(t *testing.T) {
 		Int32HashRange:          &proto.HashRange{Min: 2000, Max: 100000},
 	}
 	metadataView := coordinatorInstance.Metadata()
-	metadataView.UpdateShardMetadata("default", 1, shardMetadata)
+	metadataView.PutShard("default", 1, shardMetadata)
 
-	status := metadataView.LoadStatus()
+	status := metadataView.GetStatus()
 	assert.True(t, gproto.Equal(status.Namespaces["default"].Shards[1], shardMetadata))
 }

--- a/tests/coordinator/split_e2e_test.go
+++ b/tests/coordinator/split_e2e_test.go
@@ -74,7 +74,7 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 
 	// Wait for initial shard to be in steady state
 	require.Eventually(t, func() bool {
-		shard := metadata.LoadStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := metadata.GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 30*time.Second, 100*time.Millisecond)
 
@@ -111,7 +111,7 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 	// Wait for split to complete: parent shard (0) should be removed,
 	// and both children should be in steady state with leaders.
 	require.Eventually(t, func() bool {
-		status := metadata.LoadStatus()
+		status := metadata.GetStatus()
 		ns, ok := status.Namespaces[constant.DefaultNamespace]
 		if !ok {
 			t.Log("Namespace not found in status")
@@ -170,7 +170,7 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 	slog.Info("Split complete")
 
 	// Verify hash ranges: children should cover the entire original range
-	status := metadata.LoadStatus()
+	status := metadata.GetStatus()
 	ns := status.Namespaces[constant.DefaultNamespace]
 	leftMeta := ns.Shards[leftChild]
 	rightMeta := ns.Shards[rightChild]
@@ -336,7 +336,7 @@ func setupSplitCluster(t *testing.T) *splitTestCluster {
 
 	metadata := coordinatorInstance.Metadata()
 	require.Eventually(t, func() bool {
-		shard := metadata.LoadStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := metadata.GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 30*time.Second, 100*time.Millisecond)
 	slog.Info("Initial cluster is ready")
@@ -364,7 +364,7 @@ func (c *splitTestCluster) splitAndWait(t *testing.T) {
 	)
 
 	require.Eventually(t, func() bool {
-		status := c.metadata.LoadStatus()
+		status := c.metadata.GetStatus()
 		ns := status.Namespaces[constant.DefaultNamespace]
 		if _, parentExists := ns.Shards[0]; parentExists {
 			return false
@@ -378,7 +378,7 @@ func (c *splitTestCluster) splitAndWait(t *testing.T) {
 		return true
 	}, 60*time.Second, 500*time.Millisecond)
 
-	status := c.metadata.LoadStatus()
+	status := c.metadata.GetStatus()
 	ns := status.Namespaces[constant.DefaultNamespace]
 	c.leftMeta = ns.Shards[c.leftChild]
 	c.rightMeta = ns.Shards[c.rightChild]
@@ -880,7 +880,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 			coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 
 			metadata := coordinatorInstance.Metadata()
-			status := metadata.LoadStatus()
+			status := metadata.GetStatus()
 
 			assert.EqualValues(t, 1, len(status.Namespaces))
 			nsStatus := status.Namespaces[constant.DefaultNamespace]
@@ -888,7 +888,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 			assert.EqualValues(t, 1, nsStatus.ReplicationFactor)
 
 			assert.Eventually(t, func() bool {
-				shard := metadata.LoadStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+				shard := metadata.GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
 				return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 			}, 10*time.Second, 10*time.Millisecond)
 
@@ -923,7 +923,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 func waitForSplitPhase(t *testing.T, metadata coordmetadata.Metadata, parentShardId int64, phase string, timeout time.Duration) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		status := metadata.LoadStatus()
+		status := metadata.GetStatus()
 		ns := status.Namespaces[constant.DefaultNamespace]
 		parentMeta, exists := ns.Shards[parentShardId]
 		if !exists || parentMeta.Split == nil {
@@ -951,7 +951,7 @@ func TestCoordinator_ShardSplit_ParentLeaderKillDuringSplit(t *testing.T) {
 	assert.NoError(t, client.Close())
 
 	// Find the parent leader before initiating the split
-	status := cluster.metadata.LoadStatus()
+	status := cluster.metadata.GetStatus()
 	parentLeader := status.Namespaces[constant.DefaultNamespace].Shards[0].Leader
 	slog.Info("Parent leader identified", slog.Any("leader", parentLeader))
 
@@ -976,7 +976,7 @@ func TestCoordinator_ShardSplit_ParentLeaderKillDuringSplit(t *testing.T) {
 	slog.Info("Waiting for split to complete after parent leader kill")
 
 	require.Eventually(t, func() bool {
-		st := cluster.metadata.LoadStatus()
+		st := cluster.metadata.GetStatus()
 		ns := st.Namespaces[constant.DefaultNamespace]
 		if _, parentExists := ns.Shards[0]; parentExists {
 			return false
@@ -1033,7 +1033,7 @@ func TestCoordinator_ShardSplit_FollowerKillDuringSplit(t *testing.T) {
 	assert.NoError(t, client.Close())
 
 	// Find a follower (non-leader) server
-	status := cluster.metadata.LoadStatus()
+	status := cluster.metadata.GetStatus()
 	parentMeta := status.Namespaces[constant.DefaultNamespace].Shards[0]
 	parentLeader := parentMeta.Leader
 	follower := cluster.liveAddressExcluding(parentLeader.GetNameOrDefault())
@@ -1053,7 +1053,7 @@ func TestCoordinator_ShardSplit_FollowerKillDuringSplit(t *testing.T) {
 	// indefinitely (can't reach the dead node). So we accept the parent
 	// being either fully deleted OR marked Deleting with split metadata cleared.
 	require.Eventually(t, func() bool {
-		st := cluster.metadata.LoadStatus()
+		st := cluster.metadata.GetStatus()
 		ns := st.Namespaces[constant.DefaultNamespace]
 		if parentMeta, parentExists := ns.Shards[0]; parentExists {
 			if parentMeta.GetStatusOrDefault() != proto.ShardStatusDeleting {
@@ -1115,7 +1115,7 @@ func TestCoordinator_ShardSplit_ConcurrentSplitRejected(t *testing.T) {
 
 	// First split should still complete
 	require.Eventually(t, func() bool {
-		st := cluster.metadata.LoadStatus()
+		st := cluster.metadata.GetStatus()
 		ns := st.Namespaces[constant.DefaultNamespace]
 		if _, parentExists := ns.Shards[0]; parentExists {
 			return false

--- a/tests/resolver/target_ip_flip_test.go
+++ b/tests/resolver/target_ip_flip_test.go
@@ -86,7 +86,7 @@ func newCoordinatorCluster(t *testing.T, prefix string, serverCount int) *testCl
 	)
 
 	require.Eventually(t, func() bool {
-		shard := cluster.coordinator.Metadata().LoadStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := cluster.coordinator.Metadata().GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 20*time.Second, 100*time.Millisecond)
 
@@ -112,7 +112,7 @@ func (c *testCluster) stopAllServers(t *testing.T) {
 }
 
 func (c *testCluster) leader() *proto.DataServerIdentity {
-	return c.coordinator.Metadata().LoadStatus().Namespaces[constant.DefaultNamespace].Shards[0].Leader
+	return c.coordinator.Metadata().GetStatus().Namespaces[constant.DefaultNamespace].Shards[0].Leader
 }
 
 func (c *testCluster) bootstrapTargetExcluding(excluded *proto.DataServerIdentity) *proto.DataServerIdentity {


### PR DESCRIPTION
Motivation

- make the metadata API read more like domain operations instead of storage-oriented names
- remove internal-only helpers from the public interface

Modifications

- rename metadata getters and mutators toward `Get`/`List`/`Put`/`Delete`
- distinguish `GetDataServerIdentity` from configured `GetDataServer`
- remove `IsReady` and `StatusChangeNotify` from the public metadata interface
- update coordinator runtime, management, and tests to the renamed API