### PR TITLE
refactor: simplify metadata watch flow

### DIFF
--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,7 +47,10 @@ func newTestMetadata(t *testing.T, config *proto.ClusterConfiguration) coordmeta
 	}
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(config, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   config,
+		Version: metadatacommon.NotExists,
+	})
 	require.NoError(t, err)
 	metadataFactory := coordmetadata.NewFactoryWithProviders(
 		memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled),

--- a/oxiad/coordinator/metadata/common/error.go
+++ b/oxiad/coordinator/metadata/common/error.go
@@ -17,7 +17,6 @@ package common
 import "github.com/pkg/errors"
 
 var (
-	ErrNotInitialized   = errors.New("metadata not initialized")
-	ErrBadVersion       = errors.New("metadata bad version")
-	ErrWatchUnsupported = errors.New("metadata watch unsupported")
+	ErrNotInitialized = errors.New("metadata not initialized")
+	ErrBadVersion     = errors.New("metadata bad version")
 )

--- a/oxiad/coordinator/metadata/factory.go
+++ b/oxiad/coordinator/metadata/factory.go
@@ -44,11 +44,11 @@ type Factory struct {
 	raftInterceptor raft.Interceptor
 }
 
-func (f *Factory) OnApplied(key string, data []byte) {
+func (f *Factory) OnApplied(key string, data []byte, version int64) {
 	if f.raftInterceptor == nil {
 		return
 	}
-	f.raftInterceptor.OnApplied(key, data)
+	f.raftInterceptor.OnApplied(key, data, version)
 }
 
 func NewFactoryWithProviders(

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -17,24 +17,19 @@ package metadata
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"sync"
 	"time"
 
-	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
-
 	"github.com/cenkalti/backoff/v4"
-	"github.com/emirpasic/gods/v2/trees/redblacktree"
 	"github.com/google/uuid"
-	gproto "google.golang.org/protobuf/proto"
 
 	commonobject "github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/process"
 	commonproto "github.com/oxia-db/oxia/common/proto"
-	"github.com/oxia-db/oxia/oxiad/common/rpc"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
+	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 )
 
@@ -55,7 +50,7 @@ type Metadata interface {
 	DeleteShardStatus(namespace string, shard int64)
 
 	GetConfig() commonobject.Borrowed[*commonproto.ClusterConfiguration]
-	ConfigWatch() *commonwatch.Watch[*commonproto.ClusterConfiguration]
+	SubscribeConfig() *commonwatch.Receiver[provider.Versioned[commonobject.Borrowed[*commonproto.ClusterConfiguration]]]
 	GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer]
 
 	ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer]
@@ -68,184 +63,187 @@ type EnsembleSupplier func(
 ) ([]*commonproto.DataServerIdentity, error)
 
 type coordinatorMetadata struct {
-	logger    *slog.Logger
-	ctx       context.Context
-	ctxCancel context.CancelFunc
-	wg        sync.WaitGroup
+	logger *slog.Logger
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
 
 	statusProvider provider.Provider[*commonproto.ClusterStatus]
+	statusLock     sync.Mutex
+	changeChLock   sync.RWMutex
+	changeCh       chan struct{}
+
 	configProvider provider.Provider[*commonproto.ClusterConfiguration]
-
-	statusLock       sync.RWMutex
-	currentStatus    *commonproto.ClusterStatus
-	currentVersionID metadatacommon.Version
-	changeCh         chan struct{}
-
-	clusterConfigLock     sync.RWMutex
-	currentClusterConfig  *commonproto.ClusterConfiguration
-	clusterConfigWatch    *commonwatch.Watch[*commonproto.ClusterConfiguration]
-	namespaceConfigsIndex *redblacktree.Tree[string, *commonproto.Namespace]
+	configWatch    *commonwatch.Watch[provider.Versioned[commonobject.Borrowed[*commonproto.ClusterConfiguration]]]
 }
 
 func newMetadata(ctx context.Context, statusProvider provider.Provider[*commonproto.ClusterStatus], configProvider provider.Provider[*commonproto.ClusterConfiguration]) Metadata {
 	metadataCtx, cancel := context.WithCancel(ctx)
+	configSnapshot := configProvider.Watch().Load()
 	m := &coordinatorMetadata{
-		logger:             slog.With(slog.String("component", "coordinator-metadata")),
-		ctx:                metadataCtx,
-		ctxCancel:          cancel,
-		wg:                 sync.WaitGroup{},
-		statusProvider:     statusProvider,
-		configProvider:     configProvider,
-		currentVersionID:   metadatacommon.NotExists,
-		changeCh:           make(chan struct{}),
-		clusterConfigWatch: commonwatch.New(&commonproto.ClusterConfiguration{}),
+		logger:         slog.With(slog.String("component", "coordinator-metadata")),
+		ctx:            metadataCtx,
+		cancel:         cancel,
+		statusProvider: statusProvider,
+		changeCh:       make(chan struct{}),
+		configProvider: configProvider,
+		configWatch: commonwatch.New(provider.Versioned[commonobject.Borrowed[*commonproto.ClusterConfiguration]]{
+			Value:   commonobject.Borrow(configSnapshot.Value),
+			Version: configSnapshot.Version,
+		}),
 	}
 
 	m.doStatusRecovery()
-
-	if configWatch, err := configProvider.Watch(); err != nil && !errors.Is(err, metadatacommon.ErrWatchUnsupported) {
-		m.logger.Warn("failed to watch cluster config provider", slog.Any("error", err))
-	} else if configWatch != nil {
-		m.wg.Go(func() {
-			process.DoWithLabels(metadataCtx, map[string]string{
-				"component": "coordinator-metadata-config-watcher",
-			}, func() {
-				m.waitForConfigUpdates(configWatch)
-			})
-		})
-	}
-
+	m.wg.Go(func() {
+		process.DoWithLabels(metadataCtx, map[string]string{
+			"component": "coordinator-metadata-config-watcher",
+		}, m.relayConfigUpdates)
+	})
 	return m
 }
 
+func (m *coordinatorMetadata) computeStatus(fn func(*commonproto.ClusterStatus, metadatacommon.Version) (*commonproto.ClusterStatus, bool)) error {
+	m.statusLock.Lock()
+	defer m.statusLock.Unlock()
+
+	current := m.statusProvider.Watch().Load()
+	next, changed := fn(metadatacommon.ClusterStatusCodec.Clone(current.Value), current.Version)
+	if !changed {
+		return nil
+	}
+
+	_, err := m.statusProvider.Store(next, current.Version)
+	return err
+}
+
 func (m *coordinatorMetadata) Close() error {
-	m.ctxCancel()
+	m.cancel()
 	m.wg.Wait()
 	return nil
 }
 
+func (m *coordinatorMetadata) relayConfigUpdates() {
+	receiver := m.configProvider.Watch().Subscribe()
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-receiver.Changed():
+			snapshot := receiver.Load()
+			m.configWatch.Publish(provider.Versioned[commonobject.Borrowed[*commonproto.ClusterConfiguration]]{
+				Value:   commonobject.Borrow(snapshot.Value),
+				Version: snapshot.Version,
+			})
+		}
+	}
+}
+
 func (m *coordinatorMetadata) notifyStatusChange() {
+	m.changeChLock.Lock()
+	defer m.changeChLock.Unlock()
 	close(m.changeCh)
 	m.changeCh = make(chan struct{})
 }
 
 func (m *coordinatorMetadata) doStatusRecovery() {
-	m.statusLock.Lock()
-	defer m.statusLock.Unlock()
-
-	_ = backoff.RetryNotify(func() error {
-		clusterStatus, version, err := m.statusProvider.Get()
-		if err != nil {
-			return err
-		}
-		if clusterStatus == nil {
-			m.currentStatus = nil
-			m.currentVersionID = version
-			return nil
-		}
-		m.currentStatus = clusterStatus
-		m.currentVersionID = version
-		return nil
-	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
-		m.logger.Warn(
-			"failed to load status, retrying later",
-			slog.Any("error", err),
-			slog.Duration("retry-after", duration),
-		)
-	})
-
-	if m.currentStatus == nil {
-		m.currentStatus = commonproto.NewClusterStatus()
-	}
-	if m.currentStatus.InstanceId == "" {
-		clonedStatus := gproto.Clone(m.currentStatus).(*commonproto.ClusterStatus) //nolint:revive
-		clonedStatus.InstanceId = uuid.NewString()
-		m.persistStatusLocked(clonedStatus, "failed to initialize instance id")
+	status := m.statusProvider.Watch().Load().Value
+	if status.GetInstanceId() == "" {
+		_ = backoff.RetryNotify(func() error {
+			return m.computeStatus(func(status *commonproto.ClusterStatus, _ metadatacommon.Version) (*commonproto.ClusterStatus, bool) {
+				if status.GetInstanceId() != "" {
+					return status, false
+				}
+				status.InstanceId = uuid.NewString()
+				return status, true
+			})
+		}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+			m.logger.Warn(
+				"failed to initialize instance id",
+				slog.Any("error", err),
+				slog.Duration("retry-after", duration),
+			)
+		})
 		m.notifyStatusChange()
 	}
 }
 
