### PR TITLE
fix: restore maelstrom coordinator startup

### DIFF
--- a/oxiad/maelstrom/main.go
+++ b/oxiad/maelstrom/main.go
@@ -192,13 +192,6 @@ func main() {
 			)
 			os.Exit(1)
 		}
-		if err := metadataProvider.WaitToBecomeLeader(); err != nil {
-			slog.Error(
-				"failed to wait for coordinator metadata leadership",
-				slog.Any("error", err),
-			)
-			os.Exit(1)
-		}
 		configProvider := memory.NewProvider(provider.ClusterConfigCodec)
 		_, err = configProvider.Store(clusterConfig, provider.NotExists)
 		if err != nil {


### PR DESCRIPTION
## Motivation
A recent metadata factory refactor regressed Maelstrom startup. The Maelstrom coordinator path in `oxiad/maelstrom/main.go` was still calling `metadataProvider.WaitToBecomeLeader()` manually before constructing the metadata factory, and `Factory.CreateMetadata(...)` now performs the same leadership wait internally. With the file metadata provider, the second call blocks forever on the same file lock, so node `n1` never finishes coordinator startup and the workload sees sustained `temporarily-unavailable` errors.

## Modifications
- remove the redundant manual `WaitToBecomeLeader()` call from the Maelstrom coordinator bootstrap path
- leave leadership acquisition owned by `metadata.Factory.CreateMetadata(...)`

## Testing
- `go test ./oxiad/maelstrom`
- `make lint`
- `make maelstrom`
- `cd maelstrom && ./maelstrom test -w lin-kv --bin ../bin/oxia-maelstrom --time-limit 60 --concurrency 2n --latency 10 --latency-dist uniform`

The local Maelstrom run completed successfully after this fix. The only remaining warning was missing `gnuplot` for Jepsen graph rendering.
