### PR TITLE
refactor: align dataserver coordinator APIs

### DIFF
--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -46,7 +46,7 @@ type Metadata interface {
 	ReserveShardIDs(count uint32) int64
 
 	CreateNamespaceStatus(name string, status *commonproto.NamespaceStatus) bool
-	ListNamespaceStatus() commonobject.Borrowed[map[string]*commonproto.NamespaceStatus]
+	ListNamespaceStatus() map[string]commonobject.Borrowed[*commonproto.NamespaceStatus]
 	GetNamespaceStatus(namespace string) (commonobject.Borrowed[*commonproto.NamespaceStatus], bool)
 	DeleteNamespaceStatus(name string) commonobject.Borrowed[*commonproto.NamespaceStatus]
 	GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool)
@@ -58,7 +58,7 @@ type Metadata interface {
 	ConfigWatch() *commonwatch.Watch[*commonproto.ClusterConfiguration]
 	GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer]
 
-	ListDataServer() commonobject.Borrowed[map[string]*commonproto.DataServer]
+	ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer]
 	GetDataServer(name string) (commonobject.Borrowed[*commonproto.DataServer], bool)
 }
 
@@ -234,15 +234,15 @@ func (m *coordinatorMetadata) CreateNamespaceStatus(name string, status *commonp
 	return true
 }
 
