### PR TITLE
fix: guard maelstrom assignment leader updates

### DIFF
--- a/oxiad/maelstrom/assignments.go
+++ b/oxiad/maelstrom/assignments.go
@@ -19,7 +19,7 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 )
 
-func shardAssignmentsLeader(assignments *proto.ShardAssignments) (string, bool) {
+func getDefaultNamespaceLeader(assignments *proto.ShardAssignments) (string, bool) {
 	if assignments == nil {
 		return "", false
 	}

--- a/oxiad/maelstrom/assignments.go
+++ b/oxiad/maelstrom/assignments.go
@@ -1,0 +1,38 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+func shardAssignmentsLeader(assignments *proto.ShardAssignments) (string, bool) {
+	if assignments == nil {
+		return "", false
+	}
+
+	namespaceAssignments, ok := assignments.Namespaces[constant.DefaultNamespace]
+	if !ok || namespaceAssignments == nil || len(namespaceAssignments.Assignments) == 0 {
+		return "", false
+	}
+
+	firstAssignment := namespaceAssignments.Assignments[0]
+	if firstAssignment == nil || firstAssignment.Leader == "" {
+		return "", false
+	}
+
+	return firstAssignment.Leader, true
+}

--- a/oxiad/maelstrom/assignments_test.go
+++ b/oxiad/maelstrom/assignments_test.go
@@ -65,7 +65,7 @@ func TestShardAssignmentsLeader(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotLeader, gotOK := shardAssignmentsLeader(tt.assignments)
+			gotLeader, gotOK := getDefaultNamespaceLeader(tt.assignments)
 			require.Equal(t, tt.wantLeader, gotLeader)
 			require.Equal(t, tt.wantOK, gotOK)
 		})

--- a/oxiad/maelstrom/assignments_test.go
+++ b/oxiad/maelstrom/assignments_test.go
@@ -1,0 +1,112 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+func TestShardAssignmentsLeader(t *testing.T) {
+	tests := []struct {
+		name        string
+		assignments *proto.ShardAssignments
+		wantLeader  string
+		wantOK      bool
+	}{
+		{
+			name:        "nil assignments",
+			assignments: nil,
+		},
+		{
+			name:        "missing default namespace",
+			assignments: &proto.ShardAssignments{Namespaces: map[string]*proto.NamespaceShardsAssignment{}},
+		},
+		{
+			name: "empty default namespace assignments",
+			assignments: &proto.ShardAssignments{
+				Namespaces: map[string]*proto.NamespaceShardsAssignment{
+					constant.DefaultNamespace: {},
+				},
+			},
+		},
+		{
+			name: "valid leader",
+			assignments: &proto.ShardAssignments{
+				Namespaces: map[string]*proto.NamespaceShardsAssignment{
+					constant.DefaultNamespace: {
+						Assignments: []*proto.ShardAssignment{
+							{Leader: "n1"},
+						},
+					},
+				},
+			},
+			wantLeader: "n1",
+			wantOK:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLeader, gotOK := shardAssignmentsLeader(tt.assignments)
+			require.Equal(t, tt.wantLeader, gotLeader)
+			require.Equal(t, tt.wantOK, gotOK)
+		})
+	}
+}
+
+func TestMaelstromShardAssignmentClientSendSkipsEmptyAssignments(t *testing.T) {
+	previousStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	defer reader.Close()
+	defer writer.Close()
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = previousStdout
+	}()
+
+	provider := &maelstromCoordinatorRpcProvider{
+		dispatcher: &dispatcher{currentLeader: "existing"},
+	}
+	client := &maelstromShardAssignmentClient{
+		provider: provider,
+		node:     "n1",
+		streamId: 1,
+	}
+
+	require.NotPanics(t, func() {
+		err := client.Send(&proto.ShardAssignments{Namespaces: map[string]*proto.NamespaceShardsAssignment{}})
+		require.NoError(t, err)
+	})
+	require.Equal(t, "existing", provider.dispatcher.currentLeader)
+}
+
+func TestDispatcherSkipsEmptyAssignmentLeaderUpdate(t *testing.T) {
+	d := &dispatcher{currentLeader: "existing"}
+	require.NotPanics(t, func() {
+		d.onOxiaStreamRequestMessage(
+			MsgTypeShardAssignmentsResponse,
+			nil,
+			&proto.ShardAssignments{Namespaces: map[string]*proto.NamespaceShardsAssignment{}},
+		)
+	})
+	require.Equal(t, "existing", d.currentLeader)
+}

