### PR TITLE
refactor: move metadata lifecycle into factory

### DIFF
--- a/oxiad/coordinator/grpc_server.go
+++ b/oxiad/coordinator/grpc_server.go
@@ -52,6 +52,7 @@ type GrpcServer struct {
 	healthServer     *health.Server
 	runtime          coordruntime.Runtime
 	metadata         coordmetadata.Metadata
+	metadataFactory  *coordmetadata.Factory
 	metrics          *metric.PrometheusMetrics
 }
 
@@ -78,13 +79,18 @@ func NewGrpcServer(parent context.Context, optionsWatch *commonwatch.Watch[*opti
 		return nil, err
 	}
 
-	metadata, err := coordmetadata.NewFromOptions(parent, options)
+	metadataFactory, err := coordmetadata.New(parent, options)
+	if err != nil {
+		return nil, err
+	}
+	metadata, err := metadataFactory.CreateMetadata(parent)
 	if err != nil {
 		return nil, err
 	}
 	runtime, err := coordruntime.New(metadata, rpc.NewRpcProviderFactory(controllerTLS)) //nolint:contextcheck
 	if err != nil {
 		_ = metadata.Close()
+		_ = metadataFactory.Close()
 		return nil, err
 	}
 
@@ -120,6 +126,7 @@ func NewGrpcServer(parent context.Context, optionsWatch *commonwatch.Watch[*opti
 		healthServer:     healthServer,
 		runtime:          runtime,
 		metadata:         metadata,
+		metadataFactory:  metadataFactory,
 		metrics:          metricsServer,
 	}
 	server.wg.Go(func() {
@@ -174,6 +181,7 @@ func (s *GrpcServer) Close() error {
 		s.managementServer.Close(),
 		s.runtime.Close(),
 		s.metadata.Close(),
+		s.metadataFactory.Close(),
 	)
 	if s.metrics != nil {
 		err = multierr.Append(err, s.metrics.Close())

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -40,16 +40,18 @@ func dataServer(name *string, public, internal string) *proto.DataServerIdentity
 func newTestMetadata(t *testing.T, config *proto.ClusterConfiguration) coordmetadata.Metadata {
 	t.Helper()
 
-	metadata := coordmetadata.New(
-		t.Context(),
+	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
 		memory.NewProvider(provider.ClusterStatusCodec),
 		func() (*proto.ClusterConfiguration, error) {
 			return config, nil
 		},
 		nil,
 	)
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, metadata.Close())
+		require.NoError(t, metadataFactory.Close())
 	})
 	return metadata
 }

--- a/oxiad/coordinator/metadata/factory.go
+++ b/oxiad/coordinator/metadata/factory.go
@@ -1,0 +1,157 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"go.uber.org/multierr"
+
+	commonproto "github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/file"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/kubernetes"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/raft"
+	"github.com/oxia-db/oxia/oxiad/coordinator/option"
+)
+
+type Factory struct {
+	mu sync.Mutex
+
+	statusProvider provider.Provider[*commonproto.ClusterStatus]
+	configProvider provider.Provider[*commonproto.ClusterConfiguration]
+	metadataRaft   *raft.Raft
+}
+
+func NewFactoryWithCallbackConfig(
+	ctx context.Context,
+	statusProvider provider.Provider[*commonproto.ClusterStatus],
+	clusterConfigProvider func() (*commonproto.ClusterConfiguration, error),
+	clusterConfigNotificationsCh <-chan any,
+) *Factory {
+	return &Factory{
+		statusProvider: statusProvider,
+		configProvider: newCallbackConfigProvider(ctx, clusterConfigProvider, clusterConfigNotificationsCh),
+	}
+}
+
+func New(ctx context.Context, options *option.Options) (*Factory, error) {
+	if options == nil {
+		return nil, errors.New("options must not be nil")
+	}
+
+	meta := options.Metadata
+	if err := meta.ApplyLegacyClusterConfigPath(options.Cluster.ConfigPath); err != nil {
+		return nil, err
+	}
+
+	factory := &Factory{}
+
+	switch meta.ProviderName {
+	case provider.NameMemory:
+		factory.statusProvider = memory.NewProvider(provider.ClusterStatusCodec)
+		factory.configProvider = memory.NewProvider(provider.ClusterConfigCodec)
+	case provider.NameFile:
+		statusProvider, err := file.NewProvider(ctx, meta.File.StatusPath(), provider.ClusterStatusCodec, provider.WatchDisabled)
+		if err != nil {
+			return nil, err
+		}
+		configProvider, err := file.NewProvider(ctx, meta.File.ConfigPath(), provider.ClusterConfigCodec, provider.WatchEnabled)
+		if err != nil {
+			return nil, err
+		}
+		factory.statusProvider = statusProvider
+		factory.configProvider = configProvider
+	case provider.NameConfigMap:
+		k8sConfig := kubernetes.NewK8SClientConfig()
+		client := kubernetes.NewK8SClientset(k8sConfig)
+		statusProvider, err := kubernetes.NewConfigMapProvider(ctx, client, meta.Kubernetes.Namespace, meta.Kubernetes.StatusNameOrDefault(), provider.ClusterStatusCodec, provider.WatchDisabled)
+		if err != nil {
+			return nil, err
+		}
+		factory.statusProvider = statusProvider
+		if meta.File.Dir != "" || meta.File.ConfigName != "" {
+			configProvider, err := file.NewProvider(ctx, meta.File.ConfigPath(), provider.ClusterConfigCodec, provider.WatchEnabled)
+			if err != nil {
+				return nil, err
+			}
+			factory.configProvider = configProvider
+		} else {
+			configProvider, err := kubernetes.NewConfigMapProvider(ctx, client, meta.Kubernetes.Namespace, meta.Kubernetes.ConfigNameOrDefault(), provider.ClusterConfigCodec, provider.WatchEnabled)
+			if err != nil {
+				return nil, err
+			}
+			factory.configProvider = configProvider
+		}
+	case provider.NameRaft:
+		metadataRaft, err := raft.NewRaft(meta.Raft.Address, meta.Raft.BootstrapNodes, meta.Raft.DataDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create raft metadata provider: %w", err)
+		}
+		factory.metadataRaft = metadataRaft
+		factory.statusProvider = metadataRaft.NewStatusProvider()
+		factory.configProvider = metadataRaft.NewConfigProvider()
+	default:
+		return nil, errors.New(`must be one of "memory", "configmap", "raft" or "file"`)
+	}
+
+	return factory, nil
+}
+
+func (f *Factory) CreateMetadata(ctx context.Context) (Metadata, error) {
+	f.mu.Lock()
+	statusProvider := f.statusProvider
+	configProvider := f.configProvider
+	f.mu.Unlock()
+
+	slog.Info("Waiting to become leader", slog.String("component", "coordinator"))
+	if err := statusProvider.WaitToBecomeLeader(); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("failed to wait in becoming leader: %w", err)
+	}
+	slog.Info("This coordinator is now leader", slog.String("component", "coordinator"))
+
+	return newMetadata(ctx, statusProvider, configProvider), nil
+}
+
+func (f *Factory) Close() error {
+	f.mu.Lock()
+	statusProvider := f.statusProvider
+	configProvider := f.configProvider
+	metadataRaft := f.metadataRaft
+	f.mu.Unlock()
+
+	var statusErr error
+	if statusProvider != nil {
+		statusErr = statusProvider.Close()
+	}
+
+	var configErr error
+	if configProvider != nil {
+		configErr = configProvider.Close()
+	}
+
+	var raftErr error
+	if metadataRaft != nil {
+		raftErr = metadataRaft.Close()
+	}
+
+	return multierr.Combine(statusErr, configErr, raftErr)
+}

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -29,19 +29,12 @@ import (
 	"github.com/google/uuid"
 	gproto "google.golang.org/protobuf/proto"
 
-	"go.uber.org/multierr"
-
 	"github.com/oxia-db/oxia/common/process"
 	commonproto "github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/common/rpc"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/changes"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
-	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/file"
-	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/kubernetes"
-	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
-	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/raft"
-	"github.com/oxia-db/oxia/oxiad/coordinator/option"
 )
 
 type Metadata interface {
@@ -75,7 +68,6 @@ type coordinatorMetadata struct {
 
 	statusProvider provider.Provider[*commonproto.ClusterStatus]
 	configProvider provider.Provider[*commonproto.ClusterConfiguration]
-	backendCloser  io.Closer
 
 	statusLock       sync.RWMutex
 	currentStatus    *commonproto.ClusterStatus
@@ -89,93 +81,7 @@ type coordinatorMetadata struct {
 	namespaceConfigsIndex *redblacktree.Tree[string, *commonproto.Namespace]
 }
 
-func New(
-	ctx context.Context,
-	metadataProvider provider.Provider[*commonproto.ClusterStatus],
-	clusterConfigProvider func() (*commonproto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh chan any,
-) Metadata {
-	return newCoordinatorMetadata(ctx, metadataProvider, newCallbackConfigProvider(ctx, clusterConfigProvider, clusterConfigNotificationsCh))
-}
-
-func NewWithProviders(ctx context.Context, statusProvider provider.Provider[*commonproto.ClusterStatus], configProvider provider.Provider[*commonproto.ClusterConfiguration]) Metadata {
-	return newCoordinatorMetadata(ctx, statusProvider, configProvider)
-}
-
-func NewFromOptions(ctx context.Context, options *option.Options) (Metadata, error) {
-	if options == nil {
-		return nil, errors.New("options must not be nil")
-	}
-
-	meta := options.Metadata
-	if err := meta.ApplyLegacyClusterConfigPath(options.Cluster.ConfigPath); err != nil {
-		return nil, err
-	}
-
-	statusProvider, configProvider, backendCloser, err := newProviders(ctx, meta)
-	if err != nil {
-		return nil, err
-	}
-
-	slog.Info("Waiting to become leader", slog.String("component", "coordinator"))
-	if err := statusProvider.WaitToBecomeLeader(); err != nil {
-		_ = multierr.Combine(statusProvider.Close(), configProvider.Close(), closeIfNotNil(backendCloser))
-		return nil, fmt.Errorf("failed to wait in becoming leader: %w", err)
-	}
-	slog.Info("This coordinator is now leader", slog.String("component", "coordinator"))
-
-	return newCoordinatorMetadataWithCloser(ctx, statusProvider, configProvider, backendCloser), nil
-}
-
-func newProviders(ctx context.Context, meta option.MetadataOptions) (statusProvider provider.Provider[*commonproto.ClusterStatus], configProvider provider.Provider[*commonproto.ClusterConfiguration], backendCloser io.Closer, err error) {
-	switch meta.ProviderName {
-	case provider.NameMemory:
-		return memory.NewProvider(provider.ClusterStatusCodec), memory.NewProvider(provider.ClusterConfigCodec), nil, nil
-	case provider.NameFile:
-		statusProvider, err = file.NewProvider(ctx, meta.File.StatusPath(), provider.ClusterStatusCodec, provider.WatchDisabled)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		configProvider, err = file.NewProvider(ctx, meta.File.ConfigPath(), provider.ClusterConfigCodec, provider.WatchEnabled)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		return statusProvider, configProvider, nil, nil
-	case provider.NameConfigMap:
-		k8sConfig := kubernetes.NewK8SClientConfig()
-		client := kubernetes.NewK8SClientset(k8sConfig)
-		statusProvider, err := kubernetes.NewConfigMapProvider(ctx, client, meta.Kubernetes.Namespace, meta.Kubernetes.StatusNameOrDefault(), provider.ClusterStatusCodec, provider.WatchDisabled)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		if meta.File.Dir != "" || meta.File.ConfigName != "" {
-			configProvider, err = file.NewProvider(ctx, meta.File.ConfigPath(), provider.ClusterConfigCodec, provider.WatchEnabled)
-			if err != nil {
-				return nil, nil, nil, err
-			}
-			return statusProvider, configProvider, nil, nil
-		}
-		configProvider, err := kubernetes.NewConfigMapProvider(ctx, client, meta.Kubernetes.Namespace, meta.Kubernetes.ConfigNameOrDefault(), provider.ClusterConfigCodec, provider.WatchEnabled)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		return statusProvider, configProvider, nil, nil
-	case provider.NameRaft:
-		metadataRaft, err := raft.NewRaft(meta.Raft.Address, meta.Raft.BootstrapNodes, meta.Raft.DataDir)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to create raft metadata provider: %w", err)
-		}
-		return metadataRaft.NewStatusProvider(), metadataRaft.NewConfigProvider(), metadataRaft, nil
-	default:
-		return nil, nil, nil, errors.New(`must be one of "memory", "configmap", "raft" or "file"`)
-	}
-}
-
-func newCoordinatorMetadata(ctx context.Context, statusProvider provider.Provider[*commonproto.ClusterStatus], configProvider provider.Provider[*commonproto.ClusterConfiguration]) Metadata {
-	return newCoordinatorMetadataWithCloser(ctx, statusProvider, configProvider, nil)
-}
-
-func newCoordinatorMetadataWithCloser(ctx context.Context, statusProvider provider.Provider[*commonproto.ClusterStatus], configProvider provider.Provider[*commonproto.ClusterConfiguration], backendCloser io.Closer) Metadata {
+func newMetadata(ctx context.Context, statusProvider provider.Provider[*commonproto.ClusterStatus], configProvider provider.Provider[*commonproto.ClusterConfiguration]) Metadata {
 	metadataCtx, cancel := context.WithCancel(ctx)
 	m := &coordinatorMetadata{
 		logger:             slog.With(slog.String("component", "coordinator-metadata")),
@@ -184,7 +90,6 @@ func newCoordinatorMetadataWithCloser(ctx context.Context, statusProvider provid
 		wg:                 sync.WaitGroup{},
 		statusProvider:     statusProvider,
 		configProvider:     configProvider,
-		backendCloser:      backendCloser,
 		currentVersionID:   provider.NotExists,
 		changeCh:           make(chan struct{}),
 		clusterConfigWatch: commonwatch.New(&commonproto.ClusterConfiguration{}),
@@ -302,14 +207,7 @@ func (p *callbackConfigProvider) Close() error {
 func (m *coordinatorMetadata) Close() error {
 	m.ctxCancel()
 	m.wg.Wait()
-	return multierr.Combine(m.statusProvider.Close(), m.configProvider.Close(), closeIfNotNil(m.backendCloser))
-}
-
-func closeIfNotNil(c io.Closer) error {
-	if c == nil {
-		return nil
-	}
-	return c.Close()
+	return nil
 }
 
 func (m *coordinatorMetadata) notifyStatusChange() {

--- a/oxiad/coordinator/metadata/metadata_test.go
+++ b/oxiad/coordinator/metadata/metadata_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/option"
 )
 
-func TestNewFromOptionsLoadsFileClusterConfig(t *testing.T) {
+func TestNewFactoryFromOptionsLoadsFileClusterConfig(t *testing.T) {
 	dir := t.TempDir()
 	writeClusterConfig(t, filepath.Join(dir, option.DefaultFileConfigName))
 
-	metadata, err := NewFromOptions(t.Context(), &option.Options{
+	factory, err := New(t.Context(), &option.Options{
 		Metadata: option.MetadataOptions{
 			ProviderOptions: option.ProviderOptions{
 				ProviderName: provider.NameFile,
@@ -40,8 +40,11 @@ func TestNewFromOptionsLoadsFileClusterConfig(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	metadata, err := factory.CreateMetadata(t.Context())
+	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, metadata.Close())
+		require.NoError(t, factory.Close())
 	}()
 
 	config := metadata.GetConfig()
@@ -49,12 +52,12 @@ func TestNewFromOptionsLoadsFileClusterConfig(t *testing.T) {
 	require.Equal(t, "default", config.GetNamespaces()[0].GetName())
 }
 
-func TestNewFromOptionsMergesLegacyClusterConfigPath(t *testing.T) {
+func TestNewFactoryFromOptionsMergesLegacyClusterConfigPath(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "legacy-cluster.yaml")
 	writeClusterConfig(t, configPath)
 
-	metadata, err := NewFromOptions(t.Context(), &option.Options{
+	factory, err := New(t.Context(), &option.Options{
 		Cluster: option.ClusterOptions{
 			ConfigPath: configPath,
 		},
@@ -68,8 +71,11 @@ func TestNewFromOptionsMergesLegacyClusterConfigPath(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	metadata, err := factory.CreateMetadata(t.Context())
+	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, metadata.Close())
+		require.NoError(t, factory.Close())
 	}()
 
 	config := metadata.GetConfig()

--- a/oxiad/coordinator/runtime/controller/shard_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller_test.go
@@ -46,11 +46,18 @@ var namespaceConfig = &proto.Namespace{
 func newTestMetadata(t *testing.T, metadataProvider provider.Provider[*proto.ClusterStatus], clusterConfig *proto.ClusterConfiguration) coordmetadata.Metadata {
 	t.Helper()
 
-	metadata := coordmetadata.New(t.Context(), metadataProvider, func() (*proto.ClusterConfiguration, error) {
-		return clusterConfig, nil
-	}, nil)
+	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
+		metadataProvider,
+		func() (*proto.ClusterConfiguration, error) {
+			return clusterConfig, nil
+		},
+		nil,
+	)
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	assert.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, metadata.Close())
+		assert.NoError(t, metadataFactory.Close())
 	})
 	return metadata
 }

--- a/oxiad/coordinator/runtime/controller/split_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/split_controller_test.go
@@ -81,9 +81,15 @@ func setupSplitTest(t *testing.T, phase string) (
 
 	rpcMock := newMockRpcProvider()
 	metaProvider := memory.NewProvider(provider.ClusterStatusCodec)
-	metadata := coordmetadata.New(t.Context(), metaProvider, func() (*proto.ClusterConfiguration, error) {
-		return &proto.ClusterConfiguration{}, nil
-	}, nil)
+	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
+		metaProvider,
+		func() (*proto.ClusterConfiguration, error) {
+			return &proto.ClusterConfiguration{}, nil
+		},
+		nil,
+	)
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	assert.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, metadata.Close()) })
 
 	clusterStatus := &proto.ClusterStatus{

--- a/oxiad/coordinator/runtime/runtime_authority_test.go
+++ b/oxiad/coordinator/runtime/runtime_authority_test.go
@@ -49,14 +49,16 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 			leader.Public,
 		},
 	}
-	metadata := coordmetadata.New(
-		t.Context(),
+	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
 		memory.NewProvider(provider.ClusterStatusCodec),
 		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
 		nil,
 	)
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, metadata.Close())
+		require.NoError(t, metadataFactory.Close())
 	})
 	metadata.PutStatus(&proto.ClusterStatus{
 		Namespaces: map[string]*proto.NamespaceStatus{
@@ -115,14 +117,16 @@ func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
 			Internal: active.Internal,
 		}},
 	}
-	metadata := coordmetadata.New(
-		t.Context(),
+	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
 		memory.NewProvider(provider.ClusterStatusCodec),
 		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
 		nil,
 	)
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, metadata.Close())
+		require.NoError(t, metadataFactory.Close())
 	})
 	metadata.PutStatus(&proto.ClusterStatus{
 		Namespaces: map[string]*proto.NamespaceStatus{

--- a/oxiad/maelstrom/main.go
+++ b/oxiad/maelstrom/main.go
@@ -198,7 +198,20 @@ func main() {
 			)
 			os.Exit(1)
 		}
-		metadata := coordmetadata.New(context.Background(), metadataProvider, func() (*commonproto.ClusterConfiguration, error) { return clusterConfig, nil }, nil)
+		metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(
+			context.Background(),
+			metadataProvider,
+			func() (*commonproto.ClusterConfiguration, error) { return clusterConfig, nil },
+			nil,
+		)
+		metadata, err := metadataFactory.CreateMetadata(context.Background())
+		if err != nil {
+			slog.Error(
+				"failed to create coordinator metadata",
+				slog.Any("error", err),
+			)
+			os.Exit(1)
+		}
 		_, err = coordruntime.New(
 			metadata,
 			func(instanceID string) rpc.Provider {

--- a/tests/assignments/helpers_test.go
+++ b/tests/assignments/helpers_test.go
@@ -36,9 +36,16 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadata := coordmetadata.New(t.Context(), metadataProvider, clusterConfigProvider, clusterConfigNotificationsCh)
+	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
+		metadataProvider,
+		clusterConfigProvider,
+		clusterConfigNotificationsCh,
+	)
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, metadata.Close())
+		require.NoError(t, metadataFactory.Close())
 	})
 
 	coordinatorInstance, err := coordruntime.New(metadata, rpcProvider)

--- a/tests/control/helpers_test.go
+++ b/tests/control/helpers_test.go
@@ -36,9 +36,16 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadata := coordmetadata.New(t.Context(), metadataProvider, clusterConfigProvider, clusterConfigNotificationsCh)
+	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
+		metadataProvider,
+		clusterConfigProvider,
+		clusterConfigNotificationsCh,
+	)
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, metadata.Close())
+		require.NoError(t, metadataFactory.Close())
 	})
 
 	coordinatorInstance, err := coordruntime.New(metadata, rpcProvider)

--- a/tests/coordinator/helpers_test.go
+++ b/tests/coordinator/helpers_test.go
@@ -34,7 +34,14 @@ func createCoordinatorMetadata(
 ) coordmetadata.Metadata {
 	t.Helper()
 
-	return coordmetadata.New(t.Context(), metadataProvider, clusterConfigProvider, clusterConfigNotificationsCh)
+	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
+		metadataProvider,
+		clusterConfigProvider,
+		clusterConfigNotificationsCh,
+	)
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	require.NoError(t, err)
+	return metadata
 }
 
 func newCoordinatorInstance(

--- a/tests/mock/coordinator.go
+++ b/tests/mock/coordinator.go
@@ -31,14 +31,16 @@ import (
 func NewCoordinator(t *testing.T, config *proto.ClusterConfiguration, clusterConfigNotificationCh chan any) coordruntime.Runtime {
 	t.Helper()
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
-	metadata := coordmetadata.New(
-		t.Context(),
+	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
 		metadataProvider,
 		func() (*proto.ClusterConfiguration, error) { return config, nil },
 		clusterConfigNotificationCh,
 	)
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	assert.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, metadata.Close())
+		assert.NoError(t, metadataFactory.Close())
 	})
 	coordinatorInstance, err := coordruntime.New(metadata, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)

