### PR TITLE
fix: allow empty cluster configs

### DIFF
--- a/common/proto/metadata_ext.go
+++ b/common/proto/metadata_ext.go
@@ -205,10 +205,6 @@ func (cc *ClusterConfiguration) Validate() error {
 		return errors.New("cluster configuration: at least one server must be configured")
 	}
 
-	if len(cc.GetNamespaces()) == 0 {
-		return errors.New("cluster configuration: at least one namespace must be configured")
-	}
-
 	for _, ns := range cc.GetNamespaces() {
 		if err := validation.ValidateNamespace(ns.GetName()); err != nil {
 			return fmt.Errorf("cluster configuration: %w", err)

--- a/common/proto/metadata_ext.go
+++ b/common/proto/metadata_ext.go
@@ -201,10 +201,6 @@ func (cc *ClusterConfiguration) Validate() error {
 		return errors.New("cluster configuration: must not be nil")
 	}
 
-	if len(cc.GetServers()) == 0 {
-		return errors.New("cluster configuration: at least one server must be configured")
-	}
-
 	for _, ns := range cc.GetNamespaces() {
 		if err := validation.ValidateNamespace(ns.GetName()); err != nil {
 			return fmt.Errorf("cluster configuration: %w", err)

--- a/common/proto/metadata_ext_test.go
+++ b/common/proto/metadata_ext_test.go
@@ -140,6 +140,19 @@ servers:
 	require.Equal(t, KeySortingType_UNKNOWN, keySorting)
 }
 
+func TestValidateAllowsEmptyNamespaces(t *testing.T) {
+	config := &ClusterConfiguration{
+		Servers: []*DataServerIdentity{
+			{
+				Public:   "localhost:6648",
+				Internal: "localhost:6649",
+			},
+		},
+	}
+
+	require.NoError(t, config.Validate())
+}
+
 func TestEncodeYAMLRoundTrip(t *testing.T) {
 	name := "node-1"
 	notificationsEnabled := false

--- a/common/proto/metadata_ext_test.go
+++ b/common/proto/metadata_ext_test.go
@@ -140,16 +140,8 @@ servers:
 	require.Equal(t, KeySortingType_UNKNOWN, keySorting)
 }
 
-func TestValidateAllowsEmptyNamespaces(t *testing.T) {
-	config := &ClusterConfiguration{
-		Servers: []*DataServerIdentity{
-			{
-				Public:   "localhost:6648",
-				Internal: "localhost:6649",
-			},
-		},
-	}
-
+func TestValidateAllowsEmptyConfig(t *testing.T) {
+	config := &ClusterConfiguration{}
 	require.NoError(t, config.Validate())
 }
 

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -43,11 +43,6 @@ func newTestMetadata(t *testing.T, config *proto.ClusterConfiguration) coordmeta
 	if config == nil {
 		config = &proto.ClusterConfiguration{}
 	}
-	if len(config.Servers) == 0 {
-		config.Servers = []*proto.DataServerIdentity{
-			{Public: "seed-public-1:6648", Internal: "seed-internal-1:6649"},
-		}
-	}
 
 	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
 	_, err := configProvider.Store(config, provider.NotExists)

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -40,6 +40,15 @@ func dataServer(name *string, public, internal string) *proto.DataServerIdentity
 func newTestMetadata(t *testing.T, config *proto.ClusterConfiguration) coordmetadata.Metadata {
 	t.Helper()
 
+	if config == nil {
+		config = &proto.ClusterConfiguration{}
+	}
+	if len(config.Servers) == 0 {
+		config.Servers = []*proto.DataServerIdentity{
+			{Public: "seed-public-1:6648", Internal: "seed-internal-1:6649"},
+		}
+	}
+
 	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
 	_, err := configProvider.Store(config, provider.NotExists)
 	require.NoError(t, err)


### PR DESCRIPTION
## Motivation
- fix the CI timeout caused by `TestManagementServerListDataServers`
- restore coordinator flows that temporarily use an empty cluster configuration while namespaces or servers are being removed

## Modifications
- allow `ClusterConfiguration.Validate()` to accept empty configs instead of rejecting missing servers up front
- keep namespace replication validation in place when namespaces are present
- simplify the management server test helper so it no longer injects a synthetic server
- update regression coverage to validate an entirely empty config

## Testing
- `go test ./common/proto -run TestValidateAllowsEmptyConfig -count=1 -v`
- `go test ./oxiad/coordinator -run 'TestManagementServer(ListDataServers|GetDataServerRejectsEmptyLookup)' -count=1 -timeout=30s -v`
- `go test ./tests/coordinator -run TestCoordinator_DeleteNamespace -count=1 -timeout=60s -v`
- `make test` currently fails in `tests/coordinator` on `TestCoordinator_ShardSplit`, which appears to be an unrelated integration failure