--- a/oxiad/maelstrom/coordinator_rpc_client.go
+++ b/oxiad/maelstrom/coordinator_rpc_client.go
@@ -154,7 +154,7 @@ func newShardAssignmentClient(ctx context.Context, provider *maelstromCoordinato
 
 func (m *maelstromShardAssignmentClient) Send(response *proto.ShardAssignments) error {
 	assignments := response
-	if leader, ok := shardAssignmentsLeader(assignments); ok {
+	if leader, ok := getDefaultNamespaceLeader(assignments); ok {
 		m.provider.dispatcher.currentLeader = leader
 	}
 	req := &Message[OxiaStreamMessage]{

--- a/oxiad/maelstrom/coordinator_rpc_client.go
+++ b/oxiad/maelstrom/coordinator_rpc_client.go
@@ -29,8 +29,6 @@ import (
 
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 
-	"github.com/oxia-db/oxia/common/constant"
-
 	"github.com/oxia-db/oxia/common/proto"
 )
 
@@ -156,7 +154,9 @@ func newShardAssignmentClient(ctx context.Context, provider *maelstromCoordinato
 
 func (m *maelstromShardAssignmentClient) Send(response *proto.ShardAssignments) error {
 	assignments := response
-	m.provider.dispatcher.currentLeader = assignments.Namespaces[constant.DefaultNamespace].Assignments[0].Leader
+	if leader, ok := shardAssignmentsLeader(assignments); ok {
+		m.provider.dispatcher.currentLeader = leader
+	}
 	req := &Message[OxiaStreamMessage]{
 		Src:  thisNode,
 		Dest: m.node,

--- a/oxiad/maelstrom/dispatcher.go
+++ b/oxiad/maelstrom/dispatcher.go
@@ -88,14 +88,12 @@ func (d *dispatcher) onOxiaStreamRequestMessage(msgType MsgType, m any, message 
 	switch msgType {
 	case MsgTypeShardAssignmentsResponse:
 		r := message.(*proto.ShardAssignments)
-		if leader, ok := shardAssignmentsLeader(r); ok {
+		if leader, ok := getDefaultNamespaceLeader(r); ok {
 			d.currentLeader = leader
 			slog.Info(
 				"Received notification of new leader",
 				slog.String("leader", d.currentLeader),
 			)
-		} else {
-			slog.Debug("Received shard assignments without a default-namespace leader")
 		}
 
 	case MsgTypeAppend:

--- a/oxiad/maelstrom/dispatcher.go
+++ b/oxiad/maelstrom/dispatcher.go
@@ -28,8 +28,6 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	pb "google.golang.org/protobuf/proto"
 
-	"github.com/oxia-db/oxia/common/constant"
-
 	"github.com/oxia-db/oxia/common/proto"
 )
 
@@ -90,11 +88,15 @@ func (d *dispatcher) onOxiaStreamRequestMessage(msgType MsgType, m any, message 
 	switch msgType {
 	case MsgTypeShardAssignmentsResponse:
 		r := message.(*proto.ShardAssignments)
-		d.currentLeader = r.Namespaces[constant.DefaultNamespace].Assignments[0].Leader
-		slog.Info(
-			"Received notification of new leader",
-			slog.String("leader", d.currentLeader),
-		)
+		if leader, ok := shardAssignmentsLeader(r); ok {
+			d.currentLeader = leader
+			slog.Info(
+				"Received notification of new leader",
+				slog.String("leader", d.currentLeader),
+			)
+		} else {
+			slog.Debug("Received shard assignments without a default-namespace leader")
+		}
 
 	case MsgTypeAppend:
 		msg := m.(*Message[OxiaStreamMessage])


### PR DESCRIPTION
## Motivation
- Maelstrom could panic while processing shard assignments before the default namespace leader was available.
- The failing CI stack came from blindly indexing the first default-namespace assignment in the coordinator RPC client and dispatcher.

## Modifications
- Added a shared helper to extract the Maelstrom leader from shard assignments only when the default namespace and first assignment are present.
- Updated the coordinator RPC client and dispatcher to skip leader updates for empty or partial assignment payloads instead of panicking.
- Added regression tests for nil, missing, empty, and valid shard assignment payloads.

## Testing
- `go test ./oxiad/maelstrom`
- `make lint`
- `make maelstrom`
- `cd maelstrom && ./maelstrom test -w lin-kv --bin ../bin/oxia-maelstrom --time-limit 60 --concurrency 2n --latency 10 --latency-dist uniform`
  - completed without the assignment panic; local analysis reported only missing `gnuplot` for graph rendering