### PR TITLE
fix: align shard split bootstrap term

### DIFF
--- a/oxiad/coordinator/runtime/controller/split_controller.go
+++ b/oxiad/coordinator/runtime/controller/split_controller.go
@@ -251,8 +251,11 @@ func (sc *SplitController) runBootstrap() error {
 	}
 
 	// Step 1: Fence and elect each child leader (if not already done).
+	// Children must bootstrap in the parent's term so the parent observer
+	// cursors can stream snapshots and WAL entries without term mismatch.
+	parentTerm := parentMeta.Term
 	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		if err := sc.fenceAndElectChild(childId); err != nil {
+		if err := sc.fenceAndElectChild(childId, parentTerm); err != nil {
 			return err
 		}
 	}
@@ -265,7 +268,6 @@ func (sc *SplitController) runBootstrap() error {
 		return errors.New("parent shard has no leader")
 	}
 	parentLeader := parentMeta.Leader
-	parentTerm := parentMeta.Term
 
 	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
 		if err := sc.addChildObserver(childId, parentLeader, parentTerm); err != nil {
@@ -294,7 +296,7 @@ func (sc *SplitController) runBootstrap() error {
 
 // fenceAndElectChild fences a child shard's ensemble and elects a leader.
 // Skipped if the child already has a leader (from a previous Bootstrap run).
-func (sc *SplitController) fenceAndElectChild(childId int64) error {
+func (sc *SplitController) fenceAndElectChild(childId int64, parentTerm int64) error {
 	childMeta := sc.loadShardMeta(childId)
 	if childMeta == nil {
 		return errors.Errorf("child shard %d not found", childId)
@@ -308,7 +310,7 @@ func (sc *SplitController) fenceAndElectChild(childId int64) error {
 		return nil
 	}
 
-	childTerm := childMeta.Term + 1
+	childTerm := parentTerm
 	headEntries, err := sc.fenceEnsemble(childId, childTerm, childMeta.Ensemble)
 	if err != nil {
 		return errors.Wrapf(err, "failed to fence child shard %d", childId)

--- a/oxiad/coordinator/runtime/controller/split_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/split_controller_test.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -354,6 +355,49 @@ func TestSplitController_PhaseTransitions(t *testing.T) {
 		assert.Equal(t, proto.ShardStatusSteadyState, rightMeta.Status)
 	case <-time.After(30 * time.Second):
 		t.Fatal("Split did not complete in time")
+	}
+}
+
+func TestSplitController_BootstrapFencesChildrenInParentTerm(t *testing.T) {
+	rpcMock, statusRes, _ := setupSplitTest(t, proto.SplitPhaseBootstrap)
+
+	queueBootstrapResponses(rpcMock)
+
+	sc := &SplitController{
+		namespace:        constant.DefaultNamespace,
+		parentShardId:    0,
+		leftChildId:      1,
+		rightChildId:     2,
+		metadata:         statusRes,
+		rpcProvider:      rpcMock,
+		eventListener:    newMockSplitEventListener(),
+		ctx:              t.Context(),
+		logger:           slog.With(slog.String("component", "split-controller-test")),
+	}
+
+	require.NoError(t, sc.runBootstrap())
+
+	for _, node := range []*proto.DataServerIdentity{ls1, ls2, ls3} {
+		req := receiveNewTermRequest(t, rpcMock.GetNode(node).newTermRequests)
+		assert.Equal(t, int64(1), req.Shard)
+		assert.Equal(t, int64(5), req.Term)
+	}
+	for _, node := range []*proto.DataServerIdentity{rs1, rs2, rs3} {
+		req := receiveNewTermRequest(t, rpcMock.GetNode(node).newTermRequests)
+		assert.Equal(t, int64(2), req.Shard)
+		assert.Equal(t, int64(5), req.Term)
+	}
+}
+
+func receiveNewTermRequest(t *testing.T, requests <-chan *proto.NewTermRequest) *proto.NewTermRequest {
+	t.Helper()
+
+	select {
+	case req := <-requests:
+		return req
+	case <-time.After(defaultTimeout):
+		t.Fatal("did not receive NewTerm request in time")
+		return nil
 	}
 }
 


### PR DESCRIPTION
## Motivation
- shard split bootstrap could elect child leaders in `childMeta.Term + 1` while the parent observer cursor still streamed with the parent term
- that term mismatch caused `SendSnapshot` / follower-controller setup to reject the stream with `oxia: invalid term`, which made shard split tests intermittently hang or fail in `tests/coordinator`

## Modifications
- fence and elect split children in the parent shard term during bootstrap
- keep the parent observer setup using that same term so snapshot and WAL streaming stay coherent across the split bootstrap phase
- add a regression test that asserts child bootstrap `NewTerm` requests use the parent term

## Testing
- `go test ./oxiad/coordinator/runtime/controller -run 'TestSplitController_(BootstrapFencesChildrenInParentTerm|FullLifecycle|ResumeFromBootstrap|ResumeFromCatchUp|PhaseTransitions)' -count=1 -timeout=90s -v`
- `go test ./tests/coordinator -run TestCoordinator_ShardSplit -count=1 -timeout=10m -v`
- `make test`
