### PR TITLE
fix: deduplicate `time` field in JSON logs

### DIFF
--- a/oxiad/common/logging/logger.go
+++ b/oxiad/common/logging/logger.go
@@ -114,8 +114,9 @@ func ConfigureLogger() {
 
 	slogLogger := slog.New(
 		slogzerolog.Option{
-			Level:  &logLevelVar,
-			Logger: &zerologLogger,
+			Level:       &logLevelVar,
+			Logger:      &zerologLogger,
+			NoTimestamp: true,
 		}.NewZerologHandler(),
 	)
 	slog.SetDefault(slogLogger)


### PR DESCRIPTION
## Summary
- The slog → zerolog bridge was adding a per-event `time` field on top of the timestamp already injected by zerolog's base context, producing two `time` keys per JSON log line.
- Setting `NoTimestamp: true` on the `slog-zerolog` handler leaves zerolog's base-context `Timestamp()` as the sole source.

Before:
```
{"level":"info","time":"2026-04-28T18:22:56.600083-07:00",...,"time":"2026-04-28T18:22:56.600275-07:00","message":"Starting Oxia standalone"}
```

After:
```
{"level":"info",...,"time":"2026-04-28T18:35:05.350613-07:00","message":"Starting Oxia standalone"}
```

## Test plan
- [x] `make build` passes
- [x] `bin/oxia standalone -j` shows a single `time` field per line