### PR TITLE
refactor: add metadata config compute

### DIFF
--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -48,6 +48,7 @@ type Metadata interface {
 	DeleteShard(namespace string, shard int64)
 
 	GetConfig() *commonproto.ClusterConfiguration
+	ComputeConfig(updateFn func(config *commonproto.ClusterConfiguration) error) error
 	ConfigWatch() *commonwatch.Watch[*commonproto.ClusterConfiguration]
 	GetLoadBalancer() *commonproto.LoadBalancer
 
@@ -297,6 +298,59 @@ func validateClusterConfig(config *commonproto.ClusterConfiguration) error {
 	return nil
 }
 
+func (m *coordinatorMetadata) ComputeConfig(updateFn func(config *commonproto.ClusterConfiguration) error) error {
+	for {
+		currentConfig, version, err := m.configProvider.Get()
+		if err != nil {
+			return err
+		}
+		if currentConfig == nil {
+			currentConfig = &commonproto.ClusterConfiguration{}
+		}
+
+		nextConfig := gproto.Clone(currentConfig).(*commonproto.ClusterConfiguration) //nolint:revive
+		if err := updateFn(nextConfig); err != nil {
+			return err
+		}
+		if err := validateClusterConfig(nextConfig); err != nil {
+			return err
+		}
+
+		if _, err := m.storeConfig(nextConfig, version); err != nil {
+			if errors.Is(err, provider.ErrBadVersion) {
+				continue
+			}
+			return err
+		}
+
+		m.applyClusterConfig(nextConfig)
+		return nil
+	}
+}
+
+func (m *coordinatorMetadata) storeConfig(
+	config *commonproto.ClusterConfiguration,
+	expectedVersion provider.Version,
+) (newVersion provider.Version, err error) {
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			return
+		}
+
+		recoveredErr, ok := recovered.(error)
+		if ok && errors.Is(recoveredErr, provider.ErrBadVersion) {
+			newVersion = provider.NotExists
+			err = provider.ErrBadVersion
+			return
+		}
+
+		panic(recovered)
+	}()
+
+	return m.configProvider.Store(config, expectedVersion)
+}
+
 func (m *coordinatorMetadata) rebuildConfigIndexesLocked() {
 	nodes := redblacktree.New[string, *commonproto.DataServerIdentity]()
 	for _, server := range m.currentClusterConfig.GetServers() {
@@ -309,6 +363,22 @@ func (m *coordinatorMetadata) rebuildConfigIndexesLocked() {
 		namespaceConfigs.Put(ns.GetName(), ns)
 	}
 	m.namespaceConfigsIndex = namespaceConfigs
+}
+
+func (m *coordinatorMetadata) applyClusterConfig(config *commonproto.ClusterConfiguration) {
+	clonedConfig := gproto.Clone(config).(*commonproto.ClusterConfiguration) //nolint:revive
+
+	m.clusterConfigLock.Lock()
+	oldClusterConfig := m.currentClusterConfig
+	m.currentClusterConfig = clonedConfig
+	m.rebuildConfigIndexesLocked()
+	m.clusterConfigLock.Unlock()
+
+	if gproto.Equal(oldClusterConfig, clonedConfig) {
+		m.logger.Info("No cluster config changes detected")
+		return
+	}
+	m.clusterConfigWatch.Publish(clonedConfig)
 }
 
 func (m *coordinatorMetadata) waitForConfigUpdates(configWatch *commonwatch.Receiver[*commonproto.ClusterConfiguration]) {
@@ -331,19 +401,7 @@ func (m *coordinatorMetadata) applyConfigWatchValue(configWatch *commonwatch.Rec
 		m.logger.Warn("received invalid cluster config watch value", slog.Any("error", err))
 		return
 	}
-	clonedConfig := gproto.Clone(config).(*commonproto.ClusterConfiguration) //nolint:revive
-
-	m.clusterConfigLock.Lock()
-	oldClusterConfig := m.currentClusterConfig
-	m.currentClusterConfig = clonedConfig
-	m.rebuildConfigIndexesLocked()
-	m.clusterConfigLock.Unlock()
-
-	if gproto.Equal(oldClusterConfig, clonedConfig) {
-		m.logger.Info("No cluster config changes detected")
-		return
-	}
-	m.clusterConfigWatch.Publish(clonedConfig)
+	m.applyClusterConfig(config)
 }
 
 func (m *coordinatorMetadata) GetConfig() *commonproto.ClusterConfiguration {

--- a/oxiad/coordinator/metadata/metadata_test.go
+++ b/oxiad/coordinator/metadata/metadata_test.go
@@ -20,8 +20,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	gproto "google.golang.org/protobuf/proto"
 
+	commonproto "github.com/oxia-db/oxia/common/proto"
+	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	"github.com/oxia-db/oxia/oxiad/coordinator/option"
 )
 
@@ -81,6 +85,118 @@ func TestNewFactoryFromOptionsMergesLegacyClusterConfigPath(t *testing.T) {
 	config := metadata.GetConfig()
 	require.Len(t, config.GetNamespaces(), 1)
 	require.Equal(t, "default", config.GetNamespaces()[0].GetName())
+}
+
+func TestComputeConfigUpdatesCachedConfig(t *testing.T) {
+	statusProvider := memory.NewProvider(provider.ClusterStatusCodec)
+	configProvider := memory.NewProvider(provider.ClusterConfigCodec)
+	_, err := configProvider.Store(&commonproto.ClusterConfiguration{
+		Namespaces: []*commonproto.Namespace{{
+			Name:              "default",
+			ReplicationFactor: 1,
+			InitialShardCount: 1,
+		}},
+		Servers: []*commonproto.DataServerIdentity{{
+			Public:   "s1:9091",
+			Internal: "s1:8191",
+		}},
+	}, provider.NotExists)
+	require.NoError(t, err)
+
+	metadata := newMetadata(t.Context(), statusProvider, configProvider)
+	t.Cleanup(func() {
+		require.NoError(t, metadata.Close())
+	})
+
+	err = metadata.ComputeConfig(func(config *commonproto.ClusterConfiguration) error {
+		config.AllowExtraAuthorities = append(config.AllowExtraAuthorities, "127.0.0.1:6648")
+		return nil
+	})
+	require.NoError(t, err)
+
+	config := metadata.GetConfig()
+	require.Equal(t, []string{"127.0.0.1:6648"}, config.GetAllowExtraAuthorities())
+}
+
+func TestComputeConfigRetriesOnBadVersion(t *testing.T) {
+	statusProvider := memory.NewProvider(provider.ClusterStatusCodec)
+	configProvider := &retryConfigProvider{
+		config: &commonproto.ClusterConfiguration{
+			Namespaces: []*commonproto.Namespace{{
+				Name:              "default",
+				ReplicationFactor: 1,
+				InitialShardCount: 1,
+			}},
+			Servers: []*commonproto.DataServerIdentity{{
+				Public:   "s1:9091",
+				Internal: "s1:8191",
+			}},
+		},
+		version: provider.NotExists,
+	}
+
+	metadata := newMetadata(t.Context(), statusProvider, configProvider)
+	t.Cleanup(func() {
+		require.NoError(t, metadata.Close())
+	})
+
+	callCount := 0
+	err := metadata.ComputeConfig(func(config *commonproto.ClusterConfiguration) error {
+		callCount++
+		config.Namespaces[0].InitialShardCount++
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount)
+	require.EqualValues(t, 6, metadata.GetConfig().GetNamespaces()[0].GetInitialShardCount())
+}
+
+type retryConfigProvider struct {
+	config      *commonproto.ClusterConfiguration
+	version     provider.Version
+	storeCalled bool
+}
+
+func (*retryConfigProvider) Close() error { return nil }
+
+func (*retryConfigProvider) WaitToBecomeLeader() error { return nil }
+
+func (*retryConfigProvider) Watch() (*commonwatch.Receiver[*commonproto.ClusterConfiguration], error) {
+	return nil, provider.ErrWatchUnsupported
+}
+
+func (p *retryConfigProvider) Get() (*commonproto.ClusterConfiguration, provider.Version, error) {
+	return gproto.Clone(p.config).(*commonproto.ClusterConfiguration), p.version, nil
+}
+
+func (p *retryConfigProvider) Store(
+	value *commonproto.ClusterConfiguration,
+	expectedVersion provider.Version,
+) (provider.Version, error) {
+	if expectedVersion != p.version {
+		panic(provider.ErrBadVersion)
+	}
+
+	if !p.storeCalled {
+		p.storeCalled = true
+		p.config = &commonproto.ClusterConfiguration{
+			Namespaces: []*commonproto.Namespace{{
+				Name:              "default",
+				ReplicationFactor: 1,
+				InitialShardCount: 5,
+			}},
+			Servers: []*commonproto.DataServerIdentity{{
+				Public:   "s1:9091",
+				Internal: "s1:8191",
+			}},
+		}
+		p.version = provider.NextVersion(p.version)
+		panic(provider.ErrBadVersion)
+	}
+
+	p.config = gproto.Clone(value).(*commonproto.ClusterConfiguration)
+	p.version = provider.NextVersion(p.version)
+	return p.version, nil
 }
 
 func writeClusterConfig(t *testing.T, path string) {

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -66,6 +66,8 @@ func (*mockMetadata) IsReady(*proto.ClusterConfiguration) bool { return true }
 
 func (*mockMetadata) GetConfig() *proto.ClusterConfiguration { return nil }
 
+func (*mockMetadata) ComputeConfig(func(*proto.ClusterConfiguration) error) error { return nil }
+
 func (*mockMetadata) ConfigWatch() *commonwatch.Watch[*proto.ClusterConfiguration] {
 	return commonwatch.New(&proto.ClusterConfiguration{})
 }


### PR DESCRIPTION
## Motivation
Config updates need a cleaner mutation boundary than open-coded get/modify/store logic. We also want config writes to tolerate optimistic-concurrency conflicts without pushing retry loops into callers.

## Modifications
- added  to apply config mutations with automatic retry on bad-version conflicts
- kept metadata's existing cached config and derived indexes for read-heavy paths
- refreshed the cached config and watch after successful config writes
- added metadata tests for cache refresh and bad-version retry behavior
- updated the balancer metadata mock to satisfy the new interface

## Testing
- go test ./oxiad/coordinator/metadata ./oxiad/coordinator/runtime/balancer ./oxiad/coordinator -run '^$|TestComputeConfig|TestNewFactoryFromOptions|TestManagementServer'
- go test ./oxiad/coordinator/... -run '^$|TestComputeConfig|TestManagementServer|TestNewFactoryFromOptions'
- make lint