### PR TITLE
refactor: remove server idx placement state

### DIFF
--- a/oxia/notifications.go
+++ b/oxia/notifications.go
@@ -88,6 +88,7 @@ func newNotifications(ctx context.Context, options clientOptions, clientPool rpc
 	defer cancel()
 
 	if err := nm.initWaitGroup.Wait(timeoutCtx); err != nil {
+		_ = nm.Close()
 		return nil, err
 	}
 
@@ -161,11 +162,8 @@ func (snm *shardNotificationsManager) getNotificationsWithRetries() { //nolint:r
 				)
 			}
 
-			if !snm.initialized {
-				snm.initialized = true
-				snm.nm.initWaitGroup.Fail(err)
-				snm.nm.cancel()
-			}
+			// Initial notification stream setup is allowed to retry until the
+			// caller-provided request timeout expires in newNotifications.
 		})
 
 	// Signal that this shard notification manager is now closed

--- a/oxia/notifications.go
+++ b/oxia/notifications.go
@@ -88,7 +88,6 @@ func newNotifications(ctx context.Context, options clientOptions, clientPool rpc
 	defer cancel()
 
 	if err := nm.initWaitGroup.Wait(timeoutCtx); err != nil {
-		_ = nm.Close()
 		return nil, err
 	}
 
@@ -162,8 +161,11 @@ func (snm *shardNotificationsManager) getNotificationsWithRetries() { //nolint:r
 				)
 			}
 