-func (m *coordinatorMetadata) ListNamespaceStatus() commonobject.Borrowed[map[string]*commonproto.NamespaceStatus] {
+func (m *coordinatorMetadata) ListNamespaceStatus() map[string]commonobject.Borrowed[*commonproto.NamespaceStatus] {
 	m.statusLock.RLock()
 	defer m.statusLock.RUnlock()
 
-	namespaces := make(map[string]*commonproto.NamespaceStatus, len(m.currentStatus.Namespaces))
+	namespaces := make(map[string]commonobject.Borrowed[*commonproto.NamespaceStatus], len(m.currentStatus.Namespaces))
 	for name, status := range m.currentStatus.Namespaces {
-		namespaces[name] = status
+		namespaces[name] = commonobject.Borrow(status)
 	}
-	return commonobject.Borrow(namespaces)
+	return namespaces
 }
 
 func (m *coordinatorMetadata) GetNamespaceStatus(namespace string) (commonobject.Borrowed[*commonproto.NamespaceStatus], bool) {
@@ -434,7 +434,7 @@ func (m *coordinatorMetadata) GetLoadBalancer() commonobject.Borrowed[*commonpro
 	return commonobject.Borrow(m.GetConfig().UnsafeBorrow().GetLoadBalancerWithDefaults())
 }
 
-func (m *coordinatorMetadata) ListDataServer() commonobject.Borrowed[map[string]*commonproto.DataServer] {
+func (m *coordinatorMetadata) ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer] {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -443,7 +443,7 @@ func (m *coordinatorMetadata) ListDataServer() commonobject.Borrowed[map[string]
 		m.clusterConfigLock.RLock()
 	}
 
-	dataServers := make(map[string]*commonproto.DataServer, len(m.currentClusterConfig.GetServers()))
+	dataServers := make(map[string]commonobject.Borrowed[*commonproto.DataServer], len(m.currentClusterConfig.GetServers()))
 	for _, server := range m.currentClusterConfig.GetServers() {
 		name := server.GetNameOrDefault()
 		identity := server
@@ -461,9 +461,9 @@ func (m *coordinatorMetadata) ListDataServer() commonobject.Borrowed[map[string]
 		if value, found := m.currentClusterConfig.GetServerMetadata()[name]; found {
 			dataServer.Metadata = value
 		}
-		dataServers[name] = dataServer
+		dataServers[name] = commonobject.Borrow(dataServer)
 	}
-	return commonobject.Borrow(dataServers)
+	return dataServers
 }
 
 func (m *coordinatorMetadata) GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool) {

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -26,7 +26,6 @@ import (
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 	"github.com/emirpasic/gods/v2/trees/redblacktree"
 	"github.com/google/uuid"
 	gproto "google.golang.org/protobuf/proto"
@@ -50,6 +49,7 @@ type Metadata interface {
 	ListNamespaceStatus() commonobject.Borrowed[map[string]*commonproto.NamespaceStatus]
 	GetNamespaceStatus(namespace string) (commonobject.Borrowed[*commonproto.NamespaceStatus], bool)
 	DeleteNamespaceStatus(name string) commonobject.Borrowed[*commonproto.NamespaceStatus]
+	GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool)
 
 	UpdateShardStatus(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata)
 	DeleteShardStatus(namespace string, shard int64)
@@ -58,14 +58,8 @@ type Metadata interface {
 	ConfigWatch() *commonwatch.Watch[*commonproto.ClusterConfiguration]
 	GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer]
 
-	ListDataServers() commonobject.Borrowed[*linkedhashset.Set[string]]
-	ListDataServersWithMetadata() (
-		commonobject.Borrowed[*linkedhashset.Set[string]],
-		commonobject.Borrowed[map[string]*commonproto.DataServerMetadata],
-	)
-	GetDataServerIdentity(id string) (commonobject.Borrowed[*commonproto.DataServerIdentity], bool)
+	ListDataServer() commonobject.Borrowed[map[string]*commonproto.DataServer]
 	GetDataServer(name string) (commonobject.Borrowed[*commonproto.DataServer], bool)
-	GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool)
 }
 
 type EnsembleSupplier func(
@@ -90,7 +84,6 @@ type coordinatorMetadata struct {
 	clusterConfigLock     sync.RWMutex
 	currentClusterConfig  *commonproto.ClusterConfiguration
 	clusterConfigWatch    *commonwatch.Watch[*commonproto.ClusterConfiguration]
-	nodesIndex            *redblacktree.Tree[string, *commonproto.DataServerIdentity]
 	namespaceConfigsIndex *redblacktree.Tree[string, *commonproto.Namespace]
 }
 
@@ -380,12 +373,6 @@ func validateClusterConfig(config *commonproto.ClusterConfiguration) error {
 }
 
 func (m *coordinatorMetadata) rebuildConfigIndexesLocked() {
-	nodes := redblacktree.New[string, *commonproto.DataServerIdentity]()
-	for _, server := range m.currentClusterConfig.GetServers() {
-		nodes.Put(server.GetNameOrDefault(), server)
-	}
-	m.nodesIndex = nodes
-
 	namespaceConfigs := redblacktree.New[string, *commonproto.Namespace]()
 	for _, ns := range m.currentClusterConfig.GetNamespaces() {
 		namespaceConfigs.Put(ns.GetName(), ns)
@@ -447,7 +434,7 @@ func (m *coordinatorMetadata) GetLoadBalancer() commonobject.Borrowed[*commonpro
 	return commonobject.Borrow(m.GetConfig().UnsafeBorrow().GetLoadBalancerWithDefaults())
 }
 
-func (m *coordinatorMetadata) ListDataServers() commonobject.Borrowed[*linkedhashset.Set[string]] {
+func (m *coordinatorMetadata) ListDataServer() commonobject.Borrowed[map[string]*commonproto.DataServer] {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -456,35 +443,27 @@ func (m *coordinatorMetadata) ListDataServers() commonobject.Borrowed[*linkedhas
 		m.clusterConfigLock.RLock()
 	}
 
-	nodes := linkedhashset.New[string]()
+	dataServers := make(map[string]*commonproto.DataServer, len(m.currentClusterConfig.GetServers()))
 	for _, server := range m.currentClusterConfig.GetServers() {
-		nodes.Add(server.GetNameOrDefault())
+		name := server.GetNameOrDefault()
+		identity := server
+		if server.GetName() == "" {
+			identity = &commonproto.DataServerIdentity{
+				Name:     &name,
+				Public:   server.GetPublic(),
+				Internal: server.GetInternal(),
+			}
+		}
+		dataServer := &commonproto.DataServer{
+			Identity: identity,
+			Metadata: &commonproto.DataServerMetadata{},
+		}
+		if value, found := m.currentClusterConfig.GetServerMetadata()[name]; found {
+			dataServer.Metadata = value
+		}
+		dataServers[name] = dataServer
 	}
-	return commonobject.Borrow(nodes)
-}
-
-func (m *coordinatorMetadata) ListDataServersWithMetadata() (
-	commonobject.Borrowed[*linkedhashset.Set[string]],
-	commonobject.Borrowed[map[string]*commonproto.DataServerMetadata],
-) {
-	m.clusterConfigLock.RLock()
-	defer m.clusterConfigLock.RUnlock()
-	if m.currentClusterConfig == nil {
-		m.clusterConfigLock.RUnlock()
-		m.loadClusterConfigWithInitSlow()
-		m.clusterConfigLock.RLock()
-	}
-
-	nodes := linkedhashset.New[string]()
-	for _, server := range m.currentClusterConfig.GetServers() {
-		nodes.Add(server.GetNameOrDefault())
-	}
-
-	metadata := make(map[string]*commonproto.DataServerMetadata, len(m.currentClusterConfig.GetServerMetadata()))
-	for id, value := range m.currentClusterConfig.GetServerMetadata() {
-		metadata[id] = value
-	}
-	return commonobject.Borrow(nodes), commonobject.Borrow(metadata)
+	return commonobject.Borrow(dataServers)
 }
 
 func (m *coordinatorMetadata) GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool) {
@@ -502,22 +481,7 @@ func (m *coordinatorMetadata) GetNamespace(namespace string) (commonobject.Borro
 	return commonobject.Borrow(value), true
 }
 
-func (m *coordinatorMetadata) GetDataServerIdentity(id string) (commonobject.Borrowed[*commonproto.DataServerIdentity], bool) {
-	m.clusterConfigLock.RLock()
-	defer m.clusterConfigLock.RUnlock()
-	if m.currentClusterConfig == nil {
-		m.clusterConfigLock.RUnlock()
-		m.loadClusterConfigWithInitSlow()
-		m.clusterConfigLock.RLock()
-	}
-	value, ok := m.nodesIndex.Get(id)
-	if !ok {
-		return commonobject.Borrowed[*commonproto.DataServerIdentity]{}, false
-	}
-	return commonobject.Borrow(value), true
-}
-
-func (m *coordinatorMetadata) GetDataServer(id string) (commonobject.Borrowed[*commonproto.DataServer], bool) {
+func (m *coordinatorMetadata) GetDataServer(name string) (commonobject.Borrowed[*commonproto.DataServer], bool) {
 	m.clusterConfigLock.RLock()
 	defer m.clusterConfigLock.RUnlock()
 	if m.currentClusterConfig == nil {
@@ -526,7 +490,7 @@ func (m *coordinatorMetadata) GetDataServer(id string) (commonobject.Borrowed[*c
 		m.clusterConfigLock.RLock()
 	}
 
-	value, ok := m.currentClusterConfig.GetDataServer(id)
+	value, ok := m.currentClusterConfig.GetDataServer(name)
 	if !ok {
 		return commonobject.Borrowed[*commonproto.DataServer]{}, false
 	}

--- a/oxiad/coordinator/reconciler/dataserver_reconciler.go
+++ b/oxiad/coordinator/reconciler/dataserver_reconciler.go
@@ -41,12 +41,12 @@ func (r *dataServerReconciler) Reconcile(_ context.Context, snapshot *proto.Clus
 		if !exist {
 			continue
 		}
-		r.runtime.PutDataServerIfAbsent(dataServer)
+		r.runtime.CreateDataServer(serverName, dataServer)
 	}
 
-	for dataServerID := range r.runtime.NodeControllers() {
-		if !desired.Contains(dataServerID) {
-			r.runtime.DeleteDataServer(dataServerID)
+	for name := range r.runtime.NodeControllers() {
+		if !desired.Contains(name) {
+			r.runtime.DeleteDataServer(name)
 		}
 	}
 

--- a/oxiad/coordinator/reconciler/dataserver_reconciler.go
+++ b/oxiad/coordinator/reconciler/dataserver_reconciler.go
@@ -44,7 +44,7 @@ func (r *dataServerReconciler) Reconcile(_ context.Context, snapshot *proto.Clus
 		r.runtime.CreateDataServer(serverName, dataServer)
 	}
 
-	for name := range r.runtime.NodeControllers() {
+	for name := range r.runtime.ListDataServer() {
 		if !desired.Contains(name) {
 			r.runtime.DeleteDataServer(name)
 		}

--- a/oxiad/coordinator/reconciler/namespace_reconciler.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler.go
@@ -39,7 +39,7 @@ func (r *namespaceReconciler) Reconcile(_ context.Context, snapshot *proto.Clust
 		r.runtime.CreateNamespace(namespace.GetName(), namespace)
 	}
 
-	for name := range metadata.ListNamespaceStatus().UnsafeBorrow() {
+	for name := range metadata.ListNamespaceStatus() {
 		if _, exists := metadata.GetNamespace(name); exists {
 			continue
 		}

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 	"github.com/stretchr/testify/assert"
 	gproto "google.golang.org/protobuf/proto"
 
@@ -172,19 +171,8 @@ func (*mockNamespaceMetadata) GetLoadBalancer() commonobject.Borrowed[*proto.Loa
 	return commonobject.Borrowed[*proto.LoadBalancer]{}
 }
 
-func (*mockNamespaceMetadata) ListDataServers() commonobject.Borrowed[*linkedhashset.Set[string]] {
-	return commonobject.Borrow(linkedhashset.New[string]())
-}
-
-func (*mockNamespaceMetadata) ListDataServersWithMetadata() (
-	commonobject.Borrowed[*linkedhashset.Set[string]],
-	commonobject.Borrowed[map[string]*proto.DataServerMetadata],
-) {
-	return commonobject.Borrow(linkedhashset.New[string]()), commonobject.Borrow(map[string]*proto.DataServerMetadata{})
-}
-
-func (*mockNamespaceMetadata) GetDataServerIdentity(string) (commonobject.Borrowed[*proto.DataServerIdentity], bool) {
-	return commonobject.Borrowed[*proto.DataServerIdentity]{}, false
+func (*mockNamespaceMetadata) ListDataServer() commonobject.Borrowed[map[string]*proto.DataServer] {
+	return commonobject.Borrow(map[string]*proto.DataServer{})
 }
 
 func (*mockNamespaceMetadata) GetDataServer(string) (commonobject.Borrowed[*proto.DataServer], bool) {
@@ -225,7 +213,7 @@ func (*mockNamespaceRuntime) WaitForNextUpdate(context.Context, *proto.ShardAssi
 
 func (*mockNamespaceRuntime) BecameUnavailable(*proto.DataServerIdentity) {}
 
-func (*mockNamespaceRuntime) PutDataServerIfAbsent(*proto.DataServer) {}
+func (*mockNamespaceRuntime) CreateDataServer(string, *proto.DataServer) bool { return false }
 
 func (*mockNamespaceRuntime) DeleteDataServer(string) {}
 

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -29,7 +29,6 @@ import (
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer"
-	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
 )
 
 func hashRange(start, end uint32) *proto.HashRange {
@@ -124,12 +123,12 @@ func (m *mockNamespaceMetadata) CreateNamespaceStatus(
 	return true
 }
 
-func (m *mockNamespaceMetadata) ListNamespaceStatus() commonobject.Borrowed[map[string]*proto.NamespaceStatus] {
-	namespaces := make(map[string]*proto.NamespaceStatus, len(m.status.GetNamespaces()))
+func (m *mockNamespaceMetadata) ListNamespaceStatus() map[string]commonobject.Borrowed[*proto.NamespaceStatus] {
+	namespaces := make(map[string]commonobject.Borrowed[*proto.NamespaceStatus], len(m.status.GetNamespaces()))
 	for name, status := range m.status.GetNamespaces() {
-		namespaces[name] = status
+		namespaces[name] = commonobject.Borrow(status)
 	}
-	return commonobject.Borrow(namespaces)
+	return namespaces
 }
 
 func (m *mockNamespaceMetadata) GetNamespaceStatus(namespace string) (commonobject.Borrowed[*proto.NamespaceStatus], bool) {
@@ -171,8 +170,8 @@ func (*mockNamespaceMetadata) GetLoadBalancer() commonobject.Borrowed[*proto.Loa
 	return commonobject.Borrowed[*proto.LoadBalancer]{}
 }
 
-func (*mockNamespaceMetadata) ListDataServer() commonobject.Borrowed[map[string]*proto.DataServer] {
-	return commonobject.Borrow(map[string]*proto.DataServer{})
+func (*mockNamespaceMetadata) ListDataServer() map[string]commonobject.Borrowed[*proto.DataServer] {
+	return map[string]commonobject.Borrowed[*proto.DataServer]{}
 }
 
 func (*mockNamespaceMetadata) GetDataServer(string) (commonobject.Borrowed[*proto.DataServer], bool) {
@@ -281,7 +280,9 @@ func (m *mockNamespaceRuntime) DeleteShard(shard int64) {
 
 func (*mockNamespaceRuntime) RecomputeAssignments() {}
 
-func (*mockNamespaceRuntime) NodeControllers() map[string]controller.DataServerController { return nil }
+func (*mockNamespaceRuntime) ListDataServer() map[string]commonobject.Borrowed[*proto.DataServer] {
+	return nil
+}
 
 func (*mockNamespaceRuntime) LoadBalancer() balancer.LoadBalancer { return nil }
 

--- a/oxiad/coordinator/runtime/balancer/scheduler.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler.go
@@ -85,13 +85,14 @@ func (r *nodeBasedBalancer) quarantineNodes() *linkedhashset.Set[string] {
 	return nodes
 }
 
-func dataServersToCandidatesAndMetadata(dataServers map[string]*commonproto.DataServer) (
+func dataServersToCandidatesAndMetadata(dataServers map[string]commonobject.Borrowed[*commonproto.DataServer]) (
 	*linkedhashset.Set[string],
 	map[string]*commonproto.DataServerMetadata,
 ) {
 	candidates := linkedhashset.New[string]()
 	metadata := make(map[string]*commonproto.DataServerMetadata, len(dataServers))
-	for name, dataServer := range dataServers {
+	for name, borrowedDataServer := range dataServers {
+		dataServer := borrowedDataServer.UnsafeBorrow()
 		candidates.Add(name)
 		if dataServer.GetMetadata() != nil {
 			metadata[name] = dataServer.GetMetadata()
@@ -116,7 +117,7 @@ func (r *nodeBasedBalancer) rebalanceEnsemble() bool {
 
 	swapGroup := &sync.WaitGroup{}
 	currentStatus := r.metadata.GetStatus().UnsafeBorrow()
-	dataServers := r.metadata.ListDataServer().UnsafeBorrow()
+	dataServers := r.metadata.ListDataServer()
 	candidates, metadata := dataServersToCandidatesAndMetadata(dataServers)
 	groupedStatus, historyNodes := state.GroupingShardsNodeByStatus(candidates, currentStatus)
 	loadRatios := r.loadRatioAlgorithm(&model.RatioParams{NodeShardsInfos: groupedStatus, HistoryNodes: historyNodes})
@@ -338,7 +339,7 @@ func (r *nodeBasedBalancer) IsNodeQuarantined(highestLoadRatioNode *model.NodeLo
 
 func (r *nodeBasedBalancer) IsBalanced() bool {
 	status := r.metadata.GetStatus().UnsafeBorrow()
-	candidates, _ := dataServersToCandidatesAndMetadata(r.metadata.ListDataServer().UnsafeBorrow())
+	candidates, _ := dataServersToCandidatesAndMetadata(r.metadata.ListDataServer())
 	groupedStatus, historyNodes := state.GroupingShardsNodeByStatus(candidates, status)
 	return r.loadRatioAlgorithm(
 		&model.RatioParams{
@@ -406,7 +407,7 @@ func (r *nodeBasedBalancer) rebalanceLeader() {
 	r.checkQuarantineShards()
 
 	status := r.metadata.GetStatus().UnsafeBorrow()
-	candidates, _ := dataServersToCandidatesAndMetadata(r.metadata.ListDataServer().UnsafeBorrow())
+	candidates, _ := dataServersToCandidatesAndMetadata(r.metadata.ListDataServer())
 	totalShards, electedShards, nodeLeaders := state.NodeShardLeaders(candidates, status)
 
 	electedRate := float64(electedShards) / float64(totalShards)

--- a/oxiad/coordinator/runtime/balancer/scheduler.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler.go
@@ -85,6 +85,23 @@ func (r *nodeBasedBalancer) quarantineNodes() *linkedhashset.Set[string] {
 	return nodes
 }
 
+func dataServersToCandidatesAndMetadata(dataServers map[string]*commonproto.DataServer) (
+	*linkedhashset.Set[string],
+	map[string]*commonproto.DataServerMetadata,
+) {
+	candidates := linkedhashset.New[string]()
+	metadata := make(map[string]*commonproto.DataServerMetadata, len(dataServers))
+	for name, dataServer := range dataServers {
+		candidates.Add(name)
+		if dataServer.GetMetadata() != nil {
+			metadata[name] = dataServer.GetMetadata()
+			continue
+		}
+		metadata[name] = &commonproto.DataServerMetadata{}
+	}
+	return candidates, metadata
+}
+
 func (r *nodeBasedBalancer) quarantineShards() *linkedhashset.Set[int64] {
 	shards := linkedhashset.New[int64]()
 	r.shardQuarantineShardMap.Range(func(shardID, _ any) bool {
@@ -99,9 +116,8 @@ func (r *nodeBasedBalancer) rebalanceEnsemble() bool {
 
 	swapGroup := &sync.WaitGroup{}
 	currentStatus := r.metadata.GetStatus().UnsafeBorrow()
-	candidatesBorrowed, metadataBorrowed := r.metadata.ListDataServersWithMetadata()
-	candidates := candidatesBorrowed.UnsafeBorrow()
-	metadata := metadataBorrowed.UnsafeBorrow()
+	dataServers := r.metadata.ListDataServer().UnsafeBorrow()
+	candidates, metadata := dataServersToCandidatesAndMetadata(dataServers)
 	groupedStatus, historyNodes := state.GroupingShardsNodeByStatus(candidates, currentStatus)
 	loadRatios := r.loadRatioAlgorithm(&model.RatioParams{NodeShardsInfos: groupedStatus, HistoryNodes: historyNodes})
 
@@ -265,11 +281,14 @@ func (r *nodeBasedBalancer) swapShard(
 		return false, nil
 	}
 	var targetNode *commonproto.DataServerIdentity
-	var borrowedTargetNode commonobject.Borrowed[*commonproto.DataServerIdentity]
-	if borrowedTargetNode, exist = r.metadata.GetDataServerIdentity(targetNodeID); !exist {
+	var borrowedTargetNode commonobject.Borrowed[*commonproto.DataServer]
+	if borrowedTargetNode, exist = r.metadata.GetDataServer(targetNodeID); !exist {
 		return false, errors.New("target node does not exist")
 	}
-	targetNode = borrowedTargetNode.UnsafeBorrow()
+	targetNode = borrowedTargetNode.UnsafeBorrow().GetIdentity()
+	if targetNode == nil {
+		return false, errors.New("target node does not have identity")
+	}
 
 	r.logger.Info("propose to swap the shard", slog.Int64("shard", candidateShard.ShardID), slog.Any("from", fromNode), slog.Any("to", targetNodeID))
 	swapGroup.Add(1)
@@ -319,7 +338,7 @@ func (r *nodeBasedBalancer) IsNodeQuarantined(highestLoadRatioNode *model.NodeLo
 
 func (r *nodeBasedBalancer) IsBalanced() bool {
 	status := r.metadata.GetStatus().UnsafeBorrow()
-	candidates := r.metadata.ListDataServers().UnsafeBorrow()
+	candidates, _ := dataServersToCandidatesAndMetadata(r.metadata.ListDataServer().UnsafeBorrow())
 	groupedStatus, historyNodes := state.GroupingShardsNodeByStatus(candidates, status)
 	return r.loadRatioAlgorithm(
 		&model.RatioParams{
@@ -387,7 +406,7 @@ func (r *nodeBasedBalancer) rebalanceLeader() {
 	r.checkQuarantineShards()
 
 	status := r.metadata.GetStatus().UnsafeBorrow()
-	candidates := r.metadata.ListDataServers().UnsafeBorrow()
+	candidates, _ := dataServersToCandidatesAndMetadata(r.metadata.ListDataServer().UnsafeBorrow())
 	totalShards, electedShards, nodeLeaders := state.NodeShardLeaders(candidates, status)
 
 	electedRate := float64(electedShards) / float64(totalShards)

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -63,8 +63,8 @@ func (*mockMetadata) CreateNamespaceStatus(string, *proto.NamespaceStatus) bool 
 	return false
 }
 
-func (*mockMetadata) ListNamespaceStatus() commonobject.Borrowed[map[string]*proto.NamespaceStatus] {
-	return commonobject.Borrowed[map[string]*proto.NamespaceStatus]{}
+func (*mockMetadata) ListNamespaceStatus() map[string]commonobject.Borrowed[*proto.NamespaceStatus] {
+	return map[string]commonobject.Borrowed[*proto.NamespaceStatus]{}
 }
 
 func (*mockMetadata) GetNamespaceStatus(string) (commonobject.Borrowed[*proto.NamespaceStatus], bool) {
@@ -99,8 +99,8 @@ func (m *mockMetadata) GetLoadBalancer() commonobject.Borrowed[*proto.LoadBalanc
 	})
 }
 
-func (m *mockMetadata) ListDataServer() commonobject.Borrowed[map[string]*proto.DataServer] {
-	dataServers := make(map[string]*proto.DataServer, m.nodes.Size())
+func (m *mockMetadata) ListDataServer() map[string]commonobject.Borrowed[*proto.DataServer] {
+	dataServers := make(map[string]commonobject.Borrowed[*proto.DataServer], m.nodes.Size())
 	for _, id := range m.nodes.Values() {
 		name := id
 		identity, ok := m.nodeMap[id]
@@ -114,12 +114,12 @@ func (m *mockMetadata) ListDataServer() commonobject.Borrowed[map[string]*proto.
 		if !ok {
 			metadata = &proto.DataServerMetadata{}
 		}
-		dataServers[id] = &proto.DataServer{
+		dataServers[id] = commonobject.Borrow(&proto.DataServer{
 			Identity: identity,
 			Metadata: metadata,
-		}
+		})
 	}
-	return commonobject.Borrow(dataServers)
+	return dataServers
 }
 
 func (m *mockMetadata) GetNamespace(namespace string) (commonobject.Borrowed[*proto.Namespace], bool) {

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -99,15 +99,27 @@ func (m *mockMetadata) GetLoadBalancer() commonobject.Borrowed[*proto.LoadBalanc
 	})
 }
 
-func (m *mockMetadata) ListDataServers() commonobject.Borrowed[*linkedhashset.Set[string]] {
-	return commonobject.Borrow(m.nodes)
-}
-
-func (m *mockMetadata) ListDataServersWithMetadata() (
-	commonobject.Borrowed[*linkedhashset.Set[string]],
-	commonobject.Borrowed[map[string]*proto.DataServerMetadata],
-) {
-	return commonobject.Borrow(m.nodes), commonobject.Borrow(m.metadata)
+func (m *mockMetadata) ListDataServer() commonobject.Borrowed[map[string]*proto.DataServer] {
+	dataServers := make(map[string]*proto.DataServer, m.nodes.Size())
+	for _, id := range m.nodes.Values() {
+		name := id
+		identity, ok := m.nodeMap[id]
+		if !ok {
+			identity = &proto.DataServerIdentity{
+				Name:     &name,
+				Internal: id,
+			}
+		}
+		metadata, ok := m.metadata[id]
+		if !ok {
+			metadata = &proto.DataServerMetadata{}
+		}
+		dataServers[id] = &proto.DataServer{
+			Identity: identity,
+			Metadata: metadata,
+		}
+	}
+	return commonobject.Borrow(dataServers)
 }
 
 func (m *mockMetadata) GetNamespace(namespace string) (commonobject.Borrowed[*proto.Namespace], bool) {
@@ -118,20 +130,12 @@ func (m *mockMetadata) GetNamespace(namespace string) (commonobject.Borrowed[*pr
 	return commonobject.Borrow(nc), true
 }
 
-func (m *mockMetadata) GetDataServerIdentity(id string) (commonobject.Borrowed[*proto.DataServerIdentity], bool) {
-	n, ok := m.nodeMap[id]
-	if !ok {
-		return commonobject.Borrowed[*proto.DataServerIdentity]{}, false
-	}
-	return commonobject.Borrow(n), true
-}
-
-func (m *mockMetadata) GetDataServer(id string) (commonobject.Borrowed[*proto.DataServer], bool) {
-	n, ok := m.nodeMap[id]
+func (m *mockMetadata) GetDataServer(name string) (commonobject.Borrowed[*proto.DataServer], bool) {
+	n, ok := m.nodeMap[name]
 	if !ok {
 		return commonobject.Borrowed[*proto.DataServer]{}, false
 	}
-	metadata, ok := m.metadata[id]
+	metadata, ok := m.metadata[name]
 	if !ok {
 		metadata = &proto.DataServerMetadata{}
 	}

--- a/oxiad/coordinator/runtime/controller/dataserver_controller.go
+++ b/oxiad/coordinator/runtime/controller/dataserver_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 
 	"github.com/oxia-db/oxia/common/commonio"
+	commonobject "github.com/oxia-db/oxia/common/object"
 
 	"github.com/oxia-db/oxia/common/metric"
 	"github.com/oxia-db/oxia/common/process"
@@ -61,6 +62,8 @@ type ShardAssignmentsProvider interface {
 type DataServerController interface {
 	io.Closer
 
+	GetDataServer() commonobject.Borrowed[*proto.DataServer]
+
 	Status() DataServerStatus
 
 	SupportedFeatures() []proto.Feature
@@ -76,7 +79,7 @@ type dataServerController struct {
 
 	ctx        context.Context
 	ctxCancel  context.CancelFunc
-	dataServer *proto.DataServerIdentity
+	dataServer *proto.DataServer
 	rpc        rpc.Provider
 	insID      string
 	closed     atomic.Bool
@@ -94,6 +97,10 @@ type dataServerController struct {
 
 	dataServerRunningGauge metric.Gauge
 	failedHealthChecks     metric.Counter
+}
+
+func (n *dataServerController) GetDataServer() commonobject.Borrowed[*proto.DataServer] {
+	return commonobject.Borrow(n.dataServer)
 }
 
 func (n *dataServerController) Status() DataServerStatus {
@@ -117,7 +124,7 @@ func (n *dataServerController) SetStatus(status DataServerStatus) {
 func (n *dataServerController) maybeInitHealthClient() {
 	n.healthClientOnce.Do(func() {
 		_ = backoff.RetryNotify(func() error {
-			health, closer, err := n.rpc.GetHealthClient(n.dataServer)
+			health, closer, err := n.rpc.GetHealthClient(n.dataServer.GetIdentity())
 			if err != nil {
 				return err
 			}
@@ -154,7 +161,7 @@ func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
 	_ = backoff.RetryNotify(func() error {
 		n.logger.Debug("Ready to send assignments")
 
-		stream, err := n.rpc.PushShardAssignments(n.ctx, n.dataServer)
+		stream, err := n.rpc.PushShardAssignments(n.ctx, n.dataServer.GetIdentity())
 		if err != nil {
 			n.logger.Debug("Failed to create shard assignments stream", slog.Any("error", err))
 			return err
@@ -281,7 +288,7 @@ func (n *dataServerController) becomeUnavailable() {
 	n.statusLock.Unlock()
 
 	n.failedHealthChecks.Inc()
-	n.BecameUnavailable(n.dataServer)
+	n.BecameUnavailable(n.dataServer.GetIdentity())
 }
 
 func (n *dataServerController) becomeAvailable() {
@@ -293,13 +300,13 @@ func (n *dataServerController) becomeAvailable() {
 
 	// To avoid the send assignments stream to miss the notification about the current
 	// dataServer went down, we interrupt the current stream when the ping on the dataServer fails
-	n.rpc.ClearPooledConnections(n.dataServer)
+	n.rpc.ClearPooledConnections(n.dataServer.GetIdentity())
 	n.healthCheckBackoff.Reset()
 
 	// Bind the node before it can receive other internal traffic.
 	bo := commontime.NewBackOffWithInitialInterval(n.ctx, defaultInitialRetryBackoff)
 	if err := backoff.RetryNotify(func() error {
-		handshake, err := n.rpc.Handshake(n.ctx, n.dataServer, &proto.HandshakeRequest{
+		handshake, err := n.rpc.Handshake(n.ctx, n.dataServer.GetIdentity(), &proto.HandshakeRequest{
 			InstanceId: n.insID,
 		})
 		if err != nil {
@@ -344,7 +351,7 @@ func (n *dataServerController) healthCheckHandler(response *grpc_health_v1.Healt
 	return nil
 }
 
-func NewDataServerController(ctx context.Context, dataServer *proto.DataServerIdentity,
+func NewDataServerController(ctx context.Context, dataServer *proto.DataServer,
 	shardAssignmentsProvider ShardAssignmentsProvider,
 	dataServerEventListener DataServerEventListener,
 	rpcProvider rpc.Provider,
@@ -352,14 +359,14 @@ func NewDataServerController(ctx context.Context, dataServer *proto.DataServerId
 	return newDataServerController(ctx, dataServer, shardAssignmentsProvider, dataServerEventListener, rpcProvider, insID, defaultInitialRetryBackoff)
 }
 
-func newDataServerController(ctx context.Context, dataServer *proto.DataServerIdentity,
+func newDataServerController(ctx context.Context, dataServer *proto.DataServer,
 	shardAssignmentsProvider ShardAssignmentsProvider,
 	dataServerEventListener DataServerEventListener,
 	rpcProvider rpc.Provider,
 	insID string,
 	initialRetryBackoff time.Duration) DataServerController {
 	dataServerCtx, cancel := context.WithCancel(ctx)
-	dataServerID := dataServer.GetNameOrDefault()
+	dataServerID := dataServer.GetIdentity().GetNameOrDefault()
 	labels := map[string]any{"data-server": dataServerID}
 
 	supportedFeatures := atomic.Value{}

--- a/oxiad/coordinator/runtime/controller/dataserver_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/dataserver_controller_test.go
@@ -32,11 +32,12 @@ func TestDataServerController_HealthCheck(t *testing.T) {
 		Public:   "my-server:9190",
 		Internal: "my-server:8190",
 	}
+	dataServer := &proto.DataServer{Identity: addr, Metadata: &proto.DataServerMetadata{}}
 
 	sap := newMockShardAssignmentsProvider()
 	nal := newMockNodeAvailabilityListener()
 	rpc := newMockRpcProvider()
-	nc := newDataServerController(context.Background(), addr, sap, nal, rpc, "test-instance", 1*time.Second)
+	nc := newDataServerController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 1*time.Second)
 
 	node := rpc.GetNode(addr)
 
@@ -73,11 +74,12 @@ func TestDataServerController_HandshakeOnlyCalledOnStateTransition(t *testing.T)
 		Public:   "my-server:9190",
 		Internal: "my-server:8190",
 	}
+	dataServer := &proto.DataServer{Identity: addr, Metadata: &proto.DataServerMetadata{}}
 
 	sap := newMockShardAssignmentsProvider()
 	nal := newMockNodeAvailabilityListener()
 	rpc := newMockRpcProvider()
-	nc := newDataServerController(context.Background(), addr, sap, nal, rpc, "test-instance", 1*time.Second)
+	nc := newDataServerController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 1*time.Second)
 
 	node := rpc.GetNode(addr)
 
@@ -133,11 +135,12 @@ func TestDataServerController_ShardsAssignments(t *testing.T) {
 		Public:   "my-server:9190",
 		Internal: "my-server:8190",
 	}
+	dataServer := &proto.DataServer{Identity: addr, Metadata: &proto.DataServerMetadata{}}
 
 	sap := newMockShardAssignmentsProvider()
 	nal := newMockNodeAvailabilityListener()
 	rpc := newMockRpcProvider()
-	nc := newDataServerController(context.Background(), addr, sap, nal, rpc, "test-instance", 1*time.Second)
+	nc := newDataServerController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 1*time.Second)
 
 	node := rpc.GetNode(addr)
 

--- a/oxiad/coordinator/runtime/controller/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller.go
@@ -474,9 +474,10 @@ func (s *shardController) SyncServerAddress() {
 	shardMeta := s.metadata.Load()
 	needSync := false
 	for _, candidate := range shardMeta.Ensemble {
-		if borrowedNewInfo, ok := s.metadataStore.GetDataServerIdentity(candidate.GetNameOrDefault()); ok {
-			newInfo := borrowedNewInfo.UnsafeBorrow()
-			if newInfo.GetPublic() != candidate.GetPublic() || newInfo.GetInternal() != candidate.GetInternal() {
+		if borrowedDataServer, ok := s.metadataStore.GetDataServer(candidate.GetNameOrDefault()); ok {
+			newInfo := borrowedDataServer.UnsafeBorrow().GetIdentity()
+			if newInfo != nil &&
+				(newInfo.GetPublic() != candidate.GetPublic() || newInfo.GetInternal() != candidate.GetInternal()) {
 				needSync = true
 				break
 			}

--- a/oxiad/coordinator/runtime/controller/shard_controller_election.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller_election.go
@@ -78,9 +78,11 @@ type ShardElection struct {
 func (e *ShardElection) refreshedEnsemble(ensemble []*proto.DataServerIdentity) []*proto.DataServerIdentity {
 	refreshedEnsembleDataServerAddress := make([]*proto.DataServerIdentity, len(ensemble))
 	for idx, candidate := range ensemble {
-		if borrowedAddress, exist := e.metadataStore.GetDataServerIdentity(candidate.GetNameOrDefault()); exist {
-			refreshedEnsembleDataServerAddress[idx] = borrowedAddress.UnsafeBorrow()
-			continue
+		if borrowedDataServer, exist := e.metadataStore.GetDataServer(candidate.GetNameOrDefault()); exist {
+			if identity := borrowedDataServer.UnsafeBorrow().GetIdentity(); identity != nil {
+				refreshedEnsembleDataServerAddress[idx] = identity
+				continue
+			}
 		}
 		refreshedEnsembleDataServerAddress[idx] = candidate
 	}

--- a/oxiad/coordinator/runtime/interface.go
+++ b/oxiad/coordinator/runtime/interface.go
@@ -17,6 +17,7 @@ package runtime
 import (
 	"io"
 
+	commonobject "github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer"
@@ -32,14 +33,15 @@ type Runtime interface {
 
 	CreateDataServer(name string, dataServer *proto.DataServer) bool
 	DeleteDataServer(name string)
-	SyncShardControllerServerAddresses()
+
+	ListDataServer() map[string]commonobject.Borrowed[*proto.DataServer]
+
 	CreateNamespace(name string, namespaceConfig *proto.Namespace) bool
 	DeleteNamespace(namespace string)
-	RecomputeAssignments()
-
-	NodeControllers() map[string]controller.DataServerController
 
 	LoadBalancer() balancer.LoadBalancer
-
 	Metadata() coordmetadata.Metadata
+
+	RecomputeAssignments()
+	SyncShardControllerServerAddresses()
 }

--- a/oxiad/coordinator/runtime/interface.go
+++ b/oxiad/coordinator/runtime/interface.go
@@ -30,8 +30,8 @@ type Runtime interface {
 	controller.ShardAssignmentsProvider
 	controller.DataServerEventListener
 
-	PutDataServerIfAbsent(server *proto.DataServer)
-	DeleteDataServer(dataServerID string)
+	CreateDataServer(name string, dataServer *proto.DataServer) bool
+	DeleteDataServer(name string)
 	SyncShardControllerServerAddresses()
 	CreateNamespace(name string, namespaceConfig *proto.Namespace) bool
 	DeleteNamespace(namespace string)

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -25,7 +25,6 @@ import (
 	"go.uber.org/multierr"
 	pb "google.golang.org/protobuf/proto"
 
-	commonobject "github.com/oxia-db/oxia/common/object"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 
 	"github.com/oxia-db/oxia/oxiad/common/sharding"
@@ -100,23 +99,23 @@ func (c *runtime) NodeControllers() map[string]controller.DataServerController {
 	return res
 }
 
-func (c *runtime) PutDataServerIfAbsent(server *proto.DataServer) {
+func (c *runtime) CreateDataServer(name string, dataServer *proto.DataServer) bool {
 	c.Lock()
 	defer c.Unlock()
 
-	identity := server.GetIdentity()
+	identity := dataServer.GetIdentity()
 	if identity == nil {
-		return
+		return false
 	}
-	if _, ok := c.nodeControllers[identity.GetNameOrDefault()]; ok {
-		return
+	if _, ok := c.nodeControllers[name]; ok {
+		return false
 	}
 	c.logger.Info("Detected new node", slog.Any("server", identity))
-	if nc, ok := c.drainingNodes[identity.GetNameOrDefault()]; ok {
+	if nc, ok := c.drainingNodes[name]; ok {
 		_ = nc.Close()
-		delete(c.drainingNodes, identity.GetNameOrDefault())
+		delete(c.drainingNodes, name)
 	}
-	c.nodeControllers[identity.GetNameOrDefault()] = controller.NewDataServerController(
+	c.nodeControllers[name] = controller.NewDataServerController(
 		c.ctx,
 		identity,
 		c,
@@ -124,20 +123,21 @@ func (c *runtime) PutDataServerIfAbsent(server *proto.DataServer) {
 		c.rpc,
 		c.insID,
 	)
+	return true
 }
 
-func (c *runtime) DeleteDataServer(id string) {
+func (c *runtime) DeleteDataServer(name string) {
 	c.Lock()
 	defer c.Unlock()
 
-	nc, exist := c.nodeControllers[id]
+	nc, exist := c.nodeControllers[name]
 	if !exist {
 		return
 	}
-	c.logger.Info("Detected a removed node", slog.Any("server", id))
-	delete(c.nodeControllers, id)
+	c.logger.Info("Detected a removed node", slog.Any("server", name))
+	delete(c.nodeControllers, name)
 	nc.SetStatus(controller.Draining)
-	c.drainingNodes[id] = nc
+	c.drainingNodes[name] = nc
 }
 
 func (c *runtime) SyncShardControllerServerAddresses() {
@@ -241,14 +241,31 @@ func (c *runtime) findDataServerFeatures(dataServers []*proto.DataServerIdentity
 	return features
 }
 
+func dataServersToCandidatesAndMetadata(dataServers map[string]*proto.DataServer) (
+	*linkedhashset.Set[string],
+	map[string]*proto.DataServerMetadata,
+) {
+	candidates := linkedhashset.New[string]()
+	metadata := make(map[string]*proto.DataServerMetadata, len(dataServers))
+	for name, dataServer := range dataServers {
+		candidates.Add(name)
+		if dataServer.GetMetadata() != nil {
+			metadata[name] = dataServer.GetMetadata()
+			continue
+		}
+		metadata[name] = &proto.DataServerMetadata{}
+	}
+	return candidates, metadata
+}
+
 // selectNewEnsemble select a new server ensemble based on namespace policy and current cluster status.
 // It uses the ensemble selector to choose appropriate servers and returns the selected server metadata or an error.
 func (c *runtime) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
-	nodesBorrowed, nodesMetadataBorrowed := c.metadata.ListDataServersWithMetadata()
-	nodes := nodesBorrowed.UnsafeBorrow()
+	dataServers := c.metadata.ListDataServer().UnsafeBorrow()
+	nodes, metadata := dataServersToCandidatesAndMetadata(dataServers)
 	ensembleContext := &ensemble.Context{
 		Candidates:         nodes,
-		CandidatesMetadata: nodesMetadataBorrowed.UnsafeBorrow(),
+		CandidatesMetadata: metadata,
 		HierarchyPolicies:  ns.GetPolicy(),
 		Status:             editingStatus,
 		Replicas:           int(ns.GetReplicationFactor()),
@@ -264,12 +281,11 @@ func (c *runtime) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.Cl
 	}
 	esm := make([]*proto.DataServerIdentity, 0)
 	for _, id := range ensembles {
-		var exist bool
-		var borrowed commonobject.Borrowed[*proto.DataServerIdentity]
-		if borrowed, exist = c.metadata.GetDataServerIdentity(id); !exist {
+		dataServer, exist := dataServers[id]
+		if !exist || dataServer.GetIdentity() == nil {
 			return nil, fmt.Errorf("failed to find node %s", id)
 		}
-		esm = append(esm, borrowed.UnsafeBorrow())
+		esm = append(esm, dataServer.GetIdentity())
 	}
 	return esm, nil
 }
@@ -825,9 +841,8 @@ func New(
 		for shard := range shards.Shards {
 			shardMetadata := shards.Shards[shard]
 			var nsConfig *proto.Namespace
-			var exist bool
-			var borrowedNsConfig commonobject.Borrowed[*proto.Namespace]
-			if borrowedNsConfig, exist = c.metadata.GetNamespace(ns); !exist {
+			borrowedNsConfig, exist := c.metadata.GetNamespace(ns)
+			if !exist {
 				nsConfig = &proto.Namespace{}
 			} else {
 				nsConfig = borrowedNsConfig.UnsafeBorrow()

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/multierr"
 	pb "google.golang.org/protobuf/proto"
 
+	commonobject "github.com/oxia-db/oxia/common/object"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 
 	"github.com/oxia-db/oxia/oxiad/common/sharding"
@@ -53,9 +54,9 @@ type runtime struct {
 
 	metadata coordmetadata.Metadata
 
-	shardControllers map[int64]controller.ShardController
-	splitControllers map[int64]*controller.SplitController // keyed by parent shard ID
-	nodeControllers  map[string]controller.DataServerController
+	shardControllers      map[int64]controller.ShardController
+	splitControllers      map[int64]*controller.SplitController // keyed by parent shard ID
+	dataServerControllers map[string]controller.DataServerController
 	// Draining nodes are nodes that were removed from the
 	// nodes list. We keep sending them assignments updates
 	// because they might be still reachable to clients.
@@ -89,14 +90,14 @@ func (c *runtime) Metadata() coordmetadata.Metadata {
 	return c.metadata
 }
 
-func (c *runtime) NodeControllers() map[string]controller.DataServerController {
+func (c *runtime) ListDataServer() map[string]commonobject.Borrowed[*proto.DataServer] {
 	c.RLock()
 	defer c.RUnlock()
-	res := make(map[string]controller.DataServerController, len(c.nodeControllers))
-	for k, v := range c.nodeControllers {
-		res[k] = v
+	dataServers := make(map[string]commonobject.Borrowed[*proto.DataServer], len(c.dataServerControllers))
+	for name, dataServerController := range c.dataServerControllers {
+		dataServers[name] = dataServerController.GetDataServer()
 	}
-	return res
+	return dataServers
 }
 
 func (c *runtime) CreateDataServer(name string, dataServer *proto.DataServer) bool {
@@ -107,7 +108,7 @@ func (c *runtime) CreateDataServer(name string, dataServer *proto.DataServer) bo
 	if identity == nil {
 		return false
 	}
-	if _, ok := c.nodeControllers[name]; ok {
+	if _, ok := c.dataServerControllers[name]; ok {
 		return false
 	}
 	c.logger.Info("Detected new node", slog.Any("server", identity))
@@ -115,9 +116,9 @@ func (c *runtime) CreateDataServer(name string, dataServer *proto.DataServer) bo
 		_ = nc.Close()
 		delete(c.drainingNodes, name)
 	}
-	c.nodeControllers[name] = controller.NewDataServerController(
+	c.dataServerControllers[name] = controller.NewDataServerController(
 		c.ctx,
-		identity,
+		dataServer,
 		c,
 		c,
 		c.rpc,
@@ -130,12 +131,12 @@ func (c *runtime) DeleteDataServer(name string) {
 	c.Lock()
 	defer c.Unlock()
 
-	nc, exist := c.nodeControllers[name]
+	nc, exist := c.dataServerControllers[name]
 	if !exist {
 		return
 	}
 	c.logger.Info("Detected a removed node", slog.Any("server", name))
-	delete(c.nodeControllers, name)
+	delete(c.dataServerControllers, name)
 	nc.SetStatus(controller.Draining)
 	c.drainingNodes[name] = nc
 }
@@ -228,7 +229,7 @@ func (c *runtime) findDataServerFeatures(dataServers []*proto.DataServerIdentity
 	features := make(map[string][]proto.Feature)
 	for _, dataServer := range dataServers {
 		dataServerID := dataServer.GetNameOrDefault()
-		if serverController, exist := c.nodeControllers[dataServerID]; exist {
+		if serverController, exist := c.dataServerControllers[dataServerID]; exist {
 			features[dataServerID] = serverController.SupportedFeatures()
 			continue
 		}
@@ -241,13 +242,14 @@ func (c *runtime) findDataServerFeatures(dataServers []*proto.DataServerIdentity
 	return features
 }
 
-func dataServersToCandidatesAndMetadata(dataServers map[string]*proto.DataServer) (
+func dataServersToCandidatesAndMetadata(dataServers map[string]commonobject.Borrowed[*proto.DataServer]) (
 	*linkedhashset.Set[string],
 	map[string]*proto.DataServerMetadata,
 ) {
 	candidates := linkedhashset.New[string]()
 	metadata := make(map[string]*proto.DataServerMetadata, len(dataServers))
-	for name, dataServer := range dataServers {
+	for name, borrowedDataServer := range dataServers {
+		dataServer := borrowedDataServer.UnsafeBorrow()
 		candidates.Add(name)
 		if dataServer.GetMetadata() != nil {
 			metadata[name] = dataServer.GetMetadata()
@@ -261,7 +263,7 @@ func dataServersToCandidatesAndMetadata(dataServers map[string]*proto.DataServer
 // selectNewEnsemble select a new server ensemble based on namespace policy and current cluster status.
 // It uses the ensemble selector to choose appropriate servers and returns the selected server metadata or an error.
 func (c *runtime) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
-	dataServers := c.metadata.ListDataServer().UnsafeBorrow()
+	dataServers := c.metadata.ListDataServer()
 	nodes, metadata := dataServersToCandidatesAndMetadata(dataServers)
 	ensembleContext := &ensemble.Context{
 		Candidates:         nodes,
@@ -281,7 +283,11 @@ func (c *runtime) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.Cl
 	}
 	esm := make([]*proto.DataServerIdentity, 0)
 	for _, id := range ensembles {
-		dataServer, exist := dataServers[id]
+		borrowedDataServer, exist := dataServers[id]
+		if !exist {
+			return nil, fmt.Errorf("failed to find node %s", id)
+		}
+		dataServer := borrowedDataServer.UnsafeBorrow()
 		if !exist || dataServer.GetIdentity() == nil {
 			return nil, fmt.Errorf("failed to find node %s", id)
 		}
@@ -302,7 +308,7 @@ func (c *runtime) Close() error {
 		err = multierr.Append(err, sc.Close())
 	}
 
-	for _, nc := range c.nodeControllers {
+	for _, nc := range c.dataServerControllers {
 		err = multierr.Append(err, nc.Close())
 	}
 
@@ -797,13 +803,13 @@ func New(
 		logger: slog.With(
 			slog.String("component", "coordinator"),
 		),
-		ensembleSelector: ensemble.NewSelector(),
-		shardControllers: make(map[int64]controller.ShardController),
-		splitControllers: make(map[int64]*controller.SplitController),
-		nodeControllers:  make(map[string]controller.DataServerController),
-		drainingNodes:    make(map[string]controller.DataServerController),
-		metadata:         metadata,
-		assignmentsWatch: commonwatch.New(&proto.ShardAssignments{}),
+		ensembleSelector:      ensemble.NewSelector(),
+		shardControllers:      make(map[int64]controller.ShardController),
+		splitControllers:      make(map[int64]*controller.SplitController),
+		dataServerControllers: make(map[string]controller.DataServerController),
+		drainingNodes:         make(map[string]controller.DataServerController),
+		metadata:              metadata,
+		assignmentsWatch:      commonwatch.New(&proto.ShardAssignments{}),
 	}
 
 	c.ctx, c.ctxCancel = context.WithCancel(context.Background())
@@ -814,7 +820,7 @@ func New(
 		NodeAvailableJudger: func(nodeID string) bool {
 			c.RLock()
 			defer c.RUnlock()
-			nc := c.nodeControllers[nodeID]
+			nc := c.dataServerControllers[nodeID]
 			return nc.Status() == controller.Running
 		},
 	})
@@ -826,9 +832,10 @@ func New(
 
 	// init node controller
 	for _, node := range dataServersFromStatus(clusterStatus) {
-		c.nodeControllers[node.GetNameOrDefault()] = controller.NewDataServerController(
+		dataServer := &proto.DataServer{Identity: node, Metadata: &proto.DataServerMetadata{}}
+		c.dataServerControllers[node.GetNameOrDefault()] = controller.NewDataServerController(
 			c.ctx,
-			node,
+			dataServer,
 			c,
 			c,
 			c.rpc,

--- a/tests/balancer/shard_balancer_test.go
+++ b/tests/balancer/shard_balancer_test.go
@@ -97,7 +97,7 @@ func TestNormalShardBalancer(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		_, exist := metadata.GetDataServerIdentity(s4ad.GetNameOrDefault())
+		_, exist := metadata.GetDataServer(s4ad.GetNameOrDefault())
 		return exist
 	}, 10*time.Second, 50*time.Millisecond)
 	assert.Eventually(t, func() bool {
@@ -209,7 +209,7 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		_, exist := metadata.GetDataServerIdentity(s4ad.GetNameOrDefault())
+		_, exist := metadata.GetDataServer(s4ad.GetNameOrDefault())
 		return exist
 	}, 10*time.Second, 50*time.Millisecond)
 	assert.Eventually(t, func() bool {
@@ -327,7 +327,7 @@ func TestBalanceWithoutDeadlock(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		_, exist := metadata.GetDataServerIdentity(s4ad.GetNameOrDefault())
+		_, exist := metadata.GetDataServer(s4ad.GetNameOrDefault())
 		return exist
 	}, 60*time.Second, 1*time.Second)
 

--- a/tests/balancer/shard_balancer_test.go
+++ b/tests/balancer/shard_balancer_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
-	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
 
 	"github.com/oxia-db/oxia/oxia"
 
@@ -101,12 +100,10 @@ func TestNormalShardBalancer(t *testing.T) {
 		return exist
 	}, 10*time.Second, 50*time.Millisecond)
 	assert.Eventually(t, func() bool {
-		controllers := coordinator.NodeControllers()
-		s4Controller, s4Ok := controllers[s4ad.GetNameOrDefault()]
-		s5Controller, s5Ok := controllers[s5ad.GetNameOrDefault()]
-		return s4Ok && s5Ok &&
-			s4Controller.Status() == controller.Running &&
-			s5Controller.Status() == controller.Running
+		dataServers := coordinator.ListDataServer()
+		_, s4Ok := dataServers[s4ad.GetNameOrDefault()]
+		_, s5Ok := dataServers[s5ad.GetNameOrDefault()]
+		return s4Ok && s5Ok
 	}, 30*time.Second, 50*time.Millisecond)
 
 	balancer := coordinator.LoadBalancer()
@@ -213,12 +210,10 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 		return exist
 	}, 10*time.Second, 50*time.Millisecond)
 	assert.Eventually(t, func() bool {
-		controllers := coordinator.NodeControllers()
-		s4Controller, s4Ok := controllers[s4ad.GetNameOrDefault()]
-		s5Controller, s5Ok := controllers[s5ad.GetNameOrDefault()]
-		return s4Ok && s5Ok &&
-			s4Controller.Status() == controller.Running &&
-			s5Controller.Status() == controller.Running
+		dataServers := coordinator.ListDataServer()
+		_, s4Ok := dataServers[s4ad.GetNameOrDefault()]
+		_, s5Ok := dataServers[s5ad.GetNameOrDefault()]
+		return s4Ok && s5Ok
 	}, 30*time.Second, 50*time.Millisecond)
 
 	balancer := coordinator.LoadBalancer()

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -534,7 +534,7 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 	assert.NoError(t, err)
 	c := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
-	assert.Equal(t, 3, len(c.NodeControllers()))
+	assert.Equal(t, 3, len(c.ListDataServer()))
 
 	// Add s4, s5
 	clusterConfig.Servers = append(clusterConfig.Servers,
@@ -551,16 +551,16 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		return len(c.NodeControllers()) == 4
+		return len(c.ListDataServer()) == 4
 	}, 10*time.Second, 10*time.Millisecond)
 
-	_, ok := c.NodeControllers()[sa1.Internal]
+	_, ok := c.ListDataServer()[sa1.Internal]
 	assert.False(t, ok)
 
-	_, ok = c.NodeControllers()[sa4.Internal]
+	_, ok = c.ListDataServer()[sa4.Internal]
 	assert.True(t, ok)
 
-	_, ok = c.NodeControllers()[sa5.Internal]
+	_, ok = c.ListDataServer()[sa5.Internal]
 	assert.True(t, ok)
 
 	assert.NoError(t, c.Close())
@@ -608,7 +608,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 		return true
 	}, 10*time.Second, 10*time.Millisecond)
 
-	assert.Equal(t, 4, len(c.NodeControllers()))
+	assert.Equal(t, 4, len(c.ListDataServer()))
 
 	// Remove leader dataserver
 	leaderID := metadata.GetStatus().UnsafeBorrow().Namespaces["my-ns-1"].Shards[0].Leader.GetNameOrDefault()
@@ -625,7 +625,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	_, err = configProvider.Store(clusterConfig, version)
 	assert.NoError(t, err)
 	assert.Eventually(t, func() bool {
-		return len(c.NodeControllers()) == 3
+		return len(c.ListDataServer()) == 3
 	}, 10*time.Second, 10*time.Millisecond)
 
 	// Wait for all shards to be ready


### PR DESCRIPTION
## Motivation
- align dataserver-related runtime and metadata APIs with the namespace-oriented coordinator API style
- expose dataserver domain objects directly instead of storage-shaped helper methods
- make borrowed collection reads consistent across runtime and metadata

## Modifications
- rename runtime dataserver lifecycle methods to `CreateDataServer` and `DeleteDataServer`
- replace `NodeControllers()` with `ListDataServer()` and source dataserver reads from dataserver controllers
- update dataserver controllers to retain the full `DataServer` entity and expose it through `GetDataServer()`
- simplify metadata dataserver reads to return dataserver entities directly and align collection reads with `map[string]Borrowed[*T]`
- update reconciler, balancer, and tests to use the new dataserver and namespace collection APIs

## Testing
- `make license-check`
- `make lint`
- `go test ./oxiad/coordinator/reconciler/... ./oxiad/coordinator/runtime/... ./oxiad/coordinator`
