### PR TITLE
refactor: mark borrowed metadata reads

### DIFF
--- a/common/object/borrowed.go
+++ b/common/object/borrowed.go
@@ -1,0 +1,37 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+// Borrowed wraps a value that is exposed without copying.
+//
+// The wrapped value remains owned by the producer. Callers must treat it as
+// read-only and must not retain the borrowed reference beyond immediate use.
+type Borrowed[T any] struct {
+	value T
+}
+
+// Borrow wraps a value in a Borrowed marker so callers can see they do not own
+// the returned reference.
+func Borrow[T any](value T) Borrowed[T] {
+	return Borrowed[T]{value: value}
+}
+
+// UnsafeBorrow returns the wrapped value without copying it.
+//
+// The returned value aliases state owned elsewhere and must not be mutated or
+// retained by callers.
+func (b Borrowed[T]) UnsafeBorrow() T {
+	return b.value
+}

--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -38,7 +38,7 @@ type managementServer struct {
 }
 
 func (management *managementServer) ListDataServers(context.Context, *proto.ListDataServersRequest) (*proto.ListDataServersResponse, error) {
-	cnf := management.metadata.GetConfig()
+	cnf := management.metadata.GetConfig().UnsafeBorrow()
 
 	dataServers := make([]*proto.DataServer, 0, len(cnf.GetServers()))
 	for _, server := range cnf.GetServers() {
@@ -70,18 +70,18 @@ func (management *managementServer) GetDataServer(_ context.Context, req *proto.
 		return nil, grpcstatus.Error(codes.InvalidArgument, "data server must not be empty")
 	}
 
-	dataServer, found := management.metadata.GetDataServer(req.DataServer)
+	borrowedDataServer, found := management.metadata.GetDataServer(req.DataServer)
 	if !found {
 		return nil, grpcstatus.Errorf(codes.NotFound, "data server %q not found", req.DataServer)
 	}
 
 	return &proto.GetDataServerResponse{
-		DataServer: dataServer,
+		DataServer: borrowedDataServer.UnsafeBorrow(),
 	}, nil
 }
 
 func (management *managementServer) ListNamespaces(context.Context, *proto.ListNamespacesRequest) (*proto.ListNamespacesResponse, error) {
-	cnf := management.metadata.GetConfig()
+	cnf := management.metadata.GetConfig().UnsafeBorrow()
 
 	namespaceNames := hashset.New[string]()
 	for _, nsConfig := range cnf.GetNamespaces() {
@@ -93,7 +93,7 @@ func (management *managementServer) ListNamespaces(context.Context, *proto.ListN
 }
 
 func (management *managementServer) ListNodes(context.Context, *proto.ListNodesRequest) (*proto.ListNodesResponse, error) {
-	cnf := management.metadata.GetConfig()
+	cnf := management.metadata.GetConfig().UnsafeBorrow()
 
 	cnfNodes := cnf.GetServers()
 	cnfMeta := cnf.GetServerMetadata()

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 	gproto "google.golang.org/protobuf/proto"
 
+	commonobject "github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/process"
 	commonproto "github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/common/rpc"
@@ -41,26 +42,30 @@ import (
 type Metadata interface {
 	io.Closer
 
-	GetStatus() *commonproto.ClusterStatus
+	GetStatus() commonobject.Borrowed[*commonproto.ClusterStatus]
 	UpdateStatus(newStatus *commonproto.ClusterStatus)
 	ReserveShardIDs(count uint32) int64
-	CreateNamespaceStatus(name string, status *commonproto.NamespaceStatus) bool
 
-	ListNamespaceStatus() map[string]*commonproto.NamespaceStatus
-	GetNamespaceStatus(namespace string) (*commonproto.NamespaceStatus, bool)
-	DeleteNamespaceStatus(name string) *commonproto.NamespaceStatus
+	CreateNamespaceStatus(name string, status *commonproto.NamespaceStatus) bool
+	ListNamespaceStatus() commonobject.Borrowed[map[string]*commonproto.NamespaceStatus]
+	GetNamespaceStatus(namespace string) (commonobject.Borrowed[*commonproto.NamespaceStatus], bool)
+	DeleteNamespaceStatus(name string) commonobject.Borrowed[*commonproto.NamespaceStatus]
+
 	UpdateShardStatus(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata)
 	DeleteShardStatus(namespace string, shard int64)
 
-	GetConfig() *commonproto.ClusterConfiguration
+	GetConfig() commonobject.Borrowed[*commonproto.ClusterConfiguration]
 	ConfigWatch() *commonwatch.Watch[*commonproto.ClusterConfiguration]
-	GetLoadBalancer() *commonproto.LoadBalancer
+	GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer]
 
-	ListDataServers() *linkedhashset.Set[string]
-	ListDataServersWithMetadata() (*linkedhashset.Set[string], map[string]*commonproto.DataServerMetadata)
-	GetDataServerIdentity(id string) (*commonproto.DataServerIdentity, bool)
-	GetDataServer(name string) (*commonproto.DataServer, bool)
-	GetNamespace(namespace string) (*commonproto.Namespace, bool)
+	ListDataServers() commonobject.Borrowed[*linkedhashset.Set[string]]
+	ListDataServersWithMetadata() (
+		commonobject.Borrowed[*linkedhashset.Set[string]],
+		commonobject.Borrowed[map[string]*commonproto.DataServerMetadata],
+	)
+	GetDataServerIdentity(id string) (commonobject.Borrowed[*commonproto.DataServerIdentity], bool)
+	GetDataServer(name string) (commonobject.Borrowed[*commonproto.DataServer], bool)
+	GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool)
 }
 
 type EnsembleSupplier func(
@@ -185,10 +190,10 @@ func (m *coordinatorMetadata) persistStatusLocked(newStatus *commonproto.Cluster
 	})
 }
 
-func (m *coordinatorMetadata) GetStatus() *commonproto.ClusterStatus {
+func (m *coordinatorMetadata) GetStatus() commonobject.Borrowed[*commonproto.ClusterStatus] {
 	m.statusLock.RLock()
 	defer m.statusLock.RUnlock()
-	return m.currentStatus
+	return commonobject.Borrow(m.currentStatus)
 }
 
 func (m *coordinatorMetadata) UpdateStatus(newStatus *commonproto.ClusterStatus) {
@@ -213,7 +218,7 @@ func (m *coordinatorMetadata) ReserveShardIDs(count uint32) int64 {
 
 func (m *coordinatorMetadata) CreateNamespaceStatus(name string, status *commonproto.NamespaceStatus) bool {
 	m.loadClusterConfigWithInitSlow()
-	serverCount := len(m.GetConfig().GetServers())
+	serverCount := len(m.GetConfig().UnsafeBorrow().GetServers())
 
 	m.statusLock.Lock()
 	defer m.statusLock.Unlock()
@@ -236,36 +241,36 @@ func (m *coordinatorMetadata) CreateNamespaceStatus(name string, status *commonp
 	return true
 }
 
-func (m *coordinatorMetadata) ListNamespaceStatus() map[string]*commonproto.NamespaceStatus {
+func (m *coordinatorMetadata) ListNamespaceStatus() commonobject.Borrowed[map[string]*commonproto.NamespaceStatus] {
 	m.statusLock.RLock()
 	defer m.statusLock.RUnlock()
 
 	namespaces := make(map[string]*commonproto.NamespaceStatus, len(m.currentStatus.Namespaces))
 	for name, status := range m.currentStatus.Namespaces {
-		namespaces[name] = gproto.Clone(status).(*commonproto.NamespaceStatus) //nolint:revive
+		namespaces[name] = status
 	}
-	return namespaces
+	return commonobject.Borrow(namespaces)
 }
 
-func (m *coordinatorMetadata) GetNamespaceStatus(namespace string) (*commonproto.NamespaceStatus, bool) {
+func (m *coordinatorMetadata) GetNamespaceStatus(namespace string) (commonobject.Borrowed[*commonproto.NamespaceStatus], bool) {
 	m.statusLock.RLock()
 	defer m.statusLock.RUnlock()
 
 	namespaceStatus, exists := m.currentStatus.Namespaces[namespace]
 	if !exists {
-		return nil, false
+		return commonobject.Borrowed[*commonproto.NamespaceStatus]{}, false
 	}
-	return gproto.Clone(namespaceStatus).(*commonproto.NamespaceStatus), true //nolint:revive
+	return commonobject.Borrow(namespaceStatus), true
 }
 
-func (m *coordinatorMetadata) DeleteNamespaceStatus(name string) *commonproto.NamespaceStatus {
+func (m *coordinatorMetadata) DeleteNamespaceStatus(name string) commonobject.Borrowed[*commonproto.NamespaceStatus] {
 	m.statusLock.Lock()
 	defer m.statusLock.Unlock()
 
 	clonedStatus := gproto.Clone(m.currentStatus).(*commonproto.ClusterStatus) //nolint:revive
 	namespaceStatus, exists := clonedStatus.Namespaces[name]
 	if !exists {
-		return nil
+		return commonobject.Borrowed[*commonproto.NamespaceStatus]{}
 	}
 
 	changed := false
@@ -280,7 +285,7 @@ func (m *coordinatorMetadata) DeleteNamespaceStatus(name string) *commonproto.Na
 		m.persistStatusLocked(clonedStatus, "failed to mark namespace deleting")
 		m.notifyStatusChange()
 	}
-	return gproto.Clone(namespaceStatus).(*commonproto.NamespaceStatus) //nolint:revive
+	return commonobject.Borrow(namespaceStatus)
 }
 
 func (m *coordinatorMetadata) UpdateShardStatus(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata) {
@@ -423,7 +428,7 @@ func (m *coordinatorMetadata) applyConfigWatchValue(configWatch *commonwatch.Rec
 	m.clusterConfigWatch.Publish(clonedConfig)
 }
 
-func (m *coordinatorMetadata) GetConfig() *commonproto.ClusterConfiguration {
+func (m *coordinatorMetadata) GetConfig() commonobject.Borrowed[*commonproto.ClusterConfiguration] {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -431,18 +436,18 @@ func (m *coordinatorMetadata) GetConfig() *commonproto.ClusterConfiguration {
 		m.loadClusterConfigWithInitSlow()
 		m.clusterConfigLock.RLock()
 	}
-	return m.currentClusterConfig
+	return commonobject.Borrow(m.currentClusterConfig)
 }
 
 func (m *coordinatorMetadata) ConfigWatch() *commonwatch.Watch[*commonproto.ClusterConfiguration] {
 	return m.clusterConfigWatch
 }
 
-func (m *coordinatorMetadata) GetLoadBalancer() *commonproto.LoadBalancer {
-	return m.GetConfig().GetLoadBalancerWithDefaults()
+func (m *coordinatorMetadata) GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer] {
+	return commonobject.Borrow(m.GetConfig().UnsafeBorrow().GetLoadBalancerWithDefaults())
 }
 
-func (m *coordinatorMetadata) ListDataServers() *linkedhashset.Set[string] {
+func (m *coordinatorMetadata) ListDataServers() commonobject.Borrowed[*linkedhashset.Set[string]] {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -455,10 +460,13 @@ func (m *coordinatorMetadata) ListDataServers() *linkedhashset.Set[string] {
 	for _, server := range m.currentClusterConfig.GetServers() {
 		nodes.Add(server.GetNameOrDefault())
 	}
-	return nodes
+	return commonobject.Borrow(nodes)
 }
 
-func (m *coordinatorMetadata) ListDataServersWithMetadata() (*linkedhashset.Set[string], map[string]*commonproto.DataServerMetadata) {
+func (m *coordinatorMetadata) ListDataServersWithMetadata() (
+	commonobject.Borrowed[*linkedhashset.Set[string]],
+	commonobject.Borrowed[map[string]*commonproto.DataServerMetadata],
+) {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -476,10 +484,10 @@ func (m *coordinatorMetadata) ListDataServersWithMetadata() (*linkedhashset.Set[
 	for id, value := range m.currentClusterConfig.GetServerMetadata() {
 		metadata[id] = value
 	}
-	return nodes, metadata
+	return commonobject.Borrow(nodes), commonobject.Borrow(metadata)
 }
 
-func (m *coordinatorMetadata) GetNamespace(namespace string) (*commonproto.Namespace, bool) {
+func (m *coordinatorMetadata) GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool) {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -487,10 +495,14 @@ func (m *coordinatorMetadata) GetNamespace(namespace string) (*commonproto.Names
 		m.loadClusterConfigWithInitSlow()
 		m.clusterConfigLock.RLock()
 	}
-	return m.namespaceConfigsIndex.Get(namespace)
+	value, ok := m.namespaceConfigsIndex.Get(namespace)
+	if !ok {
+		return commonobject.Borrowed[*commonproto.Namespace]{}, false
+	}
+	return commonobject.Borrow(value), true
 }
 
-func (m *coordinatorMetadata) GetDataServerIdentity(id string) (*commonproto.DataServerIdentity, bool) {
+func (m *coordinatorMetadata) GetDataServerIdentity(id string) (commonobject.Borrowed[*commonproto.DataServerIdentity], bool) {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -498,10 +510,14 @@ func (m *coordinatorMetadata) GetDataServerIdentity(id string) (*commonproto.Dat
 		m.loadClusterConfigWithInitSlow()
 		m.clusterConfigLock.RLock()
 	}
-	return m.nodesIndex.Get(id)
+	value, ok := m.nodesIndex.Get(id)
+	if !ok {
+		return commonobject.Borrowed[*commonproto.DataServerIdentity]{}, false
+	}
+	return commonobject.Borrow(value), true
 }
 
-func (m *coordinatorMetadata) GetDataServer(id string) (*commonproto.DataServer, bool) {
+func (m *coordinatorMetadata) GetDataServer(id string) (commonobject.Borrowed[*commonproto.DataServer], bool) {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -510,7 +526,11 @@ func (m *coordinatorMetadata) GetDataServer(id string) (*commonproto.DataServer,
 		m.clusterConfigLock.RLock()
 	}
 
-	return m.currentClusterConfig.GetDataServer(id)
+	value, ok := m.currentClusterConfig.GetDataServer(id)
+	if !ok {
+		return commonobject.Borrowed[*commonproto.DataServer]{}, false
+	}
+	return commonobject.Borrow(value), true
 }
 
 func WaitForCondition(ctx context.Context, metadata Metadata, triggerFn func(), condition func(*commonproto.ClusterStatus) bool) error {
@@ -520,7 +540,7 @@ func WaitForCondition(ctx context.Context, metadata Metadata, triggerFn func(), 
 	}
 	for {
 		ch := notifier.statusChangeNotify()
-		if condition(metadata.GetStatus()) {
+		if condition(metadata.GetStatus().UnsafeBorrow()) {
 			return nil
 		}
 		if triggerFn != nil {

--- a/oxiad/coordinator/metadata/metadata_test.go
+++ b/oxiad/coordinator/metadata/metadata_test.go
@@ -47,7 +47,7 @@ func TestNewFactoryFromOptionsLoadsFileClusterConfig(t *testing.T) {
 		require.NoError(t, factory.Close())
 	}()
 
-	config := metadata.GetConfig()
+	config := metadata.GetConfig().UnsafeBorrow()
 	require.Len(t, config.GetNamespaces(), 1)
 	require.Equal(t, "default", config.GetNamespaces()[0].GetName())
 }
@@ -78,7 +78,7 @@ func TestNewFactoryFromOptionsMergesLegacyClusterConfigPath(t *testing.T) {
 		require.NoError(t, factory.Close())
 	}()
 
-	config := metadata.GetConfig()
+	config := metadata.GetConfig().UnsafeBorrow()
 	require.Len(t, config.GetNamespaces(), 1)
 	require.Equal(t, "default", config.GetNamespaces()[0].GetName())
 }

--- a/oxiad/coordinator/reconciler/cluster_reconciler.go
+++ b/oxiad/coordinator/reconciler/cluster_reconciler.go
@@ -57,7 +57,7 @@ func New(ctx context.Context, coordinatorRuntime runtime.Runtime) Reconciler {
 	}
 
 	receiver := r.runtime.Metadata().ConfigWatch().Subscribe()
-	r.reconcile0(r.runtime.Metadata().GetConfig(), receiver)
+	r.reconcile0(r.runtime.Metadata().GetConfig().UnsafeBorrow(), receiver)
 
 	r.wg.Go(func() {
 		process.DoWithLabels(reconcilerCtx, map[string]string{

--- a/oxiad/coordinator/reconciler/namespace_reconciler.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler.go
@@ -39,7 +39,7 @@ func (r *namespaceReconciler) Reconcile(_ context.Context, snapshot *proto.Clust
 		r.runtime.CreateNamespace(namespace.GetName(), namespace)
 	}
 
-	for name := range metadata.ListNamespaceStatus() {
+	for name := range metadata.ListNamespaceStatus().UnsafeBorrow() {
 		if _, exists := metadata.GetNamespace(name); exists {
 			continue
 		}

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	gproto "google.golang.org/protobuf/proto"
 
+	commonobject "github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/common/sharding"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
@@ -89,7 +90,9 @@ type mockNamespaceMetadata struct {
 
 func (*mockNamespaceMetadata) Close() error { return nil }
 
-func (m *mockNamespaceMetadata) GetStatus() *proto.ClusterStatus { return m.status }
+func (m *mockNamespaceMetadata) GetStatus() commonobject.Borrowed[*proto.ClusterStatus] {
+	return commonobject.Borrow(m.status)
+}
 
 func (m *mockNamespaceMetadata) UpdateStatus(newStatus *proto.ClusterStatus) { m.status = newStatus }
 
@@ -122,27 +125,27 @@ func (m *mockNamespaceMetadata) CreateNamespaceStatus(
 	return true
 }
 
-func (m *mockNamespaceMetadata) ListNamespaceStatus() map[string]*proto.NamespaceStatus {
+func (m *mockNamespaceMetadata) ListNamespaceStatus() commonobject.Borrowed[map[string]*proto.NamespaceStatus] {
 	namespaces := make(map[string]*proto.NamespaceStatus, len(m.status.GetNamespaces()))
 	for name, status := range m.status.GetNamespaces() {
-		namespaces[name] = gproto.Clone(status).(*proto.NamespaceStatus)
+		namespaces[name] = status
 	}
-	return namespaces
+	return commonobject.Borrow(namespaces)
 }
 
-func (m *mockNamespaceMetadata) GetNamespaceStatus(namespace string) (*proto.NamespaceStatus, bool) {
+func (m *mockNamespaceMetadata) GetNamespaceStatus(namespace string) (commonobject.Borrowed[*proto.NamespaceStatus], bool) {
 	status, exists := m.status.GetNamespaces()[namespace]
 	if !exists {
-		return nil, false
+		return commonobject.Borrowed[*proto.NamespaceStatus]{}, false
 	}
-	return gproto.Clone(status).(*proto.NamespaceStatus), true
+	return commonobject.Borrow(status), true
 }
 
-func (m *mockNamespaceMetadata) DeleteNamespaceStatus(name string) *proto.NamespaceStatus {
+func (m *mockNamespaceMetadata) DeleteNamespaceStatus(name string) commonobject.Borrowed[*proto.NamespaceStatus] {
 	cloned := gproto.Clone(m.status).(*proto.ClusterStatus)
 	namespaceStatus, exists := cloned.Namespaces[name]
 	if !exists {
-		return nil
+		return commonobject.Borrowed[*proto.NamespaceStatus]{}
 	}
 
 	for shardID, shardMetadata := range namespaceStatus.Shards {
@@ -150,40 +153,50 @@ func (m *mockNamespaceMetadata) DeleteNamespaceStatus(name string) *proto.Namesp
 		namespaceStatus.Shards[shardID] = shardMetadata
 	}
 	m.status = cloned
-	return gproto.Clone(namespaceStatus).(*proto.NamespaceStatus)
+	return commonobject.Borrow(namespaceStatus)
 }
 
 func (*mockNamespaceMetadata) UpdateShardStatus(string, int64, *proto.ShardMetadata) {}
 
 func (*mockNamespaceMetadata) DeleteShardStatus(string, int64) {}
 
-func (*mockNamespaceMetadata) GetConfig() *proto.ClusterConfiguration { return nil }
+func (*mockNamespaceMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterConfiguration] {
+	return commonobject.Borrowed[*proto.ClusterConfiguration]{}
+}
 
 func (*mockNamespaceMetadata) ConfigWatch() *commonwatch.Watch[*proto.ClusterConfiguration] {
 	return commonwatch.New(&proto.ClusterConfiguration{})
 }
 
-func (*mockNamespaceMetadata) GetLoadBalancer() *proto.LoadBalancer { return nil }
-
-func (*mockNamespaceMetadata) ListDataServers() *linkedhashset.Set[string] {
-	return linkedhashset.New[string]()
+func (*mockNamespaceMetadata) GetLoadBalancer() commonobject.Borrowed[*proto.LoadBalancer] {
+	return commonobject.Borrowed[*proto.LoadBalancer]{}
 }
 
-func (*mockNamespaceMetadata) ListDataServersWithMetadata() (*linkedhashset.Set[string], map[string]*proto.DataServerMetadata) {
-	return linkedhashset.New[string](), map[string]*proto.DataServerMetadata{}
+func (*mockNamespaceMetadata) ListDataServers() commonobject.Borrowed[*linkedhashset.Set[string]] {
+	return commonobject.Borrow(linkedhashset.New[string]())
 }
 
-func (*mockNamespaceMetadata) GetDataServerIdentity(string) (*proto.DataServerIdentity, bool) {
-	return nil, false
+func (*mockNamespaceMetadata) ListDataServersWithMetadata() (
+	commonobject.Borrowed[*linkedhashset.Set[string]],
+	commonobject.Borrowed[map[string]*proto.DataServerMetadata],
+) {
+	return commonobject.Borrow(linkedhashset.New[string]()), commonobject.Borrow(map[string]*proto.DataServerMetadata{})
 }
 
-func (*mockNamespaceMetadata) GetDataServer(string) (*proto.DataServer, bool) {
-	return nil, false
+func (*mockNamespaceMetadata) GetDataServerIdentity(string) (commonobject.Borrowed[*proto.DataServerIdentity], bool) {
+	return commonobject.Borrowed[*proto.DataServerIdentity]{}, false
 }
 
-func (m *mockNamespaceMetadata) GetNamespace(namespace string) (*proto.Namespace, bool) {
+func (*mockNamespaceMetadata) GetDataServer(string) (commonobject.Borrowed[*proto.DataServer], bool) {
+	return commonobject.Borrowed[*proto.DataServer]{}, false
+}
+
+func (m *mockNamespaceMetadata) GetNamespace(namespace string) (commonobject.Borrowed[*proto.Namespace], bool) {
 	ns, exists := m.configNS[namespace]
-	return ns, exists
+	if !exists {
+		return commonobject.Borrowed[*proto.Namespace]{}, false
+	}
+	return commonobject.Borrow(ns), true
 }
 
 var _ coordmetadata.Metadata = (*mockNamespaceMetadata)(nil)
@@ -220,7 +233,7 @@ func (*mockNamespaceRuntime) SyncShardControllerServerAddresses() {}
 
 func (m *mockNamespaceRuntime) CreateNamespace(name string, namespaceConfig *proto.Namespace) bool {
 	baseShardID := m.metadata.ReserveShardIDs(namespaceConfig.GetInitialShardCount())
-	currentStatus := m.metadata.GetStatus()
+	currentStatus := m.metadata.GetStatus().UnsafeBorrow()
 	namespaceStatus := &proto.NamespaceStatus{
 		Shards:            map[int64]*proto.ShardMetadata{},
 		ReplicationFactor: namespaceConfig.GetReplicationFactor(),
@@ -265,7 +278,7 @@ func (m *mockNamespaceRuntime) CreateNamespace(name string, namespaceConfig *pro
 }
 
 func (m *mockNamespaceRuntime) DeleteNamespace(namespace string) {
-	namespaceStatus := m.metadata.DeleteNamespaceStatus(namespace)
+	namespaceStatus := m.metadata.DeleteNamespaceStatus(namespace).UnsafeBorrow()
 	if namespaceStatus == nil {
 		return
 	}

--- a/oxiad/coordinator/runtime/balancer/scheduler.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 	"github.com/pkg/errors"
 
+	commonobject "github.com/oxia-db/oxia/common/object"
 	commonproto "github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/action"
@@ -97,8 +98,10 @@ func (r *nodeBasedBalancer) rebalanceEnsemble() bool {
 	r.checkQuarantineNodes()
 
 	swapGroup := &sync.WaitGroup{}
-	currentStatus := r.metadata.GetStatus()
-	candidates, metadata := r.metadata.ListDataServersWithMetadata()
+	currentStatus := r.metadata.GetStatus().UnsafeBorrow()
+	candidatesBorrowed, metadataBorrowed := r.metadata.ListDataServersWithMetadata()
+	candidates := candidatesBorrowed.UnsafeBorrow()
+	metadata := metadataBorrowed.UnsafeBorrow()
 	groupedStatus, historyNodes := state.GroupingShardsNodeByStatus(candidates, currentStatus)
 	loadRatios := r.loadRatioAlgorithm(&model.RatioParams{NodeShardsInfos: groupedStatus, HistoryNodes: historyNodes})
 
@@ -222,9 +225,11 @@ func (r *nodeBasedBalancer) swapShard(
 	var exist bool
 	var err error
 
-	if nsc, exist = r.metadata.GetNamespace(candidateShard.Namespace); !exist {
+	var borrowedNamespace commonobject.Borrowed[*commonproto.Namespace]
+	if borrowedNamespace, exist = r.metadata.GetNamespace(candidateShard.Namespace); !exist {
 		return false, nil
 	}
+	nsc = borrowedNamespace.UnsafeBorrow()
 
 	// With RF=1, an ensemble swap cannot safely transfer data (there's no
 	// follower to replicate from). Skip rebalancing for such namespaces.
@@ -260,9 +265,11 @@ func (r *nodeBasedBalancer) swapShard(
 		return false, nil
 	}
 	var targetNode *commonproto.DataServerIdentity
-	if targetNode, exist = r.metadata.GetDataServerIdentity(targetNodeID); !exist {
+	var borrowedTargetNode commonobject.Borrowed[*commonproto.DataServerIdentity]
+	if borrowedTargetNode, exist = r.metadata.GetDataServerIdentity(targetNodeID); !exist {
 		return false, errors.New("target node does not exist")
 	}
+	targetNode = borrowedTargetNode.UnsafeBorrow()
 
 	r.logger.Info("propose to swap the shard", slog.Int64("shard", candidateShard.ShardID), slog.Any("from", fromNode), slog.Any("to", targetNodeID))
 	swapGroup.Add(1)
@@ -311,8 +318,8 @@ func (r *nodeBasedBalancer) IsNodeQuarantined(highestLoadRatioNode *model.NodeLo
 }
 
 func (r *nodeBasedBalancer) IsBalanced() bool {
-	status := r.metadata.GetStatus()
-	candidates := r.metadata.ListDataServers()
+	status := r.metadata.GetStatus().UnsafeBorrow()
+	candidates := r.metadata.ListDataServers().UnsafeBorrow()
 	groupedStatus, historyNodes := state.GroupingShardsNodeByStatus(candidates, status)
 	return r.loadRatioAlgorithm(
 		&model.RatioParams{
@@ -379,8 +386,8 @@ func (r *nodeBasedBalancer) startBackgroundNotifier() {
 func (r *nodeBasedBalancer) rebalanceLeader() {
 	r.checkQuarantineShards()
 
-	status := r.metadata.GetStatus()
-	candidates := r.metadata.ListDataServers()
+	status := r.metadata.GetStatus().UnsafeBorrow()
+	candidates := r.metadata.ListDataServers().UnsafeBorrow()
 	totalShards, electedShards, nodeLeaders := state.NodeShardLeaders(candidates, status)
 
 	electedRate := float64(electedShards) / float64(totalShards)
@@ -503,7 +510,7 @@ func NewLoadBalancer(options Options) LoadBalancer {
 		ctx:                     ctx,
 		ctxCancel:               cancelFunc,
 		wg:                      sync.WaitGroup{},
-		loadBalancerConf:        options.Metadata.GetLoadBalancer(),
+		loadBalancerConf:        options.Metadata.GetLoadBalancer().UnsafeBorrow(),
 		actionCh:                make(chan action.Action, 1000),
 		nodeAvailableJudger:     options.NodeAvailableJudger,
 		metadata:                options.Metadata,

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 
+	commonobject "github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/proto"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
@@ -50,7 +51,9 @@ var _ coordmetadata.Metadata = (*mockMetadata)(nil)
 
 func (*mockMetadata) Close() error { return nil }
 
-func (m *mockMetadata) GetStatus() *proto.ClusterStatus { return m.status }
+func (m *mockMetadata) GetStatus() commonobject.Borrowed[*proto.ClusterStatus] {
+	return commonobject.Borrow(m.status)
+}
 
 func (m *mockMetadata) UpdateStatus(newStatus *proto.ClusterStatus) { m.status = newStatus }
 
@@ -60,13 +63,17 @@ func (*mockMetadata) CreateNamespaceStatus(string, *proto.NamespaceStatus) bool 
 	return false
 }
 
-func (*mockMetadata) ListNamespaceStatus() map[string]*proto.NamespaceStatus {
-	return nil
+func (*mockMetadata) ListNamespaceStatus() commonobject.Borrowed[map[string]*proto.NamespaceStatus] {
+	return commonobject.Borrowed[map[string]*proto.NamespaceStatus]{}
 }
 
-func (*mockMetadata) GetNamespaceStatus(string) (*proto.NamespaceStatus, bool) { return nil, false }
+func (*mockMetadata) GetNamespaceStatus(string) (commonobject.Borrowed[*proto.NamespaceStatus], bool) {
+	return commonobject.Borrowed[*proto.NamespaceStatus]{}, false
+}
 
-func (*mockMetadata) DeleteNamespaceStatus(string) *proto.NamespaceStatus { return nil }
+func (*mockMetadata) DeleteNamespaceStatus(string) commonobject.Borrowed[*proto.NamespaceStatus] {
+	return commonobject.Borrowed[*proto.NamespaceStatus]{}
+}
 
 func (*mockMetadata) UpdateShardStatus(string, int64, *proto.ShardMetadata) {}
 
@@ -74,51 +81,64 @@ func (*mockMetadata) DeleteShardStatus(string, int64) {}
 
 func (*mockMetadata) IsReady(*proto.ClusterConfiguration) bool { return true }
 
-func (*mockMetadata) GetConfig() *proto.ClusterConfiguration { return nil }
+func (*mockMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterConfiguration] {
+	return commonobject.Borrowed[*proto.ClusterConfiguration]{}
+}
 
 func (*mockMetadata) ConfigWatch() *commonwatch.Watch[*proto.ClusterConfiguration] {
 	return commonwatch.New(&proto.ClusterConfiguration{})
 }
 
-func (m *mockMetadata) GetLoadBalancer() *proto.LoadBalancer {
+func (m *mockMetadata) GetLoadBalancer() commonobject.Borrowed[*proto.LoadBalancer] {
 	if m.lbConfig != nil {
-		return m.lbConfig
+		return commonobject.Borrow(m.lbConfig)
 	}
-	return &proto.LoadBalancer{
+	return commonobject.Borrow(&proto.LoadBalancer{
 		ScheduleInterval: "30s",
 		QuarantineTime:   "5m",
-	}
+	})
 }
 
-func (m *mockMetadata) ListDataServers() *linkedhashset.Set[string] { return m.nodes }
-
-func (m *mockMetadata) ListDataServersWithMetadata() (*linkedhashset.Set[string], map[string]*proto.DataServerMetadata) {
-	return m.nodes, m.metadata
+func (m *mockMetadata) ListDataServers() commonobject.Borrowed[*linkedhashset.Set[string]] {
+	return commonobject.Borrow(m.nodes)
 }
 
-func (m *mockMetadata) GetNamespace(namespace string) (*proto.Namespace, bool) {
+func (m *mockMetadata) ListDataServersWithMetadata() (
+	commonobject.Borrowed[*linkedhashset.Set[string]],
+	commonobject.Borrowed[map[string]*proto.DataServerMetadata],
+) {
+	return commonobject.Borrow(m.nodes), commonobject.Borrow(m.metadata)
+}
+
+func (m *mockMetadata) GetNamespace(namespace string) (commonobject.Borrowed[*proto.Namespace], bool) {
 	nc, ok := m.nsConfigs[namespace]
-	return nc, ok
+	if !ok {
+		return commonobject.Borrowed[*proto.Namespace]{}, false
+	}
+	return commonobject.Borrow(nc), true
 }
 
-func (m *mockMetadata) GetDataServerIdentity(id string) (*proto.DataServerIdentity, bool) {
-	n, ok := m.nodeMap[id]
-	return n, ok
-}
-
-func (m *mockMetadata) GetDataServer(id string) (*proto.DataServer, bool) {
+func (m *mockMetadata) GetDataServerIdentity(id string) (commonobject.Borrowed[*proto.DataServerIdentity], bool) {
 	n, ok := m.nodeMap[id]
 	if !ok {
-		return nil, false
+		return commonobject.Borrowed[*proto.DataServerIdentity]{}, false
+	}
+	return commonobject.Borrow(n), true
+}
+
+func (m *mockMetadata) GetDataServer(id string) (commonobject.Borrowed[*proto.DataServer], bool) {
+	n, ok := m.nodeMap[id]
+	if !ok {
+		return commonobject.Borrowed[*proto.DataServer]{}, false
 	}
 	metadata, ok := m.metadata[id]
 	if !ok {
 		metadata = &proto.DataServerMetadata{}
 	}
-	return &proto.DataServer{
+	return commonobject.Borrow(&proto.DataServer{
 		Identity: n,
 		Metadata: metadata,
-	}, true
+	}), true
 }
 
 // alwaysErrorSelector is a selector that always returns ErrUnsatisfiedAntiAffinity.
@@ -139,7 +159,7 @@ func newTestBalancer(
 		ctx:                     ctx,
 		ctxCancel:               cancel,
 		wg:                      sync.WaitGroup{},
-		loadBalancerConf:        metadata.GetLoadBalancer(),
+		loadBalancerConf:        metadata.GetLoadBalancer().UnsafeBorrow(),
 		metadata:                metadata,
 		selector:                sel,
 		loadRatioAlgorithm:      single.DefaultShardsRank,

--- a/oxiad/coordinator/runtime/controller/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller.go
@@ -258,7 +258,7 @@ func (s *shardController) waitForSplitComplete() {
 		case <-s.ctx.Done():
 			return
 		case <-ticker.C:
-			status := s.metadataStore.GetStatus()
+			status := s.metadataStore.GetStatus().UnsafeBorrow()
 			ns, exists := status.Namespaces[s.namespace]
 			if !exists {
 				continue
@@ -358,8 +358,9 @@ func (s *shardController) onElectLeader(changeEnsembleAction *action.ChangeEnsem
 		EnableNotifications: true,
 		KeySorting:          proto.KeySortingType_UNKNOWN,
 	}
-	nsConfig, exist := s.metadataStore.GetNamespace(s.namespace)
+	borrowedNamespaceConfig, exist := s.metadataStore.GetNamespace(s.namespace)
 	if exist {
+		nsConfig := borrowedNamespaceConfig.UnsafeBorrow()
 		termOptions.EnableNotifications = nsConfig.NotificationsEnabledOrDefault()
 		termOptions.KeySorting, _ = nsConfig.GetKeySortingType()
 	}
@@ -473,7 +474,8 @@ func (s *shardController) SyncServerAddress() {
 	shardMeta := s.metadata.Load()
 	needSync := false
 	for _, candidate := range shardMeta.Ensemble {
-		if newInfo, ok := s.metadataStore.GetDataServerIdentity(candidate.GetNameOrDefault()); ok {
+		if borrowedNewInfo, ok := s.metadataStore.GetDataServerIdentity(candidate.GetNameOrDefault()); ok {
+			newInfo := borrowedNewInfo.UnsafeBorrow()
 			if newInfo.GetPublic() != candidate.GetPublic() || newInfo.GetInternal() != candidate.GetInternal() {
 				needSync = true
 				break

--- a/oxiad/coordinator/runtime/controller/shard_controller_election.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller_election.go
@@ -78,8 +78,8 @@ type ShardElection struct {
 func (e *ShardElection) refreshedEnsemble(ensemble []*proto.DataServerIdentity) []*proto.DataServerIdentity {
 	refreshedEnsembleDataServerAddress := make([]*proto.DataServerIdentity, len(ensemble))
 	for idx, candidate := range ensemble {
-		if refreshedAddress, exist := e.metadataStore.GetDataServerIdentity(candidate.GetNameOrDefault()); exist {
-			refreshedEnsembleDataServerAddress[idx] = refreshedAddress
+		if borrowedAddress, exist := e.metadataStore.GetDataServerIdentity(candidate.GetNameOrDefault()); exist {
+			refreshedEnsembleDataServerAddress[idx] = borrowedAddress.UnsafeBorrow()
 			continue
 		}
 		refreshedEnsembleDataServerAddress[idx] = candidate
@@ -225,7 +225,7 @@ func (e *ShardElection) selectNewLeader(candidatesStatus map[*proto.DataServerId
 	candidates := chooseCandidates(candidatesStatus)
 	server, err := e.leaderSelector.Select(&leaderselector.Context{
 		Candidates: candidates,
-		Status:     e.metadataStore.GetStatus(),
+		Status:     e.metadataStore.GetStatus().UnsafeBorrow(),
 	})
 	if err != nil {
 		return nil, nil, err

--- a/oxiad/coordinator/runtime/controller/split_controller.go
+++ b/oxiad/coordinator/runtime/controller/split_controller.go
@@ -111,7 +111,7 @@ func NewSplitController(cfg SplitControllerConfig) *SplitController {
 	sc.ctx, sc.ctxCancel = context.WithTimeout(context.Background(), splitTimeout)
 
 	// Load the current split metadata from cluster status
-	status := sc.metadata.GetStatus()
+	status := sc.metadata.GetStatus().UnsafeBorrow()
 	ns, exists := status.Namespaces[sc.namespace]
 	if !exists {
 		sc.logger.Error("Namespace not found in cluster status")
@@ -202,7 +202,7 @@ func (sc *SplitController) driveStateMachine() error {
 }
 
 func (sc *SplitController) currentPhase() string {
-	status := sc.metadata.GetStatus()
+	status := sc.metadata.GetStatus().UnsafeBorrow()
 	ns, exists := status.Namespaces[sc.namespace]
 	if !exists {
 		return ""
@@ -216,7 +216,7 @@ func (sc *SplitController) currentPhase() string {
 
 // updatePhase atomically updates the split phase on both parent and children.
 func (sc *SplitController) updatePhase(newPhase string) {
-	status := sc.metadata.GetStatus()
+	status := sc.metadata.GetStatus().UnsafeBorrow()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus) //nolint:revive
 
 	ns := cloned.Namespaces[sc.namespace]
@@ -669,7 +669,7 @@ func (sc *SplitController) loadParentMeta() *proto.ShardMetadata {
 }
 
 func (sc *SplitController) loadShardMeta(shardId int64) *proto.ShardMetadata {
-	status := sc.metadata.GetStatus()
+	status := sc.metadata.GetStatus().UnsafeBorrow()
 	ns, exists := status.Namespaces[sc.namespace]
 	if !exists {
 		return nil
@@ -690,7 +690,7 @@ func (sc *SplitController) updateChildMeta(childId int64, fn func(meta *proto.Sh
 }
 
 func (sc *SplitController) updateShardMeta(shardId int64, fn func(meta *proto.ShardMetadata)) {
-	status := sc.metadata.GetStatus()
+	status := sc.metadata.GetStatus().UnsafeBorrow()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus) //nolint:revive
 	ns := cloned.Namespaces[sc.namespace]
 	if meta, exists := ns.Shards[shardId]; exists {

--- a/oxiad/coordinator/runtime/controller/split_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/split_controller_test.go
@@ -239,7 +239,7 @@ func TestSplitController_FullLifecycle(t *testing.T) {
 	}
 
 	// Verify final state: parent is Deleting, children have no split metadata
-	status := statusRes.GetStatus()
+	status := statusRes.GetStatus().UnsafeBorrow()
 	ns := status.Namespaces[constant.DefaultNamespace]
 
 	parentMeta, parentExists := ns.Shards[0]
@@ -287,7 +287,7 @@ func TestSplitController_ResumeFromCatchUp(t *testing.T) {
 
 	// For CatchUp, we need child leaders to already be set (they were set during bootstrap)
 	// Update child metadata to have leaders
-	status := statusRes.GetStatus()
+	status := statusRes.GetStatus().UnsafeBorrow()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 	leftMeta := ns.Shards[1]
@@ -340,7 +340,7 @@ func TestSplitController_PhaseTransitions(t *testing.T) {
 	select {
 	case <-listener.completions:
 		// Verify final state: parent marked Deleting, children elected
-		status := statusRes.GetStatus()
+		status := statusRes.GetStatus().UnsafeBorrow()
 		ns := status.Namespaces[constant.DefaultNamespace]
 
 		parentMeta := ns.Shards[0]
@@ -385,7 +385,7 @@ func TestSplitController_TimeoutDuringBootstrap(t *testing.T) {
 	}
 
 	// Verify: parent.Split cleared, children deleted
-	status := statusRes.GetStatus()
+	status := statusRes.GetStatus().UnsafeBorrow()
 	ns := status.Namespaces[constant.DefaultNamespace]
 
 	parentMeta, parentExists := ns.Shards[0]
@@ -403,7 +403,7 @@ func TestSplitController_TimeoutDuringCatchUp(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders (as if Bootstrap completed) and ParentTermAtBootstrap
-	status := statusRes.GetStatus()
+	status := statusRes.GetStatus().UnsafeBorrow()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -448,7 +448,7 @@ func TestSplitController_TimeoutDuringCatchUp(t *testing.T) {
 	}
 
 	// Verify: parent restored, children deleted
-	finalStatus := statusRes.GetStatus()
+	finalStatus := statusRes.GetStatus().UnsafeBorrow()
 	finalNs := finalStatus.Namespaces[constant.DefaultNamespace]
 
 	pm, exists := finalNs.Shards[0]
@@ -465,7 +465,7 @@ func TestSplitController_ParentTermChangeDuringCatchUp(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders and ParentTermAtBootstrap = 5
-	status := statusRes.GetStatus()
+	status := statusRes.GetStatus().UnsafeBorrow()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -673,7 +673,7 @@ func TestSplitController_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders (as if Bootstrap completed) and ParentTermAtBootstrap
-	status := statusRes.GetStatus()
+	status := statusRes.GetStatus().UnsafeBorrow()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -722,7 +722,7 @@ func TestSplitController_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
 	}
 
 	// Verify: parent restored, children deleted
-	finalStatus := statusRes.GetStatus()
+	finalStatus := statusRes.GetStatus().UnsafeBorrow()
 	finalNs := finalStatus.Namespaces[constant.DefaultNamespace]
 
 	pm, exists := finalNs.Shards[0]
@@ -739,7 +739,7 @@ func TestSplitController_ChildFollowersDeadCommitStalls(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders (as if Bootstrap completed) and ParentTermAtBootstrap
-	status := statusRes.GetStatus()
+	status := statusRes.GetStatus().UnsafeBorrow()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -794,7 +794,7 @@ func TestSplitController_ChildFollowersDeadCommitStalls(t *testing.T) {
 	}
 
 	// Verify: parent restored, children deleted
-	finalStatus := statusRes.GetStatus()
+	finalStatus := statusRes.GetStatus().UnsafeBorrow()
 	finalNs := finalStatus.Namespaces[constant.DefaultNamespace]
 
 	pm, exists := finalNs.Shards[0]
@@ -812,7 +812,7 @@ func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 
 	// Set child leaders and ParentTermAtBootstrap as if Bootstrap completed.
 	// Also set ChildLeadersAtBootstrap with the ORIGINAL leaders.
-	status := statusRes.GetStatus()
+	status := statusRes.GetStatus().UnsafeBorrow()
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -889,7 +889,7 @@ func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 	}
 
 	// Verify parent is Deleting and children are healthy
-	finalStatus := statusRes.GetStatus()
+	finalStatus := statusRes.GetStatus().UnsafeBorrow()
 	finalNs := finalStatus.Namespaces[constant.DefaultNamespace]
 
 	pm := finalNs.Shards[0]

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/multierr"
 	pb "google.golang.org/protobuf/proto"
 
+	commonobject "github.com/oxia-db/oxia/common/object"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 
 	"github.com/oxia-db/oxia/oxiad/common/sharding"
@@ -150,7 +151,7 @@ func (c *runtime) SyncShardControllerServerAddresses() {
 
 func (c *runtime) CreateNamespace(name string, namespaceConfig *proto.Namespace) bool {
 	baseShardID := c.metadata.ReserveShardIDs(namespaceConfig.GetInitialShardCount())
-	currentStatus := c.metadata.GetStatus()
+	currentStatus := c.metadata.GetStatus().UnsafeBorrow()
 	namespaceStatus := &proto.NamespaceStatus{
 		Shards:            map[int64]*proto.ShardMetadata{},
 		ReplicationFactor: namespaceConfig.GetReplicationFactor(),
@@ -202,7 +203,7 @@ func (c *runtime) CreateNamespace(name string, namespaceConfig *proto.Namespace)
 }
 
 func (c *runtime) DeleteNamespace(namespace string) {
-	namespaceStatus := c.metadata.DeleteNamespaceStatus(namespace)
+	namespaceStatus := c.metadata.DeleteNamespaceStatus(namespace).UnsafeBorrow()
 	if namespaceStatus == nil {
 		return
 	}
@@ -243,10 +244,11 @@ func (c *runtime) findDataServerFeatures(dataServers []*proto.DataServerIdentity
 // selectNewEnsemble select a new server ensemble based on namespace policy and current cluster status.
 // It uses the ensemble selector to choose appropriate servers and returns the selected server metadata or an error.
 func (c *runtime) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
-	nodes, nodesMetadata := c.metadata.ListDataServersWithMetadata()
+	nodesBorrowed, nodesMetadataBorrowed := c.metadata.ListDataServersWithMetadata()
+	nodes := nodesBorrowed.UnsafeBorrow()
 	ensembleContext := &ensemble.Context{
 		Candidates:         nodes,
-		CandidatesMetadata: nodesMetadata,
+		CandidatesMetadata: nodesMetadataBorrowed.UnsafeBorrow(),
 		HierarchyPolicies:  ns.GetPolicy(),
 		Status:             editingStatus,
 		Replicas:           int(ns.GetReplicationFactor()),
@@ -262,12 +264,12 @@ func (c *runtime) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.Cl
 	}
 	esm := make([]*proto.DataServerIdentity, 0)
 	for _, id := range ensembles {
-		var node *proto.DataServerIdentity
 		var exist bool
-		if node, exist = c.metadata.GetDataServerIdentity(id); !exist {
+		var borrowed commonobject.Borrowed[*proto.DataServerIdentity]
+		if borrowed, exist = c.metadata.GetDataServerIdentity(id); !exist {
 			return nil, fmt.Errorf("failed to find node %s", id)
 		}
-		esm = append(esm, node)
+		esm = append(esm, borrowed.UnsafeBorrow())
 	}
 	return esm, nil
 }
@@ -400,8 +402,8 @@ func (c *runtime) handleActionChangeEnsemble(ac action.Action) {
 
 // This is called while already holding the lock on the coordinator.
 func (c *runtime) computeNewAssignments() {
-	config := c.metadata.GetConfig()
-	status := c.metadata.GetStatus()
+	config := c.metadata.GetConfig().UnsafeBorrow()
+	status := c.metadata.GetStatus().UnsafeBorrow()
 	assignments := &proto.ShardAssignments{
 		Namespaces:         map[string]*proto.NamespaceShardsAssignment{},
 		AllowedAuthorities: mergedAuthorities(status, config.GetServers(), config.GetAllowExtraAuthorities()),
@@ -509,7 +511,7 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 	c.Lock()
 	defer c.Unlock()
 
-	status := c.metadata.GetStatus()
+	status := c.metadata.GetStatus().UnsafeBorrow()
 
 	// Validate namespace
 	ns, exists := status.Namespaces[namespace]
@@ -647,7 +649,7 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 		RpcProvider:   c.rpc,
 		EventListener: c,
 		EnsembleSelector: func(ns string) ([]*proto.DataServerIdentity, error) {
-			return c.selectNewEnsemble(c.namespaceConfigForSplit(ns), c.metadata.GetStatus())
+			return c.selectNewEnsemble(c.namespaceConfigForSplit(ns), c.metadata.GetStatus().UnsafeBorrow())
 		},
 	})
 	c.splitControllers[parentShardId] = sc
@@ -688,7 +690,7 @@ func (c *runtime) SplitComplete(parentShard int64, leftChild int64, rightChild i
 	// during Cutover.
 	if sc, exists := c.shardControllers[parentShard]; exists {
 		// Sync shard controller metadata from the status resource.
-		status := c.metadata.GetStatus()
+		status := c.metadata.GetStatus().UnsafeBorrow()
 		for _, ns := range status.Namespaces {
 			if parentMeta, ok := ns.Shards[parentShard]; ok {
 				sc.Metadata().Store(parentMeta)
@@ -730,11 +732,11 @@ func (c *runtime) SplitAborted(parentShard int64, leftChild int64, rightChild in
 }
 
 func (c *runtime) namespaceConfigForSplit(namespace string) *proto.Namespace {
-	nsConfig, exist := c.metadata.GetNamespace(namespace)
+	borrowedNsConfig, exist := c.metadata.GetNamespace(namespace)
 	if !exist {
-		nsConfig = &proto.Namespace{}
+		return &proto.Namespace{}
 	}
-	return nsConfig
+	return borrowedNsConfig.UnsafeBorrow()
 }
 
 // restartInProgressSplits checks the cluster status for any shards that have
@@ -763,7 +765,7 @@ func (c *runtime) restartInProgressSplits(clusterStatus *proto.ClusterStatus) {
 				RpcProvider:   c.rpc,
 				EventListener: c,
 				EnsembleSelector: func(namespace string) ([]*proto.DataServerIdentity, error) {
-					return c.selectNewEnsemble(c.namespaceConfigForSplit(namespace), c.metadata.GetStatus())
+					return c.selectNewEnsemble(c.namespaceConfigForSplit(namespace), c.metadata.GetStatus().UnsafeBorrow())
 				},
 			})
 			c.splitControllers[shardId] = sc
@@ -801,7 +803,7 @@ func New(
 		},
 	})
 
-	clusterStatus := c.metadata.GetStatus()
+	clusterStatus := c.metadata.GetStatus().UnsafeBorrow()
 	c.insID = clusterStatus.InstanceId
 
 	c.rpc = rpcProvider(c.insID)
@@ -824,8 +826,11 @@ func New(
 			shardMetadata := shards.Shards[shard]
 			var nsConfig *proto.Namespace
 			var exist bool
-			if nsConfig, exist = c.metadata.GetNamespace(ns); !exist {
+			var borrowedNsConfig commonobject.Borrowed[*proto.Namespace]
+			if borrowedNsConfig, exist = c.metadata.GetNamespace(ns); !exist {
 				nsConfig = &proto.Namespace{}
+			} else {
+				nsConfig = borrowedNsConfig.UnsafeBorrow()
 			}
 			c.shardControllers[shard] = controller.NewShardController(ns, shard, nsConfig,
 				shardMetadata, c.metadata, c.findDataServerFeatures,

--- a/tests/assignments/leader_hint_test.go
+++ b/tests/assignments/leader_hint_test.go
@@ -54,12 +54,12 @@ func TestLeaderHintWithoutClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().GetStatus().Namespaces["default"].Shards[0]
+		shard := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow().Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 20*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().GetStatus()
+	status := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -112,12 +112,12 @@ func TestLeaderHintListWithoutClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().GetStatus().Namespaces["default"].Shards[0]
+		shard := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow().Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().GetStatus()
+	status := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -170,12 +170,12 @@ func TestLeaderHintListWithClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().GetStatus().Namespaces["default"].Shards[0]
+		shard := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow().Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().GetStatus()
+	status := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -219,12 +219,12 @@ func TestLeaderHintRangeScanWithoutClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().GetStatus().Namespaces["default"].Shards[0]
+		shard := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow().Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().GetStatus()
+	status := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -277,12 +277,12 @@ func TestLeaderHintRangeScanWithClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().GetStatus().Namespaces["default"].Shards[0]
+		shard := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow().Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().GetStatus()
+	status := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -330,12 +330,12 @@ func TestLeaderHintWithClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().GetStatus().Namespaces["default"].Shards[0]
+		shard := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow().Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 20*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().GetStatus()
+	status := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public

--- a/tests/balancer/shard_balancer_test.go
+++ b/tests/balancer/shard_balancer_test.go
@@ -80,7 +80,7 @@ func TestNormalShardBalancer(t *testing.T) {
 	metadata := coordinator.Metadata()
 
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -192,7 +192,7 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 	metadata := coordinator.Metadata()
 
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -228,7 +228,7 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 	}, 30*time.Second, 50*time.Millisecond)
 
 	// check if follow the policy
-	for name, ns := range metadata.GetStatus().Namespaces {
+	for name, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
 		for _, shard := range ns.Shards {
 			nodeIDs := linkedhashset.New[string]()
 			nodeZones := linkedhashset.New[string]()
@@ -290,8 +290,8 @@ func TestBalanceWithoutDeadlock(t *testing.T) {
 
 	metadata := coordinator.Metadata()
 	assert.Eventually(t, func() bool {
-		config := metadata.GetConfig()
-		status := metadata.GetStatus()
+		config := metadata.GetConfig().UnsafeBorrow()
+		status := metadata.GetStatus().UnsafeBorrow()
 		for _, namespace := range config.Namespaces {
 			namespaceStatus, ok := status.Namespaces[namespace.Name]
 			if !ok {

--- a/tests/control/control_request_test.go
+++ b/tests/control/control_request_test.go
@@ -64,7 +64,7 @@ func TestControlRequestFeatureEnabled(t *testing.T) {
 	assert.NoError(t, err)
 	defer client.Close()
 
-	resource := coordinatorInstance.Metadata().GetStatus()
+	resource := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
 	shardMetadata := resource.Namespaces["default"].Shards[0]
 	leader := shardMetadata.Leader
 

--- a/tests/control/record_checksum_test.go
+++ b/tests/control/record_checksum_test.go
@@ -90,7 +90,7 @@ func TestControlRequestRecordChecksum(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Wait for the checksum feature to be enabled on all replicas
-	resource := coordinatorInstance.Metadata().GetStatus()
+	resource := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
 	shardMetadata := resource.Namespaces["default"].Shards[0]
 	leader := shardMetadata.Leader
 	for _, dataServer := range shardMetadata.Ensemble {

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -82,7 +82,7 @@ func TestCoordinatorE2E(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.GetStatus()
+	status := metadata.GetStatus().UnsafeBorrow()
 
 	assert.EqualValues(t, 1, len(status.Namespaces))
 	nsStatus := status.Namespaces[constant.DefaultNamespace]
@@ -90,7 +90,7 @@ func TestCoordinatorE2E(t *testing.T) {
 	assert.EqualValues(t, 3, nsStatus.ReplicationFactor)
 
 	assert.Eventually(t, func() bool {
-		shard := metadata.GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 10*time.Second, 10*time.Millisecond)
 
@@ -119,7 +119,7 @@ func TestCoordinatorE2E_ShardsRanges(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.GetStatus()
+	status := metadata.GetStatus().UnsafeBorrow()
 	nsStatus := status.Namespaces[constant.DefaultNamespace]
 	assert.EqualValues(t, 4, len(nsStatus.Shards))
 	assert.EqualValues(t, 3, nsStatus.ReplicationFactor)
@@ -170,18 +170,18 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.GetStatus()
+	status := metadata.GetStatus().UnsafeBorrow()
 
 	nsStatus := status.Namespaces[constant.DefaultNamespace]
 	assert.EqualValues(t, 1, len(nsStatus.Shards))
 	assert.EqualValues(t, 3, nsStatus.ReplicationFactor)
 
 	assert.Eventually(t, func() bool {
-		shard := metadata.GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 10*time.Second, 10*time.Millisecond)
 
-	nsStatus = metadata.GetStatus().Namespaces[constant.DefaultNamespace]
+	nsStatus = metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace]
 
 	leader := nsStatus.Shards[0].Leader
 	var follower *proto.DataServerIdentity
@@ -218,7 +218,7 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 	delete(servers, leader.GetNameOrDefault())
 
 	assert.Eventually(t, func() bool {
-		shard := metadata.GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 10*time.Second, 10*time.Millisecond)
 
@@ -273,7 +273,7 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.GetStatus()
+	status := metadata.GetStatus().UnsafeBorrow()
 	nsDefaultStatus := status.Namespaces[constant.DefaultNamespace]
 	assert.EqualValues(t, 1, len(nsDefaultStatus.Shards))
 	assert.EqualValues(t, 3, nsDefaultStatus.ReplicationFactor)
@@ -288,7 +288,7 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -363,14 +363,14 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.GetStatus()
+	status := metadata.GetStatus().UnsafeBorrow()
 	ns1Status := status.Namespaces["my-ns-1"]
 	assert.EqualValues(t, 2, len(ns1Status.Shards))
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -381,12 +381,12 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	}, 10*time.Second, 10*time.Millisecond)
 
 	// Trigger new leader election in order to have a new term
-	ns1Status = metadata.GetStatus().Namespaces["my-ns-1"]
+	ns1Status = metadata.GetStatus().UnsafeBorrow().Namespaces["my-ns-1"]
 	coordinatorInstance.BecameUnavailable(ns1Status.Shards[0].Leader)
 
 	// Wait (again) for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -413,7 +413,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	metadata = coordinatorInstance.Metadata()
 	// Wait for all shards to be deleted
 	assert.Eventually(t, func() bool {
-		load := metadata.GetStatus()
+		load := metadata.GetStatus().UnsafeBorrow()
 		slog.Info("load", slog.Any("load", load))
 		return len(load.Namespaces) == 0
 	}, 10*time.Second, 10*time.Millisecond)
@@ -448,14 +448,14 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.GetStatus()
+	status := metadata.GetStatus().UnsafeBorrow()
 	ns1Status := status.Namespaces["my-ns-1"]
 	assert.EqualValues(t, 2, len(ns1Status.Shards))
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -480,7 +480,7 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
 		foundNS2 := false
-		for name, ns := range metadata.GetStatus().Namespaces {
+		for name, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
 			if name == "my-ns-2" {
 				foundNS2 = true
 			}
@@ -493,11 +493,11 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 		return foundNS2
 	}, 10*time.Second, 10*time.Millisecond)
 
-	ns1Status = metadata.GetStatus().Namespaces["my-ns-1"]
+	ns1Status = metadata.GetStatus().UnsafeBorrow().Namespaces["my-ns-1"]
 	assert.EqualValues(t, 2, len(ns1Status.Shards))
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
-	ns2Status := metadata.GetStatus().Namespaces["my-ns-2"]
+	ns2Status := metadata.GetStatus().UnsafeBorrow().Namespaces["my-ns-2"]
 	assert.EqualValues(t, 2, len(ns2Status.Shards))
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
@@ -598,7 +598,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -611,7 +611,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	assert.Equal(t, 4, len(c.NodeControllers()))
 
 	// Remove leader dataserver
-	leaderID := metadata.GetStatus().Namespaces["my-ns-1"].Shards[0].Leader.GetNameOrDefault()
+	leaderID := metadata.GetStatus().UnsafeBorrow().Namespaces["my-ns-1"].Shards[0].Leader.GetNameOrDefault()
 	d := make([]*proto.DataServerIdentity, 0)
 	for _, sv := range clusterConfig.Servers {
 		if sv.GetNameOrDefault() != leaderID {
@@ -630,7 +630,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
 			for _, shard := range ns.Shards {
 				return shard.Term > 0 && shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 			}
@@ -671,7 +671,7 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	metadata := c.Metadata()
 	// wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -698,7 +698,7 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().Namespaces {
+		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false

--- a/tests/coordinator/coordinator_test.go
+++ b/tests/coordinator/coordinator_test.go
@@ -60,6 +60,6 @@ func TestCoordinatorInitiateLeaderElection(t *testing.T) {
 	metadataView := coordinatorInstance.Metadata()
 	metadataView.UpdateShardStatus("default", 1, shardMetadata)
 
-	status := metadataView.GetStatus()
+	status := metadataView.GetStatus().UnsafeBorrow()
 	assert.True(t, gproto.Equal(status.Namespaces["default"].Shards[1], shardMetadata))
 }

--- a/tests/coordinator/split_e2e_test.go
+++ b/tests/coordinator/split_e2e_test.go
@@ -72,7 +72,7 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 
 	// Wait for initial shard to be in steady state
 	require.Eventually(t, func() bool {
-		shard := metadata.GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 30*time.Second, 100*time.Millisecond)
 
@@ -109,7 +109,7 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 	// Wait for split to complete: parent shard (0) should be removed,
 	// and both children should be in steady state with leaders.
 	require.Eventually(t, func() bool {
-		status := metadata.GetStatus()
+		status := metadata.GetStatus().UnsafeBorrow()
 		ns, ok := status.Namespaces[constant.DefaultNamespace]
 		if !ok {
 			t.Log("Namespace not found in status")
@@ -168,7 +168,7 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 	slog.Info("Split complete")
 
 	// Verify hash ranges: children should cover the entire original range
-	status := metadata.GetStatus()
+	status := metadata.GetStatus().UnsafeBorrow()
 	ns := status.Namespaces[constant.DefaultNamespace]
 	leftMeta := ns.Shards[leftChild]
 	rightMeta := ns.Shards[rightChild]
@@ -336,7 +336,7 @@ func setupSplitCluster(t *testing.T) *splitTestCluster {
 
 	metadata := coordinatorInstance.Metadata()
 	require.Eventually(t, func() bool {
-		shard := metadata.GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 30*time.Second, 100*time.Millisecond)
 	slog.Info("Initial cluster is ready")
@@ -364,7 +364,7 @@ func (c *splitTestCluster) splitAndWait(t *testing.T) {
 	)
 
 	require.Eventually(t, func() bool {
-		status := c.metadata.GetStatus()
+		status := c.metadata.GetStatus().UnsafeBorrow()
 		ns := status.Namespaces[constant.DefaultNamespace]
 		if _, parentExists := ns.Shards[0]; parentExists {
 			return false
@@ -378,7 +378,7 @@ func (c *splitTestCluster) splitAndWait(t *testing.T) {
 		return true
 	}, 60*time.Second, 500*time.Millisecond)
 
-	status := c.metadata.GetStatus()
+	status := c.metadata.GetStatus().UnsafeBorrow()
 	ns := status.Namespaces[constant.DefaultNamespace]
 	c.leftMeta = ns.Shards[c.leftChild]
 	c.rightMeta = ns.Shards[c.rightChild]
@@ -883,7 +883,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 			coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 			metadata := coordinatorInstance.Metadata()
-			status := metadata.GetStatus()
+			status := metadata.GetStatus().UnsafeBorrow()
 
 			assert.EqualValues(t, 1, len(status.Namespaces))
 			nsStatus := status.Namespaces[constant.DefaultNamespace]
@@ -891,7 +891,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 			assert.EqualValues(t, 1, nsStatus.ReplicationFactor)
 
 			assert.Eventually(t, func() bool {
-				shard := metadata.GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+				shard := metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
 				return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 			}, 10*time.Second, 10*time.Millisecond)
 
@@ -926,7 +926,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 func waitForSplitPhase(t *testing.T, metadata coordmetadata.Metadata, parentShardId int64, phase string, timeout time.Duration) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		status := metadata.GetStatus()
+		status := metadata.GetStatus().UnsafeBorrow()
 		ns := status.Namespaces[constant.DefaultNamespace]
 		parentMeta, exists := ns.Shards[parentShardId]
 		if !exists || parentMeta.Split == nil {
@@ -954,7 +954,7 @@ func TestCoordinator_ShardSplit_ParentLeaderKillDuringSplit(t *testing.T) {
 	assert.NoError(t, client.Close())
 
 	// Find the parent leader before initiating the split
-	status := cluster.metadata.GetStatus()
+	status := cluster.metadata.GetStatus().UnsafeBorrow()
 	parentLeader := status.Namespaces[constant.DefaultNamespace].Shards[0].Leader
 	slog.Info("Parent leader identified", slog.Any("leader", parentLeader))
 
@@ -979,7 +979,7 @@ func TestCoordinator_ShardSplit_ParentLeaderKillDuringSplit(t *testing.T) {
 	slog.Info("Waiting for split to complete after parent leader kill")
 
 	require.Eventually(t, func() bool {
-		st := cluster.metadata.GetStatus()
+		st := cluster.metadata.GetStatus().UnsafeBorrow()
 		ns := st.Namespaces[constant.DefaultNamespace]
 		if _, parentExists := ns.Shards[0]; parentExists {
 			return false
@@ -1036,7 +1036,7 @@ func TestCoordinator_ShardSplit_FollowerKillDuringSplit(t *testing.T) {
 	assert.NoError(t, client.Close())
 
 	// Find a follower (non-leader) server
-	status := cluster.metadata.GetStatus()
+	status := cluster.metadata.GetStatus().UnsafeBorrow()
 	parentMeta := status.Namespaces[constant.DefaultNamespace].Shards[0]
 	parentLeader := parentMeta.Leader
 	follower := cluster.liveAddressExcluding(parentLeader.GetNameOrDefault())
@@ -1056,7 +1056,7 @@ func TestCoordinator_ShardSplit_FollowerKillDuringSplit(t *testing.T) {
 	// indefinitely (can't reach the dead node). So we accept the parent
 	// being either fully deleted OR marked Deleting with split metadata cleared.
 	require.Eventually(t, func() bool {
-		st := cluster.metadata.GetStatus()
+		st := cluster.metadata.GetStatus().UnsafeBorrow()
 		ns := st.Namespaces[constant.DefaultNamespace]
 		if parentMeta, parentExists := ns.Shards[0]; parentExists {
 			if parentMeta.GetStatusOrDefault() != proto.ShardStatusDeleting {
@@ -1118,7 +1118,7 @@ func TestCoordinator_ShardSplit_ConcurrentSplitRejected(t *testing.T) {
 
 	// First split should still complete
 	require.Eventually(t, func() bool {
-		st := cluster.metadata.GetStatus()
+		st := cluster.metadata.GetStatus().UnsafeBorrow()
 		ns := st.Namespaces[constant.DefaultNamespace]
 		if _, parentExists := ns.Shards[0]; parentExists {
 			return false

--- a/tests/resolver/target_ip_flip_test.go
+++ b/tests/resolver/target_ip_flip_test.go
@@ -81,7 +81,7 @@ func newCoordinatorCluster(t *testing.T, prefix string, serverCount int) *testCl
 	cluster.coordinator = newCoordinatorInstance(t, metadataProvider, configProvider, coordinatorrpc.NewRpcProviderFactory(nil))
 
 	require.Eventually(t, func() bool {
-		shard := cluster.coordinator.Metadata().GetStatus().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := cluster.coordinator.Metadata().GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 20*time.Second, 100*time.Millisecond)
 
@@ -107,7 +107,7 @@ func (c *testCluster) stopAllServers(t *testing.T) {
 }
 
 func (c *testCluster) leader() *proto.DataServerIdentity {
-	return c.coordinator.Metadata().GetStatus().Namespaces[constant.DefaultNamespace].Shards[0].Leader
+	return c.coordinator.Metadata().GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0].Leader
 }
 
 func (c *testCluster) bootstrapTargetExcluding(excluded *proto.DataServerIdentity) *proto.DataServerIdentity {


### PR DESCRIPTION
## Motivation

This change introduces a shared `Borrowed[T]` wrapper for metadata-owned read results so callers can make ownership boundaries explicit without cloning everything on each read. It keeps the current runtime and controller flows intact while making metadata access patterns more intentional.

## Modifications

- add `common/object.Borrowed[T]` with `UnsafeBorrow()` and documentation for metadata-owned values
- update coordinator metadata read APIs to return borrowed wrappers for status, config, namespace, and data server reads
- adjust runtime, reconciler, management server, and tests to unwrap borrowed values explicitly at call sites
- keep write APIs unchanged and preserve existing behavior in metadata-backed flows