--- a/tests/resolver/helpers_test.go
+++ b/tests/resolver/helpers_test.go
@@ -35,9 +35,16 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadata := coordmetadata.New(t.Context(), metadataProvider, clusterConfigProvider, clusterConfigNotificationsCh)
+	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
+		metadataProvider,
+		clusterConfigProvider,
+		clusterConfigNotificationsCh,
+	)
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, metadata.Close())
+		require.NoError(t, metadataFactory.Close())
 	})
 
 	coordinatorInstance, err := coordruntime.New(metadata, rpcProvider)

--- a/tests/security/auth/helpers_test.go
+++ b/tests/security/auth/helpers_test.go
@@ -36,9 +36,16 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadata := coordmetadata.New(t.Context(), metadataProvider, clusterConfigProvider, clusterConfigNotificationsCh)
+	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
+		metadataProvider,
+		clusterConfigProvider,
+		clusterConfigNotificationsCh,
+	)
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, metadata.Close())
+		require.NoError(t, metadataFactory.Close())
 	})
 
 	coordinatorInstance, err := coordruntime.New(metadata, rpcProvider)

--- a/tests/security/tls/helpers_test.go
+++ b/tests/security/tls/helpers_test.go
@@ -36,9 +36,16 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadata := coordmetadata.New(t.Context(), metadataProvider, clusterConfigProvider, clusterConfigNotificationsCh)
+	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
+		metadataProvider,
+		clusterConfigProvider,
+		clusterConfigNotificationsCh,
+	)
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, metadata.Close())
+		require.NoError(t, metadataFactory.Close())
 	})
 
 	coordinatorInstance, err := coordruntime.New(metadata, rpcProvider)


### PR DESCRIPTION
## Motivation
- Metadata construction still mixed provider wiring, shared backend ownership, and metadata lifecycle in one place.
- The metadata object should only manage its own goroutines, while the factory should own provider and shared backend lifecycle.

## Modifications
- Added a concrete stateful metadata factory in `oxiad/coordinator/metadata/factory.go`.
- Moved metadata/provider/backend initialization into factory construction and made `CreateMetadata(ctx)` produce metadata from already-owned providers.
- Moved provider shutdown ownership from `Metadata.Close()` into `Factory.Close()`.
- Updated coordinator server, Maelstrom, and affected tests to create metadata through the factory and close the factory explicitly.

## Testing
- `go test ./oxiad/coordinator/metadata ./oxiad/coordinator ./oxiad/maelstrom ./tests/mock ./tests/control ./tests/resolver ./tests/assignments ./tests/security/auth ./tests/security/tls -run '^$|TestNewFactoryFromOptions|TestManagementServer|TestComputeNewAssignmentsIncludesExtraAuthorities|TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities'`
- `make lint`
