### PR TITLE
refactor: remove metadata callback config provider

### DIFF
--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -40,12 +40,12 @@ func dataServer(name *string, public, internal string) *proto.DataServerIdentity
 func newTestMetadata(t *testing.T, config *proto.ClusterConfiguration) coordmetadata.Metadata {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(config, provider.NotExists)
+	require.NoError(t, err)
+	metadataFactory := coordmetadata.NewFactoryWithProviders(
 		memory.NewProvider(provider.ClusterStatusCodec),
-		func() (*proto.ClusterConfiguration, error) {
-			return config, nil
-		},
-		nil,
+		configProvider,
 	)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)

--- a/oxiad/coordinator/metadata/factory.go
+++ b/oxiad/coordinator/metadata/factory.go
@@ -40,15 +40,13 @@ type Factory struct {
 	metadataRaft   *raft.Raft
 }
 
-func NewFactoryWithCallbackConfig(
-	ctx context.Context,
+func NewFactoryWithProviders(
 	statusProvider provider.Provider[*commonproto.ClusterStatus],
-	clusterConfigProvider func() (*commonproto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh <-chan any,
+	configProvider provider.Provider[*commonproto.ClusterConfiguration],
 ) *Factory {
 	return &Factory{
 		statusProvider: statusProvider,
-		configProvider: newCallbackConfigProvider(ctx, clusterConfigProvider, clusterConfigNotificationsCh),
+		configProvider: configProvider,
 	}
 }
 

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -112,98 +112,6 @@ func newMetadata(ctx context.Context, statusProvider provider.Provider[*commonpr
 	return m
 }
 
-type callbackConfigProvider struct {
-	ctx           context.Context
-	ctxCancel     context.CancelFunc
-	wg            sync.WaitGroup
-	load          func() (*commonproto.ClusterConfiguration, error)
-	notifications <-chan any
-	watcher       *commonwatch.Watch[*commonproto.ClusterConfiguration]
-}
-
-func newCallbackConfigProvider(
-	ctx context.Context,
-	load func() (*commonproto.ClusterConfiguration, error),
-	notifications <-chan any,
-) provider.Provider[*commonproto.ClusterConfiguration] {
-	watchCtx, cancel := context.WithCancel(ctx)
-	p := &callbackConfigProvider{
-		ctx:           watchCtx,
-		ctxCancel:     cancel,
-		load:          load,
-		notifications: notifications,
-	}
-	if notifications != nil {
-		initialValue, _, err := p.Get()
-		if err != nil {
-			slog.Warn("Failed to load initial watched callback config provider metadata", slog.Any("error", err))
-		}
-		p.watcher = commonwatch.New(initialValue)
-		p.wg.Go(func() {
-			process.DoWithLabels(p.ctx, map[string]string{
-				"component": "callback-config-provider-watch",
-			}, p.watchLoop)
-		})
-	}
-	return p
-}
-
-func (p *callbackConfigProvider) Get() (*commonproto.ClusterConfiguration, provider.Version, error) {
-	config, err := p.LoadConfig()
-	return config, provider.NotExists, err
-}
-
-func (p *callbackConfigProvider) LoadConfig() (*commonproto.ClusterConfiguration, error) {
-	if p.load == nil {
-		return nil, provider.ErrNotInitialized
-	}
-	return p.load()
-}
-
-func (*callbackConfigProvider) Store(*commonproto.ClusterConfiguration, provider.Version) (provider.Version, error) {
-	return provider.NotExists, errors.New("callback config provider is read-only")
-}
-
-func (*callbackConfigProvider) WaitToBecomeLeader() error {
-	return nil
-}
-
-func (p *callbackConfigProvider) Watch() (*commonwatch.Receiver[*commonproto.ClusterConfiguration], error) {
-	if p.watcher == nil {
-		return nil, provider.ErrWatchUnsupported
-	}
-	return p.watcher.Subscribe(), nil
-}
-
-func (p *callbackConfigProvider) watchLoop() {
-	for {
-		select {
-		case <-p.ctx.Done():
-			return
-		case _, ok := <-p.notifications:
-			if !ok {
-				return
-			}
-			p.publishCurrentValue()
-		}
-	}
-}
-
-func (p *callbackConfigProvider) publishCurrentValue() {
-	value, _, err := p.Get()
-	if err != nil {
-		slog.Warn("Failed to load watched callback config provider metadata", slog.Any("error", err))
-		return
-	}
-	p.watcher.Publish(value)
-}
-
-func (p *callbackConfigProvider) Close() error {
-	p.ctxCancel()
-	p.wg.Wait()
-	return nil
-}
-
 func (m *coordinatorMetadata) Close() error {
 	m.ctxCancel()
 	m.wg.Wait()
@@ -361,12 +269,6 @@ func (m *coordinatorMetadata) loadClusterConfigWithInitSlow() {
 }
 
 func loadClusterConfigFromProvider(configProvider provider.Provider[*commonproto.ClusterConfiguration]) (*commonproto.ClusterConfiguration, error) {
-	if loader, ok := configProvider.(interface {
-		LoadConfig() (*commonproto.ClusterConfiguration, error)
-	}); ok {
-		return loader.LoadConfig()
-	}
-
 	config, _, err := configProvider.Get()
 	if err != nil {
 		return nil, err
@@ -425,11 +327,9 @@ func (m *coordinatorMetadata) waitForConfigUpdates(configWatch *commonwatch.Rece
 
 func (m *coordinatorMetadata) applyConfigWatchValue(configWatch *commonwatch.Receiver[*commonproto.ClusterConfiguration]) {
 	config := configWatch.Load()
-	if !m.usesCallbackConfigProvider() {
-		if err := validateClusterConfig(config); err != nil {
-			m.logger.Warn("received invalid cluster config watch value", slog.Any("error", err))
-			return
-		}
+	if err := validateClusterConfig(config); err != nil {
+		m.logger.Warn("received invalid cluster config watch value", slog.Any("error", err))
+		return
 	}
 	clonedConfig := gproto.Clone(config).(*commonproto.ClusterConfiguration) //nolint:revive
 
@@ -444,11 +344,6 @@ func (m *coordinatorMetadata) applyConfigWatchValue(configWatch *commonwatch.Rec
 		return
 	}
 	m.clusterConfigWatch.Publish(clonedConfig)
-}
-
-func (m *coordinatorMetadata) usesCallbackConfigProvider() bool {
-	_, ok := m.configProvider.(*callbackConfigProvider)
-	return ok
 }
 
 func (m *coordinatorMetadata) GetConfig() *commonproto.ClusterConfiguration {

--- a/oxiad/coordinator/metadata/provider/memory/memory.go
+++ b/oxiad/coordinator/metadata/provider/memory/memory.go
@@ -33,6 +33,7 @@ type Provider[T gproto.Message] struct {
 	codec   provider.Codec[T]
 	value   T
 	version provider.Version
+	watch   *commonwatch.Watch[T]
 }
 
 func (*Provider[T]) WaitToBecomeLeader() error {
@@ -40,9 +41,11 @@ func (*Provider[T]) WaitToBecomeLeader() error {
 }
 
 func NewProvider[T gproto.Message](codec provider.Codec[T]) provider.Provider[T] {
+	var zero T
 	return &Provider[T]{
 		codec:   codec,
 		version: provider.NotExists,
+		watch:   commonwatch.New(zero),
 	}
 }
 
@@ -67,9 +70,13 @@ func (m *Provider[T]) Store(value T, expectedVersion provider.Version) (newVersi
 
 	m.value = m.codec.Clone(value)
 	m.version = provider.NextVersion(m.version)
+	m.watch.Publish(m.codec.Clone(m.value))
 	return m.version, nil
 }
 
-func (*Provider[T]) Watch() (*commonwatch.Receiver[T], error) {
-	return nil, provider.ErrWatchUnsupported
+func (m *Provider[T]) Watch() (*commonwatch.Receiver[T], error) {
+	m.Lock()
+	defer m.Unlock()
+
+	return m.watch.Subscribe(), nil
 }

--- a/oxiad/coordinator/metadata/provider/memory/memory.go
+++ b/oxiad/coordinator/metadata/provider/memory/memory.go
@@ -15,6 +15,7 @@
 package memory
 
 import (
+	"reflect"
 	"sync"
 
 	gproto "google.golang.org/protobuf/proto"
@@ -41,11 +42,10 @@ func (*Provider[T]) WaitToBecomeLeader() error {
 }
 
 func NewProvider[T gproto.Message](codec provider.Codec[T]) provider.Provider[T] {
-	var zero T
 	return &Provider[T]{
 		codec:   codec,
 		version: provider.NotExists,
-		watch:   commonwatch.New(zero),
+		watch:   commonwatch.New(newZeroValue[T]()),
 	}
 }
 
@@ -76,4 +76,17 @@ func (m *Provider[T]) Store(value T, expectedVersion provider.Version) (newVersi
 
 func (m *Provider[T]) Watch() (*commonwatch.Receiver[T], error) {
 	return m.watch.Subscribe(), nil
+}
+
+func newZeroValue[T gproto.Message]() T {
+	var zero T
+	messageType := reflect.TypeFor[T]()
+	if messageType.Kind() == reflect.Pointer {
+		value, ok := reflect.New(messageType.Elem()).Interface().(T)
+		if !ok {
+			panic("failed to allocate metadata memory provider watch seed")
+		}
+		return value
+	}
+	return zero
 }

--- a/oxiad/coordinator/metadata/provider/memory/memory.go
+++ b/oxiad/coordinator/metadata/provider/memory/memory.go
@@ -75,8 +75,5 @@ func (m *Provider[T]) Store(value T, expectedVersion provider.Version) (newVersi
 }
 
 func (m *Provider[T]) Watch() (*commonwatch.Receiver[T], error) {
-	m.Lock()
-	defer m.Unlock()
-
 	return m.watch.Subscribe(), nil
 }

--- a/oxiad/coordinator/metadata/provider/memory/memory.go
+++ b/oxiad/coordinator/metadata/provider/memory/memory.go
@@ -15,7 +15,6 @@
 package memory
 
 import (
-	"reflect"
 	"sync"
 
 	gproto "google.golang.org/protobuf/proto"
@@ -45,7 +44,7 @@ func NewProvider[T gproto.Message](codec provider.Codec[T]) provider.Provider[T]
 	return &Provider[T]{
 		codec:   codec,
 		version: provider.NotExists,
-		watch:   commonwatch.New(newZeroValue[T]()),
+		watch:   commonwatch.New(codec.NewZero()),
 	}
 }
 
@@ -76,17 +75,4 @@ func (m *Provider[T]) Store(value T, expectedVersion provider.Version) (newVersi
 
 func (m *Provider[T]) Watch() (*commonwatch.Receiver[T], error) {
 	return m.watch.Subscribe(), nil
-}
-
-func newZeroValue[T gproto.Message]() T {
-	var zero T
-	messageType := reflect.TypeFor[T]()
-	if messageType.Kind() == reflect.Pointer {
-		value, ok := reflect.New(messageType.Elem()).Interface().(T)
-		if !ok {
-			panic("failed to allocate metadata memory provider watch seed")
-		}
-		return value
-	}
-	return zero
 }

--- a/oxiad/coordinator/metadata/provider/provider.go
+++ b/oxiad/coordinator/metadata/provider/provider.go
@@ -76,6 +76,7 @@ func (wm WatchMode) Enabled() bool {
 
 type Codec[T gproto.Message] interface {
 	Clone(value T) T
+	NewZero() T
 	Unmarshal(data []byte) (T, error)
 	MarshalYAML(value T) ([]byte, error)
 	MarshalJSON(value T) ([]byte, error)
@@ -112,6 +113,10 @@ func (statusCodec) Clone(value *commonproto.ClusterStatus) *commonproto.ClusterS
 	return cloneMessage(value)
 }
 
+func (statusCodec) NewZero() *commonproto.ClusterStatus {
+	return &commonproto.ClusterStatus{}
+}
+
 func (statusCodec) MarshalYAML(value *commonproto.ClusterStatus) ([]byte, error) {
 	return commonproto.MarshalClusterStatusYAML(value)
 }
@@ -126,6 +131,10 @@ func (statusCodec) ConfigMapDataKey() string {
 
 func (configCodec) Unmarshal(data []byte) (*commonproto.ClusterConfiguration, error) {
 	return commonproto.UnmarshalClusterConfigurationYAML(data)
+}
+
+func (configCodec) NewZero() *commonproto.ClusterConfiguration {
+	return &commonproto.ClusterConfiguration{}
 }
 
 func (configCodec) Clone(value *commonproto.ClusterConfiguration) *commonproto.ClusterConfiguration {

--- a/oxiad/coordinator/runtime/controller/shard_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller_test.go
@@ -46,13 +46,24 @@ var namespaceConfig = &proto.Namespace{
 func newTestMetadata(t *testing.T, metadataProvider provider.Provider[*proto.ClusterStatus], clusterConfig *proto.ClusterConfiguration) coordmetadata.Metadata {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
-		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) {
-			return clusterConfig, nil
-		},
-		nil,
-	)
+	if clusterConfig == nil {
+		clusterConfig = &proto.ClusterConfiguration{}
+	}
+	if len(clusterConfig.Namespaces) == 0 {
+		clusterConfig.Namespaces = []*proto.Namespace{namespaceConfig}
+	}
+	if len(clusterConfig.Servers) == 0 {
+		clusterConfig.Servers = []*proto.DataServerIdentity{
+			{Public: "seed-public-1:6648", Internal: "seed-internal-1:6649"},
+			{Public: "seed-public-2:7648", Internal: "seed-internal-2:7649"},
+			{Public: "seed-public-3:8648", Internal: "seed-internal-3:8649"},
+		}
+	}
+
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	assert.NoError(t, err)
 	t.Cleanup(func() {

--- a/oxiad/coordinator/runtime/controller/split_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/split_controller_test.go
@@ -81,13 +81,17 @@ func setupSplitTest(t *testing.T, phase string) (
 
 	rpcMock := newMockRpcProvider()
 	metaProvider := memory.NewProvider(provider.ClusterStatusCodec)
-	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
-		metaProvider,
-		func() (*proto.ClusterConfiguration, error) {
-			return &proto.ClusterConfiguration{}, nil
-		},
-		nil,
-	)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(&proto.ClusterConfiguration{
+		Namespaces: []*proto.Namespace{{
+			Name:              constant.DefaultNamespace,
+			InitialShardCount: 1,
+			ReplicationFactor: 3,
+		}},
+		Servers: []*proto.DataServerIdentity{ps1, ps2, ps3},
+	}, provider.NotExists)
+	require.NoError(t, err)
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metaProvider, configProvider)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	assert.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, metadata.Close()) })

--- a/oxiad/coordinator/runtime/runtime_authority_test.go
+++ b/oxiad/coordinator/runtime/runtime_authority_test.go
@@ -49,10 +49,12 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 			leader.Public,
 		},
 	}
-	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	require.NoError(t, err)
+	metadataFactory := coordmetadata.NewFactoryWithProviders(
 		memory.NewProvider(provider.ClusterStatusCodec),
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil,
+		configProvider,
 	)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
@@ -117,10 +119,12 @@ func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
 			Internal: active.Internal,
 		}},
 	}
-	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	require.NoError(t, err)
+	metadataFactory := coordmetadata.NewFactoryWithProviders(
 		memory.NewProvider(provider.ClusterStatusCodec),
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil,
+		configProvider,
 	)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)

--- a/oxiad/maelstrom/main.go
+++ b/oxiad/maelstrom/main.go
@@ -30,6 +30,7 @@ import (
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/file"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/option"
@@ -198,11 +199,18 @@ func main() {
 			)
 			os.Exit(1)
 		}
-		metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(
-			context.Background(),
+		configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+		_, err = configProvider.Store(clusterConfig, provider.NotExists)
+		if err != nil {
+			slog.Error(
+				"failed to seed coordinator config provider",
+				slog.Any("error", err),
+			)
+			os.Exit(1)
+		}
+		metadataFactory := coordmetadata.NewFactoryWithProviders(
 			metadataProvider,
-			func() (*commonproto.ClusterConfiguration, error) { return clusterConfig, nil },
-			nil,
+			configProvider,
 		)
 		metadata, err := metadataFactory.CreateMetadata(context.Background())
 		if err != nil {

--- a/tests/assignments/helpers_test.go
+++ b/tests/assignments/helpers_test.go
@@ -23,53 +23,10 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
-	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
+	"github.com/oxia-db/oxia/tests/mock"
 )
-
-func newConfigProvider(
-	t *testing.T,
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh <-chan any,
-) provider.Provider[*proto.ClusterConfiguration] {
-	t.Helper()
-
-	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
-	clusterConfig, err := clusterConfigProvider()
-	require.NoError(t, err)
-	_, err = configProvider.Store(clusterConfig, provider.NotExists)
-	require.NoError(t, err)
-
-	if clusterConfigNotificationsCh != nil {
-		go func() {
-			for {
-				select {
-				case <-t.Context().Done():
-					return
-				case _, ok := <-clusterConfigNotificationsCh:
-					if !ok {
-						return
-					}
-				}
-
-				clusterConfig, err := clusterConfigProvider()
-				if err != nil {
-					panic(err)
-				}
-				_, version, err := configProvider.Get()
-				if err != nil {
-					panic(err)
-				}
-				if _, err = configProvider.Store(clusterConfig, version); err != nil {
-					panic(err)
-				}
-			}
-		}()
-	}
-
-	return configProvider
-}
 
 func newCoordinatorInstance(
 	t *testing.T,
@@ -80,7 +37,7 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, newConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, mock.NewConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/assignments/helpers_test.go
+++ b/tests/assignments/helpers_test.go
@@ -23,9 +23,53 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
 )
+
+func newConfigProvider(
+	t *testing.T,
+	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
+	clusterConfigNotificationsCh <-chan any,
+) provider.Provider[*proto.ClusterConfiguration] {
+	t.Helper()
+
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	clusterConfig, err := clusterConfigProvider()
+	require.NoError(t, err)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	require.NoError(t, err)
+
+	if clusterConfigNotificationsCh != nil {
+		go func() {
+			for {
+				select {
+				case <-t.Context().Done():
+					return
+				case _, ok := <-clusterConfigNotificationsCh:
+					if !ok {
+						return
+					}
+				}
+
+				clusterConfig, err := clusterConfigProvider()
+				if err != nil {
+					panic(err)
+				}
+				_, version, err := configProvider.Get()
+				if err != nil {
+					panic(err)
+				}
+				if _, err = configProvider.Store(clusterConfig, version); err != nil {
+					panic(err)
+				}
+			}
+		}()
+	}
+
+	return configProvider
+}
 
 func newCoordinatorInstance(
 	t *testing.T,
@@ -36,11 +80,7 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
-		metadataProvider,
-		clusterConfigProvider,
-		clusterConfigNotificationsCh,
-	)
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, newConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/assignments/helpers_test.go
+++ b/tests/assignments/helpers_test.go
@@ -25,19 +25,17 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
-	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func newCoordinatorInstance(
 	t *testing.T,
 	metadataProvider provider.Provider[*proto.ClusterStatus],
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh chan any,
+	configProvider provider.Provider[*proto.ClusterConfiguration],
 	rpcProvider rpc.ProviderFactory,
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, mock.NewConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/assignments/leader_hint_test.go
+++ b/tests/assignments/leader_hint_test.go
@@ -41,11 +41,11 @@ func TestLeaderHintWithoutClient(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil,
+		configProvider,
 		rpc.NewRpcProviderFactory(nil),
 	)
 	defer coordinatorInstance.Close()
@@ -97,11 +97,11 @@ func TestLeaderHintListWithoutClient(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil,
+		configProvider,
 		rpc.NewRpcProviderFactory(nil),
 	)
 	defer coordinatorInstance.Close()
@@ -153,11 +153,11 @@ func TestLeaderHintListWithClient(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil,
+		configProvider,
 		rpc.NewRpcProviderFactory(nil),
 	)
 	defer coordinatorInstance.Close()
@@ -200,11 +200,11 @@ func TestLeaderHintRangeScanWithoutClient(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil,
+		configProvider,
 		rpc.NewRpcProviderFactory(nil),
 	)
 	defer coordinatorInstance.Close()
@@ -256,11 +256,11 @@ func TestLeaderHintRangeScanWithClient(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil,
+		configProvider,
 		rpc.NewRpcProviderFactory(nil),
 	)
 	defer coordinatorInstance.Close()
@@ -307,11 +307,11 @@ func TestLeaderHintWithClient(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil,
+		configProvider,
 		rpc.NewRpcProviderFactory(nil),
 	)
 	defer coordinatorInstance.Close()

--- a/tests/assignments/leader_hint_test.go
+++ b/tests/assignments/leader_hint_test.go
@@ -41,7 +41,9 @@ func TestLeaderHintWithoutClient(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
@@ -97,7 +99,9 @@ func TestLeaderHintListWithoutClient(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
@@ -153,7 +157,9 @@ func TestLeaderHintListWithClient(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
@@ -200,7 +206,9 @@ func TestLeaderHintRangeScanWithoutClient(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
@@ -256,7 +264,9 @@ func TestLeaderHintRangeScanWithClient(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
@@ -307,7 +317,9 @@ func TestLeaderHintWithClient(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,

--- a/tests/balancer/leader_balancer_test.go
+++ b/tests/balancer/leader_balancer_test.go
@@ -101,8 +101,8 @@ func TestLeaderBalanced(t *testing.T) {
 		},
 	}
 
-	ch := make(chan any, 1)
-	coordinator := mock.NewCoordinator(t, cc, ch)
+	configProvider := mock.NewConfigProvider(t, cc)
+	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
 
 	metadata := coordinator.Metadata()
@@ -144,8 +144,8 @@ func TestLeaderBalancedNodeCrashAndBack(t *testing.T) {
 		},
 	}
 
-	ch := make(chan any, 1)
-	coordinator := mock.NewCoordinator(t, cc, ch)
+	configProvider := mock.NewConfigProvider(t, cc)
+	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
 
 	metadata := coordinator.Metadata()
@@ -214,8 +214,8 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 		},
 	}
 
-	ch := make(chan any, 1)
-	coordinator := mock.NewCoordinator(t, cc, ch)
+	configProvider := mock.NewConfigProvider(t, cc)
+	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
 
 	metadata := coordinator.Metadata()
@@ -225,7 +225,7 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 	waitForLeadersBalanced(t, metadata, balancer, candidates, 4)
 
 	cc.Servers = append(cc.Servers, dataServers(s4ad, s5ad, s6ad)...)
-	ch <- nil
+	mock.PutConfig(t, configProvider, cc)
 	candidates = linkedhashset.New(s1ad.GetNameOrDefault(), s2ad.GetNameOrDefault(), s3ad.GetNameOrDefault(), s4ad.GetNameOrDefault(), s5ad.GetNameOrDefault(), s6ad.GetNameOrDefault())
 
 	// wait for leader balanced

--- a/tests/balancer/leader_balancer_test.go
+++ b/tests/balancer/leader_balancer_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/state"
 
 	"github.com/oxia-db/oxia/tests/mock"
@@ -101,7 +103,9 @@ func TestLeaderBalanced(t *testing.T) {
 		},
 	}
 
-	configProvider := mock.NewConfigProvider(t, cc)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(cc, provider.NotExists)
+	require.NoError(t, err)
 	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
 
@@ -144,7 +148,9 @@ func TestLeaderBalancedNodeCrashAndBack(t *testing.T) {
 		},
 	}
 
-	configProvider := mock.NewConfigProvider(t, cc)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(cc, provider.NotExists)
+	require.NoError(t, err)
 	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
 
@@ -159,7 +165,7 @@ func TestLeaderBalancedNodeCrashAndBack(t *testing.T) {
 
 	// wait for leader moved
 	ctx := t.Context()
-	err := coordmetadata.WaitForCondition(ctx, metadata, nil, func(status *proto.ClusterStatus) bool {
+	err = coordmetadata.WaitForCondition(ctx, metadata, nil, func(status *proto.ClusterStatus) bool {
 		_, _, nodeShards := state.NodeShardLeaders(candidates, status)
 		shards := nodeShards[s3ad.GetNameOrDefault()]
 		return shards.Size() == 0
@@ -214,7 +220,9 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 		},
 	}
 
-	configProvider := mock.NewConfigProvider(t, cc)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(cc, provider.NotExists)
+	require.NoError(t, err)
 	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
 
@@ -225,7 +233,10 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 	waitForLeadersBalanced(t, metadata, balancer, candidates, 4)
 
 	cc.Servers = append(cc.Servers, dataServers(s4ad, s5ad, s6ad)...)
-	mock.PutConfig(t, configProvider, cc)
+	_, version, err := configProvider.Get()
+	require.NoError(t, err)
+	_, err = configProvider.Store(cc, version)
+	require.NoError(t, err)
 	candidates = linkedhashset.New(s1ad.GetNameOrDefault(), s2ad.GetNameOrDefault(), s3ad.GetNameOrDefault(), s4ad.GetNameOrDefault(), s5ad.GetNameOrDefault(), s6ad.GetNameOrDefault())
 
 	// wait for leader balanced

--- a/tests/balancer/shard_balancer_test.go
+++ b/tests/balancer/shard_balancer_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
 
 	"github.com/oxia-db/oxia/oxia"
@@ -68,7 +70,9 @@ func TestNormalShardBalancer(t *testing.T) {
 		Servers: shardBalancerDataServers(s1ad, s2ad, s3ad),
 	}
 
-	configProvider := mock.NewConfigProvider(t, &cc)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(&cc, provider.NotExists)
+	assert.NoError(t, err)
 	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
 
@@ -86,7 +90,10 @@ func TestNormalShardBalancer(t *testing.T) {
 	}, 10*time.Second, 50*time.Millisecond)
 
 	cc.Servers = append(cc.Servers, shardBalancerDataServers(s4ad, s5ad)...)
-	mock.PutConfig(t, configProvider, &cc)
+	_, version, err := configProvider.Get()
+	assert.NoError(t, err)
+	_, err = configProvider.Store(&cc, version)
+	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
 		_, exist := metadata.GetDataServerIdentity(s4ad.GetNameOrDefault())
@@ -175,7 +182,9 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 		Servers:        shardBalancerDataServers(s1ad, s2ad, s3ad),
 	}
 
-	configProvider := mock.NewConfigProvider(t, &cc)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(&cc, provider.NotExists)
+	assert.NoError(t, err)
 	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
 
@@ -193,7 +202,10 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 	}, 10*time.Second, 50*time.Millisecond)
 
 	cc.Servers = append(cc.Servers, shardBalancerDataServers(s4ad, s5ad)...)
-	mock.PutConfig(t, configProvider, &cc)
+	_, version, err := configProvider.Get()
+	assert.NoError(t, err)
+	_, err = configProvider.Store(&cc, version)
+	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
 		_, exist := metadata.GetDataServerIdentity(s4ad.GetNameOrDefault())
@@ -269,7 +281,9 @@ func TestBalanceWithoutDeadlock(t *testing.T) {
 		},
 		Servers: shardBalancerDataServers(s1ad, s2ad, s3ad),
 	}
-	configProvider := mock.NewConfigProvider(t, &cc)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(&cc, provider.NotExists)
+	assert.NoError(t, err)
 	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
 
@@ -306,7 +320,10 @@ func TestBalanceWithoutDeadlock(t *testing.T) {
 	}
 
 	cc.Servers = append(cc.Servers, shardBalancerDataServers(s4ad, s5ad, s6ad)...)
-	mock.PutConfig(t, configProvider, &cc)
+	_, version, err := configProvider.Get()
+	assert.NoError(t, err)
+	_, err = configProvider.Store(&cc, version)
+	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
 		_, exist := metadata.GetDataServerIdentity(s4ad.GetNameOrDefault())

--- a/tests/balancer/shard_balancer_test.go
+++ b/tests/balancer/shard_balancer_test.go
@@ -68,8 +68,8 @@ func TestNormalShardBalancer(t *testing.T) {
 		Servers: shardBalancerDataServers(s1ad, s2ad, s3ad),
 	}
 
-	ch := make(chan any, 1)
-	coordinator := mock.NewCoordinator(t, &cc, ch)
+	configProvider := mock.NewConfigProvider(t, &cc)
+	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
 
 	metadata := coordinator.Metadata()
@@ -86,7 +86,7 @@ func TestNormalShardBalancer(t *testing.T) {
 	}, 10*time.Second, 50*time.Millisecond)
 
 	cc.Servers = append(cc.Servers, shardBalancerDataServers(s4ad, s5ad)...)
-	ch <- struct{}{}
+	mock.PutConfig(t, configProvider, &cc)
 
 	assert.Eventually(t, func() bool {
 		_, exist := metadata.GetDataServerIdentity(s4ad.GetNameOrDefault())
@@ -175,8 +175,8 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 		Servers:        shardBalancerDataServers(s1ad, s2ad, s3ad),
 	}
 
-	ch := make(chan any, 1)
-	coordinator := mock.NewCoordinator(t, &cc, ch)
+	configProvider := mock.NewConfigProvider(t, &cc)
+	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
 
 	metadata := coordinator.Metadata()
@@ -193,7 +193,7 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 	}, 10*time.Second, 50*time.Millisecond)
 
 	cc.Servers = append(cc.Servers, shardBalancerDataServers(s4ad, s5ad)...)
-	ch <- struct{}{}
+	mock.PutConfig(t, configProvider, &cc)
 
 	assert.Eventually(t, func() bool {
 		_, exist := metadata.GetDataServerIdentity(s4ad.GetNameOrDefault())
@@ -269,8 +269,8 @@ func TestBalanceWithoutDeadlock(t *testing.T) {
 		},
 		Servers: shardBalancerDataServers(s1ad, s2ad, s3ad),
 	}
-	ch := make(chan any, 1)
-	coordinator := mock.NewCoordinator(t, &cc, ch)
+	configProvider := mock.NewConfigProvider(t, &cc)
+	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
 
 	metadata := coordinator.Metadata()
@@ -306,7 +306,7 @@ func TestBalanceWithoutDeadlock(t *testing.T) {
 	}
 
 	cc.Servers = append(cc.Servers, shardBalancerDataServers(s4ad, s5ad, s6ad)...)
-	ch <- struct{}{}
+	mock.PutConfig(t, configProvider, &cc)
 
 	assert.Eventually(t, func() bool {
 		_, exist := metadata.GetDataServerIdentity(s4ad.GetNameOrDefault())

--- a/tests/control/control_request_test.go
+++ b/tests/control/control_request_test.go
@@ -48,7 +48,9 @@ func TestControlRequestFeatureEnabled(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,

--- a/tests/control/control_request_test.go
+++ b/tests/control/control_request_test.go
@@ -48,11 +48,11 @@ func TestControlRequestFeatureEnabled(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil,
+		configProvider,
 		rpc.NewRpcProviderFactory(nil),
 	)
 	defer coordinatorInstance.Close()

--- a/tests/control/helpers_test.go
+++ b/tests/control/helpers_test.go
@@ -23,53 +23,10 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
-	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
+	"github.com/oxia-db/oxia/tests/mock"
 )
-
-func newConfigProvider(
-	t *testing.T,
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh <-chan any,
-) provider.Provider[*proto.ClusterConfiguration] {
-	t.Helper()
-
-	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
-	clusterConfig, err := clusterConfigProvider()
-	require.NoError(t, err)
-	_, err = configProvider.Store(clusterConfig, provider.NotExists)
-	require.NoError(t, err)
-
-	if clusterConfigNotificationsCh != nil {
-		go func() {
-			for {
-				select {
-				case <-t.Context().Done():
-					return
-				case _, ok := <-clusterConfigNotificationsCh:
-					if !ok {
-						return
-					}
-				}
-
-				clusterConfig, err := clusterConfigProvider()
-				if err != nil {
-					panic(err)
-				}
-				_, version, err := configProvider.Get()
-				if err != nil {
-					panic(err)
-				}
-				if _, err = configProvider.Store(clusterConfig, version); err != nil {
-					panic(err)
-				}
-			}
-		}()
-	}
-
-	return configProvider
-}
 
 func newCoordinatorInstance(
 	t *testing.T,
@@ -80,7 +37,7 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, newConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, mock.NewConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/control/helpers_test.go
+++ b/tests/control/helpers_test.go
@@ -23,9 +23,53 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
 )
+
+func newConfigProvider(
+	t *testing.T,
+	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
+	clusterConfigNotificationsCh <-chan any,
+) provider.Provider[*proto.ClusterConfiguration] {
+	t.Helper()
+
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	clusterConfig, err := clusterConfigProvider()
+	require.NoError(t, err)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	require.NoError(t, err)
+
+	if clusterConfigNotificationsCh != nil {
+		go func() {
+			for {
+				select {
+				case <-t.Context().Done():
+					return
+				case _, ok := <-clusterConfigNotificationsCh:
+					if !ok {
+						return
+					}
+				}
+
+				clusterConfig, err := clusterConfigProvider()
+				if err != nil {
+					panic(err)
+				}
+				_, version, err := configProvider.Get()
+				if err != nil {
+					panic(err)
+				}
+				if _, err = configProvider.Store(clusterConfig, version); err != nil {
+					panic(err)
+				}
+			}
+		}()
+	}
+
+	return configProvider
+}
 
 func newCoordinatorInstance(
 	t *testing.T,
@@ -36,11 +80,7 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
-		metadataProvider,
-		clusterConfigProvider,
-		clusterConfigNotificationsCh,
-	)
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, newConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/control/helpers_test.go
+++ b/tests/control/helpers_test.go
@@ -25,19 +25,17 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
-	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func newCoordinatorInstance(
 	t *testing.T,
 	metadataProvider provider.Provider[*proto.ClusterStatus],
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh chan any,
+	configProvider provider.Provider[*proto.ClusterConfiguration],
 	rpcProvider rpc.ProviderFactory,
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, mock.NewConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/control/record_checksum_test.go
+++ b/tests/control/record_checksum_test.go
@@ -69,7 +69,9 @@ func TestControlRequestRecordChecksum(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,

--- a/tests/control/record_checksum_test.go
+++ b/tests/control/record_checksum_test.go
@@ -69,11 +69,11 @@ func TestControlRequestRecordChecksum(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil,
+		configProvider,
 		rpc.NewRpcProviderFactory(nil),
 	)
 	defer coordinatorInstance.Close()

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/oxia"
+	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func newServer(t *testing.T) (s *dataserver.Server, addr *proto.DataServerIdentity) {
@@ -76,7 +77,8 @@ func TestCoordinatorE2E(t *testing.T) {
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
 	status := metadata.GetStatus()
@@ -110,7 +112,8 @@ func TestCoordinatorE2E_ShardsRanges(t *testing.T) {
 		InitialShardCount: 4,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
 	status := metadata.GetStatus()
@@ -158,7 +161,8 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
 	status := metadata.GetStatus()
@@ -258,7 +262,8 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 		InitialShardCount: 3,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
 	status := metadata.GetStatus()
@@ -345,7 +350,8 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 		InitialShardCount: 2,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
 	status := metadata.GetStatus()
@@ -389,7 +395,8 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	newClusterConfig := newClusterConfig([]*proto.Namespace{}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	slog.Info("Restarting coordinator")
-	newMetadata := createCoordinatorMetadata(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return newClusterConfig, nil }, nil)
+	newConfigProvider := mock.NewConfigProvider(t, newClusterConfig)
+	newMetadata := createCoordinatorMetadata(t, metadataProvider, newConfigProvider)
 	t.Cleanup(func() {
 		assert.NoError(t, newMetadata.Close())
 	})
@@ -429,12 +436,8 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 		InitialShardCount: 2,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	configChangesCh := make(chan any)
-	configProvider := func() (*proto.ClusterConfiguration, error) {
-		return clusterConfig, nil
-	}
-
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProviderFactory(nil))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
 	status := metadata.GetStatus()
@@ -461,7 +464,7 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 		InitialShardCount: 2,
 		ReplicationFactor: 1,
 	})
-	configChangesCh <- nil
+	mock.PutConfig(t, configProvider, clusterConfig)
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
@@ -515,12 +518,8 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 		InitialShardCount: 2,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	configProvider := func() (*proto.ClusterConfiguration, error) {
-		return clusterConfig, nil
-	}
-
-	configChangesCh := make(chan any)
-	c := newCoordinatorInstance(t, metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProviderFactory(nil))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	c := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	assert.Equal(t, 3, len(c.NodeControllers()))
 
@@ -532,7 +531,7 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 	// Remove s1
 	clusterConfig.Servers = clusterConfig.Servers[1:]
 
-	configChangesCh <- nil
+	mock.PutConfig(t, configProvider, clusterConfig)
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
@@ -574,12 +573,8 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3, sa4})
 
-	configProvider := func() (*proto.ClusterConfiguration, error) {
-		return clusterConfig, nil
-	}
-
-	configChangesCh := make(chan any)
-	c := newCoordinatorInstance(t, metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProviderFactory(nil))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	c := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := c.Metadata()
 
@@ -607,7 +602,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	}
 	clusterConfig.Servers = d
 
-	configChangesCh <- nil
+	mock.PutConfig(t, configProvider, clusterConfig)
 	assert.Eventually(t, func() bool {
 		return len(c.NodeControllers()) == 3
 	}, 10*time.Second, 10*time.Millisecond)
@@ -647,11 +642,8 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 		ReplicationFactor: 3,
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
-	configChangesCh := make(chan any)
-	c := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) {
-		return clusterConfig, nil
-	}, configChangesCh,
-		rpc2.NewRpcProviderFactory(nil))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	c := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := c.Metadata()
 	// wait for all shards to be ready
@@ -677,7 +669,7 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	}
 
 	clusterConfig.Servers = clusterServer
-	configChangesCh <- nil
+	mock.PutConfig(t, configProvider, clusterConfig)
 
 	assert.Eventually(t, func() bool {
 		for _, ns := range metadata.GetStatus().Namespaces {

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/oxia"
-	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func newServer(t *testing.T) (s *dataserver.Server, addr *proto.DataServerIdentity) {
@@ -77,7 +76,9 @@ func TestCoordinatorE2E(t *testing.T) {
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
@@ -112,7 +113,9 @@ func TestCoordinatorE2E_ShardsRanges(t *testing.T) {
 		InitialShardCount: 4,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
@@ -161,7 +164,9 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
@@ -262,7 +267,9 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 		InitialShardCount: 3,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
@@ -350,7 +357,9 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 		InitialShardCount: 2,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
@@ -395,7 +404,9 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	newClusterConfig := newClusterConfig([]*proto.Namespace{}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	slog.Info("Restarting coordinator")
-	newConfigProvider := mock.NewConfigProvider(t, newClusterConfig)
+	newConfigProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err = newConfigProvider.Store(newClusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	newMetadata := createCoordinatorMetadata(t, metadataProvider, newConfigProvider)
 	t.Cleanup(func() {
 		assert.NoError(t, newMetadata.Close())
@@ -436,7 +447,9 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 		InitialShardCount: 2,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
@@ -464,7 +477,10 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 		InitialShardCount: 2,
 		ReplicationFactor: 1,
 	})
-	mock.PutConfig(t, configProvider, clusterConfig)
+	_, version, err := configProvider.Get()
+	assert.NoError(t, err)
+	_, err = configProvider.Store(clusterConfig, version)
+	assert.NoError(t, err)
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
@@ -518,7 +534,9 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 		InitialShardCount: 2,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	c := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	assert.Equal(t, 3, len(c.NodeControllers()))
@@ -531,7 +549,10 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 	// Remove s1
 	clusterConfig.Servers = clusterConfig.Servers[1:]
 
-	mock.PutConfig(t, configProvider, clusterConfig)
+	_, version, err := configProvider.Get()
+	assert.NoError(t, err)
+	_, err = configProvider.Store(clusterConfig, version)
+	assert.NoError(t, err)
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
@@ -573,7 +594,9 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3, sa4})
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	c := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := c.Metadata()
@@ -602,7 +625,10 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	}
 	clusterConfig.Servers = d
 
-	mock.PutConfig(t, configProvider, clusterConfig)
+	_, version, err := configProvider.Get()
+	assert.NoError(t, err)
+	_, err = configProvider.Store(clusterConfig, version)
+	assert.NoError(t, err)
 	assert.Eventually(t, func() bool {
 		return len(c.NodeControllers()) == 3
 	}, 10*time.Second, 10*time.Millisecond)
@@ -642,7 +668,9 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 		ReplicationFactor: 3,
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	c := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := c.Metadata()
@@ -669,7 +697,10 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	}
 
 	clusterConfig.Servers = clusterServer
-	mock.PutConfig(t, configProvider, clusterConfig)
+	_, version, err := configProvider.Get()
+	assert.NoError(t, err)
+	_, err = configProvider.Store(clusterConfig, version)
+	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
 		for _, ns := range metadata.GetStatus().Namespaces {

--- a/tests/coordinator/coordinator_test.go
+++ b/tests/coordinator/coordinator_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	metadata2 "github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
-	"github.com/oxia-db/oxia/tests/mock"
 
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
@@ -44,7 +43,9 @@ func TestCoordinatorInitiateLeaderElection(t *testing.T) {
 		InitialShardCount: 2,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := metadata2.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	metadata := createCoordinatorMetadata(t, metadataProvider, configProvider)
 	defer func() {
 		assert.NoError(t, metadata.Close())

--- a/tests/coordinator/coordinator_test.go
+++ b/tests/coordinator/coordinator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	metadata2 "github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
+	"github.com/oxia-db/oxia/tests/mock"
 
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
@@ -43,7 +44,8 @@ func TestCoordinatorInitiateLeaderElection(t *testing.T) {
 		InitialShardCount: 2,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	metadata := createCoordinatorMetadata(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil)
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	metadata := createCoordinatorMetadata(t, metadataProvider, configProvider)
 	defer func() {
 		assert.NoError(t, metadata.Close())
 	}()

--- a/tests/coordinator/helpers_test.go
+++ b/tests/coordinator/helpers_test.go
@@ -22,9 +22,53 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
 )
+
+func newConfigProvider(
+	t *testing.T,
+	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
+	clusterConfigNotificationsCh <-chan any,
+) provider.Provider[*proto.ClusterConfiguration] {
+	t.Helper()
+
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	clusterConfig, err := clusterConfigProvider()
+	require.NoError(t, err)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	require.NoError(t, err)
+
+	if clusterConfigNotificationsCh != nil {
+		go func() {
+			for {
+				select {
+				case <-t.Context().Done():
+					return
+				case _, ok := <-clusterConfigNotificationsCh:
+					if !ok {
+						return
+					}
+				}
+
+				clusterConfig, err := clusterConfigProvider()
+				if err != nil {
+					panic(err)
+				}
+				_, version, err := configProvider.Get()
+				if err != nil {
+					panic(err)
+				}
+				if _, err = configProvider.Store(clusterConfig, version); err != nil {
+					panic(err)
+				}
+			}
+		}()
+	}
+
+	return configProvider
+}
 
 func createCoordinatorMetadata(
 	t *testing.T,
@@ -34,11 +78,12 @@ func createCoordinatorMetadata(
 ) coordmetadata.Metadata {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
-		metadataProvider,
-		clusterConfigProvider,
-		clusterConfigNotificationsCh,
-	)
+	configProvider := newConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh)
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
+	t.Cleanup(func() {
+		require.NoError(t, metadataFactory.Close())
+	})
+
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	return metadata

--- a/tests/coordinator/helpers_test.go
+++ b/tests/coordinator/helpers_test.go
@@ -24,18 +24,15 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
-	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func createCoordinatorMetadata(
 	t *testing.T,
 	metadataProvider provider.Provider[*proto.ClusterStatus],
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh chan any,
+	configProvider provider.Provider[*proto.ClusterConfiguration],
 ) coordmetadata.Metadata {
 	t.Helper()
 
-	configProvider := mock.NewConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh)
 	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
 	t.Cleanup(func() {
 		require.NoError(t, metadataFactory.Close())
@@ -49,13 +46,12 @@ func createCoordinatorMetadata(
 func newCoordinatorInstance(
 	t *testing.T,
 	metadataProvider provider.Provider[*proto.ClusterStatus],
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh chan any,
+	configProvider provider.Provider[*proto.ClusterConfiguration],
 	rpcProvider rpc2.ProviderFactory,
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadata := createCoordinatorMetadata(t, metadataProvider, clusterConfigProvider, clusterConfigNotificationsCh)
+	metadata := createCoordinatorMetadata(t, metadataProvider, configProvider)
 	t.Cleanup(func() {
 		require.NoError(t, metadata.Close())
 	})

--- a/tests/coordinator/helpers_test.go
+++ b/tests/coordinator/helpers_test.go
@@ -22,53 +22,10 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
-	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
+	"github.com/oxia-db/oxia/tests/mock"
 )
-
-func newConfigProvider(
-	t *testing.T,
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh <-chan any,
-) provider.Provider[*proto.ClusterConfiguration] {
-	t.Helper()
-
-	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
-	clusterConfig, err := clusterConfigProvider()
-	require.NoError(t, err)
-	_, err = configProvider.Store(clusterConfig, provider.NotExists)
-	require.NoError(t, err)
-
-	if clusterConfigNotificationsCh != nil {
-		go func() {
-			for {
-				select {
-				case <-t.Context().Done():
-					return
-				case _, ok := <-clusterConfigNotificationsCh:
-					if !ok {
-						return
-					}
-				}
-
-				clusterConfig, err := clusterConfigProvider()
-				if err != nil {
-					panic(err)
-				}
-				_, version, err := configProvider.Get()
-				if err != nil {
-					panic(err)
-				}
-				if _, err = configProvider.Store(clusterConfig, version); err != nil {
-					panic(err)
-				}
-			}
-		}()
-	}
-
-	return configProvider
-}
 
 func createCoordinatorMetadata(
 	t *testing.T,
@@ -78,7 +35,7 @@ func createCoordinatorMetadata(
 ) coordmetadata.Metadata {
 	t.Helper()
 
-	configProvider := newConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh)
+	configProvider := mock.NewConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh)
 	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
 	t.Cleanup(func() {
 		require.NoError(t, metadataFactory.Close())

--- a/tests/coordinator/split_e2e_test.go
+++ b/tests/coordinator/split_e2e_test.go
@@ -42,7 +42,6 @@ import (
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
 	"github.com/oxia-db/oxia/oxiad/dataserver"
-	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func TestCoordinator_ShardSplit(t *testing.T) {
@@ -62,7 +61,9 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	require.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 	clientPool := rpc.NewClientPool(nil, nil)
 
@@ -321,7 +322,9 @@ func setupSplitCluster(t *testing.T) *splitTestCluster {
 		ReplicationFactor: 3,
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	require.NoError(t, err)
 
 	coordinatorInstance := newCoordinatorInstance(
 		t,
@@ -873,7 +876,9 @@ func TestCoordinator_KeySorting(t *testing.T) {
 				KeySorting:        keySortingValue,
 			}}, []*proto.DataServerIdentity{sa1})
 
-			configProvider := mock.NewConfigProvider(t, clusterConfig)
+			configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+			_, err = configProvider.Store(clusterConfig, provider.NotExists)
+			require.NoError(t, err)
 			coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 			metadata := coordinatorInstance.Metadata()

--- a/tests/coordinator/split_e2e_test.go
+++ b/tests/coordinator/split_e2e_test.go
@@ -42,6 +42,7 @@ import (
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
 	"github.com/oxia-db/oxia/oxiad/dataserver"
+	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func TestCoordinator_ShardSplit(t *testing.T) {
@@ -61,13 +62,8 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
-	coordinatorInstance := newCoordinatorInstance(
-		t,
-		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil,
-		rpc2.NewRpcProviderFactory(nil),
-	)
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 	clientPool := rpc.NewClientPool(nil, nil)
 
 	metadata := coordinatorInstance.Metadata()
@@ -325,12 +321,12 @@ func setupSplitCluster(t *testing.T) *splitTestCluster {
 		ReplicationFactor: 3,
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
 
 	coordinatorInstance := newCoordinatorInstance(
 		t,
 		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil,
+		configProvider,
 		rpc2.NewRpcProviderFactory(nil),
 	)
 
@@ -877,7 +873,8 @@ func TestCoordinator_KeySorting(t *testing.T) {
 				KeySorting:        keySortingValue,
 			}}, []*proto.DataServerIdentity{sa1})
 
-			coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
+			configProvider := mock.NewConfigProvider(t, clusterConfig)
+			coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 			metadata := coordinatorInstance.Metadata()
 			status := metadata.GetStatus()

--- a/tests/mock/coordinator.go
+++ b/tests/mock/coordinator.go
@@ -31,11 +31,32 @@ import (
 func NewCoordinator(t *testing.T, config *proto.ClusterConfiguration, clusterConfigNotificationCh chan any) coordruntime.Runtime {
 	t.Helper()
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
-	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
-		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return config, nil },
-		clusterConfigNotificationCh,
-	)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(config, provider.NotExists)
+	assert.NoError(t, err)
+	if clusterConfigNotificationCh != nil {
+		go func() {
+			for {
+				select {
+				case <-t.Context().Done():
+					return
+				case _, ok := <-clusterConfigNotificationCh:
+					if !ok {
+						return
+					}
+				}
+
+				_, version, err := configProvider.Get()
+				if err != nil {
+					panic(err)
+				}
+				if _, err = configProvider.Store(config, version); err != nil {
+					panic(err)
+				}
+			}
+		}()
+	}
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	assert.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/mock/coordinator.go
+++ b/tests/mock/coordinator.go
@@ -31,31 +31,9 @@ import (
 func NewCoordinator(t *testing.T, config *proto.ClusterConfiguration, clusterConfigNotificationCh chan any) coordruntime.Runtime {
 	t.Helper()
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
-	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
-	_, err := configProvider.Store(config, provider.NotExists)
-	assert.NoError(t, err)
-	if clusterConfigNotificationCh != nil {
-		go func() {
-			for {
-				select {
-				case <-t.Context().Done():
-					return
-				case _, ok := <-clusterConfigNotificationCh:
-					if !ok {
-						return
-					}
-				}
-
-				_, version, err := configProvider.Get()
-				if err != nil {
-					panic(err)
-				}
-				if _, err = configProvider.Store(config, version); err != nil {
-					panic(err)
-				}
-			}
-		}()
-	}
+	configProvider := NewConfigProvider(t, func() (*proto.ClusterConfiguration, error) {
+		return config, nil
+	}, clusterConfigNotificationCh)
 	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	assert.NoError(t, err)

--- a/tests/mock/coordinator.go
+++ b/tests/mock/coordinator.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/oxia-db/oxia/common/proto"
+	commonproto "github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
@@ -28,12 +28,9 @@ import (
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
 )
 
-func NewCoordinator(t *testing.T, config *proto.ClusterConfiguration, clusterConfigNotificationCh chan any) coordruntime.Runtime {
+func NewCoordinator(t *testing.T, configProvider provider.Provider[*commonproto.ClusterConfiguration]) coordruntime.Runtime {
 	t.Helper()
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
-	configProvider := NewConfigProvider(t, func() (*proto.ClusterConfiguration, error) {
-		return config, nil
-	}, clusterConfigNotificationCh)
 	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	assert.NoError(t, err)

--- a/tests/mock/metadata.go
+++ b/tests/mock/metadata.go
@@ -24,54 +24,23 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 )
 
-func NewConfigProvider(
-	t *testing.T,
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh <-chan any,
-) provider.Provider[*proto.ClusterConfiguration] {
+func NewConfigProvider(t *testing.T, clusterConfig *proto.ClusterConfiguration) provider.Provider[*proto.ClusterConfiguration] {
 	t.Helper()
 
 	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
-	clusterConfig, err := clusterConfigProvider()
-	require.NoError(t, err)
-	_, err = configProvider.Store(clusterConfig, provider.NotExists)
-	require.NoError(t, err)
-
-	if clusterConfigNotificationsCh != nil {
-		go replayConfigChanges(t, configProvider, clusterConfigProvider, clusterConfigNotificationsCh)
-	}
-
+	PutConfig(t, configProvider, clusterConfig)
 	return configProvider
 }
 
-func replayConfigChanges(
+func PutConfig(
 	t *testing.T,
 	configProvider provider.Provider[*proto.ClusterConfiguration],
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh <-chan any,
+	clusterConfig *proto.ClusterConfiguration,
 ) {
 	t.Helper()
 
-	for {
-		select {
-		case <-t.Context().Done():
-			return
-		case _, ok := <-clusterConfigNotificationsCh:
-			if !ok {
-				return
-			}
-		}
-
-		clusterConfig, err := clusterConfigProvider()
-		if err != nil {
-			panic(err)
-		}
-		_, version, err := configProvider.Get()
-		if err != nil {
-			panic(err)
-		}
-		if _, err = configProvider.Store(clusterConfig, version); err != nil {
-			panic(err)
-		}
-	}
+	_, version, err := configProvider.Get()
+	require.NoError(t, err)
+	_, err = configProvider.Store(clusterConfig, version)
+	require.NoError(t, err)
 }

--- a/tests/mock/metadata.go
+++ b/tests/mock/metadata.go
@@ -1,0 +1,77 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
+)
+
+func NewConfigProvider(
+	t *testing.T,
+	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
+	clusterConfigNotificationsCh <-chan any,
+) provider.Provider[*proto.ClusterConfiguration] {
+	t.Helper()
+
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	clusterConfig, err := clusterConfigProvider()
+	require.NoError(t, err)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	require.NoError(t, err)
+
+	if clusterConfigNotificationsCh != nil {
+		go replayConfigChanges(t, configProvider, clusterConfigProvider, clusterConfigNotificationsCh)
+	}
+
+	return configProvider
+}
+
+func replayConfigChanges(
+	t *testing.T,
+	configProvider provider.Provider[*proto.ClusterConfiguration],
+	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
+	clusterConfigNotificationsCh <-chan any,
+) {
+	t.Helper()
+
+	for {
+		select {
+		case <-t.Context().Done():
+			return
+		case _, ok := <-clusterConfigNotificationsCh:
+			if !ok {
+				return
+			}
+		}
+
+		clusterConfig, err := clusterConfigProvider()
+		if err != nil {
+			panic(err)
+		}
+		_, version, err := configProvider.Get()
+		if err != nil {
+			panic(err)
+		}
+		if _, err = configProvider.Store(clusterConfig, version); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/tests/resolver/helpers_test.go
+++ b/tests/resolver/helpers_test.go
@@ -22,53 +22,10 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
-	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	coordinatorrpc "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
+	"github.com/oxia-db/oxia/tests/mock"
 )
-
-func newConfigProvider(
-	t *testing.T,
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh <-chan any,
-) provider.Provider[*proto.ClusterConfiguration] {
-	t.Helper()
-
-	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
-	clusterConfig, err := clusterConfigProvider()
-	require.NoError(t, err)
-	_, err = configProvider.Store(clusterConfig, provider.NotExists)
-	require.NoError(t, err)
-
-	if clusterConfigNotificationsCh != nil {
-		go func() {
-			for {
-				select {
-				case <-t.Context().Done():
-					return
-				case _, ok := <-clusterConfigNotificationsCh:
-					if !ok {
-						return
-					}
-				}
-
-				clusterConfig, err := clusterConfigProvider()
-				if err != nil {
-					panic(err)
-				}
-				_, version, err := configProvider.Get()
-				if err != nil {
-					panic(err)
-				}
-				if _, err = configProvider.Store(clusterConfig, version); err != nil {
-					panic(err)
-				}
-			}
-		}()
-	}
-
-	return configProvider
-}
 
 func newCoordinatorInstance(
 	t *testing.T,
@@ -79,7 +36,7 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, newConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, mock.NewConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/resolver/helpers_test.go
+++ b/tests/resolver/helpers_test.go
@@ -22,9 +22,53 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	coordinatorrpc "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
 )
+
+func newConfigProvider(
+	t *testing.T,
+	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
+	clusterConfigNotificationsCh <-chan any,
+) provider.Provider[*proto.ClusterConfiguration] {
+	t.Helper()
+
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	clusterConfig, err := clusterConfigProvider()
+	require.NoError(t, err)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	require.NoError(t, err)
+
+	if clusterConfigNotificationsCh != nil {
+		go func() {
+			for {
+				select {
+				case <-t.Context().Done():
+					return
+				case _, ok := <-clusterConfigNotificationsCh:
+					if !ok {
+						return
+					}
+				}
+
+				clusterConfig, err := clusterConfigProvider()
+				if err != nil {
+					panic(err)
+				}
+				_, version, err := configProvider.Get()
+				if err != nil {
+					panic(err)
+				}
+				if _, err = configProvider.Store(clusterConfig, version); err != nil {
+					panic(err)
+				}
+			}
+		}()
+	}
+
+	return configProvider
+}
 
 func newCoordinatorInstance(
 	t *testing.T,
@@ -35,11 +79,7 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
-		metadataProvider,
-		clusterConfigProvider,
-		clusterConfigNotificationsCh,
-	)
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, newConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/resolver/helpers_test.go
+++ b/tests/resolver/helpers_test.go
@@ -24,19 +24,17 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	coordinatorrpc "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
-	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func newCoordinatorInstance(
 	t *testing.T,
 	metadataProvider provider.Provider[*proto.ClusterStatus],
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh chan any,
+	configProvider provider.Provider[*proto.ClusterConfiguration],
 	rpcProvider coordinatorrpc.ProviderFactory,
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, mock.NewConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/resolver/target_ip_flip_test.go
+++ b/tests/resolver/target_ip_flip_test.go
@@ -74,7 +74,9 @@ func newCoordinatorCluster(t *testing.T, prefix string, serverCount int) *testCl
 		Servers:               cluster.addresses,
 		AllowExtraAuthorities: []string{cluster.authority},
 	}
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	require.NoError(t, err)
 	cluster.coordinator = newCoordinatorInstance(t, metadataProvider, configProvider, coordinatorrpc.NewRpcProviderFactory(nil))
 
 	require.Eventually(t, func() bool {

--- a/tests/resolver/target_ip_flip_test.go
+++ b/tests/resolver/target_ip_flip_test.go
@@ -65,25 +65,17 @@ func newCoordinatorCluster(t *testing.T, prefix string, serverCount int) *testCl
 	}
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
-	cluster.coordinator = newCoordinatorInstance(
-		t,
-		metadataProvider,
-		func() (*proto.ClusterConfiguration, error) {
-			return &proto.ClusterConfiguration{
-				Namespaces: []*proto.Namespace{{
-					Name:              constant.DefaultNamespace,
-					ReplicationFactor: 1,
-					InitialShardCount: 3,
-				}},
-				Servers: func() []*proto.DataServerIdentity {
-					return cluster.addresses
-				}(),
-				AllowExtraAuthorities: []string{cluster.authority},
-			}, nil
-		},
-		nil,
-		coordinatorrpc.NewRpcProviderFactory(nil),
-	)
+	clusterConfig := &proto.ClusterConfiguration{
+		Namespaces: []*proto.Namespace{{
+			Name:              constant.DefaultNamespace,
+			ReplicationFactor: 1,
+			InitialShardCount: 3,
+		}},
+		Servers:               cluster.addresses,
+		AllowExtraAuthorities: []string{cluster.authority},
+	}
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	cluster.coordinator = newCoordinatorInstance(t, metadataProvider, configProvider, coordinatorrpc.NewRpcProviderFactory(nil))
 
 	require.Eventually(t, func() bool {
 		shard := cluster.coordinator.Metadata().GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]

--- a/tests/security/auth/auth_oidc_test.go
+++ b/tests/security/auth/auth_oidc_test.go
@@ -48,7 +48,6 @@ import (
 	"github.com/oxia-db/oxia/oxia"
 
 	clientauth "github.com/oxia-db/oxia/common/auth"
-	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (address string, closeFunc func()) {
@@ -108,7 +107,9 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(s1Addr, s2Addr, s3Addr)
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	return s1Addr.Public, func() {
@@ -294,7 +295,9 @@ func TestOIDCWithPerIssuerConfig(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(s1Addr, s2Addr, s3Addr)
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 	defer coordinatorInstance.Close()
@@ -443,7 +446,9 @@ func TestOIDCWithStaticKeyFile(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(s1Addr, s2Addr, s3Addr)
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 	defer coordinatorInstance.Close()

--- a/tests/security/auth/auth_oidc_test.go
+++ b/tests/security/auth/auth_oidc_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/oxia-db/oxia/oxia"
 
 	clientauth "github.com/oxia-db/oxia/common/auth"
+	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (address string, closeFunc func()) {
@@ -107,9 +108,8 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(s1Addr, s2Addr, s3Addr)
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil, rpc2.NewRpcProviderFactory(nil))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	return s1Addr.Public, func() {
 		s1.Close()
@@ -294,10 +294,9 @@ func TestOIDCWithPerIssuerConfig(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(s1Addr, s2Addr, s3Addr)
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil, rpc2.NewRpcProviderFactory(nil))
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 	defer coordinatorInstance.Close()
 
 	// Test authentication with issuer 1
@@ -444,10 +443,9 @@ func TestOIDCWithStaticKeyFile(t *testing.T) {
 
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(s1Addr, s2Addr, s3Addr)
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider,
-		func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil },
-		nil, rpc2.NewRpcProviderFactory(nil))
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 	defer coordinatorInstance.Close()
 
 	// Create a valid token

--- a/tests/security/auth/helpers_test.go
+++ b/tests/security/auth/helpers_test.go
@@ -25,19 +25,17 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
-	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func newCoordinatorInstance(
 	t *testing.T,
 	metadataProvider provider.Provider[*proto.ClusterStatus],
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh chan any,
+	configProvider provider.Provider[*proto.ClusterConfiguration],
 	rpcProvider rpc2.ProviderFactory,
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, mock.NewConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/security/auth/helpers_test.go
+++ b/tests/security/auth/helpers_test.go
@@ -23,9 +23,53 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
 )
+
+func newConfigProvider(
+	t *testing.T,
+	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
+	clusterConfigNotificationsCh <-chan any,
+) provider.Provider[*proto.ClusterConfiguration] {
+	t.Helper()
+
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	clusterConfig, err := clusterConfigProvider()
+	require.NoError(t, err)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	require.NoError(t, err)
+
+	if clusterConfigNotificationsCh != nil {
+		go func() {
+			for {
+				select {
+				case <-t.Context().Done():
+					return
+				case _, ok := <-clusterConfigNotificationsCh:
+					if !ok {
+						return
+					}
+				}
+
+				clusterConfig, err := clusterConfigProvider()
+				if err != nil {
+					panic(err)
+				}
+				_, version, err := configProvider.Get()
+				if err != nil {
+					panic(err)
+				}
+				if _, err = configProvider.Store(clusterConfig, version); err != nil {
+					panic(err)
+				}
+			}
+		}()
+	}
+
+	return configProvider
+}
 
 func newCoordinatorInstance(
 	t *testing.T,
@@ -36,11 +80,7 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
-		metadataProvider,
-		clusterConfigProvider,
-		clusterConfigNotificationsCh,
-	)
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, newConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/security/auth/helpers_test.go
+++ b/tests/security/auth/helpers_test.go
@@ -23,53 +23,10 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
-	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
+	"github.com/oxia-db/oxia/tests/mock"
 )
-
-func newConfigProvider(
-	t *testing.T,
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh <-chan any,
-) provider.Provider[*proto.ClusterConfiguration] {
-	t.Helper()
-
-	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
-	clusterConfig, err := clusterConfigProvider()
-	require.NoError(t, err)
-	_, err = configProvider.Store(clusterConfig, provider.NotExists)
-	require.NoError(t, err)
-
-	if clusterConfigNotificationsCh != nil {
-		go func() {
-			for {
-				select {
-				case <-t.Context().Done():
-					return
-				case _, ok := <-clusterConfigNotificationsCh:
-					if !ok {
-						return
-					}
-				}
-
-				clusterConfig, err := clusterConfigProvider()
-				if err != nil {
-					panic(err)
-				}
-				_, version, err := configProvider.Get()
-				if err != nil {
-					panic(err)
-				}
-				if _, err = configProvider.Store(clusterConfig, version); err != nil {
-					panic(err)
-				}
-			}
-		}()
-	}
-
-	return configProvider
-}
 
 func newCoordinatorInstance(
 	t *testing.T,
@@ -80,7 +37,7 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, newConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, mock.NewConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/security/tls/helpers_test.go
+++ b/tests/security/tls/helpers_test.go
@@ -25,19 +25,17 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
-	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func newCoordinatorInstance(
 	t *testing.T,
 	metadataProvider provider.Provider[*proto.ClusterStatus],
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh chan any,
+	configProvider provider.Provider[*proto.ClusterConfiguration],
 	rpcProvider rpc2.ProviderFactory,
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, mock.NewConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/security/tls/helpers_test.go
+++ b/tests/security/tls/helpers_test.go
@@ -23,9 +23,53 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
 )
+
+func newConfigProvider(
+	t *testing.T,
+	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
+	clusterConfigNotificationsCh <-chan any,
+) provider.Provider[*proto.ClusterConfiguration] {
+	t.Helper()
+
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	clusterConfig, err := clusterConfigProvider()
+	require.NoError(t, err)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	require.NoError(t, err)
+
+	if clusterConfigNotificationsCh != nil {
+		go func() {
+			for {
+				select {
+				case <-t.Context().Done():
+					return
+				case _, ok := <-clusterConfigNotificationsCh:
+					if !ok {
+						return
+					}
+				}
+
+				clusterConfig, err := clusterConfigProvider()
+				if err != nil {
+					panic(err)
+				}
+				_, version, err := configProvider.Get()
+				if err != nil {
+					panic(err)
+				}
+				if _, err = configProvider.Store(clusterConfig, version); err != nil {
+					panic(err)
+				}
+			}
+		}()
+	}
+
+	return configProvider
+}
 
 func newCoordinatorInstance(
 	t *testing.T,
@@ -36,11 +80,7 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithCallbackConfig(t.Context(),
-		metadataProvider,
-		clusterConfigProvider,
-		clusterConfigNotificationsCh,
-	)
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, newConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/security/tls/helpers_test.go
+++ b/tests/security/tls/helpers_test.go
@@ -23,53 +23,10 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
-	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
+	"github.com/oxia-db/oxia/tests/mock"
 )
-
-func newConfigProvider(
-	t *testing.T,
-	clusterConfigProvider func() (*proto.ClusterConfiguration, error),
-	clusterConfigNotificationsCh <-chan any,
-) provider.Provider[*proto.ClusterConfiguration] {
-	t.Helper()
-
-	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
-	clusterConfig, err := clusterConfigProvider()
-	require.NoError(t, err)
-	_, err = configProvider.Store(clusterConfig, provider.NotExists)
-	require.NoError(t, err)
-
-	if clusterConfigNotificationsCh != nil {
-		go func() {
-			for {
-				select {
-				case <-t.Context().Done():
-					return
-				case _, ok := <-clusterConfigNotificationsCh:
-					if !ok {
-						return
-					}
-				}
-
-				clusterConfig, err := clusterConfigProvider()
-				if err != nil {
-					panic(err)
-				}
-				_, version, err := configProvider.Get()
-				if err != nil {
-					panic(err)
-				}
-				if _, err = configProvider.Store(clusterConfig, version); err != nil {
-					panic(err)
-				}
-			}
-		}()
-	}
-
-	return configProvider
-}
 
 func newCoordinatorInstance(
 	t *testing.T,
@@ -80,7 +37,7 @@ func newCoordinatorInstance(
 ) coordruntime.Runtime {
 	t.Helper()
 
-	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, newConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
+	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, mock.NewConfigProvider(t, clusterConfigProvider, clusterConfigNotificationsCh))
 	metadata, err := metadataFactory.CreateMetadata(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/tests/security/tls/tls_encryption_test.go
+++ b/tests/security/tls/tls_encryption_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/oxia-db/oxia/common/security"
 	"github.com/oxia-db/oxia/oxia"
+	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func getPeerTLSOption() (*security.TLSOptions, error) {
@@ -125,7 +126,8 @@ func TestClusterHandshakeSuccess(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(tlsConf))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
 }
 
@@ -144,7 +146,8 @@ func TestClientHandshakeFailByNoTlsConfig(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(tlsConf))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
 
 	client, err := oxia.NewSyncClient(sa1.Public, oxia.WithRequestTimeout(1*time.Second))
@@ -167,7 +170,8 @@ func TestClientHandshakeByAuthFail(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(tlsConf))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
 
 	tlsOption, err := getClientTLSOption()
@@ -196,7 +200,8 @@ func TestClientHandshakeWithInsecure(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(tlsConf))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
 
 	tlsOption, err := getClientTLSOption()
@@ -226,7 +231,8 @@ func TestClientHandshakeSuccess(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(tlsConf))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
 
 	tlsOption, err := getClientTLSOption()
@@ -253,7 +259,8 @@ func TestOnlyEnablePublicTls(t *testing.T) {
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
 
-	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, func() (*proto.ClusterConfiguration, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
+	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 	defer coordinatorInstance.Close()
 
 	// failed without cert

--- a/tests/security/tls/tls_encryption_test.go
+++ b/tests/security/tls/tls_encryption_test.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/oxia-db/oxia/common/security"
 	"github.com/oxia-db/oxia/oxia"
-	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func getPeerTLSOption() (*security.TLSOptions, error) {
@@ -126,7 +125,9 @@ func TestClusterHandshakeSuccess(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
 }
@@ -146,7 +147,9 @@ func TestClientHandshakeFailByNoTlsConfig(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
 
@@ -170,7 +173,9 @@ func TestClientHandshakeByAuthFail(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
 
@@ -200,7 +205,9 @@ func TestClientHandshakeWithInsecure(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
 
@@ -231,7 +238,9 @@ func TestClientHandshakeSuccess(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err = configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
 
@@ -259,7 +268,9 @@ func TestOnlyEnablePublicTls(t *testing.T) {
 	metadataProvider := memory.NewProvider(provider.ClusterStatusCodec)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
 
-	configProvider := mock.NewConfigProvider(t, clusterConfig)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(clusterConfig, provider.NotExists)
+	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 	defer coordinatorInstance.Close()
 


### PR DESCRIPTION
## Motivation
- metadata still carried a callback-specific config provider path that duplicated provider behavior and kept tests and Maelstrom from using real watched config providers
- the callback adapter also forced metadata to keep special-case loading and validation logic

## Modifications
- made the memory metadata provider support `Watch()` so config updates can flow through real providers
- removed `NewFactoryWithCallbackConfig` and deleted `callbackConfigProvider` plus the callback-specific config load/watch branches from metadata
- switched tests and Maelstrom to seed a real config provider and replay config-change notifications through provider `Store(...)`
- updated controller test fixtures to use valid cluster configurations now that config validation is consistently enforced

## Testing
- `go test ./oxiad/coordinator/metadata/provider/... ./oxiad/coordinator/metadata ./oxiad/coordinator ./oxiad/maelstrom ./tests/mock ./tests/control ./tests/resolver ./tests/assignments ./tests/security/auth ./tests/security/tls -run '^$'`
- `go test ./tests/coordinator -run '^TestCoordinator_DynamicallAddNamespace$|^TestCoordinator_AddRemoveNodes$|^TestCoordinator_ShrinkCluster$|^TestCoordinator_RefreshServerInfo$' -count=1`
- `go test ./tests/balancer -run '^TestLeaderBalancedNodeAdded$|^TestNormalShardBalancer$' -count=1`
- `go test ./oxiad/coordinator/runtime/... -run '^TestComputeNewAssignmentsIncludesExtraAuthorities$|^TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities$|^TestSplitController_FullLifecycle$|^TestShardController$' -count=1`
- `make lint`