-			// Initial notification stream setup is allowed to retry until the
-			// caller-provided request timeout expires in newNotifications.
+			if !snm.initialized {
+				snm.initialized = true
+				snm.nm.initWaitGroup.Fail(err)
+				snm.nm.cancel()
+			}
 		})
 
 	// Signal that this shard notification manager is now closed

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -210,9 +210,6 @@ func (m *coordinatorMetadata) ReserveShardIDs(count uint32) int64 {
 }
 
 func (m *coordinatorMetadata) CreateNamespaceStatus(name string, status *commonproto.NamespaceStatus) bool {
-	m.loadClusterConfigWithInitSlow()
-	serverCount := len(m.GetConfig().UnsafeBorrow().GetServers())
-
 	m.statusLock.Lock()
 	defer m.statusLock.Unlock()
 
@@ -227,7 +224,6 @@ func (m *coordinatorMetadata) CreateNamespaceStatus(name string, status *commonp
 
 	namespaceStatus := gproto.Clone(status).(*commonproto.NamespaceStatus) //nolint:revive
 	clonedStatus.Namespaces[name] = namespaceStatus
-	clonedStatus.ServerIdx = (clonedStatus.ServerIdx + uint32(len(namespaceStatus.Shards))*namespaceStatus.GetReplicationFactor()) % uint32(serverCount)
 
 	m.persistStatusLocked(clonedStatus, "failed to create namespace status")
 	m.notifyStatusChange()

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -44,8 +44,8 @@ func shardMetadata(status string, ensemble []*proto.DataServerIdentity, start, e
 	}
 }
 
-func loadAwareEnsembleSupplier(servers []*proto.DataServerIdentity) func(*proto.Namespace, *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
-	return func(nc *proto.Namespace, cs *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
+func loadAwareEnsembleSupplier(servers []*proto.DataServerIdentity) func(*proto.Namespace, int64, *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
+	return func(nc *proto.Namespace, _ int64, cs *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
 		load := make(map[string]int, len(servers))
 		for _, s := range servers {
 			load[s.GetInternal()] = 0
@@ -66,11 +66,12 @@ func loadAwareEnsembleSupplier(servers []*proto.DataServerIdentity) func(*proto.
 	}
 }
 
-func simpleEnsembleSupplier(candidates []*proto.DataServerIdentity, nc *proto.Namespace, cs *proto.ClusterStatus) []*proto.DataServerIdentity {
+func simpleEnsembleSupplier(candidates []*proto.DataServerIdentity, shardID int64, replicationFactor uint32) []*proto.DataServerIdentity {
 	n := len(candidates)
-	res := make([]*proto.DataServerIdentity, nc.GetReplicationFactor())
-	for i := uint32(0); i < nc.GetReplicationFactor(); i++ {
-		res[i] = candidates[int(cs.ServerIdx+i)%n]
+	res := make([]*proto.DataServerIdentity, replicationFactor)
+	start := int(shardID % int64(n))
+	for i := uint32(0); i < replicationFactor; i++ {
+		res[i] = candidates[(start+int(i))%n]
 	}
 	return res
 }
@@ -81,9 +82,8 @@ func assertStatusEqual(t *testing.T, expected, actual *proto.ClusterStatus) {
 }
 
 type mockNamespaceMetadata struct {
-	status        *proto.ClusterStatus
-	configServers []*proto.DataServerIdentity
-	configNS      map[string]*proto.Namespace
+	status   *proto.ClusterStatus
+	configNS map[string]*proto.Namespace
 }
 
 func (*mockNamespaceMetadata) Close() error { return nil }
@@ -117,7 +117,6 @@ func (m *mockNamespaceMetadata) CreateNamespaceStatus(
 
 	namespaceStatus := gproto.Clone(status).(*proto.NamespaceStatus)
 	cloned.Namespaces[name] = namespaceStatus
-	cloned.ServerIdx = (cloned.ServerIdx + uint32(len(namespaceStatus.Shards))*namespaceStatus.GetReplicationFactor()) % uint32(len(m.configServers))
 
 	m.status = cloned
 	return true
@@ -190,7 +189,7 @@ var _ coordmetadata.Metadata = (*mockNamespaceMetadata)(nil)
 
 type mockNamespaceRuntime struct {
 	metadata            *mockNamespaceMetadata
-	selectNewEnsembleFn func(*proto.Namespace, *proto.ClusterStatus) ([]*proto.DataServerIdentity, error)
+	selectNewEnsembleFn func(*proto.Namespace, int64, *proto.ClusterStatus) ([]*proto.DataServerIdentity, error)
 	added               map[int64]string
 	deleted             []int64
 }
@@ -227,7 +226,6 @@ func (m *mockNamespaceRuntime) CreateNamespace(name string, namespaceConfig *pro
 	}
 	status := &proto.ClusterStatus{
 		Namespaces: make(map[string]*proto.NamespaceStatus, len(currentStatus.GetNamespaces())+1),
-		ServerIdx:  currentStatus.GetServerIdx(),
 	}
 	for name, existingNamespaceStatus := range currentStatus.GetNamespaces() {
 		status.Namespaces[name] = existingNamespaceStatus
@@ -235,7 +233,7 @@ func (m *mockNamespaceRuntime) CreateNamespace(name string, namespaceConfig *pro
 	status.Namespaces[name] = namespaceStatus
 
 	for _, shard := range sharding.GenerateShards(baseShardID, namespaceConfig.GetInitialShardCount()) {
-		ensemble, err := m.selectNewEnsembleFn(namespaceConfig, status)
+		ensemble, err := m.selectNewEnsembleFn(namespaceConfig, shard.Id, status)
 		if err != nil {
 			continue
 		}
@@ -301,8 +299,7 @@ func TestNamespaceReconcilerInitialPlacementSeesPriorShards(t *testing.T) {
 	const replicationFactor = 3
 
 	metadata := &mockNamespaceMetadata{
-		status:        proto.NewClusterStatus(),
-		configServers: servers,
+		status: proto.NewClusterStatus(),
 		configNS: map[string]*proto.Namespace{
 			"ns-1": {
 				Name:              "ns-1",
@@ -357,9 +354,7 @@ func TestNamespaceReconcilerNamespaceAddedPersistsAggregateStatus(t *testing.T) 
 				},
 			},
 			ShardIdGenerator: 1,
-			ServerIdx:        3,
 		},
-		configServers: servers,
 		configNS: map[string]*proto.Namespace{
 			"ns-1": {
 				Name:              "ns-1",
@@ -375,8 +370,8 @@ func TestNamespaceReconcilerNamespaceAddedPersistsAggregateStatus(t *testing.T) 
 	}
 	runtime := &mockNamespaceRuntime{
 		metadata: metadata,
-		selectNewEnsembleFn: func(namespaceConfig *proto.Namespace, status *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
-			return simpleEnsembleSupplier(servers, namespaceConfig, status), nil
+		selectNewEnsembleFn: func(namespaceConfig *proto.Namespace, shardID int64, _ *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
+			return simpleEnsembleSupplier(servers, shardID, namespaceConfig.GetReplicationFactor()), nil
 		},
 	}
 
@@ -405,13 +400,12 @@ func TestNamespaceReconcilerNamespaceAddedPersistsAggregateStatus(t *testing.T) 
 			"ns-2": {
 				ReplicationFactor: 3,
 				Shards: map[int64]*proto.ShardMetadata{
-					1: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s4, s1, s2}, 0, math.MaxUint32/2),
-					2: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s4, s1, s2}, math.MaxUint32/2+1, math.MaxUint32),
+					1: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s2, s3, s4}, 0, math.MaxUint32/2),
+					2: shardMetadata(proto.ShardStatusUnknown, []*proto.DataServerIdentity{s3, s4, s1}, math.MaxUint32/2+1, math.MaxUint32),
 				},
 			},
 		},
 		ShardIdGenerator: 3,
-		ServerIdx:        1,
 	}, metadata.status)
 
 	assert.Equal(t, map[int64]string{
@@ -441,9 +435,7 @@ func TestNamespaceReconcilerNamespaceRemovedMarksDeletingAndDeletesRuntimeShards
 				},
 			},
 			ShardIdGenerator: 3,
-			ServerIdx:        1,
 		},
-		configServers: servers,
 		configNS: map[string]*proto.Namespace{
 			"ns-1": {
 				Name:              "ns-1",
@@ -454,8 +446,8 @@ func TestNamespaceReconcilerNamespaceRemovedMarksDeletingAndDeletesRuntimeShards
 	}
 	runtime := &mockNamespaceRuntime{
 		metadata: metadata,
-		selectNewEnsembleFn: func(namespaceConfig *proto.Namespace, status *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
-			return simpleEnsembleSupplier(servers, namespaceConfig, status), nil
+		selectNewEnsembleFn: func(namespaceConfig *proto.Namespace, shardID int64, _ *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
+			return simpleEnsembleSupplier(servers, shardID, namespaceConfig.GetReplicationFactor()), nil
 		},
 	}
 
@@ -486,7 +478,6 @@ func TestNamespaceReconcilerNamespaceRemovedMarksDeletingAndDeletesRuntimeShards
 			},
 		},
 		ShardIdGenerator: 3,
-		ServerIdx:        1,
 	}, metadata.status)
 
 	sort.Slice(runtime.deleted, func(i, j int) bool { return runtime.deleted[i] < runtime.deleted[j] })

--- a/oxiad/coordinator/runtime/balancer/scheduler.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler.go
@@ -259,6 +259,8 @@ func (r *nodeBasedBalancer) swapShard(
 		CandidatesMetadata: metadata,
 		HierarchyPolicies:  nsc.GetPolicy(),
 		Status:             currentStatus,
+		Namespace:          candidateShard.Namespace,
+		Shard:              candidateShard.ShardID,
 		LoadRatioSupplier:  func() *model.Ratio { return loadRatios },
 	}
 	fromNodeID := fromNode.GetNameOrDefault()

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -22,12 +22,14 @@ import (
 	"time"
 
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
+	"github.com/stretchr/testify/assert"
 
 	commonobject "github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/proto"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/action"
+	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/model"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/selector"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/selector/single"
 )
@@ -185,6 +187,17 @@ func (s *selectRecordingSelector) Select(_ *single.Context) (string, error) {
 	return "", selector.ErrUnsatisfiedAntiAffinity
 }
 
+type contextRecordingSelector struct {
+	namespace string
+	shard     int64
+}
+
+func (s *contextRecordingSelector) Select(ctx *single.Context) (string, error) {
+	s.namespace = ctx.Namespace
+	s.shard = ctx.Shard
+	return "", selector.ErrUnsatisfiedAntiAffinity
+}
+
 func TestSwapShardSkipsRF1Namespace(t *testing.T) {
 	// Two nodes with an imbalanced distribution: sv-1 owns all 3 shards,
 	// sv-2 owns none. With RF=3 the balancer would try to swap, but with
@@ -237,6 +250,81 @@ func TestSwapShardSkipsRF1Namespace(t *testing.T) {
 	if len(b.actionCh) != 0 {
 		t.Fatalf("expected 0 actions, got %d", len(b.actionCh))
 	}
+}
+
+func TestSwapShardPassesNamespaceAndShardToSelector(t *testing.T) {
+	sv1 := dataServer("sv-1")
+	sv2 := dataServer("sv-2")
+	sv3 := dataServer("sv-3")
+
+	status := &proto.ClusterStatus{
+		Namespaces: map[string]*proto.NamespaceStatus{
+			"ns-1": {
+				ReplicationFactor: 2,
+				Shards: map[int64]*proto.ShardMetadata{
+					42: {Status: proto.ShardStatusSteadyState, Ensemble: []*proto.DataServerIdentity{sv1, sv2}},
+				},
+			},
+		},
+	}
+
+	nodes := linkedhashset.New("sv-1", "sv-2", "sv-3")
+	sel := &contextRecordingSelector{}
+	metadata := &mockMetadata{
+		status:   status,
+		nodes:    nodes,
+		metadata: map[string]*proto.DataServerMetadata{},
+		nsConfigs: map[string]*proto.Namespace{
+			"ns-1": {Name: "ns-1", ReplicationFactor: 2},
+		},
+		nodeMap: map[string]*proto.DataServerIdentity{
+			"sv-1": sv1,
+			"sv-2": sv2,
+			"sv-3": sv3,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	b := newTestBalancer(ctx, cancel, metadata, sel)
+	candidates, candidatesMetadata := dataServersToCandidatesAndMetadata(metadata.ListDataServer())
+	loadRatios := single.DefaultShardsRank(&model.RatioParams{
+		NodeShardsInfos: map[string][]model.ShardInfo{
+			"sv-1": {{
+				Namespace: "ns-1",
+				ShardID:   42,
+				Ensemble:  []*proto.DataServerIdentity{sv1, sv2},
+			}},
+			"sv-2": {{
+				Namespace: "ns-1",
+				ShardID:   42,
+				Ensemble:  []*proto.DataServerIdentity{sv1, sv2},
+			}},
+			"sv-3": {},
+		},
+	})
+
+	_, err := b.swapShard(
+		&model.ShardLoadRatio{
+			ShardInfo: &model.ShardInfo{
+				Namespace: "ns-1",
+				ShardID:   42,
+				Ensemble:  []*proto.DataServerIdentity{sv1, sv2},
+			},
+			Ratio: 1,
+		},
+		sv1,
+		&sync.WaitGroup{},
+		loadRatios,
+		candidates,
+		candidatesMetadata,
+		status,
+	)
+	assert.ErrorIs(t, err, selector.ErrUnsatisfiedAntiAffinity)
+
+	assert.Equal(t, "ns-1", sel.namespace)
+	assert.EqualValues(t, 42, sel.shard)
 }
 
 func TestBalanceHighestNodeDoesNotHangOnSelectorError(t *testing.T) {

--- a/oxiad/coordinator/runtime/balancer/selector/ensemble/context.go
+++ b/oxiad/coordinator/runtime/balancer/selector/ensemble/context.go
@@ -26,6 +26,8 @@ type Context struct {
 	CandidatesMetadata map[string]*commonproto.DataServerMetadata
 	HierarchyPolicies  *commonproto.HierarchyPolicies
 	Status             *commonproto.ClusterStatus
+	Namespace          string
+	Shard              int64
 	Replicas           int
 
 	LoadRatioSupplier func() *model.Ratio

--- a/oxiad/coordinator/runtime/balancer/selector/ensemble/selector.go
+++ b/oxiad/coordinator/runtime/balancer/selector/ensemble/selector.go
@@ -34,6 +34,8 @@ func (ensemble *ensemble) Select(context *Context) ([]string, error) {
 		Candidates:         context.Candidates,
 		CandidatesMetadata: context.CandidatesMetadata,
 		Status:             context.Status,
+		Namespace:          context.Namespace,
+		Shard:              context.Shard,
 		HierarchyPolicies:  context.HierarchyPolicies,
 		LoadRatioSupplier:  context.LoadRatioSupplier,
 	}

--- a/oxiad/coordinator/runtime/balancer/selector/ensemble/selector_test.go
+++ b/oxiad/coordinator/runtime/balancer/selector/ensemble/selector_test.go
@@ -42,11 +42,10 @@ func TestSelectMultipleAntiAffinitiesSatisfied(t *testing.T) {
 	context := &Context{
 		CandidatesMetadata: candidatesMetadata,
 		Candidates:         linkedhashset.New("s1", "s2", "s3", "s4"),
-		Status: &proto.ClusterStatus{
-			ServerIdx: 0,
-		},
-		HierarchyPolicies: nsPolicies,
-		Replicas:          3,
+		Namespace:          "ns-1",
+		Shard:              7,
+		HierarchyPolicies:  nsPolicies,
+		Replicas:           3,
 	}
 
 	esm, err := ensembleSelector.Select(context)

--- a/oxiad/coordinator/runtime/balancer/selector/single/context.go
+++ b/oxiad/coordinator/runtime/balancer/selector/single/context.go
@@ -29,6 +29,8 @@ type Context struct {
 	CandidatesMetadata map[string]*commonproto.DataServerMetadata
 	HierarchyPolicies  *commonproto.HierarchyPolicies
 	Status             *commonproto.ClusterStatus
+	Namespace          string
+	Shard              int64
 
 	LoadRatioSupplier func() *model.Ratio
 

--- a/oxiad/coordinator/runtime/balancer/selector/single/final_selector.go
+++ b/oxiad/coordinator/runtime/balancer/selector/single/final_selector.go
@@ -37,16 +37,12 @@ func (*finalSelector) Select(ssContext *Context) (string, error) {
 	if ssContext.selected != nil {
 		replicaOrdinal = ssContext.selected.Size()
 	}
-	startIdx := deterministicStartIdx(ssContext.Namespace, ssContext.Shard, replicaOrdinal, len(candidatesArr))
-	return candidatesArr[startIdx], nil
-}
-
-func deterministicStartIdx(namespace string, shard int64, replicaOrdinal int, candidates int) int {
 	hasher := fnv.New64a()
-	_, _ = hasher.Write([]byte(namespace))
+	_, _ = hasher.Write([]byte(ssContext.Namespace))
 	var buf [16]byte
-	binary.LittleEndian.PutUint64(buf[:8], uint64(shard))
+	binary.LittleEndian.PutUint64(buf[:8], uint64(ssContext.Shard))
 	binary.LittleEndian.PutUint64(buf[8:], uint64(replicaOrdinal))
 	_, _ = hasher.Write(buf[:])
-	return int(hasher.Sum64() % uint64(candidates))
+	startIdx := int(hasher.Sum64() % uint64(len(candidatesArr)))
+	return candidatesArr[startIdx], nil
 }

--- a/oxiad/coordinator/runtime/balancer/selector/single/final_selector.go
+++ b/oxiad/coordinator/runtime/balancer/selector/single/final_selector.go
@@ -15,7 +15,9 @@
 package single
 
 import (
-	"math/rand/v2"
+	"encoding/binary"
+	"hash/fnv"
+	"sort"
 
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/selector"
 )
@@ -25,14 +27,26 @@ var _ selector.Selector[*Context, string] = &finalSelector{}
 type finalSelector struct{}
 
 func (*finalSelector) Select(ssContext *Context) (string, error) {
-	status := ssContext.Status
 	candidatesArr := ssContext.Candidates.Values()
 	if len(candidatesArr) == 0 {
 		return "", selector.ErrNoFunctioning
 	}
-	if status != nil {
-		startIdx := ssContext.Status.ServerIdx
-		return candidatesArr[int(startIdx)%len(candidatesArr)], nil
+
+	sort.Strings(candidatesArr)
+	replicaOrdinal := 0
+	if ssContext.selected != nil {
+		replicaOrdinal = ssContext.selected.Size()
 	}
-	return candidatesArr[rand.IntN(len(candidatesArr))], nil //nolint:gosec
+	startIdx := deterministicStartIdx(ssContext.Namespace, ssContext.Shard, replicaOrdinal, len(candidatesArr))
+	return candidatesArr[startIdx], nil
+}
+
+func deterministicStartIdx(namespace string, shard int64, replicaOrdinal int, candidates int) int {
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(namespace))
+	var buf [16]byte
+	binary.LittleEndian.PutUint64(buf[:8], uint64(shard))
+	binary.LittleEndian.PutUint64(buf[8:], uint64(replicaOrdinal))
+	_, _ = hasher.Write(buf[:])
+	return int(hasher.Sum64() % uint64(candidates))
 }

--- a/oxiad/coordinator/runtime/balancer/selector/single/final_selector_test.go
+++ b/oxiad/coordinator/runtime/balancer/selector/single/final_selector_test.go
@@ -1,0 +1,72 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package single
+
+import (
+	"testing"
+
+	"github.com/emirpasic/gods/v2/sets/linkedhashset"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFinalSelectorIgnoresCandidateInsertionOrder(t *testing.T) {
+	selector := &finalSelector{}
+	selected := linkedhashset.New[string]()
+
+	firstContext := &Context{
+		Candidates: linkedhashset.New("s3", "s1", "s2"),
+		Namespace:  "ns-1",
+		Shard:      7,
+	}
+	firstContext.SetSelected(selected)
+
+	secondContext := &Context{
+		Candidates: linkedhashset.New("s2", "s3", "s1"),
+		Namespace:  "ns-1",
+		Shard:      7,
+	}
+	secondContext.SetSelected(selected)
+
+	first, err := selector.Select(firstContext)
+	require.NoError(t, err)
+
+	second, err := selector.Select(secondContext)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+}
+
+func TestFinalSelectorAdvancesWithReplicaOrdinal(t *testing.T) {
+	selector := &finalSelector{}
+	selected := linkedhashset.New[string]()
+	context := &Context{
+		Candidates: linkedhashset.New("s4", "s1", "s3", "s2"),
+		Namespace:  "ns-1",
+		Shard:      11,
+	}
+	context.SetSelected(selected)
+
+	first, err := selector.Select(context)
+	require.NoError(t, err)
+
+	selected.Add(first)
+	context.SetSelected(selected)
+
+	second, err := selector.Select(context)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first, second)
+}

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -159,7 +159,6 @@ func (c *runtime) CreateNamespace(name string, namespaceConfig *proto.Namespace)
 	}
 	status := &proto.ClusterStatus{
 		Namespaces: make(map[string]*proto.NamespaceStatus, len(currentStatus.GetNamespaces())+1),
-		ServerIdx:  currentStatus.GetServerIdx(),
 	}
 	for name, existingNamespaceStatus := range currentStatus.GetNamespaces() {
 		status.Namespaces[name] = existingNamespaceStatus
@@ -167,7 +166,7 @@ func (c *runtime) CreateNamespace(name string, namespaceConfig *proto.Namespace)
 	status.Namespaces[name] = namespaceStatus
 
 	for _, shard := range sharding.GenerateShards(baseShardID, namespaceConfig.GetInitialShardCount()) {
-		esm, err := c.selectNewEnsemble(namespaceConfig, status)
+		esm, err := c.selectNewEnsemble(name, shard.Id, namespaceConfig, status)
 		if err != nil {
 			c.logger.Error("failed to select new ensembles", slog.Any("shard", shard), slog.Any("error", err))
 			continue
@@ -262,7 +261,7 @@ func dataServersToCandidatesAndMetadata(dataServers map[string]commonobject.Borr
 
 // selectNewEnsemble select a new server ensemble based on namespace policy and current cluster status.
 // It uses the ensemble selector to choose appropriate servers and returns the selected server metadata or an error.
-func (c *runtime) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
+func (c *runtime) selectNewEnsemble(namespace string, shard int64, ns *proto.Namespace, editingStatus *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
 	dataServers := c.metadata.ListDataServer()
 	nodes, metadata := dataServersToCandidatesAndMetadata(dataServers)
 	ensembleContext := &ensemble.Context{
@@ -270,6 +269,8 @@ func (c *runtime) selectNewEnsemble(ns *proto.Namespace, editingStatus *proto.Cl
 		CandidatesMetadata: metadata,
 		HierarchyPolicies:  ns.GetPolicy(),
 		Status:             editingStatus,
+		Namespace:          namespace,
+		Shard:              shard,
 		Replicas:           int(ns.GetReplicationFactor()),
 		LoadRatioSupplier: func() *model.Ratio {
 			groupedStatus, historyNodes := state.GroupingShardsNodeByStatus(nodes, editingStatus)
@@ -582,7 +583,7 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 	// status so the right child's selection sees the updated load distribution
 	// and picks a different server.
 	nsConfig := c.namespaceConfigForSplit(namespace)
-	leftEnsemble, err := c.selectNewEnsemble(nsConfig, cloned)
+	leftEnsemble, err := c.selectNewEnsemble(namespace, leftChildId, nsConfig, cloned)
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "failed to select ensemble for left child")
 	}
@@ -596,9 +597,7 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 			Max: sp,
 		},
 	}
-	cloned.ServerIdx += nsConfig.GetReplicationFactor()
-
-	rightEnsemble, err := c.selectNewEnsemble(nsConfig, cloned)
+	rightEnsemble, err := c.selectNewEnsemble(namespace, rightChildId, nsConfig, cloned)
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "failed to select ensemble for right child")
 	}
@@ -671,7 +670,7 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 		RpcProvider:   c.rpc,
 		EventListener: c,
 		EnsembleSelector: func(ns string) ([]*proto.DataServerIdentity, error) {
-			return c.selectNewEnsemble(c.namespaceConfigForSplit(ns), c.metadata.GetStatus().UnsafeBorrow())
+			return c.selectNewEnsemble(ns, 0, c.namespaceConfigForSplit(ns), c.metadata.GetStatus().UnsafeBorrow())
 		},
 	})
 	c.splitControllers[parentShardId] = sc
@@ -787,7 +786,7 @@ func (c *runtime) restartInProgressSplits(clusterStatus *proto.ClusterStatus) {
 				RpcProvider:   c.rpc,
 				EventListener: c,
 				EnsembleSelector: func(namespace string) ([]*proto.DataServerIdentity, error) {
-					return c.selectNewEnsemble(c.namespaceConfigForSplit(namespace), c.metadata.GetStatus().UnsafeBorrow())
+					return c.selectNewEnsemble(namespace, 0, c.namespaceConfigForSplit(namespace), c.metadata.GetStatus().UnsafeBorrow())
 				},
 			})
 			c.splitControllers[shardId] = sc


### PR DESCRIPTION
## Motivation
- stop relying on persisted `ServerIdx` state for initial shard placement
- make bootstrap and split-child placement deterministic from shard identity instead of mutable status cursor state
- keep this PR scoped to placement logic without changing the cluster status wire format

## Modifications
- remove `ServerIdx` updates from namespace status creation and split-child placement
- thread namespace and shard identifiers into the ensemble selector context
- replace the final selector fallback with a deterministic hash-based tie-break over sorted candidates and replica ordinal
- update namespace reconciler and selector tests to cover the deterministic placement behavior

## Testing
- `make license-check`
- `make lint`
- `go test ./oxiad/coordinator/metadata ./oxiad/coordinator/reconciler/... ./oxiad/coordinator/runtime/... ./oxiad/coordinator`
