### PR TITLE
refactor: remove metadata config watch relay

### DIFF
--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/uuid"
 
 	commonobject "github.com/oxia-db/oxia/common/object"
-	"github.com/oxia-db/oxia/common/process"
 	commonproto "github.com/oxia-db/oxia/common/proto"
 	oxiatime "github.com/oxia-db/oxia/common/time"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
@@ -51,7 +50,7 @@ type Metadata interface {
 	DeleteShardStatus(namespace string, shard int64)
 
 	GetConfig() commonobject.Borrowed[*commonproto.ClusterConfiguration]
-	SubscribeConfig() *commonwatch.Receiver[provider.Versioned[commonobject.Borrowed[*commonproto.ClusterConfiguration]]]
+	SubscribeConfig() *commonwatch.Receiver[provider.Versioned[*commonproto.ClusterConfiguration]]
 	GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer]
 
 	ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer]
@@ -75,12 +74,10 @@ type coordinatorMetadata struct {
 	changeCh       chan struct{}
 
 	configProvider provider.Provider[*commonproto.ClusterConfiguration]
-	configWatch    *commonwatch.Watch[provider.Versioned[commonobject.Borrowed[*commonproto.ClusterConfiguration]]]
 }
 
 func newMetadata(ctx context.Context, statusProvider provider.Provider[*commonproto.ClusterStatus], configProvider provider.Provider[*commonproto.ClusterConfiguration]) Metadata {
 	metadataCtx, cancel := context.WithCancel(ctx)
-	configSnapshot := configProvider.Watch().Load()
 	m := &coordinatorMetadata{
 		logger:         slog.With(slog.String("component", "coordinator-metadata")),
 		ctx:            metadataCtx,
@@ -88,18 +85,9 @@ func newMetadata(ctx context.Context, statusProvider provider.Provider[*commonpr
 		statusProvider: statusProvider,
 		changeCh:       make(chan struct{}),
 		configProvider: configProvider,
-		configWatch: commonwatch.New(provider.Versioned[commonobject.Borrowed[*commonproto.ClusterConfiguration]]{
-			Value:   commonobject.Borrow(configSnapshot.Value),
-			Version: configSnapshot.Version,
-		}),
 	}
 
 	m.doStatusRecovery()
-	m.wg.Go(func() {
-		process.DoWithLabels(metadataCtx, map[string]string{
-			"component": "coordinator-metadata-config-watcher",
-		}, m.relayConfigUpdates)
-	})
 	return m
 }
 
@@ -124,22 +112,6 @@ func (m *coordinatorMetadata) Close() error {
 	m.cancel()
 	m.wg.Wait()
 	return nil
-}
-
-func (m *coordinatorMetadata) relayConfigUpdates() {
-	receiver := m.configProvider.Watch().Subscribe()
-	for {
-		select {
-		case <-m.ctx.Done():
-			return
-		case <-receiver.Changed():
-			snapshot := receiver.Load()
-			m.configWatch.Publish(provider.Versioned[commonobject.Borrowed[*commonproto.ClusterConfiguration]]{
-				Value:   commonobject.Borrow(snapshot.Value),
-				Version: snapshot.Version,
-			})
-		}
-	}
 }
 
 func (m *coordinatorMetadata) notifyStatusChange() {
@@ -350,8 +322,8 @@ func (m *coordinatorMetadata) GetConfig() commonobject.Borrowed[*commonproto.Clu
 	return commonobject.Borrow(m.configProvider.Watch().Load().Value)
 }
 
-func (m *coordinatorMetadata) SubscribeConfig() *commonwatch.Receiver[provider.Versioned[commonobject.Borrowed[*commonproto.ClusterConfiguration]]] {
-	return m.configWatch.Subscribe()
+func (m *coordinatorMetadata) SubscribeConfig() *commonwatch.Receiver[provider.Versioned[*commonproto.ClusterConfiguration]] {
+	return m.configProvider.Watch().Subscribe()
 }
 
 func (m *coordinatorMetadata) GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer] {

--- a/oxiad/coordinator/reconciler/cluster_reconciler.go
+++ b/oxiad/coordinator/reconciler/cluster_reconciler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"go.uber.org/multierr"
 
-	commonobject "github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/process"
 	"github.com/oxia-db/oxia/common/proto"
 	oxiatime "github.com/oxia-db/oxia/common/time"
@@ -59,7 +58,7 @@ func New(ctx context.Context, coordinatorRuntime runtime.Runtime) Reconciler {
 	}
 
 	receiver := r.runtime.Metadata().SubscribeConfig()
-	r.reconcile0(receiver.Load().Value.UnsafeBorrow(), receiver)
+	r.reconcile0(receiver.Load().Value, receiver)
 
 	r.wg.Go(func() {
 		process.DoWithLabels(reconcilerCtx, map[string]string{
@@ -91,23 +90,23 @@ func (r *clusterReconciler) Reconcile(_ context.Context, snapshot *proto.Cluster
 	return nil
 }
 
-func (r *clusterReconciler) bgWatchClusterConfiguration(receiver *commonwatch.Receiver[provider.Versioned[commonobject.Borrowed[*proto.ClusterConfiguration]]]) {
+func (r *clusterReconciler) bgWatchClusterConfiguration(receiver *commonwatch.Receiver[provider.Versioned[*proto.ClusterConfiguration]]) {
 	for {
 		select {
 		case <-r.ctx.Done():
 			return
 		case <-receiver.Changed():
-			r.reconcile0(receiver.Load().Value.UnsafeBorrow(), receiver)
+			r.reconcile0(receiver.Load().Value, receiver)
 		}
 	}
 }
 
-func (r *clusterReconciler) reconcile0(snapshot *proto.ClusterConfiguration, receiver *commonwatch.Receiver[provider.Versioned[commonobject.Borrowed[*proto.ClusterConfiguration]]]) {
+func (r *clusterReconciler) reconcile0(snapshot *proto.ClusterConfiguration, receiver *commonwatch.Receiver[provider.Versioned[*proto.ClusterConfiguration]]) {
 	_ = backoff.RetryNotify(func() error {
 		// update the snapshot when we are retrying
 		select {
 		case <-receiver.Changed():
-			snapshot = receiver.Load().Value.UnsafeBorrow()
+			snapshot = receiver.Load().Value
 		default:
 		}
 		return r.Reconcile(r.ctx, snapshot)

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -162,9 +162,9 @@ func (*mockNamespaceMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterCo
 	return commonobject.Borrowed[*proto.ClusterConfiguration]{}
 }
 
-func (*mockNamespaceMetadata) SubscribeConfig() *commonwatch.Receiver[provider.Versioned[commonobject.Borrowed[*proto.ClusterConfiguration]]] {
-	return commonwatch.New(provider.Versioned[commonobject.Borrowed[*proto.ClusterConfiguration]]{
-		Value:   commonobject.Borrow(&proto.ClusterConfiguration{}),
+func (*mockNamespaceMetadata) SubscribeConfig() *commonwatch.Receiver[provider.Versioned[*proto.ClusterConfiguration]] {
+	return commonwatch.New(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   &proto.ClusterConfiguration{},
 		Version: "",
 	}).Subscribe()
 }

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -88,9 +88,9 @@ func (*mockMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterConfigurati
 	return commonobject.Borrowed[*proto.ClusterConfiguration]{}
 }
 
-func (*mockMetadata) SubscribeConfig() *commonwatch.Receiver[provider.Versioned[commonobject.Borrowed[*proto.ClusterConfiguration]]] {
-	return commonwatch.New(provider.Versioned[commonobject.Borrowed[*proto.ClusterConfiguration]]{
-		Value:   commonobject.Borrow(&proto.ClusterConfiguration{}),
+func (*mockMetadata) SubscribeConfig() *commonwatch.Receiver[provider.Versioned[*proto.ClusterConfiguration]] {
+	return commonwatch.New(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   &proto.ClusterConfiguration{},
 		Version: "",
 	}).Subscribe()
 }


### PR DESCRIPTION
## Motivation
- remove the extra metadata-owned config relay watch
- use the provider config watch directly since the relay was only adapting the payload shape

## Modifications
- changed `Metadata.SubscribeConfig()` to return `provider.Versioned[*ClusterConfiguration]` directly
- removed `configWatch` and the relay goroutine from coordinator metadata
- updated the cluster reconciler and metadata test doubles to consume the direct provider receiver

## Testing
- `go test ./oxiad/coordinator/metadata ./oxiad/coordinator/reconciler ./oxiad/coordinator/runtime/balancer ./tests/mock`
- `make lint`