-func (m *coordinatorMetadata) persistStatusLocked(newStatus *commonproto.ClusterStatus, warnMessage string) {
+func (m *coordinatorMetadata) GetStatus() commonobject.Borrowed[*commonproto.ClusterStatus] {
+	return commonobject.Borrow(m.statusProvider.Watch().Load().Value)
+}
+
+func (m *coordinatorMetadata) UpdateStatus(newStatus *commonproto.ClusterStatus) {
 	_ = backoff.RetryNotify(func() error {
-		versionID, err := m.statusProvider.Store(newStatus, m.currentVersionID)
-		if err != nil {
-			return err
-		}
-		m.currentStatus = newStatus
-		m.currentVersionID = versionID
-		return nil
+		return m.computeStatus(func(_ *commonproto.ClusterStatus, _ metadatacommon.Version) (*commonproto.ClusterStatus, bool) {
+			return newStatus, true
+		})
 	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
 		m.logger.Warn(
-			warnMessage,
+			"failed to update status",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
 		)
 	})
-}
-
-func (m *coordinatorMetadata) GetStatus() commonobject.Borrowed[*commonproto.ClusterStatus] {
-	m.statusLock.RLock()
-	defer m.statusLock.RUnlock()
-	return commonobject.Borrow(m.currentStatus)
-}
-
-func (m *coordinatorMetadata) UpdateStatus(newStatus *commonproto.ClusterStatus) {
-	m.statusLock.Lock()
-	defer m.statusLock.Unlock()
-
-	m.persistStatusLocked(newStatus, "failed to update status")
 	m.notifyStatusChange()
 }
 
 func (m *coordinatorMetadata) ReserveShardIDs(count uint32) int64 {
-	m.statusLock.Lock()
-	defer m.statusLock.Unlock()
-
-	clonedStatus := gproto.Clone(m.currentStatus).(*commonproto.ClusterStatus) //nolint:revive
-	base := clonedStatus.ShardIdGenerator
-	clonedStatus.ShardIdGenerator += int64(count)
-	m.persistStatusLocked(clonedStatus, "failed to reserve shard ids")
+	var base int64
+	_ = backoff.RetryNotify(func() error {
+		return m.computeStatus(func(status *commonproto.ClusterStatus, _ metadatacommon.Version) (*commonproto.ClusterStatus, bool) {
+			base = status.GetShardIdGenerator()
+			status.ShardIdGenerator += int64(count)
+			return status, true
+		})
+	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+		m.logger.Warn(
+			"failed to reserve shard ids",
+			slog.Any("error", err),
+			slog.Duration("retry-after", duration),
+		)
+	})
 	m.notifyStatusChange()
 	return base
 }
 
 func (m *coordinatorMetadata) CreateNamespaceStatus(name string, status *commonproto.NamespaceStatus) bool {
-	m.statusLock.Lock()
-	defer m.statusLock.Unlock()
-
-	clonedStatus := gproto.Clone(m.currentStatus).(*commonproto.ClusterStatus) //nolint:revive
-	if clonedStatus.Namespaces == nil {
-		clonedStatus.Namespaces = map[string]*commonproto.NamespaceStatus{}
+	created := false
+	_ = backoff.RetryNotify(func() error {
+		return m.computeStatus(func(clusterStatus *commonproto.ClusterStatus, _ metadatacommon.Version) (*commonproto.ClusterStatus, bool) {
+			if clusterStatus.Namespaces == nil {
+				clusterStatus.Namespaces = map[string]*commonproto.NamespaceStatus{}
+			}
+			if _, exists := clusterStatus.Namespaces[name]; exists {
+				return clusterStatus, false
+			}
+			clusterStatus.Namespaces[name] = status
+			created = true
+			return clusterStatus, true
+		})
+	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+		m.logger.Warn(
+			"failed to create namespace status",
+			slog.Any("error", err),
+			slog.Duration("retry-after", duration),
+		)
+	})
+	if created {
+		m.notifyStatusChange()
 	}
-
-	if _, exists := clonedStatus.Namespaces[name]; exists {
-		return false
-	}
-
-	namespaceStatus := gproto.Clone(status).(*commonproto.NamespaceStatus) //nolint:revive
-	clonedStatus.Namespaces[name] = namespaceStatus
-
-	m.persistStatusLocked(clonedStatus, "failed to create namespace status")
-	m.notifyStatusChange()
-	return true
+	return created
 }
 
 func (m *coordinatorMetadata) ListNamespaceStatus() map[string]commonobject.Borrowed[*commonproto.NamespaceStatus] {
-	m.statusLock.RLock()
-	defer m.statusLock.RUnlock()
-
-	namespaces := make(map[string]commonobject.Borrowed[*commonproto.NamespaceStatus], len(m.currentStatus.Namespaces))
-	for name, status := range m.currentStatus.Namespaces {
+	status := m.statusProvider.Watch().Load().Value
+	namespaces := make(map[string]commonobject.Borrowed[*commonproto.NamespaceStatus], len(status.GetNamespaces()))
+	for name, status := range status.GetNamespaces() {
 		namespaces[name] = commonobject.Borrow(status)
 	}
 	return namespaces
 }
 
 func (m *coordinatorMetadata) GetNamespaceStatus(namespace string) (commonobject.Borrowed[*commonproto.NamespaceStatus], bool) {
-	m.statusLock.RLock()
-	defer m.statusLock.RUnlock()
-
-	namespaceStatus, exists := m.currentStatus.Namespaces[namespace]
+	status := m.statusProvider.Watch().Load().Value
+	namespaceStatus, exists := status.GetNamespaces()[namespace]
 	if !exists {
 		return commonobject.Borrowed[*commonproto.NamespaceStatus]{}, false
 	}
@@ -253,177 +251,103 @@ func (m *coordinatorMetadata) GetNamespaceStatus(namespace string) (commonobject
 }
 
 func (m *coordinatorMetadata) DeleteNamespaceStatus(name string) commonobject.Borrowed[*commonproto.NamespaceStatus] {
-	m.statusLock.Lock()
-	defer m.statusLock.Unlock()
-
-	clonedStatus := gproto.Clone(m.currentStatus).(*commonproto.ClusterStatus) //nolint:revive
-	namespaceStatus, exists := clonedStatus.Namespaces[name]
-	if !exists {
-		return commonobject.Borrowed[*commonproto.NamespaceStatus]{}
-	}
-
+	var namespaceStatus *commonproto.NamespaceStatus
 	changed := false
-	for shardID, shardMetadata := range namespaceStatus.Shards {
-		if shardMetadata.Status != commonproto.ShardStatusDeleting {
-			shardMetadata.Status = commonproto.ShardStatusDeleting
-			namespaceStatus.Shards[shardID] = shardMetadata
-			changed = true
-		}
-	}
+	_ = backoff.RetryNotify(func() error {
+		return m.computeStatus(func(clusterStatus *commonproto.ClusterStatus, _ metadatacommon.Version) (*commonproto.ClusterStatus, bool) {
+			ns, exists := clusterStatus.Namespaces[name]
+			if !exists {
+				return clusterStatus, false
+			}
+			namespaceStatus = ns
+			for shardID, shardMetadata := range ns.Shards {
+				if shardMetadata.Status != commonproto.ShardStatusDeleting {
+					shardMetadata.Status = commonproto.ShardStatusDeleting
+					ns.Shards[shardID] = shardMetadata
+					changed = true
+				}
+			}
+			return clusterStatus, changed
+		})
+	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+		m.logger.Warn(
+			"failed to mark namespace deleting",
+			slog.Any("error", err),
+			slog.Duration("retry-after", duration),
+		)
+	})
 	if changed {
-		m.persistStatusLocked(clonedStatus, "failed to mark namespace deleting")
 		m.notifyStatusChange()
 	}
 	return commonobject.Borrow(namespaceStatus)
 }
 
 func (m *coordinatorMetadata) UpdateShardStatus(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata) {
-	m.statusLock.Lock()
-	defer m.statusLock.Unlock()
-
-	clonedStatus := gproto.Clone(m.currentStatus).(*commonproto.ClusterStatus) //nolint:revive
-	ns, exist := clonedStatus.Namespaces[namespace]
-	if !exist {
-		return
-	}
-	ns.Shards[shard] = gproto.Clone(shardMetadata).(*commonproto.ShardMetadata) //nolint:revive
-	m.persistStatusLocked(clonedStatus, "failed to update shard metadata")
-	m.notifyStatusChange()
-}
-
-func (m *coordinatorMetadata) DeleteShardStatus(namespace string, shard int64) {
-	m.statusLock.Lock()
-	defer m.statusLock.Unlock()
-
-	clonedStatus := gproto.Clone(m.currentStatus).(*commonproto.ClusterStatus) //nolint:revive
-	ns, exist := clonedStatus.Namespaces[namespace]
-	if !exist {
-		return
-	}
-	delete(ns.Shards, shard)
-	if len(ns.Shards) == 0 {
-		delete(clonedStatus.Namespaces, namespace)
-	}
-	m.persistStatusLocked(clonedStatus, "failed to delete shard metadata")
-	m.notifyStatusChange()
-}
-
-func (m *coordinatorMetadata) statusChangeNotify() <-chan struct{} {
-	m.statusLock.RLock()
-	defer m.statusLock.RUnlock()
-	return m.changeCh
-}
-
-func (m *coordinatorMetadata) loadClusterConfigWithInitSlow() {
-	m.clusterConfigLock.Lock()
-	defer m.clusterConfigLock.Unlock()
-	if m.currentClusterConfig != nil {
-		return
-	}
-
+	changed := false
 	_ = backoff.RetryNotify(func() error {
-		newConfig, err := loadClusterConfigFromProvider(m.configProvider)
-		if err != nil {
-			return err
-		}
-		m.currentClusterConfig = gproto.Clone(newConfig).(*commonproto.ClusterConfiguration) //nolint:revive
-		m.rebuildConfigIndexesLocked()
-		m.clusterConfigWatch.Publish(m.currentClusterConfig)
-		return nil
+		return m.computeStatus(func(clusterStatus *commonproto.ClusterStatus, _ metadatacommon.Version) (*commonproto.ClusterStatus, bool) {
+			ns, exist := clusterStatus.Namespaces[namespace]
+			if !exist {
+				return clusterStatus, false
+			}
+			ns.Shards[shard] = shardMetadata
+			changed = true
+			return clusterStatus, true
+		})
 	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
 		m.logger.Warn(
-			"failed to load cluster configuration, retrying later",
+			"failed to update shard metadata",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
 		)
 	})
-}
-
-func loadClusterConfigFromProvider(configProvider provider.Provider[*commonproto.ClusterConfiguration]) (*commonproto.ClusterConfiguration, error) {
-	config, _, err := configProvider.Get()
-	if err != nil {
-		return nil, err
-	}
-	if config == nil {
-		return nil, metadatacommon.ErrNotInitialized
-	}
-	if err := validateClusterConfig(config); err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
-func validateClusterConfig(config *commonproto.ClusterConfiguration) error {
-	if config == nil {
-		return metadatacommon.ErrNotInitialized
-	}
-	if err := config.Validate(); err != nil {
-		return err
-	}
-	for _, authority := range config.GetAllowExtraAuthorities() {
-		if err := rpc.ValidateAuthorityAddress(authority); err != nil {
-			return fmt.Errorf("cluster configuration: invalid allowExtraAuthorities entry %q: %w", authority, err)
-		}
-	}
-	return nil
-}
-
-func (m *coordinatorMetadata) rebuildConfigIndexesLocked() {
-	namespaceConfigs := redblacktree.New[string, *commonproto.Namespace]()
-	for _, ns := range m.currentClusterConfig.GetNamespaces() {
-		namespaceConfigs.Put(ns.GetName(), ns)
-	}
-	m.namespaceConfigsIndex = namespaceConfigs
-}
-
-func (m *coordinatorMetadata) waitForConfigUpdates(configWatch *commonwatch.Receiver[*commonproto.ClusterConfiguration]) {
-	m.applyConfigWatchValue(configWatch)
-	for {
-		select {
-		case <-m.ctx.Done():
-			return
-
-		case <-configWatch.Changed():
-			m.logger.Info("Received cluster config change event")
-			m.applyConfigWatchValue(configWatch)
-		}
+	if changed {
+		m.notifyStatusChange()
 	}
 }
 
-func (m *coordinatorMetadata) applyConfigWatchValue(configWatch *commonwatch.Receiver[*commonproto.ClusterConfiguration]) {
-	config := configWatch.Load()
-	if err := validateClusterConfig(config); err != nil {
-		m.logger.Warn("received invalid cluster config watch value", slog.Any("error", err))
-		return
+func (m *coordinatorMetadata) DeleteShardStatus(namespace string, shard int64) {
+	changed := false
+	_ = backoff.RetryNotify(func() error {
+		return m.computeStatus(func(clusterStatus *commonproto.ClusterStatus, _ metadatacommon.Version) (*commonproto.ClusterStatus, bool) {
+			ns, exist := clusterStatus.Namespaces[namespace]
+			if !exist {
+				return clusterStatus, false
+			}
+			if _, exists := ns.Shards[shard]; !exists {
+				return clusterStatus, false
+			}
+			delete(ns.Shards, shard)
+			if len(ns.Shards) == 0 {
+				delete(clusterStatus.Namespaces, namespace)
+			}
+			changed = true
+			return clusterStatus, true
+		})
+	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+		m.logger.Warn(
+			"failed to delete shard metadata",
+			slog.Any("error", err),
+			slog.Duration("retry-after", duration),
+		)
+	})
+	if changed {
+		m.notifyStatusChange()
 	}
-	clonedConfig := gproto.Clone(config).(*commonproto.ClusterConfiguration) //nolint:revive
+}
 
-	m.clusterConfigLock.Lock()
-	oldClusterConfig := m.currentClusterConfig
-	m.currentClusterConfig = clonedConfig
-	m.rebuildConfigIndexesLocked()
-	m.clusterConfigLock.Unlock()
-
-	if gproto.Equal(oldClusterConfig, clonedConfig) {
-		m.logger.Info("No cluster config changes detected")
-		return
-	}
-	m.clusterConfigWatch.Publish(clonedConfig)
+func (m *coordinatorMetadata) statusChangeNotify() <-chan struct{} {
+	m.changeChLock.RLock()
+	defer m.changeChLock.RUnlock()
+	return m.changeCh
 }
 
 func (m *coordinatorMetadata) GetConfig() commonobject.Borrowed[*commonproto.ClusterConfiguration] {
-	m.clusterConfigLock.RLock()
-	defer m.clusterConfigLock.RUnlock()
-	if m.currentClusterConfig == nil {
-		m.clusterConfigLock.RUnlock()
-		m.loadClusterConfigWithInitSlow()
-		m.clusterConfigLock.RLock()
-	}
-	return commonobject.Borrow(m.currentClusterConfig)
+	return commonobject.Borrow(m.configProvider.Watch().Load().Value)
 }
 
-func (m *coordinatorMetadata) ConfigWatch() *commonwatch.Watch[*commonproto.ClusterConfiguration] {
-	return m.clusterConfigWatch
+func (m *coordinatorMetadata) SubscribeConfig() *commonwatch.Receiver[provider.Versioned[commonobject.Borrowed[*commonproto.ClusterConfiguration]]] {
+	return m.configWatch.Subscribe()
 }
 
 func (m *coordinatorMetadata) GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer] {
@@ -431,16 +355,9 @@ func (m *coordinatorMetadata) GetLoadBalancer() commonobject.Borrowed[*commonpro
 }
 
 func (m *coordinatorMetadata) ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer] {
-	m.clusterConfigLock.RLock()
-	defer m.clusterConfigLock.RUnlock()
-	if m.currentClusterConfig == nil {
-		m.clusterConfigLock.RUnlock()
-		m.loadClusterConfigWithInitSlow()
-		m.clusterConfigLock.RLock()
-	}
-
-	dataServers := make(map[string]commonobject.Borrowed[*commonproto.DataServer], len(m.currentClusterConfig.GetServers()))
-	for _, server := range m.currentClusterConfig.GetServers() {
+	config := m.GetConfig().UnsafeBorrow()
+	dataServers := make(map[string]commonobject.Borrowed[*commonproto.DataServer], len(config.GetServers()))
+	for _, server := range config.GetServers() {
 		name := server.GetNameOrDefault()
 		identity := server
 		if server.GetName() == "" {
@@ -454,7 +371,7 @@ func (m *coordinatorMetadata) ListDataServer() map[string]commonobject.Borrowed[
 			Identity: identity,
 			Metadata: &commonproto.DataServerMetadata{},
 		}
-		if value, found := m.currentClusterConfig.GetServerMetadata()[name]; found {
+		if value, found := config.GetServerMetadata()[name]; found {
 			dataServer.Metadata = value
 		}
 		dataServers[name] = commonobject.Borrow(dataServer)
@@ -463,30 +380,16 @@ func (m *coordinatorMetadata) ListDataServer() map[string]commonobject.Borrowed[
 }
 
 func (m *coordinatorMetadata) GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool) {
-	m.clusterConfigLock.RLock()
-	defer m.clusterConfigLock.RUnlock()
-	if m.currentClusterConfig == nil {
-		m.clusterConfigLock.RUnlock()
-		m.loadClusterConfigWithInitSlow()
-		m.clusterConfigLock.RLock()
+	for _, ns := range m.GetConfig().UnsafeBorrow().GetNamespaces() {
+		if ns.GetName() == namespace {
+			return commonobject.Borrow(ns), true
+		}
 	}
-	value, ok := m.namespaceConfigsIndex.Get(namespace)
-	if !ok {
-		return commonobject.Borrowed[*commonproto.Namespace]{}, false
-	}
-	return commonobject.Borrow(value), true
+	return commonobject.Borrowed[*commonproto.Namespace]{}, false
 }
 
 func (m *coordinatorMetadata) GetDataServer(name string) (commonobject.Borrowed[*commonproto.DataServer], bool) {
-	m.clusterConfigLock.RLock()
-	defer m.clusterConfigLock.RUnlock()
-	if m.currentClusterConfig == nil {
-		m.clusterConfigLock.RUnlock()
-		m.loadClusterConfigWithInitSlow()
-		m.clusterConfigLock.RLock()
-	}
-
-	value, ok := m.currentClusterConfig.GetDataServer(name)
+	value, ok := m.GetConfig().UnsafeBorrow().GetDataServer(name)
 	if !ok {
 		return commonobject.Borrowed[*commonproto.DataServer]{}, false
 	}

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -28,6 +28,7 @@ import (
 	commonobject "github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/process"
 	commonproto "github.com/oxia-db/oxia/common/proto"
+	oxiatime "github.com/oxia-db/oxia/common/time"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
@@ -112,7 +113,10 @@ func (m *coordinatorMetadata) computeStatus(fn func(*commonproto.ClusterStatus, 
 		return nil
 	}
 
-	_, err := m.statusProvider.Store(next, current.Version)
+	_, err := m.statusProvider.Store(provider.Versioned[*commonproto.ClusterStatus]{
+		Value:   next,
+		Version: current.Version,
+	})
 	return err
 }
 
@@ -156,7 +160,7 @@ func (m *coordinatorMetadata) doStatusRecovery() {
 				status.InstanceId = uuid.NewString()
 				return status, true
 			})
-		}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+		}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
 			m.logger.Warn(
 				"failed to initialize instance id",
 				slog.Any("error", err),
@@ -176,7 +180,7 @@ func (m *coordinatorMetadata) UpdateStatus(newStatus *commonproto.ClusterStatus)
 		return m.computeStatus(func(_ *commonproto.ClusterStatus, _ metadatacommon.Version) (*commonproto.ClusterStatus, bool) {
 			return newStatus, true
 		})
-	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
 		m.logger.Warn(
 			"failed to update status",
 			slog.Any("error", err),
@@ -194,7 +198,7 @@ func (m *coordinatorMetadata) ReserveShardIDs(count uint32) int64 {
 			status.ShardIdGenerator += int64(count)
 			return status, true
 		})
-	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
 		m.logger.Warn(
 			"failed to reserve shard ids",
 			slog.Any("error", err),
@@ -219,7 +223,7 @@ func (m *coordinatorMetadata) CreateNamespaceStatus(name string, status *commonp
 			created = true
 			return clusterStatus, true
 		})
-	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
 		m.logger.Warn(
 			"failed to create namespace status",
 			slog.Any("error", err),
@@ -269,7 +273,7 @@ func (m *coordinatorMetadata) DeleteNamespaceStatus(name string) commonobject.Bo
 			}
 			return clusterStatus, changed
 		})
-	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
 		m.logger.Warn(
 			"failed to mark namespace deleting",
 			slog.Any("error", err),
@@ -294,7 +298,7 @@ func (m *coordinatorMetadata) UpdateShardStatus(namespace string, shard int64, s
 			changed = true
 			return clusterStatus, true
 		})
-	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
 		m.logger.Warn(
 			"failed to update shard metadata",
 			slog.Any("error", err),
@@ -324,7 +328,7 @@ func (m *coordinatorMetadata) DeleteShardStatus(namespace string, shard int64) {
 			changed = true
 			return clusterStatus, true
 		})
-	}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
+	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
 		m.logger.Warn(
 			"failed to delete shard metadata",
 			slog.Any("error", err),

--- a/oxiad/coordinator/metadata/provider/file/provider.go
+++ b/oxiad/coordinator/metadata/provider/file/provider.go
@@ -52,7 +52,7 @@ type Provider[T gproto.Message] struct {
 	ctxCancel context.CancelFunc
 	wg        sync.WaitGroup
 
-	watcher *commonwatch.Watch[T]
+	watcher *commonwatch.Watch[provider.Versioned[T]]
 	logger  *slog.Logger
 }
 
@@ -75,12 +75,12 @@ func NewProvider[T gproto.Message](ctx context.Context, path string, codec metad
 			return nil, err
 		}
 	}
+	initialSnapshot, err := p.loadLatest()
+	if err != nil {
+		return nil, err
+	}
+	p.watcher = commonwatch.New(initialSnapshot)
 	if watchEnabled.Enabled() {
-		initialValue, _, err := p.Get()
-		if err != nil {
-			return nil, err
-		}
-		p.watcher = commonwatch.New(initialValue)
 		p.wg.Go(func() {
 			process.DoWithLabels(p.ctx, map[string]string{
 				"component":     "metadata-provider",
@@ -116,27 +116,54 @@ func (m *Provider[T]) WaitToBecomeLeader() error {
 	return nil
 }
 
-func (m *Provider[T]) Get() (value T, version metadatacommon.Version, err error) {
+func (m *Provider[T]) loadLatest() (snapshot provider.Versioned[T], err error) {
+	retry := backoff.NewExponentialBackOff()
+	err = backoff.RetryNotify(func() error {
+		var readErr error
+		snapshot, readErr = m.loadLatestOnce()
+		return readErr
+	}, backoff.WithContext(retry, m.ctx), func(err error, duration time.Duration) {
+		m.logger.Warn("Failed to read file metadata, retrying",
+			slog.Any("error", err),
+			slog.Duration("retry-after", duration))
+	})
+	return snapshot, err
+}
+
+func (m *Provider[T]) loadLatestOnce() (snapshot provider.Versioned[T], err error) {
 	content, err := os.ReadFile(m.path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return value, metadatacommon.NotExists, nil
+			return provider.Versioned[T]{
+				Value:   m.codec.NewZero(),
+				Version: metadatacommon.NotExists,
+			}, nil
 		}
-		return value, metadatacommon.NotExists, err
+		return snapshot, err
 	}
 
 	if len(content) == 0 {
-		return value, metadatacommon.NotExists, nil
+		return provider.Versioned[T]{
+			Value:   m.codec.NewZero(),
+			Version: metadatacommon.NotExists,
+		}, nil
 	}
-	value, err = m.codec.UnmarshalYAML(content)
-	return value, m.version, err
+	value, err := m.codec.UnmarshalYAML(content)
+	if err != nil {
+		panic(err)
+	}
+	return provider.Versioned[T]{
+		Value:   value,
+		Version: m.version,
+	}, nil
 }
 
 func (m *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (newVersion metadatacommon.Version, err error) {
-	_, existingVersion, err := m.Get()
+	existingSnapshot, err := m.loadLatest()
 	if err != nil {
 		return metadatacommon.NotExists, err
 	}
+	existingVersion := existingSnapshot.Version
 
 	if expectedVersion != existingVersion {
 		panic(metadatacommon.ErrBadVersion)
@@ -152,26 +179,27 @@ func (m *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (ne
 		return metadatacommon.NotExists, err
 	}
 	m.version = newVersion
+	m.watcher.Publish(provider.Versioned[T]{
+		Value:   m.codec.Clone(value),
+		Version: newVersion,
+	})
 
 	return newVersion, nil
 }
 
-func (m *Provider[T]) Watch() (*commonwatch.Receiver[T], error) {
-	if !m.watchEnabled.Enabled() || m.watcher == nil {
-		return nil, metadatacommon.ErrWatchUnsupported
-	}
-	return m.watcher.Subscribe(), nil
+func (m *Provider[T]) Watch() *commonwatch.Watch[provider.Versioned[T]] {
+	return m.watcher
 }
 
 func (m *Provider[T]) watchLoop() {
 	retry := backoff.NewExponentialBackOff()
 	retry.InitialInterval = time.Second
 	_ = backoff.RetryNotify(func() error {
-		value, _, err := m.Get()
+		snapshot, err := m.loadLatest()
 		if err != nil {
 			return err
 		}
-		m.watcher.Publish(value)
+		m.watcher.Publish(snapshot)
 		return m.watchOnce()
 	}, backoff.WithContext(retry, m.ctx), func(err error, duration time.Duration) {
 		m.logger.Warn("File metadata watch failed, reconnecting",
@@ -212,11 +240,11 @@ func (m *Provider[T]) watchOnce() error {
 			}
 			if filepath.Clean(event.Name) == watchedPath &&
 				event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Rename|fsnotify.Remove) != 0 {
-				value, _, err := m.Get()
+				snapshot, err := m.loadLatest()
 				if err != nil {
 					return err
 				}
-				m.watcher.Publish(value)
+				m.watcher.Publish(snapshot)
 			}
 		}
 	}

--- a/oxiad/coordinator/metadata/provider/file/provider.go
+++ b/oxiad/coordinator/metadata/provider/file/provider.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/oxia-db/oxia/common/process"
 	commonproto "github.com/oxia-db/oxia/common/proto"
+	oxiatime "github.com/oxia-db/oxia/common/time"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
@@ -117,12 +118,11 @@ func (m *Provider[T]) WaitToBecomeLeader() error {
 }
 
 func (m *Provider[T]) loadLatest() (snapshot provider.Versioned[T], err error) {
-	retry := backoff.NewExponentialBackOff()
 	err = backoff.RetryNotify(func() error {
 		var readErr error
 		snapshot, readErr = m.loadLatestOnce()
 		return readErr
-	}, backoff.WithContext(retry, m.ctx), func(err error, duration time.Duration) {
+	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
 		m.logger.Warn("Failed to read file metadata, retrying",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration))
@@ -158,19 +158,19 @@ func (m *Provider[T]) loadLatestOnce() (snapshot provider.Versioned[T], err erro
 	}, nil
 }
 
-func (m *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (newVersion metadatacommon.Version, err error) {
+func (m *Provider[T]) Store(snapshot provider.Versioned[T]) (newVersion metadatacommon.Version, err error) {
 	existingSnapshot, err := m.loadLatest()
 	if err != nil {
 		return metadatacommon.NotExists, err
 	}
 	existingVersion := existingSnapshot.Version
 
-	if expectedVersion != existingVersion {
+	if snapshot.Version != existingVersion {
 		panic(metadatacommon.ErrBadVersion)
 	}
 
 	newVersion = metadatacommon.NextVersion(existingVersion)
-	newContent, err := m.codec.MarshalYAML(value)
+	newContent, err := m.codec.MarshalYAML(snapshot.Value)
 	if err != nil {
 		return metadatacommon.NotExists, err
 	}
@@ -180,7 +180,7 @@ func (m *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (ne
 	}
 	m.version = newVersion
 	m.watcher.Publish(provider.Versioned[T]{
-		Value:   m.codec.Clone(value),
+		Value:   m.codec.Clone(snapshot.Value),
 		Version: newVersion,
 	})
 
@@ -192,8 +192,6 @@ func (m *Provider[T]) Watch() *commonwatch.Watch[provider.Versioned[T]] {
 }
 
 func (m *Provider[T]) watchLoop() {
-	retry := backoff.NewExponentialBackOff()
-	retry.InitialInterval = time.Second
 	_ = backoff.RetryNotify(func() error {
 		snapshot, err := m.loadLatest()
 		if err != nil {
@@ -201,7 +199,7 @@ func (m *Provider[T]) watchLoop() {
 		}
 		m.watcher.Publish(snapshot)
 		return m.watchOnce()
-	}, backoff.WithContext(retry, m.ctx), func(err error, duration time.Duration) {
+	}, oxiatime.NewBackOffWithInitialInterval(m.ctx, time.Second), func(err error, duration time.Duration) {
 		m.logger.Warn("File metadata watch failed, reconnecting",
 			slog.String("path", m.path),
 			slog.Any("error", err),

--- a/oxiad/coordinator/metadata/provider/kubernetes/provider.go
+++ b/oxiad/coordinator/metadata/provider/kubernetes/provider.go
@@ -42,6 +42,7 @@ import (
 	"github.com/oxia-db/oxia/common/metric"
 	"github.com/oxia-db/oxia/common/process"
 	commonproto "github.com/oxia-db/oxia/common/proto"
+	oxiatime "github.com/oxia-db/oxia/common/time"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
@@ -142,12 +143,11 @@ func (m *Provider[T]) loadLatest() (snapshot provider.Versioned[T], err error) {
 
 	m.Lock()
 	defer m.Unlock()
-	retry := backoff.NewExponentialBackOff()
 	err = backoff.RetryNotify(func() error {
 		var getErr error
 		snapshot, getErr = m.loadLatestWithoutLock()
 		return getErr
-	}, backoff.WithContext(retry, m.ctx), func(err error, duration time.Duration) {
+	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
 		m.logger.Warn("Failed to read config map metadata, retrying",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration))
@@ -192,31 +192,30 @@ func (m *Provider[T]) loadLatestWithoutLock() (snapshot provider.Versioned[T], e
 	}, nil
 }
 
-func (m *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (metadatacommon.Version, error) {
+func (m *Provider[T]) Store(snapshot provider.Versioned[T]) (metadatacommon.Version, error) {
 	timer := m.storeLatencyHisto.Timer()
 	defer timer.Done()
 
 	m.Lock()
 	defer m.Unlock()
 
-	snapshot, err := m.loadLatestWithoutLock()
+	current, err := m.loadLatestWithoutLock()
 	if err != nil {
-		return snapshot.Version, err
+		return current.Version, err
 	}
-	version := snapshot.Version
 
-	if version != expectedVersion {
+	if current.Version != snapshot.Version {
 		slog.Error("Store metadata failed for version mismatch",
-			slog.Any("local-version", version),
-			slog.Any("expected-version", expectedVersion))
+			slog.Any("local-version", current.Version),
+			slog.Any("expected-version", snapshot.Version))
 		panic(metadatacommon.ErrBadVersion)
 	}
 
-	data, err := m.codec.MarshalYAML(value)
+	data, err := m.codec.MarshalYAML(snapshot.Value)
 	if err != nil {
 		return metadatacommon.NotExists, err
 	}
-	cmData := makeDesiredConfigMap(m.name, m.codec.GetKey(), data, expectedVersion)
+	cmData := makeDesiredConfigMap(m.name, m.codec.GetKey(), data, snapshot.Version)
 	desiredBytes, err := json.Marshal(cmData)
 	if err != nil {
 		return metadatacommon.NotExists, err
@@ -236,12 +235,12 @@ func (m *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (me
 		if k8serrors.IsConflict(err) {
 			panic(metadatacommon.ErrBadVersion)
 		}
-		return version, err
+		return current.Version, err
 	}
-	version = metadatacommon.Version(cm.ResourceVersion)
+	version := metadatacommon.Version(cm.ResourceVersion)
 	m.metadataSize.Store(int64(len(cmData.Data[m.codec.GetKey()])))
 	m.watcher.Publish(provider.Versioned[T]{
-		Value:   m.codec.Clone(value),
+		Value:   m.codec.Clone(snapshot.Value),
 		Version: version,
 	})
 	return version, nil
@@ -320,8 +319,6 @@ func (m *Provider[T]) Watch() *commonwatch.Watch[provider.Versioned[T]] {
 }
 
 func (m *Provider[T]) watchLoop() {
-	retry := backoff.NewExponentialBackOff()
-	retry.InitialInterval = time.Second
 	_ = backoff.RetryNotify(func() error {
 		snapshot, err := m.loadLatest()
 		if err != nil {
@@ -329,7 +326,7 @@ func (m *Provider[T]) watchLoop() {
 		}
 		m.watcher.Publish(snapshot)
 		return m.watch()
-	}, backoff.WithContext(retry, m.ctx), func(err error, duration time.Duration) {
+	}, oxiatime.NewBackOffWithInitialInterval(m.ctx, time.Second), func(err error, duration time.Duration) {
 		m.logger.Warn("K8S config map watch failed, reconnecting",
 			slog.String("k8s-namespace", m.namespace),
 			slog.String("k8s-config-map", m.name),

--- a/oxiad/coordinator/metadata/provider/kubernetes/provider.go
+++ b/oxiad/coordinator/metadata/provider/kubernetes/provider.go
@@ -75,7 +75,7 @@ type Provider[T gproto.Message] struct {
 	ctxCancel context.CancelFunc
 	wg        sync.WaitGroup
 
-	watcher *commonwatch.Watch[T]
+	watcher *commonwatch.Watch[provider.Versioned[T]]
 
 	logger *slog.Logger
 }
@@ -102,12 +102,12 @@ func NewProvider[T gproto.Message](
 	}
 
 	m.ctx, m.ctxCancel = context.WithCancel(ctx)
+	initialSnapshot, err := m.loadLatest() //nolint:contextcheck // Constructor seeds the watch from the provider-owned context.
+	if err != nil {
+		return nil, err
+	}
+	m.watcher = commonwatch.New(initialSnapshot)
 	if watchEnabled.Enabled() {
-		initialValue, _, err := m.getWithoutLock() //nolint:contextcheck // Constructor seeds the watch from the provider-owned context.
-		if err != nil {
-			return nil, err
-		}
-		m.watcher = commonwatch.New(initialValue)
 		m.wg.Go(func() {
 			process.DoWithLabels(m.ctx, map[string]string{
 				"component":     "metadata-provider",
@@ -136,38 +136,60 @@ func NewDefaultClientset() (kubernetes.Interface, error) {
 	return kubernetes.NewForConfig(config)
 }
 
-func (m *Provider[T]) Get() (value T, version metadatacommon.Version, err error) {
+func (m *Provider[T]) loadLatest() (snapshot provider.Versioned[T], err error) {
 	timer := m.getLatencyHisto.Timer()
 	defer timer.Done()
 
 	m.Lock()
 	defer m.Unlock()
-	return m.getWithoutLock()
+	retry := backoff.NewExponentialBackOff()
+	err = backoff.RetryNotify(func() error {
+		var getErr error
+		snapshot, getErr = m.loadLatestWithoutLock()
+		return getErr
+	}, backoff.WithContext(retry, m.ctx), func(err error, duration time.Duration) {
+		m.logger.Warn("Failed to read config map metadata, retrying",
+			slog.Any("error", err),
+			slog.Duration("retry-after", duration))
+	})
+	return snapshot, err
 }
 
-func (m *Provider[T]) getWithoutLock() (value T, version metadatacommon.Version, err error) {
+func (m *Provider[T]) loadLatestWithoutLock() (snapshot provider.Versioned[T], err error) {
 	ctx, cancel := context.WithTimeout(m.ctx, k8sRequestTimeout)
 	defer cancel()
 
 	cm, err := m.kubernetes.CoreV1().ConfigMaps(m.namespace).Get(ctx, m.name, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return value, metadatacommon.NotExists, nil
+			return provider.Versioned[T]{
+				Value:   m.codec.NewZero(),
+				Version: metadatacommon.NotExists,
+			}, nil
 		}
-		return value, "", err
+		return snapshot, err
 	}
 
 	data, ok := cm.Data[m.codec.GetKey()]
 	if !ok {
-		return value, metadatacommon.NotExists, nil
+		return provider.Versioned[T]{
+			Value:   m.codec.NewZero(),
+			Version: metadatacommon.NotExists,
+		}, nil
 	}
 
-	version = metadatacommon.Version(cm.ResourceVersion)
+	version := metadatacommon.Version(cm.ResourceVersion)
 	slog.Debug("Get metadata successful",
 		slog.String("version", cm.ResourceVersion))
 	m.metadataSize.Store(int64(len(data)))
-	value, err = m.codec.UnmarshalYAML([]byte(data))
-	return value, version, err
+	value, err := m.codec.UnmarshalYAML([]byte(data))
+	if err != nil {
+		panic(err)
+	}
+	return provider.Versioned[T]{
+		Value:   value,
+		Version: version,
+	}, nil
 }
 
 func (m *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (metadatacommon.Version, error) {
@@ -177,10 +199,11 @@ func (m *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (me
 	m.Lock()
 	defer m.Unlock()
 
-	_, version, err := m.getWithoutLock()
+	snapshot, err := m.loadLatestWithoutLock()
 	if err != nil {
-		return version, err
+		return snapshot.Version, err
 	}
+	version := snapshot.Version
 
 	if version != expectedVersion {
 		slog.Error("Store metadata failed for version mismatch",
@@ -217,6 +240,10 @@ func (m *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (me
 	}
 	version = metadatacommon.Version(cm.ResourceVersion)
 	m.metadataSize.Store(int64(len(cmData.Data[m.codec.GetKey()])))
+	m.watcher.Publish(provider.Versioned[T]{
+		Value:   m.codec.Clone(value),
+		Version: version,
+	})
 	return version, nil
 }
 
@@ -288,22 +315,19 @@ func (m *Provider[T]) Close() error {
 	return nil
 }
 
-func (m *Provider[T]) Watch() (*commonwatch.Receiver[T], error) {
-	if !m.watchEnabled.Enabled() || m.watcher == nil {
-		return nil, metadatacommon.ErrWatchUnsupported
-	}
-	return m.watcher.Subscribe(), nil
+func (m *Provider[T]) Watch() *commonwatch.Watch[provider.Versioned[T]] {
+	return m.watcher
 }
 
 func (m *Provider[T]) watchLoop() {
 	retry := backoff.NewExponentialBackOff()
 	retry.InitialInterval = time.Second
 	_ = backoff.RetryNotify(func() error {
-		value, _, err := m.Get()
+		snapshot, err := m.loadLatest()
 		if err != nil {
 			return err
 		}
-		m.watcher.Publish(value)
+		m.watcher.Publish(snapshot)
 		return m.watch()
 	}, backoff.WithContext(retry, m.ctx), func(err error, duration time.Duration) {
 		m.logger.Warn("K8S config map watch failed, reconnecting",
@@ -331,11 +355,11 @@ func (m *Provider[T]) watch() error {
 		if res.Type != k8swatch.Added && res.Type != k8swatch.Modified {
 			continue
 		}
-		value, _, err := m.Get()
+		snapshot, err := m.loadLatest()
 		if err != nil {
 			return err
 		}
-		m.watcher.Publish(value)
+		m.watcher.Publish(snapshot)
 	}
 
 	if m.ctx.Err() != nil {

--- a/oxiad/coordinator/metadata/provider/kubernetes/provider.go
+++ b/oxiad/coordinator/metadata/provider/kubernetes/provider.go
@@ -199,18 +199,6 @@ func (m *Provider[T]) Store(snapshot provider.Versioned[T]) (metadatacommon.Vers
 	m.Lock()
 	defer m.Unlock()
 
-	current, err := m.loadLatestWithoutLock()
-	if err != nil {
-		return current.Version, err
-	}
-
-	if current.Version != snapshot.Version {
-		slog.Error("Store metadata failed for version mismatch",
-			slog.Any("local-version", current.Version),
-			slog.Any("expected-version", snapshot.Version))
-		panic(metadatacommon.ErrBadVersion)
-	}
-
 	data, err := m.codec.MarshalYAML(snapshot.Value)
 	if err != nil {
 		return metadatacommon.NotExists, err
@@ -224,18 +212,26 @@ func (m *Provider[T]) Store(snapshot provider.Versioned[T]) (metadatacommon.Vers
 	ctx, cancel := context.WithTimeout(m.ctx, k8sRequestTimeout)
 	defer cancel()
 
-	cm, err := m.kubernetes.CoreV1().ConfigMaps(m.namespace).Patch(ctx, m.name, types.ApplyPatchType, desiredBytes, metav1.PatchOptions{
-		FieldManager: fieldManager,
-		Force:        gproto.Bool(true),
-	})
-	if k8serrors.IsNotFound(err) {
+	var cm *corev1.ConfigMap
+	if snapshot.Version == metadatacommon.NotExists {
 		cm, err = m.kubernetes.CoreV1().ConfigMaps(m.namespace).Create(ctx, cmData, metav1.CreateOptions{})
-	}
-	if err != nil {
-		if k8serrors.IsConflict(err) {
+		if k8serrors.IsAlreadyExists(err) {
 			panic(metadatacommon.ErrBadVersion)
 		}
-		return current.Version, err
+	} else {
+		if snapshot.Version == "" {
+			panic(metadatacommon.ErrBadVersion)
+		}
+		cm, err = m.kubernetes.CoreV1().ConfigMaps(m.namespace).Patch(ctx, m.name, types.ApplyPatchType, desiredBytes, metav1.PatchOptions{
+			FieldManager: fieldManager,
+			Force:        gproto.Bool(true),
+		})
+		if k8serrors.IsNotFound(err) || k8serrors.IsConflict(err) {
+			panic(metadatacommon.ErrBadVersion)
+		}
+	}
+	if err != nil {
+		return metadatacommon.NotExists, err
 	}
 	version := metadatacommon.Version(cm.ResourceVersion)
 	m.metadataSize.Store(int64(len(cmData.Data[m.codec.GetKey()])))

--- a/oxiad/coordinator/metadata/provider/memory/provider.go
+++ b/oxiad/coordinator/metadata/provider/memory/provider.go
@@ -35,7 +35,7 @@ type Provider[T gproto.Message] struct {
 	value        T
 	version      metadatacommon.Version
 	watchEnabled metadatacommon.WatchMode
-	watch        *commonwatch.Watch[T]
+	watch        *commonwatch.Watch[provider.Versioned[T]]
 }
 
 func (*Provider[T]) WaitToBecomeLeader() error {
@@ -45,24 +45,19 @@ func (*Provider[T]) WaitToBecomeLeader() error {
 func NewProvider[T gproto.Message](codec metadatacommon.Codec[T], watchEnabled metadatacommon.WatchMode) provider.Provider[T] {
 	p := &Provider[T]{
 		codec:        codec,
+		value:        codec.NewZero(),
 		version:      metadatacommon.NotExists,
 		watchEnabled: watchEnabled,
-	}
-	if watchEnabled.Enabled() {
-		p.watch = commonwatch.New(codec.NewZero())
+		watch: commonwatch.New(provider.Versioned[T]{
+			Value:   codec.NewZero(),
+			Version: metadatacommon.NotExists,
+		}),
 	}
 	return p
 }
 
 func (*Provider[T]) Close() error {
 	return nil
-}
-
-func (m *Provider[T]) Get() (value T, version metadatacommon.Version, err error) {
-	m.Lock()
-	defer m.Unlock()
-
-	return m.codec.Clone(m.value), m.version, nil
 }
 
 func (m *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (newVersion metadatacommon.Version, err error) {
@@ -75,15 +70,13 @@ func (m *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (ne
 
 	m.value = m.codec.Clone(value)
 	m.version = metadatacommon.NextVersion(m.version)
-	if m.watch != nil {
-		m.watch.Publish(m.codec.Clone(m.value))
-	}
+	m.watch.Publish(provider.Versioned[T]{
+		Value:   m.codec.Clone(m.value),
+		Version: m.version,
+	})
 	return m.version, nil
 }
 
-func (m *Provider[T]) Watch() (*commonwatch.Receiver[T], error) {
-	if !m.watchEnabled.Enabled() || m.watch == nil {
-		return nil, metadatacommon.ErrWatchUnsupported
-	}
-	return m.watch.Subscribe(), nil
+func (m *Provider[T]) Watch() *commonwatch.Watch[provider.Versioned[T]] {
+	return m.watch
 }

--- a/oxiad/coordinator/metadata/provider/memory/provider.go
+++ b/oxiad/coordinator/metadata/provider/memory/provider.go
@@ -60,15 +60,15 @@ func (*Provider[T]) Close() error {
 	return nil
 }
 
-func (m *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (newVersion metadatacommon.Version, err error) {
+func (m *Provider[T]) Store(snapshot provider.Versioned[T]) (newVersion metadatacommon.Version, err error) {
 	m.Lock()
 	defer m.Unlock()
 
-	if expectedVersion != m.version {
+	if snapshot.Version != m.version {
 		panic(metadatacommon.ErrBadVersion)
 	}
 
-	m.value = m.codec.Clone(value)
+	m.value = m.codec.Clone(snapshot.Value)
 	m.version = metadatacommon.NextVersion(m.version)
 	m.watch.Publish(provider.Versioned[T]{
 		Value:   m.codec.Clone(m.value),

--- a/oxiad/coordinator/metadata/provider/provider.go
+++ b/oxiad/coordinator/metadata/provider/provider.go
@@ -23,14 +23,17 @@ import (
 	metadataconstant "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
 )
 
+type Versioned[T any] struct {
+	Value   T
+	Version metadataconstant.Version
+}
+
 type Provider[T gproto.Message] interface {
 	io.Closer
-
-	Get() (value T, version metadataconstant.Version, err error)
 
 	Store(value T, expectedVersion metadataconstant.Version) (newVersion metadataconstant.Version, err error)
 
 	WaitToBecomeLeader() error
 
-	Watch() (*commonwatch.Receiver[T], error)
+	Watch() *commonwatch.Watch[Versioned[T]]
 }

--- a/oxiad/coordinator/metadata/provider/provider.go
+++ b/oxiad/coordinator/metadata/provider/provider.go
@@ -31,7 +31,7 @@ type Versioned[T any] struct {
 type Provider[T gproto.Message] interface {
 	io.Closer
 
-	Store(value T, expectedVersion metadataconstant.Version) (newVersion metadataconstant.Version, err error)
+	Store(snapshot Versioned[T]) (newVersion metadataconstant.Version, err error)
 
 	WaitToBecomeLeader() error
 

--- a/oxiad/coordinator/metadata/provider/provider_test.go
+++ b/oxiad/coordinator/metadata/provider/provider_test.go
@@ -96,11 +96,17 @@ func TestProvider(t *testing.T) {
 			}
 
 			assert.PanicsWithError(t, metadatacommon.ErrBadVersion.Error(), func() {
-				_, err := m.Store(status, "")
+				_, err := m.Store(provider.Versioned[*proto.ClusterStatus]{
+					Value:   status,
+					Version: "",
+				})
 				assert.NoError(t, err)
 			})
 
-			newVersion, err := m.Store(status, metadatacommon.NotExists)
+			newVersion, err := m.Store(provider.Versioned[*proto.ClusterStatus]{
+				Value:   status,
+				Version: metadatacommon.NotExists,
+			})
 			assert.NoError(t, err)
 			assert.EqualValues(t, metadatacommon.Version("0"), newVersion)
 
@@ -179,7 +185,10 @@ func TestProviderConfigResource(t *testing.T) {
 				}},
 			}
 
-			newVersion, err := m.Store(config, metadatacommon.NotExists)
+			newVersion, err := m.Store(provider.Versioned[*proto.ClusterConfiguration]{
+				Value:   config,
+				Version: metadatacommon.NotExists,
+			})
 			assert.NoError(t, err)
 			assert.EqualValues(t, metadatacommon.Version("0"), newVersion)
 

--- a/oxiad/coordinator/metadata/provider/provider_test.go
+++ b/oxiad/coordinator/metadata/provider/provider_test.go
@@ -86,10 +86,10 @@ func TestProvider(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			m := newProvider(t)
 
-			res, version, err := m.Get()
-			assert.NoError(t, err)
+			snapshot := m.Watch().Load()
+			res, version := snapshot.Value, snapshot.Version
 			assert.Equal(t, metadatacommon.NotExists, version)
-			assert.Nil(t, res)
+			assert.True(t, gproto.Equal(&proto.ClusterStatus{}, res))
 
 			status := &proto.ClusterStatus{
 				Namespaces: map[string]*proto.NamespaceStatus{},
@@ -104,8 +104,8 @@ func TestProvider(t *testing.T) {
 			assert.NoError(t, err)
 			assert.EqualValues(t, metadatacommon.Version("0"), newVersion)
 
-			res, version, err = m.Get()
-			assert.NoError(t, err)
+			snapshot = m.Watch().Load()
+			res, version = snapshot.Value, snapshot.Version
 			assert.EqualValues(t, metadatacommon.Version("0"), version)
 			assert.True(t, gproto.Equal(&proto.ClusterStatus{
 				Namespaces: map[string]*proto.NamespaceStatus{},
@@ -183,8 +183,8 @@ func TestProviderConfigResource(t *testing.T) {
 			assert.NoError(t, err)
 			assert.EqualValues(t, metadatacommon.Version("0"), newVersion)
 
-			res, version, err := m.Get()
-			assert.NoError(t, err)
+			snapshot := m.Watch().Load()
+			res, version := snapshot.Value, snapshot.Version
 			assert.EqualValues(t, metadatacommon.Version("0"), version)
 			assert.True(t, gproto.Equal(config, res))
 

--- a/oxiad/coordinator/metadata/provider/raft/provider.go
+++ b/oxiad/coordinator/metadata/provider/raft/provider.go
@@ -120,7 +120,7 @@ func (mpr *Provider[T]) loadLatest() provider.Versioned[T] {
 	}
 }
 
-func (mpr *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (newVersion metadatacommon.Version, err error) {
+func (mpr *Provider[T]) Store(snapshot provider.Versioned[T]) (newVersion metadatacommon.Version, err error) {
 	mpr.raft.Lock()
 	defer mpr.raft.Unlock()
 
@@ -128,7 +128,7 @@ func (mpr *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (
 		return metadatacommon.NotExists, err
 	}
 
-	data, err := mpr.codec.MarshalJSON(value)
+	data, err := mpr.codec.MarshalJSON(snapshot.Value)
 	if err != nil {
 		return metadatacommon.NotExists, err
 	}
@@ -136,13 +136,13 @@ func (mpr *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (
 	mpr.raft.logger.Debug("Store into raft",
 		slog.String("key", mpr.codec.GetKey()),
 		slog.Any("metadata", data),
-		slog.Any("expected-version", expectedVersion),
+		slog.Any("expected-version", snapshot.Version),
 		slog.Any("current-version", mpr.raft.sc.document(mpr.codec.GetKey()).CurrentVersion))
 
 	cmd := raftOpCmd{
 		Key:             mpr.codec.GetKey(),
 		NewState:        json.RawMessage(data),
-		ExpectedVersion: fromVersion(expectedVersion),
+		ExpectedVersion: fromVersion(snapshot.Version),
 	}
 
 	serializedCmd, err := json.Marshal(cmd)
@@ -165,7 +165,7 @@ func (mpr *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (
 
 	newVersion = toVersion(applyRes.newVersion)
 	mpr.watch.Publish(provider.Versioned[T]{
-		Value:   mpr.codec.Clone(value),
+		Value:   mpr.codec.Clone(snapshot.Value),
 		Version: newVersion,
 	})
 	return newVersion, nil

--- a/oxiad/coordinator/metadata/provider/raft/provider.go
+++ b/oxiad/coordinator/metadata/provider/raft/provider.go
@@ -37,7 +37,7 @@ type Provider[T gproto.Message] struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 	wg        sync.WaitGroup
-	watch     *commonwatch.Watch[T]
+	watch     *commonwatch.Watch[provider.Versioned[T]]
 	logger    *slog.Logger
 }
 
@@ -54,18 +54,11 @@ func NewProvider[T gproto.Message](ctx context.Context, r *Raft, codec metadatac
 		),
 	}
 
-	value, version, err := p.Get()
-	if err != nil {
-		p.logger.Warn("Failed to load initial raft metadata", slog.Any("error", err))
-		value = p.codec.NewZero()
-	} else if version == metadatacommon.NotExists {
-		value = p.codec.NewZero()
-	}
-	p.watch = commonwatch.New(value)
+	p.watch = commonwatch.New(p.loadLatest())
 	return p
 }
 
-func (mpr *Provider[T]) OnApplied(key string, data []byte) {
+func (mpr *Provider[T]) OnApplied(key string, data []byte, version int64) {
 	if mpr.codec.GetKey() != key {
 		return
 	}
@@ -75,7 +68,10 @@ func (mpr *Provider[T]) OnApplied(key string, data []byte) {
 		mpr.logger.Warn("Failed to unmarshal data", slog.Any("error", err))
 		return
 	}
-	mpr.watch.Publish(entity)
+	mpr.watch.Publish(provider.Versioned[T]{
+		Value:   entity,
+		Version: toVersion(version),
+	})
 }
 
 func (mpr *Provider[T]) WaitToBecomeLeader() error {
@@ -98,7 +94,7 @@ func fromVersion(v metadatacommon.Version) int64 {
 	return n
 }
 
-func (mpr *Provider[T]) Get() (value T, version metadatacommon.Version, err error) {
+func (mpr *Provider[T]) loadLatest() provider.Versioned[T] {
 	mpr.raft.Lock()
 	defer mpr.raft.Unlock()
 
@@ -109,10 +105,19 @@ func (mpr *Provider[T]) Get() (value T, version metadatacommon.Version, err erro
 		slog.Any("metadata", document.State),
 		slog.Any("current-version", document.CurrentVersion))
 	if len(document.State) == 0 {
-		return value, toVersion(document.CurrentVersion), nil
+		return provider.Versioned[T]{
+			Value:   mpr.codec.NewZero(),
+			Version: toVersion(document.CurrentVersion),
+		}
 	}
-	value, err = mpr.codec.UnmarshalJSON(document.State)
-	return value, toVersion(document.CurrentVersion), err
+	value, err := mpr.codec.UnmarshalJSON(document.State)
+	if err != nil {
+		panic(err)
+	}
+	return provider.Versioned[T]{
+		Value:   value,
+		Version: toVersion(document.CurrentVersion),
+	}
 }
 
 func (mpr *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (newVersion metadatacommon.Version, err error) {
@@ -158,12 +163,14 @@ func (mpr *Provider[T]) Store(value T, expectedVersion metadatacommon.Version) (
 		panic(metadatacommon.ErrBadVersion)
 	}
 
-	return toVersion(applyRes.newVersion), nil
+	newVersion = toVersion(applyRes.newVersion)
+	mpr.watch.Publish(provider.Versioned[T]{
+		Value:   mpr.codec.Clone(value),
+		Version: newVersion,
+	})
+	return newVersion, nil
 }
 
-func (mpr *Provider[T]) Watch() (*commonwatch.Receiver[T], error) {
-	if !mpr.watchMode.Enabled() || mpr.watch == nil {
-		return nil, metadatacommon.ErrWatchUnsupported
-	}
-	return mpr.watch.Subscribe(), nil
+func (mpr *Provider[T]) Watch() *commonwatch.Watch[provider.Versioned[T]] {
+	return mpr.watch
 }

--- a/oxiad/coordinator/metadata/provider/raft/raft_fsm.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft_fsm.go
@@ -73,7 +73,7 @@ func (sc *stateContainer) Apply(logEntry *raft.Log) any {
 	document.State = cloneBytes(opCmd.NewState)
 	document.CurrentVersion++
 	if sc.interceptor != nil {
-		sc.interceptor.OnApplied(opCmd.Key, document.State)
+		sc.interceptor.OnApplied(opCmd.Key, document.State, document.CurrentVersion)
 	}
 
 	sc.logger.Info("Applied raft log entry",

--- a/oxiad/coordinator/metadata/provider/raft/raft_interceptor.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft_interceptor.go
@@ -15,5 +15,5 @@
 package raft
 
 type Interceptor interface {
-	OnApplied(key string, data []byte)
+	OnApplied(key string, data []byte, version int64)
 }

--- a/oxiad/coordinator/reconciler/cluster_reconciler.go
+++ b/oxiad/coordinator/reconciler/cluster_reconciler.go
@@ -23,10 +23,12 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"go.uber.org/multierr"
 
+	commonobject "github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/process"
 	"github.com/oxia-db/oxia/common/proto"
 	oxiatime "github.com/oxia-db/oxia/common/time"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime"
 )
 
@@ -56,8 +58,8 @@ func New(ctx context.Context, coordinatorRuntime runtime.Runtime) Reconciler {
 		},
 	}
 
-	receiver := r.runtime.Metadata().ConfigWatch().Subscribe()
-	r.reconcile0(r.runtime.Metadata().GetConfig().UnsafeBorrow(), receiver)
+	receiver := r.runtime.Metadata().SubscribeConfig()
+	r.reconcile0(receiver.Load().Value.UnsafeBorrow(), receiver)
 
 	r.wg.Go(func() {
 		process.DoWithLabels(reconcilerCtx, map[string]string{
@@ -89,23 +91,23 @@ func (r *clusterReconciler) Reconcile(_ context.Context, snapshot *proto.Cluster
 	return nil
 }
 
-func (r *clusterReconciler) bgWatchClusterConfiguration(receiver *commonwatch.Receiver[*proto.ClusterConfiguration]) {
+func (r *clusterReconciler) bgWatchClusterConfiguration(receiver *commonwatch.Receiver[provider.Versioned[commonobject.Borrowed[*proto.ClusterConfiguration]]]) {
 	for {
 		select {
 		case <-r.ctx.Done():
 			return
 		case <-receiver.Changed():
-			r.reconcile0(receiver.Load(), receiver)
+			r.reconcile0(receiver.Load().Value.UnsafeBorrow(), receiver)
 		}
 	}
 }
 
-func (r *clusterReconciler) reconcile0(snapshot *proto.ClusterConfiguration, receiver *commonwatch.Receiver[*proto.ClusterConfiguration]) {
+func (r *clusterReconciler) reconcile0(snapshot *proto.ClusterConfiguration, receiver *commonwatch.Receiver[provider.Versioned[commonobject.Borrowed[*proto.ClusterConfiguration]]]) {
 	_ = backoff.RetryNotify(func() error {
 		// update the snapshot when we are retrying
 		select {
 		case <-receiver.Changed():
-			snapshot = receiver.Load()
+			snapshot = receiver.Load().Value.UnsafeBorrow()
 		default:
 		}
 		return r.Reconcile(r.ctx, snapshot)

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/common/sharding"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer"
 )
 
@@ -161,8 +162,11 @@ func (*mockNamespaceMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterCo
 	return commonobject.Borrowed[*proto.ClusterConfiguration]{}
 }
 
-func (*mockNamespaceMetadata) ConfigWatch() *commonwatch.Watch[*proto.ClusterConfiguration] {
-	return commonwatch.New(&proto.ClusterConfiguration{})
+func (*mockNamespaceMetadata) SubscribeConfig() *commonwatch.Receiver[provider.Versioned[commonobject.Borrowed[*proto.ClusterConfiguration]]] {
+	return commonwatch.New(provider.Versioned[commonobject.Borrowed[*proto.ClusterConfiguration]]{
+		Value:   commonobject.Borrow(&proto.ClusterConfiguration{}),
+		Version: "",
+	}).Subscribe()
 }
 
 func (*mockNamespaceMetadata) GetLoadBalancer() commonobject.Borrowed[*proto.LoadBalancer] {

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/action"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/model"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/selector"
@@ -87,8 +88,11 @@ func (*mockMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterConfigurati
 	return commonobject.Borrowed[*proto.ClusterConfiguration]{}
 }
 
-func (*mockMetadata) ConfigWatch() *commonwatch.Watch[*proto.ClusterConfiguration] {
-	return commonwatch.New(&proto.ClusterConfiguration{})
+func (*mockMetadata) SubscribeConfig() *commonwatch.Receiver[provider.Versioned[commonobject.Borrowed[*proto.ClusterConfiguration]]] {
+	return commonwatch.New(provider.Versioned[commonobject.Borrowed[*proto.ClusterConfiguration]]{
+		Value:   commonobject.Borrow(&proto.ClusterConfiguration{}),
+		Version: "",
+	}).Subscribe()
 }
 
 func (m *mockMetadata) GetLoadBalancer() commonobject.Borrowed[*proto.LoadBalancer] {

--- a/oxiad/coordinator/runtime/controller/shard_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller_test.go
@@ -63,7 +63,10 @@ func newTestMetadata(t *testing.T, metadataProvider provider.Provider[*proto.Clu
 	}
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	metadataFactory := coordmetadata.NewFactoryWithProviders(metadataProvider, configProvider)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())

--- a/oxiad/coordinator/runtime/controller/split_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/split_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,14 +84,17 @@ func setupSplitTest(t *testing.T, phase string) (
 	rpcMock := newMockRpcProvider()
 	metaProvider := memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled)
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(&proto.ClusterConfiguration{
-		Namespaces: []*proto.Namespace{{
-			Name:              constant.DefaultNamespace,
-			InitialShardCount: 1,
-			ReplicationFactor: 3,
-		}},
-		Servers: []*proto.DataServerIdentity{ps1, ps2, ps3},
-	}, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value: &proto.ClusterConfiguration{
+			Namespaces: []*proto.Namespace{{
+				Name:              constant.DefaultNamespace,
+				InitialShardCount: 1,
+				ReplicationFactor: 3,
+			}},
+			Servers: []*proto.DataServerIdentity{ps1, ps2, ps3},
+		},
+		Version: metadatacommon.NotExists,
+	})
 	require.NoError(t, err)
 	metadataFactory := coordmetadata.NewFactoryWithProviders(metaProvider, configProvider)
 	metadata, err := metadataFactory.CreateMetadata(t.Context())

--- a/oxiad/coordinator/runtime/runtime_authority_test.go
+++ b/oxiad/coordinator/runtime/runtime_authority_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,7 +52,10 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 		},
 	}
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	require.NoError(t, err)
 	metadataFactory := coordmetadata.NewFactoryWithProviders(
 		memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled),
@@ -121,7 +125,10 @@ func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
 		}},
 	}
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	require.NoError(t, err)
 	metadataFactory := coordmetadata.NewFactoryWithProviders(
 		memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled),

--- a/oxiad/maelstrom/main.go
+++ b/oxiad/maelstrom/main.go
@@ -30,6 +30,7 @@ import (
 	commonproto "github.com/oxia-db/oxia/common/proto"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	coordreconciler "github.com/oxia-db/oxia/oxiad/coordinator/reconciler"
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
@@ -233,7 +234,10 @@ func runCoordinator(dispatcher *dispatcher, servers []*commonproto.DataServerIde
 
 	statusProvider := memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled)
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	if _, err := configProvider.Store(clusterConfig, metadatacommon.NotExists); err != nil {
+	if _, err := configProvider.Store(provider.Versioned[*commonproto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	}); err != nil {
 		return errors.Wrap(err, "failed to seed coordinator config provider")
 	}
 

--- a/tests/assignments/leader_hint_test.go
+++ b/tests/assignments/leader_hint_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/stretchr/testify/assert"
 
@@ -43,7 +44,10 @@ func TestLeaderHintWithoutClient(t *testing.T) {
 	metadataProvider := memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
@@ -101,7 +105,10 @@ func TestLeaderHintListWithoutClient(t *testing.T) {
 	metadataProvider := memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
@@ -159,7 +166,10 @@ func TestLeaderHintListWithClient(t *testing.T) {
 	metadataProvider := memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
@@ -208,7 +218,10 @@ func TestLeaderHintRangeScanWithoutClient(t *testing.T) {
 	metadataProvider := memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
@@ -266,7 +279,10 @@ func TestLeaderHintRangeScanWithClient(t *testing.T) {
 	metadataProvider := memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,
@@ -319,7 +335,10 @@ func TestLeaderHintWithClient(t *testing.T) {
 	metadataProvider := memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,

--- a/tests/balancer/leader_balancer_test.go
+++ b/tests/balancer/leader_balancer_test.go
@@ -234,8 +234,7 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 	waitForLeadersBalanced(t, metadata, balancer, candidates, 4)
 
 	cc.Servers = append(cc.Servers, dataServers(s4ad, s5ad, s6ad)...)
-	_, version, err := configProvider.Get()
-	require.NoError(t, err)
+	version := configProvider.Watch().Load().Version
 	_, err = configProvider.Store(cc, version)
 	require.NoError(t, err)
 	candidates = linkedhashset.New(s1ad.GetNameOrDefault(), s2ad.GetNameOrDefault(), s3ad.GetNameOrDefault(), s4ad.GetNameOrDefault(), s5ad.GetNameOrDefault(), s6ad.GetNameOrDefault())

--- a/tests/balancer/leader_balancer_test.go
+++ b/tests/balancer/leader_balancer_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 	"github.com/stretchr/testify/require"
@@ -105,7 +106,10 @@ func TestLeaderBalanced(t *testing.T) {
 	}
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(cc, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   cc,
+		Version: metadatacommon.NotExists,
+	})
 	require.NoError(t, err)
 	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
@@ -150,7 +154,10 @@ func TestLeaderBalancedNodeCrashAndBack(t *testing.T) {
 	}
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(cc, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   cc,
+		Version: metadatacommon.NotExists,
+	})
 	require.NoError(t, err)
 	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
@@ -222,7 +229,10 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 	}
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(cc, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   cc,
+		Version: metadatacommon.NotExists,
+	})
 	require.NoError(t, err)
 	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
@@ -235,7 +245,10 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 
 	cc.Servers = append(cc.Servers, dataServers(s4ad, s5ad, s6ad)...)
 	version := configProvider.Watch().Load().Version
-	_, err = configProvider.Store(cc, version)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   cc,
+		Version: version,
+	})
 	require.NoError(t, err)
 	candidates = linkedhashset.New(s1ad.GetNameOrDefault(), s2ad.GetNameOrDefault(), s3ad.GetNameOrDefault(), s4ad.GetNameOrDefault(), s5ad.GetNameOrDefault(), s6ad.GetNameOrDefault())
 

--- a/tests/balancer/shard_balancer_test.go
+++ b/tests/balancer/shard_balancer_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 	"github.com/stretchr/testify/assert"
@@ -71,7 +72,10 @@ func TestNormalShardBalancer(t *testing.T) {
 	}
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(&cc, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   &cc,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
@@ -91,7 +95,10 @@ func TestNormalShardBalancer(t *testing.T) {
 
 	cc.Servers = append(cc.Servers, shardBalancerDataServers(s4ad, s5ad)...)
 	version := configProvider.Watch().Load().Version
-	_, err = configProvider.Store(&cc, version)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   &cc,
+		Version: version,
+	})
 	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
@@ -180,7 +187,10 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 	}
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(&cc, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   &cc,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
@@ -200,7 +210,10 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 
 	cc.Servers = append(cc.Servers, shardBalancerDataServers(s4ad, s5ad)...)
 	version := configProvider.Watch().Load().Version
-	_, err = configProvider.Store(&cc, version)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   &cc,
+		Version: version,
+	})
 	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
@@ -276,7 +289,10 @@ func TestBalanceWithoutDeadlock(t *testing.T) {
 		Servers: shardBalancerDataServers(s1ad, s2ad, s3ad),
 	}
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(&cc, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   &cc,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinator := mock.NewCoordinator(t, configProvider)
 	defer coordinator.Close()
@@ -315,7 +331,10 @@ func TestBalanceWithoutDeadlock(t *testing.T) {
 
 	cc.Servers = append(cc.Servers, shardBalancerDataServers(s4ad, s5ad, s6ad)...)
 	version := configProvider.Watch().Load().Version
-	_, err = configProvider.Store(&cc, version)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   &cc,
+		Version: version,
+	})
 	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {

--- a/tests/balancer/shard_balancer_test.go
+++ b/tests/balancer/shard_balancer_test.go
@@ -90,8 +90,7 @@ func TestNormalShardBalancer(t *testing.T) {
 	}, 10*time.Second, 50*time.Millisecond)
 
 	cc.Servers = append(cc.Servers, shardBalancerDataServers(s4ad, s5ad)...)
-	_, version, err := configProvider.Get()
-	assert.NoError(t, err)
+	version := configProvider.Watch().Load().Version
 	_, err = configProvider.Store(&cc, version)
 	assert.NoError(t, err)
 
@@ -200,8 +199,7 @@ func TestPolicyBasedShardBalancer(t *testing.T) {
 	}, 10*time.Second, 50*time.Millisecond)
 
 	cc.Servers = append(cc.Servers, shardBalancerDataServers(s4ad, s5ad)...)
-	_, version, err := configProvider.Get()
-	assert.NoError(t, err)
+	version := configProvider.Watch().Load().Version
 	_, err = configProvider.Store(&cc, version)
 	assert.NoError(t, err)
 
@@ -316,8 +314,7 @@ func TestBalanceWithoutDeadlock(t *testing.T) {
 	}
 
 	cc.Servers = append(cc.Servers, shardBalancerDataServers(s4ad, s5ad, s6ad)...)
-	_, version, err := configProvider.Get()
-	assert.NoError(t, err)
+	version := configProvider.Watch().Load().Version
 	_, err = configProvider.Store(&cc, version)
 	assert.NoError(t, err)
 

--- a/tests/control/control_request_test.go
+++ b/tests/control/control_request_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/stretchr/testify/assert"
 
@@ -50,7 +51,10 @@ func TestControlRequestFeatureEnabled(t *testing.T) {
 	metadataProvider := memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,

--- a/tests/control/record_checksum_test.go
+++ b/tests/control/record_checksum_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/stretchr/testify/assert"
 
@@ -71,7 +72,10 @@ func TestControlRequestRecordChecksum(t *testing.T) {
 	metadataProvider := memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled)
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err = configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(
 		t,

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/stretchr/testify/assert"
 
@@ -77,7 +78,10 @@ func TestCoordinatorE2E(t *testing.T) {
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
@@ -114,7 +118,10 @@ func TestCoordinatorE2E_ShardsRanges(t *testing.T) {
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
@@ -165,7 +172,10 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
@@ -268,7 +278,10 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
@@ -358,7 +371,10 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
@@ -405,7 +421,10 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 
 	slog.Info("Restarting coordinator")
 	newConfigProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err = newConfigProvider.Store(newClusterConfig, metadatacommon.NotExists)
+	_, err = newConfigProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   newClusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	restartedCoordinator := newCoordinatorInstance(t, metadataProvider, newConfigProvider, rpc2.NewRpcProviderFactory(nil))
 	coordinatorInstance = restartedCoordinator
@@ -443,7 +462,10 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
@@ -473,7 +495,10 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 		ReplicationFactor: 1,
 	})
 	version := configProvider.Watch().Load().Version
-	_, err = configProvider.Store(clusterConfig, version)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: version,
+	})
 	assert.NoError(t, err)
 
 	// Wait for all shards to be ready
@@ -529,7 +554,10 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	c := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
@@ -544,7 +572,10 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 	clusterConfig.Servers = clusterConfig.Servers[1:]
 
 	version := configProvider.Watch().Load().Version
-	_, err = configProvider.Store(clusterConfig, version)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: version,
+	})
 	assert.NoError(t, err)
 
 	// Wait for all shards to be ready
@@ -588,7 +619,10 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3, sa4})
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	c := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
@@ -619,7 +653,10 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	clusterConfig.Servers = d
 
 	version := configProvider.Watch().Load().Version
-	_, err = configProvider.Store(clusterConfig, version)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: version,
+	})
 	assert.NoError(t, err)
 	assert.Eventually(t, func() bool {
 		return len(c.ListDataServer()) == 3
@@ -661,7 +698,10 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	c := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
@@ -690,7 +730,10 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 
 	clusterConfig.Servers = clusterServer
 	version := configProvider.Watch().Load().Version
-	_, err = configProvider.Store(clusterConfig, version)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: version,
+	})
 	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -472,8 +472,7 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 		InitialShardCount: 2,
 		ReplicationFactor: 1,
 	})
-	_, version, err := configProvider.Get()
-	assert.NoError(t, err)
+	version := configProvider.Watch().Load().Version
 	_, err = configProvider.Store(clusterConfig, version)
 	assert.NoError(t, err)
 
@@ -544,8 +543,7 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 	// Remove s1
 	clusterConfig.Servers = clusterConfig.Servers[1:]
 
-	_, version, err := configProvider.Get()
-	assert.NoError(t, err)
+	version := configProvider.Watch().Load().Version
 	_, err = configProvider.Store(clusterConfig, version)
 	assert.NoError(t, err)
 
@@ -620,8 +618,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	}
 	clusterConfig.Servers = d
 
-	_, version, err := configProvider.Get()
-	assert.NoError(t, err)
+	version := configProvider.Watch().Load().Version
 	_, err = configProvider.Store(clusterConfig, version)
 	assert.NoError(t, err)
 	assert.Eventually(t, func() bool {
@@ -692,8 +689,7 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	}
 
 	clusterConfig.Servers = clusterServer
-	_, version, err := configProvider.Get()
-	assert.NoError(t, err)
+	version := configProvider.Watch().Load().Version
 	_, err = configProvider.Store(clusterConfig, version)
 	assert.NoError(t, err)
 

--- a/tests/coordinator/coordinator_test.go
+++ b/tests/coordinator/coordinator_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/stretchr/testify/assert"
 	gproto "google.golang.org/protobuf/proto"
@@ -43,7 +44,10 @@ func TestCoordinatorInitiateLeaderElection(t *testing.T) {
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	configProvider := metadata2.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 	defer coordinatorInstance.Close()

--- a/tests/coordinator/split_e2e_test.go
+++ b/tests/coordinator/split_e2e_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,7 +64,10 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	require.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 	clientPool := rpc.NewClientPool(nil, nil)
@@ -324,7 +328,10 @@ func setupSplitCluster(t *testing.T) *splitTestCluster {
 		InitialShardCount: 1,
 	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	require.NoError(t, err)
 
 	coordinatorInstance := newCoordinatorInstance(
@@ -878,7 +885,10 @@ func TestCoordinator_KeySorting(t *testing.T) {
 			}}, []*proto.DataServerIdentity{sa1})
 
 			configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-			_, err = configProvider.Store(clusterConfig, metadatacommon.NotExists)
+			_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+				Value:   clusterConfig,
+				Version: metadatacommon.NotExists,
+			})
 			require.NoError(t, err)
 			coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 

--- a/tests/mock/metadata.go
+++ b/tests/mock/metadata.go
@@ -41,8 +41,7 @@ func PutConfig(
 ) {
 	t.Helper()
 
-	_, version, err := configProvider.Get()
-	require.NoError(t, err)
-	_, err = configProvider.Store(clusterConfig, version)
+	version := configProvider.Watch().Load().Version
+	_, err := configProvider.Store(clusterConfig, version)
 	require.NoError(t, err)
 }

--- a/tests/mock/metadata.go
+++ b/tests/mock/metadata.go
@@ -42,6 +42,9 @@ func PutConfig(
 	t.Helper()
 
 	version := configProvider.Watch().Load().Version
-	_, err := configProvider.Store(clusterConfig, version)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: version,
+	})
 	require.NoError(t, err)
 }

--- a/tests/resolver/target_ip_flip_test.go
+++ b/tests/resolver/target_ip_flip_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,7 +77,10 @@ func newCoordinatorCluster(t *testing.T, prefix string, serverCount int) *testCl
 		AllowExtraAuthorities: []string{cluster.authority},
 	}
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	require.NoError(t, err)
 	cluster.coordinator = newCoordinatorInstance(t, metadataProvider, configProvider, coordinatorrpc.NewRpcProviderFactory(nil))
 

--- a/tests/security/auth/auth_oidc_test.go
+++ b/tests/security/auth/auth_oidc_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
@@ -109,7 +110,10 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 	clusterConfig := newDefaultClusterConfig(s1Addr, s2Addr, s3Addr)
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err = configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
@@ -297,7 +301,10 @@ func TestOIDCWithPerIssuerConfig(t *testing.T) {
 	metadataProvider := memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled)
 	clusterConfig := newDefaultClusterConfig(s1Addr, s2Addr, s3Addr)
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err = configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
@@ -448,7 +455,10 @@ func TestOIDCWithStaticKeyFile(t *testing.T) {
 	metadataProvider := memory.NewProvider(metadatacommon.ClusterStatusCodec, metadatacommon.WatchDisabled)
 	clusterConfig := newDefaultClusterConfig(s1Addr, s2Addr, s3Addr)
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err = configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))

--- a/tests/security/tls/tls_encryption_test.go
+++ b/tests/security/tls/tls_encryption_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
 
 	"github.com/stretchr/testify/assert"
 
@@ -127,7 +128,10 @@ func TestClusterHandshakeSuccess(t *testing.T) {
 	assert.NoError(t, err)
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err = configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
@@ -149,7 +153,10 @@ func TestClientHandshakeFailByNoTlsConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err = configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
@@ -175,7 +182,10 @@ func TestClientHandshakeByAuthFail(t *testing.T) {
 	assert.NoError(t, err)
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err = configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
@@ -207,7 +217,10 @@ func TestClientHandshakeWithInsecure(t *testing.T) {
 	assert.NoError(t, err)
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err = configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
@@ -240,7 +253,10 @@ func TestClientHandshakeSuccess(t *testing.T) {
 	assert.NoError(t, err)
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err = configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err = configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(tlsConf))
 	defer coordinatorInstance.Close()
@@ -270,7 +286,10 @@ func TestOnlyEnablePublicTls(t *testing.T) {
 	clusterConfig := newDefaultClusterConfig(sa1, sa2, sa3)
 
 	configProvider := memory.NewProvider(metadatacommon.ClusterConfigCodec, metadatacommon.WatchEnabled)
-	_, err := configProvider.Store(clusterConfig, metadatacommon.NotExists)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
 	assert.NoError(t, err)
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 	defer coordinatorInstance.Close()


### PR DESCRIPTION
## Motivation
- simplify the metadata/provider boundary around committed configuration and status snapshots
- remove duplicated local watch state in metadata and use provider-backed watches directly
- make config subscription semantics explicit now that metadata returns a receiver rather than a watch object

## Modifications
- removed the generic metadata value layer and centered reads on provider versioned watches
- changed provider watches to expose seeded `Versioned[T]` snapshots and updated metadata to compute writes from the current watched version
- changed config subscription to `SubscribeConfig()` and exposed `Versioned[Borrowed[*ClusterConfiguration]]` to signal borrowed ownership to callers
- updated reconciler, provider implementations, raft interception, and affected tests to the new watch-based API

## Testing
- `go test ./oxiad/coordinator/metadata ./oxiad/coordinator/reconciler ./oxiad/coordinator/runtime/balancer ./tests/mock`
- `make lint`
