### PR TITLE
feat: add create dataserver admin API

### DIFF
--- a/cmd/admin/cmd.go
+++ b/cmd/admin/cmd.go
@@ -39,6 +39,7 @@ var (
 func init() {
 	defaultAdminClientAddress := fmt.Sprintf("localhost:%d", oxiacommon.DefaultAdminPort)
 	Cmd.PersistentFlags().StringVar(&commons.AdminConfig.AdminAddress, "admin-address", defaultAdminClientAddress, "Admin client address")
+	Cmd.PersistentFlags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
 
 	Cmd.AddCommand(dataserver.Cmd)
 	Cmd.AddCommand(listnamespaces.Cmd)

--- a/cmd/admin/commons/mock_admin_client.go
+++ b/cmd/admin/commons/mock_admin_client.go
@@ -63,6 +63,14 @@ func (m *MockAdminClient) GetDataServer(dataServer string) (*proto.DataServer, e
 	return nil, errors.New("data server not found")
 }
 
+func (m *MockAdminClient) CreateDataServer(dataServer *proto.DataServer) (*proto.DataServer, error) {
+	args := m.MethodCalled("CreateDataServer", dataServer)
+	if v, ok := args.Get(0).(*proto.DataServer); ok {
+		return v, args.Error(1)
+	}
+	return nil, errors.New("failed to create data server")
+}
+
 func (m *MockAdminClient) SplitShard(namespace string, shardId int64, splitPoint *uint32) *oxia.SplitShardResult {
 	args := m.MethodCalled("SplitShard", namespace, shardId, splitPoint)
 	if v, ok := args.Get(0).(*oxia.SplitShardResult); ok {

--- a/cmd/admin/commons/output.go
+++ b/cmd/admin/commons/output.go
@@ -91,25 +91,6 @@ func FormatLabels(labels map[string]string) string {
 	return strings.Join(parts, ",")
 }
 
-func ParseStringMap(values []string) (map[string]string, error) {
-	if len(values) == 0 {
-		return map[string]string{}, nil
-	}
-
-	labels := make(map[string]string, len(values))
-	for _, value := range values {
-		if value == "" {
-			continue
-		}
-		key, labelValue, ok := strings.Cut(value, "=")
-		if !ok || key == "" {
-			return nil, errors.Errorf("invalid entry %q, expected key=value", value)
-		}
-		labels[key] = labelValue
-	}
-	return labels, nil
-}
-
 func writeJSON(out io.Writer, value any) error {
 	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {

--- a/cmd/admin/commons/output.go
+++ b/cmd/admin/commons/output.go
@@ -91,6 +91,25 @@ func FormatLabels(labels map[string]string) string {
 	return strings.Join(parts, ",")
 }
 
+func ParseLabels(values []string) (map[string]string, error) {
+	if len(values) == 0 {
+		return map[string]string{}, nil
+	}
+
+	labels := make(map[string]string, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		key, labelValue, ok := strings.Cut(value, "=")
+		if !ok || key == "" {
+			return nil, errors.Errorf("invalid label %q, expected key=value", value)
+		}
+		labels[key] = labelValue
+	}
+	return labels, nil
+}
+
 func writeJSON(out io.Writer, value any) error {
 	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {

--- a/cmd/admin/commons/output.go
+++ b/cmd/admin/commons/output.go
@@ -91,7 +91,7 @@ func FormatLabels(labels map[string]string) string {
 	return strings.Join(parts, ",")
 }
 
-func ParseLabels(values []string) (map[string]string, error) {
+func ParseStringMap(values []string) (map[string]string, error) {
 	if len(values) == 0 {
 		return map[string]string{}, nil
 	}
@@ -103,7 +103,7 @@ func ParseLabels(values []string) (map[string]string, error) {
 		}
 		key, labelValue, ok := strings.Cut(value, "=")
 		if !ok || key == "" {
-			return nil, errors.Errorf("invalid label %q, expected key=value", value)
+			return nil, errors.Errorf("invalid entry %q, expected key=value", value)
 		}
 		labels[key] = labelValue
 	}

--- a/cmd/admin/dataserver/cmd.go
+++ b/cmd/admin/dataserver/cmd.go
@@ -15,6 +15,7 @@
 package dataserver
 
 import (
+	createcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/create"
 	getcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/get"
 
 	"github.com/spf13/cobra"
@@ -29,5 +30,6 @@ var (
 )
 
 func init() {
+	Cmd.AddCommand(createcmd.Cmd)
 	Cmd.AddCommand(getcmd.Cmd)
 }

--- a/cmd/admin/dataserver/create/cmd.go
+++ b/cmd/admin/dataserver/create/cmd.go
@@ -27,18 +27,32 @@ import (
 	"github.com/oxia-db/oxia/oxia"
 )
 
-var Cmd = newCmd()
+var Cmd = &cobra.Command{
+	Use:          "create <name> --public <address> --internal <address>",
+	Short:        "Create a data server",
+	Long:         `Create a data server`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         exec,
+	SilenceUsage: true,
+}
+
+func init() {
+	Cmd.Flags().String("public", "", "Public address for the data server")
+	Cmd.Flags().String("internal", "", "Internal address for the data server")
+	Cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
+	_ = Cmd.MarkFlagRequired("public")
+	_ = Cmd.MarkFlagRequired("internal")
+}
 
 func newCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "create <name> --public <address> --internal <address>",
-		Short:        "Create a data server",
-		Long:         `Create a data server`,
-		Args:         cobra.ExactArgs(1),
-		RunE:         exec,
-		SilenceUsage: true,
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
 	}
-
 	cmd.Flags().String("public", "", "Public address for the data server")
 	cmd.Flags().String("internal", "", "Internal address for the data server")
 	cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")

--- a/cmd/admin/dataserver/create/cmd.go
+++ b/cmd/admin/dataserver/create/cmd.go
@@ -1,0 +1,114 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package create
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/oxia-db/oxia/cmd/admin/commons"
+	dataserveroutput "github.com/oxia-db/oxia/cmd/admin/dataserver/output"
+	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxia"
+)
+
+var Cmd = &cobra.Command{
+	Use:          "create <name> --public <address> --internal <address>",
+	Short:        "Create a data server",
+	Long:         `Create a data server`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         exec,
+	SilenceUsage: true,
+}
+
+func init() {
+	Cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
+	Cmd.Flags().String("public", "", "Public address for the data server")
+	Cmd.Flags().String("internal", "", "Internal address for the data server")
+	Cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
+	_ = Cmd.MarkFlagRequired("public")
+	_ = Cmd.MarkFlagRequired("internal")
+}
+
+func exec(cmd *cobra.Command, args []string) error {
+	outputFormat, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+	if err := commons.ValidateOutputFormat(outputFormat); err != nil {
+		return err
+	}
+
+	publicAddress, err := cmd.Flags().GetString("public")
+	if err != nil {
+		return err
+	}
+	internalAddress, err := cmd.Flags().GetString("internal")
+	if err != nil {
+		return err
+	}
+	labelValues, err := cmd.Flags().GetStringArray("label")
+	if err != nil {
+		return err
+	}
+
+	labels, err := parseLabels(labelValues)
+	if err != nil {
+		return err
+	}
+
+	client, err := commons.AdminConfig.NewAdminClient()
+	if err != nil {
+		return err
+	}
+	defer func(client oxia.AdminClient) {
+		_ = client.Close()
+	}(client)
+
+	name := args[0]
+	created, err := client.CreateDataServer(&proto.DataServer{
+		Identity: &proto.DataServerIdentity{
+			Name:     &name,
+			Public:   publicAddress,
+			Internal: internalAddress,
+		},
+		Metadata: &proto.DataServerMetadata{
+			Labels: labels,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return dataserveroutput.WriteDataServer(cmd.OutOrStdout(), outputFormat, created)
+}
+
+func parseLabels(values []string) (map[string]string, error) {
+	if len(values) == 0 {
+		return map[string]string{}, nil
+	}
+
+	labels := make(map[string]string, len(values))
+	for _, value := range values {
+		key, labelValue, ok := strings.Cut(value, "=")
+		if !ok || key == "" {
+			return nil, fmt.Errorf("invalid label %q, expected key=value", value)
+		}
+		labels[key] = labelValue
+	}
+	return labels, nil
+}

--- a/cmd/admin/dataserver/create/cmd.go
+++ b/cmd/admin/dataserver/create/cmd.go
@@ -49,23 +49,6 @@ func init() {
 	_ = Cmd.MarkFlagRequired(internalFlagName)
 }
 
-func newCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:          Cmd.Use,
-		Short:        Cmd.Short,
-		Long:         Cmd.Long,
-		Args:         Cmd.Args,
-		RunE:         Cmd.RunE,
-		SilenceUsage: Cmd.SilenceUsage,
-	}
-	cmd.Flags().String(publicFlagName, "", "Public address for the data server")
-	cmd.Flags().String(internalFlagName, "", "Internal address for the data server")
-	cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
-	_ = cmd.MarkFlagRequired(publicFlagName)
-	_ = cmd.MarkFlagRequired(internalFlagName)
-	return cmd
-}
-
 func exec(cmd *cobra.Command, args []string) error {
 	var (
 		outputFormat    string

--- a/cmd/admin/dataserver/create/cmd.go
+++ b/cmd/admin/dataserver/create/cmd.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
 	dataserveroutput "github.com/oxia-db/oxia/cmd/admin/dataserver/output"
+	cmdparse "github.com/oxia-db/oxia/cmd/common/parse"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxia"
 )
@@ -38,7 +39,6 @@ func newCmd() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
 	cmd.Flags().String("public", "", "Public address for the data server")
 	cmd.Flags().String("internal", "", "Internal address for the data server")
 	cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
@@ -48,28 +48,30 @@ func newCmd() *cobra.Command {
 }
 
 func exec(cmd *cobra.Command, args []string) error {
-	outputFormat, err := cmd.Flags().GetString("output")
-	if err != nil {
+	var (
+		outputFormat    string
+		publicAddress   string
+		internalAddress string
+		labelValues     []string
+		err             error
+	)
+	if outputFormat, err = cmd.Flags().GetString("output"); err != nil {
 		return err
 	}
 	if err := commons.ValidateOutputFormat(outputFormat); err != nil {
 		return err
 	}
-
-	publicAddress, err := cmd.Flags().GetString("public")
-	if err != nil {
+	if publicAddress, err = cmd.Flags().GetString("public"); err != nil {
 		return err
 	}
-	internalAddress, err := cmd.Flags().GetString("internal")
-	if err != nil {
+	if internalAddress, err = cmd.Flags().GetString("internal"); err != nil {
 		return err
 	}
-	labelValues, err := cmd.Flags().GetStringArray("label")
-	if err != nil {
+	if labelValues, err = cmd.Flags().GetStringArray("label"); err != nil {
 		return err
 	}
 
-	labels, err := commons.ParseStringMap(labelValues)
+	labels, err := cmdparse.StringMap(labelValues)
 	if err != nil {
 		return err
 	}

--- a/cmd/admin/dataserver/create/cmd.go
+++ b/cmd/admin/dataserver/create/cmd.go
@@ -27,6 +27,11 @@ import (
 	"github.com/oxia-db/oxia/oxia"
 )
 
+const (
+	publicFlagName   = "public"
+	internalFlagName = "internal"
+)
+
 var Cmd = &cobra.Command{
 	Use:          "create <name> --public <address> --internal <address>",
 	Short:        "Create a data server",
@@ -37,11 +42,11 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	Cmd.Flags().String("public", "", "Public address for the data server")
-	Cmd.Flags().String("internal", "", "Internal address for the data server")
+	Cmd.Flags().String(publicFlagName, "", "Public address for the data server")
+	Cmd.Flags().String(internalFlagName, "", "Internal address for the data server")
 	Cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
-	_ = Cmd.MarkFlagRequired("public")
-	_ = Cmd.MarkFlagRequired("internal")
+	_ = Cmd.MarkFlagRequired(publicFlagName)
+	_ = Cmd.MarkFlagRequired(internalFlagName)
 }
 
 func newCmd() *cobra.Command {
@@ -53,11 +58,11 @@ func newCmd() *cobra.Command {
 		RunE:         Cmd.RunE,
 		SilenceUsage: Cmd.SilenceUsage,
 	}
-	cmd.Flags().String("public", "", "Public address for the data server")
-	cmd.Flags().String("internal", "", "Internal address for the data server")
+	cmd.Flags().String(publicFlagName, "", "Public address for the data server")
+	cmd.Flags().String(internalFlagName, "", "Internal address for the data server")
 	cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
-	_ = cmd.MarkFlagRequired("public")
-	_ = cmd.MarkFlagRequired("internal")
+	_ = cmd.MarkFlagRequired(publicFlagName)
+	_ = cmd.MarkFlagRequired(internalFlagName)
 	return cmd
 }
 
@@ -75,10 +80,10 @@ func exec(cmd *cobra.Command, args []string) error {
 	if err := commons.ValidateOutputFormat(outputFormat); err != nil {
 		return err
 	}
-	if publicAddress, err = cmd.Flags().GetString("public"); err != nil {
+	if publicAddress, err = cmd.Flags().GetString(publicFlagName); err != nil {
 		return err
 	}
-	if internalAddress, err = cmd.Flags().GetString("internal"); err != nil {
+	if internalAddress, err = cmd.Flags().GetString(internalFlagName); err != nil {
 		return err
 	}
 	if labelValues, err = cmd.Flags().GetStringArray("label"); err != nil {

--- a/cmd/admin/dataserver/create/cmd.go
+++ b/cmd/admin/dataserver/create/cmd.go
@@ -69,7 +69,7 @@ func exec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	labels, err := commons.ParseLabels(labelValues)
+	labels, err := commons.ParseStringMap(labelValues)
 	if err != nil {
 		return err
 	}

--- a/cmd/admin/dataserver/create/cmd.go
+++ b/cmd/admin/dataserver/create/cmd.go
@@ -15,7 +15,7 @@
 package create
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -26,22 +26,25 @@ import (
 	"github.com/oxia-db/oxia/oxia"
 )
 
-var Cmd = &cobra.Command{
-	Use:          "create <name> --public <address> --internal <address>",
-	Short:        "Create a data server",
-	Long:         `Create a data server`,
-	Args:         cobra.ExactArgs(1),
-	RunE:         exec,
-	SilenceUsage: true,
-}
+var Cmd = newCmd()
 
-func init() {
-	Cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
-	Cmd.Flags().String("public", "", "Public address for the data server")
-	Cmd.Flags().String("internal", "", "Internal address for the data server")
-	Cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
-	_ = Cmd.MarkFlagRequired("public")
-	_ = Cmd.MarkFlagRequired("internal")
+func newCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "create <name> --public <address> --internal <address>",
+		Short:        "Create a data server",
+		Long:         `Create a data server`,
+		Args:         cobra.ExactArgs(1),
+		RunE:         exec,
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
+	cmd.Flags().String("public", "", "Public address for the data server")
+	cmd.Flags().String("internal", "", "Internal address for the data server")
+	cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
+	_ = cmd.MarkFlagRequired("public")
+	_ = cmd.MarkFlagRequired("internal")
+	return cmd
 }
 
 func exec(cmd *cobra.Command, args []string) error {
@@ -66,9 +69,14 @@ func exec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	labels, err := parseLabels(labelValues)
+	labels, err := commons.ParseLabels(labelValues)
 	if err != nil {
 		return err
+	}
+
+	name := strings.TrimSpace(args[0])
+	if name == "" {
+		return errors.New("data server name must not be empty")
 	}
 
 	client, err := commons.AdminConfig.NewAdminClient()
@@ -79,7 +87,6 @@ func exec(cmd *cobra.Command, args []string) error {
 		_ = client.Close()
 	}(client)
 
-	name := args[0]
 	created, err := client.CreateDataServer(&proto.DataServer{
 		Identity: &proto.DataServerIdentity{
 			Name:     &name,
@@ -95,20 +102,4 @@ func exec(cmd *cobra.Command, args []string) error {
 	}
 
 	return dataserveroutput.WriteDataServer(cmd.OutOrStdout(), outputFormat, created)
-}
-
-func parseLabels(values []string) (map[string]string, error) {
-	if len(values) == 0 {
-		return map[string]string{}, nil
-	}
-
-	labels := make(map[string]string, len(values))
-	for _, value := range values {
-		key, labelValue, ok := strings.Cut(value, "=")
-		if !ok || key == "" {
-			return nil, fmt.Errorf("invalid label %q, expected key=value", value)
-		}
-		labels[key] = labelValue
-	}
-	return labels, nil
 }

--- a/cmd/admin/dataserver/create/cmd_test.go
+++ b/cmd/admin/dataserver/create/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -29,12 +30,15 @@ import (
 )
 
 func runCmd(args ...string) (string, error) {
-	cmd := newCmd()
 	actual := new(bytes.Buffer)
-	cmd.SetOut(actual)
-	cmd.SetErr(actual)
-	cmd.SetArgs(args)
-	err := cmd.Execute()
+	root := &cobra.Command{Use: "admin"}
+	root.PersistentFlags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
+	cmd := newCmd()
+	root.AddCommand(cmd)
+	root.SetOut(actual)
+	root.SetErr(actual)
+	root.SetArgs(append([]string{"create"}, args...))
+	err := root.Execute()
 	return strings.TrimSpace(actual.String()), err
 }
 

--- a/cmd/admin/dataserver/create/cmd_test.go
+++ b/cmd/admin/dataserver/create/cmd_test.go
@@ -29,14 +29,12 @@ import (
 )
 
 func runCmd(args ...string) (string, error) {
+	cmd := newCmd()
 	actual := new(bytes.Buffer)
-	Cmd.SetOut(actual)
-	Cmd.SetErr(actual)
-	Cmd.SetArgs(args)
-	if err := Cmd.Flags().Set("output", ""); err != nil {
-		return strings.TrimSpace(actual.String()), err
-	}
-	err := Cmd.Execute()
+	cmd.SetOut(actual)
+	cmd.SetErr(actual)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
 	return strings.TrimSpace(actual.String()), err
 }
 
@@ -106,6 +104,26 @@ func Test_cmd_createDataServer_DefaultTable(t *testing.T) {
 	assert.Contains(t, out, "internal1")
 }
 
+func Test_cmd_createDataServer_Name(t *testing.T) {
+	serverName := "server-1"
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	commons.MockedAdminClient.On("Close").Return(nil)
+	commons.MockedAdminClient.On("CreateDataServer", mock.Anything).Return(&proto.DataServer{
+		Identity: &proto.DataServerIdentity{
+			Name:     &serverName,
+			Public:   "public1",
+			Internal: "internal1",
+		},
+	}, nil)
+
+	out, err := runCmd(serverName, "--public", "public1", "--internal", "internal1", "-o", "name")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "dataserver/server-1", out)
+}
+
 func Test_cmd_createDataServer_InvalidLabel(t *testing.T) {
 	commons.MockedAdminClient = commons.NewMockAdminClient()
 	t.Cleanup(func() { commons.MockedAdminClient = nil })
@@ -115,4 +133,15 @@ func Test_cmd_createDataServer_InvalidLabel(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `invalid label "rack", expected key=value`)
 	assert.Contains(t, out, `invalid label "rack", expected key=value`)
+}
+
+func Test_cmd_createDataServer_RejectsEmptyName(t *testing.T) {
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	out, err := runCmd("   ", "--public", "public1", "--internal", "internal1")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "data server name must not be empty")
+	assert.Contains(t, out, "data server name must not be empty")
 }

--- a/cmd/admin/dataserver/create/cmd_test.go
+++ b/cmd/admin/dataserver/create/cmd_test.go
@@ -1,0 +1,118 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/cmd/admin/commons"
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+func runCmd(args ...string) (string, error) {
+	actual := new(bytes.Buffer)
+	Cmd.SetOut(actual)
+	Cmd.SetErr(actual)
+	Cmd.SetArgs(args)
+	if err := Cmd.Flags().Set("output", ""); err != nil {
+		return strings.TrimSpace(actual.String()), err
+	}
+	err := Cmd.Execute()
+	return strings.TrimSpace(actual.String()), err
+}
+
+func Test_cmd_createDataServer(t *testing.T) {
+	serverName := "server-1"
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	expected := &proto.DataServer{
+		Identity: &proto.DataServerIdentity{
+			Name:     &serverName,
+			Public:   "public1",
+			Internal: "internal1",
+		},
+		Metadata: &proto.DataServerMetadata{
+			Labels: map[string]string{"rack": "rack-1"},
+		},
+	}
+
+	commons.MockedAdminClient.On("Close").Return(nil)
+	commons.MockedAdminClient.On("CreateDataServer", mock.MatchedBy(func(ds *proto.DataServer) bool {
+		return ds.GetNameOrDefault() == serverName &&
+			ds.GetIdentity().GetPublic() == "public1" &&
+			ds.GetIdentity().GetInternal() == "internal1" &&
+			ds.GetMetadata().GetLabels()["rack"] == "rack-1"
+	})).Return(expected, nil)
+
+	out, err := runCmd(serverName, "--public", "public1", "--internal", "internal1", "--label", "rack=rack-1", "-o", "json")
+
+	assert.NoError(t, err)
+	var dataServer proto.DataServer
+	assert.NoError(t, json.Unmarshal([]byte(out), &dataServer))
+	require.NotNil(t, dataServer.Identity)
+	require.NotNil(t, dataServer.Identity.Name)
+	assert.Equal(t, serverName, *dataServer.Identity.Name)
+	assert.Equal(t, "public1", dataServer.Identity.GetPublic())
+	assert.Equal(t, "internal1", dataServer.Identity.GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-1"}, dataServer.GetMetadata().GetLabels())
+}
+
+func Test_cmd_createDataServer_DefaultTable(t *testing.T) {
+	serverName := "server-1"
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	commons.MockedAdminClient.On("Close").Return(nil)
+	commons.MockedAdminClient.On("CreateDataServer", mock.Anything).Return(&proto.DataServer{
+		Identity: &proto.DataServerIdentity{
+			Name:     &serverName,
+			Public:   "public1",
+			Internal: "internal1",
+		},
+		Metadata: &proto.DataServerMetadata{
+			Labels: map[string]string{"rack": "rack-1"},
+		},
+	}, nil)
+
+	out, err := runCmd(serverName, "--public", "public1", "--internal", "internal1")
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "PUBLIC")
+	assert.Contains(t, out, "INTERNAL")
+	assert.Contains(t, out, "LABELS")
+	assert.Contains(t, out, "server-1")
+	assert.Contains(t, out, "public1")
+	assert.Contains(t, out, "internal1")
+}
+
+func Test_cmd_createDataServer_InvalidLabel(t *testing.T) {
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	out, err := runCmd("server-1", "--public", "public1", "--internal", "internal1", "--label", "rack")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid label "rack", expected key=value`)
+	assert.Contains(t, out, `invalid label "rack", expected key=value`)
+}

--- a/cmd/admin/dataserver/create/cmd_test.go
+++ b/cmd/admin/dataserver/create/cmd_test.go
@@ -29,11 +29,10 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 )
 
-func runCmd(args ...string) (string, error) {
+func runCmd(cmd *cobra.Command, args ...string) (string, error) {
 	actual := new(bytes.Buffer)
 	root := &cobra.Command{Use: "admin"}
 	root.PersistentFlags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
-	cmd := newCmd()
 	root.AddCommand(cmd)
 	root.SetOut(actual)
 	root.SetErr(actual)
@@ -66,7 +65,20 @@ func Test_cmd_createDataServer(t *testing.T) {
 			ds.GetMetadata().GetLabels()["rack"] == "rack-1"
 	})).Return(expected, nil)
 
-	out, err := runCmd(serverName, "--public", "public1", "--internal", "internal1", "--label", "rack=rack-1", "-o", "json")
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	cmd.Flags().String(publicFlagName, "", "Public address for the data server")
+	cmd.Flags().String(internalFlagName, "", "Internal address for the data server")
+	cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
+	_ = cmd.MarkFlagRequired(publicFlagName)
+	_ = cmd.MarkFlagRequired(internalFlagName)
+	out, err := runCmd(cmd, serverName, "--public", "public1", "--internal", "internal1", "--label", "rack=rack-1", "-o", "json")
 
 	assert.NoError(t, err)
 	var dataServer proto.DataServer
@@ -96,7 +108,20 @@ func Test_cmd_createDataServer_DefaultTable(t *testing.T) {
 		},
 	}, nil)
 
-	out, err := runCmd(serverName, "--public", "public1", "--internal", "internal1")
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	cmd.Flags().String(publicFlagName, "", "Public address for the data server")
+	cmd.Flags().String(internalFlagName, "", "Internal address for the data server")
+	cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
+	_ = cmd.MarkFlagRequired(publicFlagName)
+	_ = cmd.MarkFlagRequired(internalFlagName)
+	out, err := runCmd(cmd, serverName, "--public", "public1", "--internal", "internal1")
 
 	assert.NoError(t, err)
 	assert.Contains(t, out, "NAME")
@@ -122,7 +147,20 @@ func Test_cmd_createDataServer_Name(t *testing.T) {
 		},
 	}, nil)
 
-	out, err := runCmd(serverName, "--public", "public1", "--internal", "internal1", "-o", "name")
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	cmd.Flags().String(publicFlagName, "", "Public address for the data server")
+	cmd.Flags().String(internalFlagName, "", "Internal address for the data server")
+	cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
+	_ = cmd.MarkFlagRequired(publicFlagName)
+	_ = cmd.MarkFlagRequired(internalFlagName)
+	out, err := runCmd(cmd, serverName, "--public", "public1", "--internal", "internal1", "-o", "name")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "dataserver/server-1", out)
@@ -132,7 +170,20 @@ func Test_cmd_createDataServer_InvalidLabel(t *testing.T) {
 	commons.MockedAdminClient = commons.NewMockAdminClient()
 	t.Cleanup(func() { commons.MockedAdminClient = nil })
 
-	out, err := runCmd("server-1", "--public", "public1", "--internal", "internal1", "--label", "rack")
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	cmd.Flags().String(publicFlagName, "", "Public address for the data server")
+	cmd.Flags().String(internalFlagName, "", "Internal address for the data server")
+	cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
+	_ = cmd.MarkFlagRequired(publicFlagName)
+	_ = cmd.MarkFlagRequired(internalFlagName)
+	out, err := runCmd(cmd, "server-1", "--public", "public1", "--internal", "internal1", "--label", "rack")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `invalid entry "rack", expected key=value`)
@@ -143,7 +194,20 @@ func Test_cmd_createDataServer_RejectsEmptyName(t *testing.T) {
 	commons.MockedAdminClient = commons.NewMockAdminClient()
 	t.Cleanup(func() { commons.MockedAdminClient = nil })
 
-	out, err := runCmd("   ", "--public", "public1", "--internal", "internal1")
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	cmd.Flags().String(publicFlagName, "", "Public address for the data server")
+	cmd.Flags().String(internalFlagName, "", "Internal address for the data server")
+	cmd.Flags().StringArray("label", nil, "Label to attach to the data server in key=value form")
+	_ = cmd.MarkFlagRequired(publicFlagName)
+	_ = cmd.MarkFlagRequired(internalFlagName)
+	out, err := runCmd(cmd, "   ", "--public", "public1", "--internal", "internal1")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "data server name must not be empty")

--- a/cmd/admin/dataserver/create/cmd_test.go
+++ b/cmd/admin/dataserver/create/cmd_test.go
@@ -131,8 +131,8 @@ func Test_cmd_createDataServer_InvalidLabel(t *testing.T) {
 	out, err := runCmd("server-1", "--public", "public1", "--internal", "internal1", "--label", "rack")
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), `invalid label "rack", expected key=value`)
-	assert.Contains(t, out, `invalid label "rack", expected key=value`)
+	assert.Contains(t, err.Error(), `invalid entry "rack", expected key=value`)
+	assert.Contains(t, out, `invalid entry "rack", expected key=value`)
 }
 
 func Test_cmd_createDataServer_RejectsEmptyName(t *testing.T) {

--- a/cmd/admin/dataserver/get/cmd.go
+++ b/cmd/admin/dataserver/get/cmd.go
@@ -22,16 +22,23 @@ import (
 	"github.com/oxia-db/oxia/oxia"
 )
 
-var Cmd = newCmd()
+var Cmd = &cobra.Command{
+	Use:          "get [dataserver]",
+	Short:        "Get a data server or list data server identities",
+	Long:         `Get a data server or list data server identities`,
+	Args:         cobra.MaximumNArgs(1),
+	RunE:         exec,
+	SilenceUsage: true,
+}
 
 func newCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:          "get [dataserver]",
-		Short:        "Get a data server or list data server identities",
-		Long:         `Get a data server or list data server identities`,
-		Args:         cobra.MaximumNArgs(1),
-		RunE:         exec,
-		SilenceUsage: true,
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
 	}
 }
 

--- a/cmd/admin/dataserver/get/cmd.go
+++ b/cmd/admin/dataserver/get/cmd.go
@@ -22,17 +22,17 @@ import (
 	"github.com/oxia-db/oxia/oxia"
 )
 
-var Cmd = &cobra.Command{
-	Use:          "get [dataserver]",
-	Short:        "Get a data server or list data server identities",
-	Long:         `Get a data server or list data server identities`,
-	Args:         cobra.MaximumNArgs(1),
-	RunE:         exec,
-	SilenceUsage: true,
-}
+var Cmd = newCmd()
 
-func init() {
-	Cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
+func newCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:          "get [dataserver]",
+		Short:        "Get a data server or list data server identities",
+		Long:         `Get a data server or list data server identities`,
+		Args:         cobra.MaximumNArgs(1),
+		RunE:         exec,
+		SilenceUsage: true,
+	}
 }
 
 func exec(cmd *cobra.Command, args []string) error {

--- a/cmd/admin/dataserver/get/cmd.go
+++ b/cmd/admin/dataserver/get/cmd.go
@@ -31,17 +31,6 @@ var Cmd = &cobra.Command{
 	SilenceUsage: true,
 }
 
-func newCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:          Cmd.Use,
-		Short:        Cmd.Short,
-		Long:         Cmd.Long,
-		Args:         Cmd.Args,
-		RunE:         Cmd.RunE,
-		SilenceUsage: Cmd.SilenceUsage,
-	}
-}
-
 func exec(cmd *cobra.Command, args []string) error {
 	outputFormat, err := cmd.Flags().GetString("output")
 	if err != nil {

--- a/cmd/admin/dataserver/get/cmd_test.go
+++ b/cmd/admin/dataserver/get/cmd_test.go
@@ -29,11 +29,11 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 )
 
-func runCmd(args ...string) (string, error) {
+func runCmd(cmd *cobra.Command, args ...string) (string, error) {
 	actual := new(bytes.Buffer)
 	root := &cobra.Command{Use: "admin"}
 	root.PersistentFlags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
-	root.AddCommand(newCmd())
+	root.AddCommand(cmd)
 	root.SetOut(actual)
 	root.SetErr(actual)
 	root.SetArgs(append([]string{"get"}, args...))
@@ -57,7 +57,15 @@ func Test_cmd_getDataServer(t *testing.T) {
 		},
 	}, nil)
 
-	out, err := runCmd("-o", "json", serverName)
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	out, err := runCmd(cmd, "-o", "json", serverName)
 
 	assert.NoError(t, err)
 	var dataServer proto.DataServer
@@ -99,7 +107,15 @@ func Test_cmd_getDataServersIdentities(t *testing.T) {
 		},
 	}, nil)
 
-	out, err := runCmd("-o", "json")
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	out, err := runCmd(cmd, "-o", "json")
 
 	assert.NoError(t, err)
 	var dataServers []proto.DataServer
@@ -135,7 +151,15 @@ func Test_cmd_getDataServer_YAML(t *testing.T) {
 		},
 	}, nil)
 
-	out, err := runCmd("-o", "yaml", serverName)
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	out, err := runCmd(cmd, "-o", "yaml", serverName)
 
 	assert.NoError(t, err)
 	var dataServer map[string]any
@@ -170,7 +194,15 @@ func Test_cmd_getDataServersIdentities_Name(t *testing.T) {
 		},
 	}, nil)
 
-	out, err := runCmd("-o", "name")
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	out, err := runCmd(cmd, "-o", "name")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "dataserver/server-1\ndataserver/internal2", out)
@@ -179,7 +211,15 @@ func Test_cmd_getDataServersIdentities_Name(t *testing.T) {
 func Test_cmd_getDataServer_InvalidOutput(t *testing.T) {
 	commons.MockedAdminClient = nil
 
-	out, err := runCmd("-o", "xml")
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	out, err := runCmd(cmd, "-o", "xml")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `unsupported output format "xml"`)
@@ -202,7 +242,15 @@ func Test_cmd_getDataServer_DefaultTable(t *testing.T) {
 		},
 	}, nil)
 
-	out, err := runCmd(serverName)
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	out, err := runCmd(cmd, serverName)
 
 	assert.NoError(t, err)
 	assert.Contains(t, out, "NAME")
@@ -238,7 +286,15 @@ func Test_cmd_getDataServersIdentities_DefaultTable(t *testing.T) {
 		},
 	}, nil)
 
-	out, err := runCmd()
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	out, err := runCmd(cmd)
 
 	assert.NoError(t, err)
 	assert.Contains(t, out, "NAME")

--- a/cmd/admin/dataserver/get/cmd_test.go
+++ b/cmd/admin/dataserver/get/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -30,13 +31,13 @@ import (
 
 func runCmd(args ...string) (string, error) {
 	actual := new(bytes.Buffer)
-	Cmd.SetOut(actual)
-	Cmd.SetErr(actual)
-	Cmd.SetArgs(args)
-	if err := Cmd.Flags().Set("output", ""); err != nil {
-		return strings.TrimSpace(actual.String()), err
-	}
-	err := Cmd.Execute()
+	root := &cobra.Command{Use: "admin"}
+	root.PersistentFlags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
+	root.AddCommand(newCmd())
+	root.SetOut(actual)
+	root.SetErr(actual)
+	root.SetArgs(append([]string{"get"}, args...))
+	err := root.Execute()
 	return strings.TrimSpace(actual.String()), err
 }
 

--- a/cmd/common/parse/map.go
+++ b/cmd/common/parse/map.go
@@ -1,0 +1,40 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func StringMap(values []string) (map[string]string, error) {
+	if len(values) == 0 {
+		return map[string]string{}, nil
+	}
+
+	result := make(map[string]string, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		key, mapValue, ok := strings.Cut(value, "=")
+		if !ok || key == "" {
+			return nil, errors.Errorf("invalid entry %q, expected key=value", value)
+		}
+		result[key] = mapValue
+	}
+	return result, nil
+}

--- a/common/proto/admin.pb.go
+++ b/common/proto/admin.pb.go
@@ -206,6 +206,94 @@ func (x *GetDataServerResponse) GetDataServer() *DataServer {
 	return nil
 }
 
+type CreateDataServerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DataServer    *DataServer            `protobuf:"bytes,1,opt,name=data_server,json=dataServer,proto3" json:"data_server,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateDataServerRequest) Reset() {
+	*x = CreateDataServerRequest{}
+	mi := &file_admin_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateDataServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateDataServerRequest) ProtoMessage() {}
+
+func (x *CreateDataServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateDataServerRequest.ProtoReflect.Descriptor instead.
+func (*CreateDataServerRequest) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *CreateDataServerRequest) GetDataServer() *DataServer {
+	if x != nil {
+		return x.DataServer
+	}
+	return nil
+}
+
+type CreateDataServerResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DataServer    *DataServer            `protobuf:"bytes,1,opt,name=data_server,json=dataServer,proto3" json:"data_server,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateDataServerResponse) Reset() {
+	*x = CreateDataServerResponse{}
+	mi := &file_admin_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateDataServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateDataServerResponse) ProtoMessage() {}
+
+func (x *CreateDataServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateDataServerResponse.ProtoReflect.Descriptor instead.
+func (*CreateDataServerResponse) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *CreateDataServerResponse) GetDataServer() *DataServer {
+	if x != nil {
+		return x.DataServer
+	}
+	return nil
+}
+
 type ListNamespacesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -214,7 +302,7 @@ type ListNamespacesRequest struct {
 
 func (x *ListNamespacesRequest) Reset() {
 	*x = ListNamespacesRequest{}
-	mi := &file_admin_proto_msgTypes[4]
+	mi := &file_admin_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -226,7 +314,7 @@ func (x *ListNamespacesRequest) String() string {
 func (*ListNamespacesRequest) ProtoMessage() {}
 
 func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[4]
+	mi := &file_admin_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -239,7 +327,7 @@ func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListNamespacesRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{4}
+	return file_admin_proto_rawDescGZIP(), []int{6}
 }
 
 type ListNamespacesResponse struct {
@@ -251,7 +339,7 @@ type ListNamespacesResponse struct {
 
 func (x *ListNamespacesResponse) Reset() {
 	*x = ListNamespacesResponse{}
-	mi := &file_admin_proto_msgTypes[5]
+	mi := &file_admin_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -263,7 +351,7 @@ func (x *ListNamespacesResponse) String() string {
 func (*ListNamespacesResponse) ProtoMessage() {}
 
 func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[5]
+	mi := &file_admin_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -276,7 +364,7 @@ func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListNamespacesResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{5}
+	return file_admin_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ListNamespacesResponse) GetNamespaces() []string {
@@ -298,7 +386,7 @@ type SplitShardRequest struct {
 
 func (x *SplitShardRequest) Reset() {
 	*x = SplitShardRequest{}
-	mi := &file_admin_proto_msgTypes[6]
+	mi := &file_admin_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -310,7 +398,7 @@ func (x *SplitShardRequest) String() string {
 func (*SplitShardRequest) ProtoMessage() {}
 
 func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[6]
+	mi := &file_admin_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -323,7 +411,7 @@ func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardRequest.ProtoReflect.Descriptor instead.
 func (*SplitShardRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{6}
+	return file_admin_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *SplitShardRequest) GetNamespace() string {
@@ -357,7 +445,7 @@ type SplitShardResponse struct {
 
 func (x *SplitShardResponse) Reset() {
 	*x = SplitShardResponse{}
-	mi := &file_admin_proto_msgTypes[7]
+	mi := &file_admin_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -369,7 +457,7 @@ func (x *SplitShardResponse) String() string {
 func (*SplitShardResponse) ProtoMessage() {}
 
 func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[7]
+	mi := &file_admin_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -382,7 +470,7 @@ func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardResponse.ProtoReflect.Descriptor instead.
 func (*SplitShardResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{7}
+	return file_admin_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *SplitShardResponse) GetLeftChildShard() int64 {
@@ -412,6 +500,12 @@ const file_admin_proto_rawDesc = "" +
 	"dataServer\"V\n" +
 	"\x15GetDataServerResponse\x12=\n" +
 	"\vdata_server\x18\x01 \x01(\v2\x1c.io.oxia.proto.v1.DataServerR\n" +
+	"dataServer\"X\n" +
+	"\x17CreateDataServerRequest\x12=\n" +
+	"\vdata_server\x18\x01 \x01(\v2\x1c.io.oxia.proto.v1.DataServerR\n" +
+	"dataServer\"Y\n" +
+	"\x18CreateDataServerResponse\x12=\n" +
+	"\vdata_server\x18\x01 \x01(\v2\x1c.io.oxia.proto.v1.DataServerR\n" +
 	"dataServer\"\x17\n" +
 	"\x15ListNamespacesRequest\"8\n" +
 	"\x16ListNamespacesResponse\x12\x1e\n" +
@@ -426,10 +520,11 @@ const file_admin_proto_rawDesc = "" +
 	"\f_split_point\"j\n" +
 	"\x12SplitShardResponse\x12(\n" +
 	"\x10left_child_shard\x18\x01 \x01(\x03R\x0eleftChildShard\x12*\n" +
-	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\x93\x03\n" +
+	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\xfe\x03\n" +
 	"\tOxiaAdmin\x12f\n" +
 	"\x0fListDataServers\x12(.io.oxia.proto.v1.ListDataServersRequest\x1a).io.oxia.proto.v1.ListDataServersResponse\x12`\n" +
-	"\rGetDataServer\x12&.io.oxia.proto.v1.GetDataServerRequest\x1a'.io.oxia.proto.v1.GetDataServerResponse\x12c\n" +
+	"\rGetDataServer\x12&.io.oxia.proto.v1.GetDataServerRequest\x1a'.io.oxia.proto.v1.GetDataServerResponse\x12i\n" +
+	"\x10CreateDataServer\x12).io.oxia.proto.v1.CreateDataServerRequest\x1a*.io.oxia.proto.v1.CreateDataServerResponse\x12c\n" +
 	"\x0eListNamespaces\x12'.io.oxia.proto.v1.ListNamespacesRequest\x1a(.io.oxia.proto.v1.ListNamespacesResponse\x12W\n" +
 	"\n" +
 	"SplitShard\x12#.io.oxia.proto.v1.SplitShardRequest\x1a$.io.oxia.proto.v1.SplitShardResponseB(P\x01Z$github.com/oxia-db/oxia/common/protob\x06proto3"
@@ -446,34 +541,40 @@ func file_admin_proto_rawDescGZIP() []byte {
 	return file_admin_proto_rawDescData
 }
 
-var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_admin_proto_goTypes = []any{
-	(*ListDataServersRequest)(nil),  // 0: io.oxia.proto.v1.ListDataServersRequest
-	(*ListDataServersResponse)(nil), // 1: io.oxia.proto.v1.ListDataServersResponse
-	(*GetDataServerRequest)(nil),    // 2: io.oxia.proto.v1.GetDataServerRequest
-	(*GetDataServerResponse)(nil),   // 3: io.oxia.proto.v1.GetDataServerResponse
-	(*ListNamespacesRequest)(nil),   // 4: io.oxia.proto.v1.ListNamespacesRequest
-	(*ListNamespacesResponse)(nil),  // 5: io.oxia.proto.v1.ListNamespacesResponse
-	(*SplitShardRequest)(nil),       // 6: io.oxia.proto.v1.SplitShardRequest
-	(*SplitShardResponse)(nil),      // 7: io.oxia.proto.v1.SplitShardResponse
-	(*DataServer)(nil),              // 8: io.oxia.proto.v1.DataServer
+	(*ListDataServersRequest)(nil),   // 0: io.oxia.proto.v1.ListDataServersRequest
+	(*ListDataServersResponse)(nil),  // 1: io.oxia.proto.v1.ListDataServersResponse
+	(*GetDataServerRequest)(nil),     // 2: io.oxia.proto.v1.GetDataServerRequest
+	(*GetDataServerResponse)(nil),    // 3: io.oxia.proto.v1.GetDataServerResponse
+	(*CreateDataServerRequest)(nil),  // 4: io.oxia.proto.v1.CreateDataServerRequest
+	(*CreateDataServerResponse)(nil), // 5: io.oxia.proto.v1.CreateDataServerResponse
+	(*ListNamespacesRequest)(nil),    // 6: io.oxia.proto.v1.ListNamespacesRequest
+	(*ListNamespacesResponse)(nil),   // 7: io.oxia.proto.v1.ListNamespacesResponse
+	(*SplitShardRequest)(nil),        // 8: io.oxia.proto.v1.SplitShardRequest
+	(*SplitShardResponse)(nil),       // 9: io.oxia.proto.v1.SplitShardResponse
+	(*DataServer)(nil),               // 10: io.oxia.proto.v1.DataServer
 }
 var file_admin_proto_depIdxs = []int32{
-	8, // 0: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
-	8, // 1: io.oxia.proto.v1.GetDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
-	0, // 2: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
-	2, // 3: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
-	4, // 4: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
-	6, // 5: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
-	1, // 6: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
-	3, // 7: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.GetDataServerResponse
-	5, // 8: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
-	7, // 9: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
-	6, // [6:10] is the sub-list for method output_type
-	2, // [2:6] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	10, // 0: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
+	10, // 1: io.oxia.proto.v1.GetDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	10, // 2: io.oxia.proto.v1.CreateDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
+	10, // 3: io.oxia.proto.v1.CreateDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	0,  // 4: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
+	2,  // 5: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
+	4,  // 6: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:input_type -> io.oxia.proto.v1.CreateDataServerRequest
+	6,  // 7: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
+	8,  // 8: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
+	1,  // 9: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
+	3,  // 10: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.GetDataServerResponse
+	5,  // 11: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:output_type -> io.oxia.proto.v1.CreateDataServerResponse
+	7,  // 12: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
+	9,  // 13: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
+	9,  // [9:14] is the sub-list for method output_type
+	4,  // [4:9] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_admin_proto_init() }
@@ -482,14 +583,14 @@ func file_admin_proto_init() {
 		return
 	}
 	file_metadata_proto_init()
-	file_admin_proto_msgTypes[6].OneofWrappers = []any{}
+	file_admin_proto_msgTypes[8].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_admin_proto_rawDesc), len(file_admin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/common/proto/admin.proto
+++ b/common/proto/admin.proto
@@ -28,6 +28,7 @@ service OxiaAdmin {
 
   rpc ListDataServers(ListDataServersRequest) returns (ListDataServersResponse);
   rpc GetDataServer(GetDataServerRequest) returns (GetDataServerResponse);
+  rpc CreateDataServer(CreateDataServerRequest) returns (CreateDataServerResponse);
 
   rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse);
 
@@ -51,6 +52,14 @@ message GetDataServerRequest {
 }
 
 message GetDataServerResponse {
+  DataServer data_server = 1;
+}
+
+message CreateDataServerRequest {
+  DataServer data_server = 1;
+}
+
+message CreateDataServerResponse {
   DataServer data_server = 1;
 }
 

--- a/common/proto/admin_grpc.pb.go
+++ b/common/proto/admin_grpc.pb.go
@@ -36,10 +36,11 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	OxiaAdmin_ListDataServers_FullMethodName = "/io.oxia.proto.v1.OxiaAdmin/ListDataServers"
-	OxiaAdmin_GetDataServer_FullMethodName   = "/io.oxia.proto.v1.OxiaAdmin/GetDataServer"
-	OxiaAdmin_ListNamespaces_FullMethodName  = "/io.oxia.proto.v1.OxiaAdmin/ListNamespaces"
-	OxiaAdmin_SplitShard_FullMethodName      = "/io.oxia.proto.v1.OxiaAdmin/SplitShard"
+	OxiaAdmin_ListDataServers_FullMethodName  = "/io.oxia.proto.v1.OxiaAdmin/ListDataServers"
+	OxiaAdmin_GetDataServer_FullMethodName    = "/io.oxia.proto.v1.OxiaAdmin/GetDataServer"
+	OxiaAdmin_CreateDataServer_FullMethodName = "/io.oxia.proto.v1.OxiaAdmin/CreateDataServer"
+	OxiaAdmin_ListNamespaces_FullMethodName   = "/io.oxia.proto.v1.OxiaAdmin/ListNamespaces"
+	OxiaAdmin_SplitShard_FullMethodName       = "/io.oxia.proto.v1.OxiaAdmin/SplitShard"
 )
 
 // OxiaAdminClient is the client API for OxiaAdmin service.
@@ -48,6 +49,7 @@ const (
 type OxiaAdminClient interface {
 	ListDataServers(ctx context.Context, in *ListDataServersRequest, opts ...grpc.CallOption) (*ListDataServersResponse, error)
 	GetDataServer(ctx context.Context, in *GetDataServerRequest, opts ...grpc.CallOption) (*GetDataServerResponse, error)
+	CreateDataServer(ctx context.Context, in *CreateDataServerRequest, opts ...grpc.CallOption) (*CreateDataServerResponse, error)
 	ListNamespaces(ctx context.Context, in *ListNamespacesRequest, opts ...grpc.CallOption) (*ListNamespacesResponse, error)
 	// *
 	// Triggers a shard split. The specified shard is split into two child
@@ -83,6 +85,16 @@ func (c *oxiaAdminClient) GetDataServer(ctx context.Context, in *GetDataServerRe
 	return out, nil
 }
 
+func (c *oxiaAdminClient) CreateDataServer(ctx context.Context, in *CreateDataServerRequest, opts ...grpc.CallOption) (*CreateDataServerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateDataServerResponse)
+	err := c.cc.Invoke(ctx, OxiaAdmin_CreateDataServer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *oxiaAdminClient) ListNamespaces(ctx context.Context, in *ListNamespacesRequest, opts ...grpc.CallOption) (*ListNamespacesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListNamespacesResponse)
@@ -109,6 +121,7 @@ func (c *oxiaAdminClient) SplitShard(ctx context.Context, in *SplitShardRequest,
 type OxiaAdminServer interface {
 	ListDataServers(context.Context, *ListDataServersRequest) (*ListDataServersResponse, error)
 	GetDataServer(context.Context, *GetDataServerRequest) (*GetDataServerResponse, error)
+	CreateDataServer(context.Context, *CreateDataServerRequest) (*CreateDataServerResponse, error)
 	ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error)
 	// *
 	// Triggers a shard split. The specified shard is split into two child
@@ -129,6 +142,9 @@ func (UnimplementedOxiaAdminServer) ListDataServers(context.Context, *ListDataSe
 }
 func (UnimplementedOxiaAdminServer) GetDataServer(context.Context, *GetDataServerRequest) (*GetDataServerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetDataServer not implemented")
+}
+func (UnimplementedOxiaAdminServer) CreateDataServer(context.Context, *CreateDataServerRequest) (*CreateDataServerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateDataServer not implemented")
 }
 func (UnimplementedOxiaAdminServer) ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListNamespaces not implemented")
@@ -193,6 +209,24 @@ func _OxiaAdmin_GetDataServer_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _OxiaAdmin_CreateDataServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateDataServerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OxiaAdminServer).CreateDataServer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OxiaAdmin_CreateDataServer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OxiaAdminServer).CreateDataServer(ctx, req.(*CreateDataServerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _OxiaAdmin_ListNamespaces_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ListNamespacesRequest)
 	if err := dec(in); err != nil {
@@ -243,6 +277,10 @@ var OxiaAdmin_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetDataServer",
 			Handler:    _OxiaAdmin_GetDataServer_Handler,
+		},
+		{
+			MethodName: "CreateDataServer",
+			Handler:    _OxiaAdmin_CreateDataServer_Handler,
 		},
 		{
 			MethodName: "ListNamespaces",

--- a/common/proto/admin_vtproto.pb.go
+++ b/common/proto/admin_vtproto.pb.go
@@ -93,6 +93,40 @@ func (m *GetDataServerResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *CreateDataServerRequest) CloneVT() *CreateDataServerRequest {
+	if m == nil {
+		return (*CreateDataServerRequest)(nil)
+	}
+	r := new(CreateDataServerRequest)
+	r.DataServer = m.DataServer.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *CreateDataServerRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *CreateDataServerResponse) CloneVT() *CreateDataServerResponse {
+	if m == nil {
+		return (*CreateDataServerResponse)(nil)
+	}
+	r := new(CreateDataServerResponse)
+	r.DataServer = m.DataServer.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *CreateDataServerResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *ListNamespacesRequest) CloneVT() *ListNamespacesRequest {
 	if m == nil {
 		return (*ListNamespacesRequest)(nil)
@@ -252,6 +286,44 @@ func (this *GetDataServerResponse) EqualVT(that *GetDataServerResponse) bool {
 
 func (this *GetDataServerResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*GetDataServerResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *CreateDataServerRequest) EqualVT(that *CreateDataServerRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.DataServer.EqualVT(that.DataServer) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *CreateDataServerRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*CreateDataServerRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *CreateDataServerResponse) EqualVT(that *CreateDataServerResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.DataServer.EqualVT(that.DataServer) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *CreateDataServerResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*CreateDataServerResponse)
 	if !ok {
 		return false
 	}
@@ -506,6 +578,92 @@ func (m *GetDataServerResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 	return len(dAtA) - i, nil
 }
 
+func (m *CreateDataServerRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CreateDataServerRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *CreateDataServerRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.DataServer != nil {
+		size, err := m.DataServer.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *CreateDataServerResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CreateDataServerResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *CreateDataServerResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.DataServer != nil {
+		size, err := m.DataServer.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ListNamespacesRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -715,6 +873,34 @@ func (m *GetDataServerRequest) SizeVT() (n int) {
 }
 
 func (m *GetDataServerResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.DataServer != nil {
+		l = m.DataServer.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *CreateDataServerRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.DataServer != nil {
+		l = m.DataServer.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *CreateDataServerResponse) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1036,6 +1222,180 @@ func (m *GetDataServerResponse) UnmarshalVT(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: GetDataServerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DataServer == nil {
+				m.DataServer = &DataServer{}
+			}
+			if err := m.DataServer.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateDataServerRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateDataServerRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateDataServerRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DataServer == nil {
+				m.DataServer = &DataServer{}
+			}
+			if err := m.DataServer.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateDataServerResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateDataServerResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateDataServerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -1691,6 +2051,180 @@ func (m *GetDataServerResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: GetDataServerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DataServer == nil {
+				m.DataServer = &DataServer{}
+			}
+			if err := m.DataServer.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateDataServerRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateDataServerRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateDataServerRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DataServer == nil {
+				m.DataServer = &DataServer{}
+			}
+			if err := m.DataServer.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateDataServerResponse) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateDataServerResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateDataServerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/oxia/admin.go
+++ b/oxia/admin.go
@@ -25,6 +25,7 @@ type AdminClient interface {
 
 	ListDataServers() ([]*proto.DataServer, error)
 	GetDataServer(dataServer string) (*proto.DataServer, error)
+	CreateDataServer(dataServer *proto.DataServer) (*proto.DataServer, error)
 
 	ListNamespaces() *ListNamespacesResult
 

--- a/oxia/admin_client_impl.go
+++ b/oxia/admin_client_impl.go
@@ -67,6 +67,23 @@ func (admin *adminClientImpl) GetDataServer(dataServer string) (*proto.DataServe
 	return response.DataServer, nil
 }
 
+func (admin *adminClientImpl) CreateDataServer(dataServer *proto.DataServer) (*proto.DataServer, error) {
+	client, err := admin.clientPool.GetAminRpc(admin.adminAddr)
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+
+	if client == nil {
+		return nil, wrapAdminError(ErrUnknown, errors.New("unable to connect to admin server"))
+	}
+
+	response, err := client.CreateDataServer(context.Background(), &proto.CreateDataServerRequest{DataServer: dataServer})
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+	return response.DataServer, nil
+}
+
 func (admin *adminClientImpl) Close() error {
 	return admin.clientPool.Close()
 }

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -36,6 +36,8 @@ type mockAdminRpcClient struct {
 	listDataServersErr      error
 	getDataServerResponse   *proto.GetDataServerResponse
 	getDataServerErr        error
+	createDataServerResp    *proto.CreateDataServerResponse
+	createDataServerErr     error
 }
 
 func (m *mockAdminRpcClient) ListDataServers(context.Context, *proto.ListDataServersRequest, ...grpc.CallOption) (*proto.ListDataServersResponse, error) {
@@ -44,6 +46,10 @@ func (m *mockAdminRpcClient) ListDataServers(context.Context, *proto.ListDataSer
 
 func (m *mockAdminRpcClient) GetDataServer(context.Context, *proto.GetDataServerRequest, ...grpc.CallOption) (*proto.GetDataServerResponse, error) {
 	return m.getDataServerResponse, m.getDataServerErr
+}
+
+func (m *mockAdminRpcClient) CreateDataServer(context.Context, *proto.CreateDataServerRequest, ...grpc.CallOption) (*proto.CreateDataServerResponse, error) {
+	return m.createDataServerResp, m.createDataServerErr
 }
 
 func (*mockAdminRpcClient) ListNamespaces(context.Context, *proto.ListNamespacesRequest, ...grpc.CallOption) (*proto.ListNamespacesResponse, error) {
@@ -198,6 +204,45 @@ func TestAdminClientGetDataServerReturnsResponse(t *testing.T) {
 	}
 
 	dataServer, err := admin.GetDataServer(serverName)
+	require.NoError(t, err)
+	require.NotNil(t, dataServer)
+	require.NotNil(t, dataServer.Identity)
+	require.NotNil(t, dataServer.Identity.Name)
+	assert.Equal(t, serverName, *dataServer.Identity.Name)
+	assert.Equal(t, "public-1", dataServer.Identity.GetPublic())
+	assert.Equal(t, "internal-1", dataServer.Identity.GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-1"}, dataServer.Metadata.GetLabels())
+}
+
+func TestAdminClientCreateDataServerReturnsResponse(t *testing.T) {
+	serverName := "server-1"
+	admin := &adminClientImpl{
+		adminAddr: "admin-addr",
+		clientPool: &mockAdminClientPool{
+			adminClient: &mockAdminRpcClient{
+				createDataServerResp: &proto.CreateDataServerResponse{
+					DataServer: &proto.DataServer{
+						Identity: &proto.DataServerIdentity{
+							Name:     &serverName,
+							Public:   "public-1",
+							Internal: "internal-1",
+						},
+						Metadata: &proto.DataServerMetadata{
+							Labels: map[string]string{"rack": "rack-1"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dataServer, err := admin.CreateDataServer(&proto.DataServer{
+		Identity: &proto.DataServerIdentity{
+			Name:     &serverName,
+			Public:   "public-1",
+			Internal: "internal-1",
+		},
+	})
 	require.NoError(t, err)
 	require.NotNil(t, dataServer)
 	require.NotNil(t, dataServer.Identity)

--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -98,15 +98,15 @@ func (management *managementServer) CreateDataServer(_ context.Context, req *pro
 		return nil, grpcstatus.Error(codes.InvalidArgument, "data server internal address must not be empty")
 	}
 
-	created, err := management.metadata.CreateDataServer(req.DataServer)
+	err := management.metadata.CreateDataServer(req.DataServer)
 	if err != nil {
+		if errors.Is(err, metadatacommon.ErrAlreadyExists) {
+			return nil, grpcstatus.Errorf(codes.AlreadyExists, "data server %q already exists", req.DataServer.GetNameOrDefault())
+		}
 		if errors.Is(err, metadatacommon.ErrBadVersion) {
 			return nil, grpcstatus.Errorf(codes.Aborted, "failed to create data server %q due to concurrent config update", req.DataServer.GetNameOrDefault())
 		}
 		return nil, grpcstatus.Errorf(codes.Internal, "failed to create data server %q: %v", req.DataServer.GetNameOrDefault(), err)
-	}
-	if !created {
-		return nil, grpcstatus.Errorf(codes.AlreadyExists, "data server %q already exists", req.DataServer.GetNameOrDefault())
 	}
 
 	return &proto.CreateDataServerResponse{

--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -109,13 +109,8 @@ func (management *managementServer) CreateDataServer(_ context.Context, req *pro
 		return nil, grpcstatus.Errorf(codes.AlreadyExists, "data server %q already exists", req.DataServer.GetNameOrDefault())
 	}
 
-	dataServer, found := management.metadata.GetDataServer(req.DataServer.GetIdentity().GetName())
-	if !found {
-		return nil, grpcstatus.Errorf(codes.Internal, "created data server %q not found in config", req.DataServer.GetNameOrDefault())
-	}
-
 	return &proto.CreateDataServerResponse{
-		DataServer: dataServer.UnsafeBorrow(),
+		DataServer: req.DataServer,
 	}, nil
 }
 

--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -16,15 +16,16 @@ package coordinator
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/emirpasic/gods/v2/sets/hashset"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/proto"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
 )
 
@@ -77,6 +78,44 @@ func (management *managementServer) GetDataServer(_ context.Context, req *proto.
 
 	return &proto.GetDataServerResponse{
 		DataServer: borrowedDataServer.UnsafeBorrow(),
+	}, nil
+}
+
+func (management *managementServer) CreateDataServer(_ context.Context, req *proto.CreateDataServerRequest) (*proto.CreateDataServerResponse, error) {
+	if req == nil || req.DataServer == nil {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "data server must not be nil")
+	}
+	if req.DataServer.Identity == nil {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "data server identity must not be nil")
+	}
+	if req.DataServer.Identity.GetName() == "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "data server identity name must not be empty")
+	}
+	if req.DataServer.Identity.GetPublic() == "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "data server public address must not be empty")
+	}
+	if req.DataServer.Identity.GetInternal() == "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "data server internal address must not be empty")
+	}
+
+	created, err := management.metadata.CreateDataServer(req.DataServer)
+	if err != nil {
+		if errors.Is(err, metadatacommon.ErrBadVersion) {
+			return nil, grpcstatus.Errorf(codes.Aborted, "failed to create data server %q due to concurrent config update", req.DataServer.GetNameOrDefault())
+		}
+		return nil, grpcstatus.Errorf(codes.Internal, "failed to create data server %q: %v", req.DataServer.GetNameOrDefault(), err)
+	}
+	if !created {
+		return nil, grpcstatus.Errorf(codes.AlreadyExists, "data server %q already exists", req.DataServer.GetNameOrDefault())
+	}
+
+	dataServer, found := management.metadata.GetDataServer(req.DataServer.GetIdentity().GetName())
+	if !found {
+		return nil, grpcstatus.Errorf(codes.Internal, "created data server %q not found in config", req.DataServer.GetNameOrDefault())
+	}
+
+	return &proto.CreateDataServerResponse{
+		DataServer: dataServer.UnsafeBorrow(),
 	}, nil
 }
 

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -196,3 +196,86 @@ func TestManagementServerGetDataServerRejectsEmptyLookup(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, grpcstatus.Code(err))
 }
+
+func TestManagementServerCreateDataServer(t *testing.T) {
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{}),
+		nil,
+	)
+
+	serverName := "server-1"
+	res, err := management.CreateDataServer(context.Background(), &proto.CreateDataServerRequest{
+		DataServer: &proto.DataServer{
+			Identity: &proto.DataServerIdentity{
+				Name:     &serverName,
+				Public:   "public-1",
+				Internal: "internal-1",
+			},
+			Metadata: &proto.DataServerMetadata{
+				Labels: map[string]string{"rack": "rack-1"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, res.DataServer)
+	require.NotNil(t, res.DataServer.Identity)
+	require.NotNil(t, res.DataServer.Identity.Name)
+	assert.Equal(t, serverName, *res.DataServer.Identity.Name)
+	assert.Equal(t, "public-1", res.DataServer.Identity.GetPublic())
+	assert.Equal(t, "internal-1", res.DataServer.Identity.GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-1"}, res.DataServer.Metadata.GetLabels())
+
+	created, found := management.metadata.GetDataServer(serverName)
+	require.True(t, found)
+	assert.Equal(t, "public-1", created.UnsafeBorrow().Identity.GetPublic())
+}
+
+func TestManagementServerCreateDataServerRejectsInvalidRequest(t *testing.T) {
+	management := newManagementServer(newTestMetadata(t, &proto.ClusterConfiguration{}), nil)
+	serverName := "server-1"
+
+	testCases := []struct {
+		name string
+		req  *proto.CreateDataServerRequest
+	}{
+		{name: "nil request", req: nil},
+		{name: "nil dataserver", req: &proto.CreateDataServerRequest{}},
+		{name: "nil identity", req: &proto.CreateDataServerRequest{DataServer: &proto.DataServer{}}},
+		{name: "empty name", req: &proto.CreateDataServerRequest{DataServer: &proto.DataServer{Identity: &proto.DataServerIdentity{Public: "public", Internal: "internal"}}}},
+		{name: "empty public", req: &proto.CreateDataServerRequest{DataServer: &proto.DataServer{Identity: &proto.DataServerIdentity{Name: &serverName, Internal: "internal"}}}},
+		{name: "empty internal", req: &proto.CreateDataServerRequest{DataServer: &proto.DataServer{Identity: &proto.DataServerIdentity{Name: &serverName, Public: "public"}}}},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := management.CreateDataServer(context.Background(), tt.req)
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, grpcstatus.Code(err))
+		})
+	}
+}
+
+func TestManagementServerCreateDataServerAlreadyExists(t *testing.T) {
+	serverName := "server-1"
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{
+			Servers: []*proto.DataServerIdentity{
+				dataServer(&serverName, "public-1", "internal-1"),
+			},
+		}),
+		nil,
+	)
+
+	_, err := management.CreateDataServer(context.Background(), &proto.CreateDataServerRequest{
+		DataServer: &proto.DataServer{
+			Identity: &proto.DataServerIdentity{
+				Name:     &serverName,
+				Public:   "public-1",
+				Internal: "internal-1",
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, grpcstatus.Code(err))
+}

--- a/oxiad/coordinator/metadata/common/error.go
+++ b/oxiad/coordinator/metadata/common/error.go
@@ -19,4 +19,5 @@ import "github.com/pkg/errors"
 var (
 	ErrNotInitialized = errors.New("metadata not initialized")
 	ErrBadVersion     = errors.New("metadata bad version")
+	ErrAlreadyExists  = errors.New("metadata already exists")
 )

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -53,7 +53,7 @@ type Metadata interface {
 	SubscribeConfig() *commonwatch.Receiver[provider.Versioned[*commonproto.ClusterConfiguration]]
 	GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer]
 
-	CreateDataServer(dataServer *commonproto.DataServer) (bool, error)
+	CreateDataServer(dataServer *commonproto.DataServer) error
 	ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer]
 	GetDataServer(name string) (commonobject.Borrowed[*commonproto.DataServer], bool)
 }
@@ -356,13 +356,14 @@ func (m *coordinatorMetadata) GetLoadBalancer() commonobject.Borrowed[*commonpro
 	return commonobject.Borrow(m.GetConfig().UnsafeBorrow().GetLoadBalancerWithDefaults())
 }
 
-func (m *coordinatorMetadata) CreateDataServer(dataServer *commonproto.DataServer) (bool, error) {
+func (m *coordinatorMetadata) CreateDataServer(dataServer *commonproto.DataServer) error {
 	name := dataServer.GetIdentity().GetName()
-	created := false
+	alreadyExists := false
 
 	err := m.computeConfig(func(config *commonproto.ClusterConfiguration, _ metadatacommon.Version) (*commonproto.ClusterConfiguration, bool) {
 		if _, exists := config.GetDataServer(name); exists {
-			return config, false
+			alreadyExists = true
+			return nil, false
 		}
 
 		config.Servers = append(config.Servers, cloneDataServerIdentity(dataServer.GetIdentity()))
@@ -373,10 +374,15 @@ func (m *coordinatorMetadata) CreateDataServer(dataServer *commonproto.DataServe
 			config.ServerMetadata[name] = cloneDataServerMetadata(metadata)
 		}
 
-		created = true
 		return config, true
 	})
-	return created, err
+	if err != nil {
+		return err
+	}
+	if alreadyExists {
+		return metadatacommon.ErrAlreadyExists
+	}
+	return nil
 }
 
 func cloneDataServerIdentity(identity *commonproto.DataServerIdentity) *commonproto.DataServerIdentity {

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -366,12 +366,12 @@ func (m *coordinatorMetadata) CreateDataServer(dataServer *commonproto.DataServe
 			return nil, false
 		}
 
-		config.Servers = append(config.Servers, cloneDataServerIdentity(dataServer.GetIdentity()))
+		config.Servers = append(config.Servers, dataServer.GetIdentity())
 		if metadata := dataServer.GetMetadata(); metadata != nil {
 			if config.ServerMetadata == nil {
 				config.ServerMetadata = map[string]*commonproto.DataServerMetadata{}
 			}
-			config.ServerMetadata[name] = cloneDataServerMetadata(metadata)
+			config.ServerMetadata[name] = metadata
 		}
 
 		return config, true
@@ -383,37 +383,6 @@ func (m *coordinatorMetadata) CreateDataServer(dataServer *commonproto.DataServe
 		return metadatacommon.ErrAlreadyExists
 	}
 	return nil
-}
-
-func cloneDataServerIdentity(identity *commonproto.DataServerIdentity) *commonproto.DataServerIdentity {
-	if identity == nil {
-		return nil
-	}
-
-	cloned := &commonproto.DataServerIdentity{
-		Public:   identity.GetPublic(),
-		Internal: identity.GetInternal(),
-	}
-	if identity.Name != nil {
-		name := identity.GetName()
-		cloned.Name = &name
-	}
-	return cloned
-}
-
-func cloneDataServerMetadata(metadata *commonproto.DataServerMetadata) *commonproto.DataServerMetadata {
-	if metadata == nil {
-		return nil
-	}
-
-	cloned := &commonproto.DataServerMetadata{}
-	if len(metadata.GetLabels()) > 0 {
-		cloned.Labels = make(map[string]string, len(metadata.GetLabels()))
-		for key, value := range metadata.GetLabels() {
-			cloned.Labels[key] = value
-		}
-	}
-	return cloned
 }
 
 func (m *coordinatorMetadata) ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer] {

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -107,6 +107,9 @@ func (m *coordinatorMetadata) computeStatus(fn func(*commonproto.ClusterStatus, 
 		Value:   next,
 		Version: current.Version,
 	})
+	if errors.Is(err, metadatacommon.ErrBadVersion) {
+		panic(err)
+	}
 	return err
 }
 

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -113,21 +113,21 @@ func (m *coordinatorMetadata) computeStatus(fn func(*commonproto.ClusterStatus, 
 	return err
 }
 
-func (m *coordinatorMetadata) computeConfig(fn func(*commonproto.ClusterConfiguration, metadatacommon.Version) (*commonproto.ClusterConfiguration, bool)) error {
+func (m *coordinatorMetadata) computeConfig(fn func(*commonproto.ClusterConfiguration, metadatacommon.Version) (*commonproto.ClusterConfiguration, error)) error {
 	m.configLock.Lock()
 	defer m.configLock.Unlock()
 
 	current := m.configProvider.Watch().Load()
-	next, changed := fn(metadatacommon.ClusterConfigCodec.Clone(current.Value), current.Version)
-	if !changed {
-		return nil
+	next, err := fn(metadatacommon.ClusterConfigCodec.Clone(current.Value), current.Version)
+	if err != nil {
+		return err
 	}
 
 	if err := next.Validate(); err != nil {
 		return err
 	}
 
-	_, err := m.configProvider.Store(provider.Versioned[*commonproto.ClusterConfiguration]{
+	_, err = m.configProvider.Store(provider.Versioned[*commonproto.ClusterConfiguration]{
 		Value:   next,
 		Version: current.Version,
 	})
@@ -358,12 +358,10 @@ func (m *coordinatorMetadata) GetLoadBalancer() commonobject.Borrowed[*commonpro
 
 func (m *coordinatorMetadata) CreateDataServer(dataServer *commonproto.DataServer) error {
 	name := dataServer.GetIdentity().GetName()
-	var createErr error
 
-	if err := m.computeConfig(func(config *commonproto.ClusterConfiguration, _ metadatacommon.Version) (*commonproto.ClusterConfiguration, bool) {
+	return m.computeConfig(func(config *commonproto.ClusterConfiguration, _ metadatacommon.Version) (*commonproto.ClusterConfiguration, error) {
 		if _, exists := config.GetDataServer(name); exists {
-			createErr = metadatacommon.ErrAlreadyExists
-			return nil, false
+			return nil, metadatacommon.ErrAlreadyExists
 		}
 
 		config.Servers = append(config.Servers, dataServer.GetIdentity())
@@ -374,11 +372,8 @@ func (m *coordinatorMetadata) CreateDataServer(dataServer *commonproto.DataServe
 			config.ServerMetadata[name] = metadata
 		}
 
-		return config, true
-	}); err != nil {
-		return err
-	}
-	return createErr
+		return config, nil
+	})
 }
 
 func (m *coordinatorMetadata) ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer] {

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -358,11 +358,11 @@ func (m *coordinatorMetadata) GetLoadBalancer() commonobject.Borrowed[*commonpro
 
 func (m *coordinatorMetadata) CreateDataServer(dataServer *commonproto.DataServer) error {
 	name := dataServer.GetIdentity().GetName()
-	alreadyExists := false
+	var createErr error
 
-	err := m.computeConfig(func(config *commonproto.ClusterConfiguration, _ metadatacommon.Version) (*commonproto.ClusterConfiguration, bool) {
+	if err := m.computeConfig(func(config *commonproto.ClusterConfiguration, _ metadatacommon.Version) (*commonproto.ClusterConfiguration, bool) {
 		if _, exists := config.GetDataServer(name); exists {
-			alreadyExists = true
+			createErr = metadatacommon.ErrAlreadyExists
 			return nil, false
 		}
 
@@ -375,14 +375,10 @@ func (m *coordinatorMetadata) CreateDataServer(dataServer *commonproto.DataServe
 		}
 
 		return config, true
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
-	if alreadyExists {
-		return metadatacommon.ErrAlreadyExists
-	}
-	return nil
+	return createErr
 }
 
 func (m *coordinatorMetadata) ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer] {

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -53,6 +53,7 @@ type Metadata interface {
 	SubscribeConfig() *commonwatch.Receiver[provider.Versioned[*commonproto.ClusterConfiguration]]
 	GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer]
 
+	CreateDataServer(dataServer *commonproto.DataServer) (bool, error)
 	ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer]
 	GetDataServer(name string) (commonobject.Borrowed[*commonproto.DataServer], bool)
 }
@@ -74,6 +75,7 @@ type coordinatorMetadata struct {
 	changeCh       chan struct{}
 
 	configProvider provider.Provider[*commonproto.ClusterConfiguration]
+	configLock     sync.Mutex
 }
 
 func newMetadata(ctx context.Context, statusProvider provider.Provider[*commonproto.ClusterStatus], configProvider provider.Provider[*commonproto.ClusterConfiguration]) Metadata {
@@ -102,6 +104,27 @@ func (m *coordinatorMetadata) computeStatus(fn func(*commonproto.ClusterStatus, 
 	}
 
 	_, err := m.statusProvider.Store(provider.Versioned[*commonproto.ClusterStatus]{
+		Value:   next,
+		Version: current.Version,
+	})
+	return err
+}
+
+func (m *coordinatorMetadata) computeConfig(fn func(*commonproto.ClusterConfiguration, metadatacommon.Version) (*commonproto.ClusterConfiguration, bool)) error {
+	m.configLock.Lock()
+	defer m.configLock.Unlock()
+
+	current := m.configProvider.Watch().Load()
+	next, changed := fn(metadatacommon.ClusterConfigCodec.Clone(current.Value), current.Version)
+	if !changed {
+		return nil
+	}
+
+	if err := next.Validate(); err != nil {
+		return err
+	}
+
+	_, err := m.configProvider.Store(provider.Versioned[*commonproto.ClusterConfiguration]{
 		Value:   next,
 		Version: current.Version,
 	})
@@ -328,6 +351,60 @@ func (m *coordinatorMetadata) SubscribeConfig() *commonwatch.Receiver[provider.V
 
 func (m *coordinatorMetadata) GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer] {
 	return commonobject.Borrow(m.GetConfig().UnsafeBorrow().GetLoadBalancerWithDefaults())
+}
+
+func (m *coordinatorMetadata) CreateDataServer(dataServer *commonproto.DataServer) (bool, error) {
+	name := dataServer.GetIdentity().GetName()
+	created := false
+
+	err := m.computeConfig(func(config *commonproto.ClusterConfiguration, _ metadatacommon.Version) (*commonproto.ClusterConfiguration, bool) {
+		if _, exists := config.GetDataServer(name); exists {
+			return config, false
+		}
+
+		config.Servers = append(config.Servers, cloneDataServerIdentity(dataServer.GetIdentity()))
+		if metadata := dataServer.GetMetadata(); metadata != nil {
+			if config.ServerMetadata == nil {
+				config.ServerMetadata = map[string]*commonproto.DataServerMetadata{}
+			}
+			config.ServerMetadata[name] = cloneDataServerMetadata(metadata)
+		}
+
+		created = true
+		return config, true
+	})
+	return created, err
+}
+
+func cloneDataServerIdentity(identity *commonproto.DataServerIdentity) *commonproto.DataServerIdentity {
+	if identity == nil {
+		return nil
+	}
+
+	cloned := &commonproto.DataServerIdentity{
+		Public:   identity.GetPublic(),
+		Internal: identity.GetInternal(),
+	}
+	if identity.Name != nil {
+		name := identity.GetName()
+		cloned.Name = &name
+	}
+	return cloned
+}
+
+func cloneDataServerMetadata(metadata *commonproto.DataServerMetadata) *commonproto.DataServerMetadata {
+	if metadata == nil {
+		return nil
+	}
+
+	cloned := &commonproto.DataServerMetadata{}
+	if len(metadata.GetLabels()) > 0 {
+		cloned.Labels = make(map[string]string, len(metadata.GetLabels()))
+		for key, value := range metadata.GetLabels() {
+			cloned.Labels[key] = value
+		}
+	}
+	return cloned
 }
 
 func (m *coordinatorMetadata) ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer] {

--- a/oxiad/coordinator/metadata/provider/file/provider.go
+++ b/oxiad/coordinator/metadata/provider/file/provider.go
@@ -166,7 +166,7 @@ func (m *Provider[T]) Store(snapshot provider.Versioned[T]) (newVersion metadata
 	existingVersion := existingSnapshot.Version
 
 	if snapshot.Version != existingVersion {
-		panic(metadatacommon.ErrBadVersion)
+		return metadatacommon.NotExists, metadatacommon.ErrBadVersion
 	}
 
 	newVersion = metadatacommon.NextVersion(existingVersion)

--- a/oxiad/coordinator/metadata/provider/kubernetes/provider.go
+++ b/oxiad/coordinator/metadata/provider/kubernetes/provider.go
@@ -216,18 +216,18 @@ func (m *Provider[T]) Store(snapshot provider.Versioned[T]) (metadatacommon.Vers
 	if snapshot.Version == metadatacommon.NotExists {
 		cm, err = m.kubernetes.CoreV1().ConfigMaps(m.namespace).Create(ctx, cmData, metav1.CreateOptions{})
 		if k8serrors.IsAlreadyExists(err) {
-			panic(metadatacommon.ErrBadVersion)
+			return metadatacommon.NotExists, metadatacommon.ErrBadVersion
 		}
 	} else {
 		if snapshot.Version == "" {
-			panic(metadatacommon.ErrBadVersion)
+			return metadatacommon.NotExists, metadatacommon.ErrBadVersion
 		}
 		cm, err = m.kubernetes.CoreV1().ConfigMaps(m.namespace).Patch(ctx, m.name, types.ApplyPatchType, desiredBytes, metav1.PatchOptions{
 			FieldManager: fieldManager,
 			Force:        gproto.Bool(true),
 		})
 		if k8serrors.IsNotFound(err) || k8serrors.IsConflict(err) {
-			panic(metadatacommon.ErrBadVersion)
+			return metadatacommon.NotExists, metadatacommon.ErrBadVersion
 		}
 	}
 	if err != nil {

--- a/oxiad/coordinator/metadata/provider/memory/provider.go
+++ b/oxiad/coordinator/metadata/provider/memory/provider.go
@@ -65,7 +65,7 @@ func (m *Provider[T]) Store(snapshot provider.Versioned[T]) (newVersion metadata
 	defer m.Unlock()
 
 	if snapshot.Version != m.version {
-		panic(metadatacommon.ErrBadVersion)
+		return metadatacommon.NotExists, metadatacommon.ErrBadVersion
 	}
 
 	m.value = m.codec.Clone(snapshot.Value)

--- a/oxiad/coordinator/metadata/provider/provider_test.go
+++ b/oxiad/coordinator/metadata/provider/provider_test.go
@@ -95,13 +95,11 @@ func TestProvider(t *testing.T) {
 				Namespaces: map[string]*proto.NamespaceStatus{},
 			}
 
-			assert.PanicsWithError(t, metadatacommon.ErrBadVersion.Error(), func() {
-				_, err := m.Store(provider.Versioned[*proto.ClusterStatus]{
-					Value:   status,
-					Version: "",
-				})
-				assert.NoError(t, err)
+			_, err := m.Store(provider.Versioned[*proto.ClusterStatus]{
+				Value:   status,
+				Version: "",
 			})
+			assert.ErrorIs(t, err, metadatacommon.ErrBadVersion)
 
 			newVersion, err := m.Store(provider.Versioned[*proto.ClusterStatus]{
 				Value:   status,

--- a/oxiad/coordinator/metadata/provider/raft/provider.go
+++ b/oxiad/coordinator/metadata/provider/raft/provider.go
@@ -160,7 +160,7 @@ func (mpr *Provider[T]) Store(snapshot provider.Versioned[T]) (newVersion metada
 		return metadatacommon.NotExists, errors.New("failed to apply new cluster state")
 	}
 	if !applyRes.changeApplied {
-		panic(metadatacommon.ErrBadVersion)
+		return metadatacommon.NotExists, metadatacommon.ErrBadVersion
 	}
 
 	newVersion = toVersion(applyRes.newVersion)

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -173,8 +173,8 @@ func (*mockNamespaceMetadata) GetLoadBalancer() commonobject.Borrowed[*proto.Loa
 	return commonobject.Borrowed[*proto.LoadBalancer]{}
 }
 
-func (*mockNamespaceMetadata) CreateDataServer(*proto.DataServer) (bool, error) {
-	return false, nil
+func (*mockNamespaceMetadata) CreateDataServer(*proto.DataServer) error {
+	return nil
 }
 
 func (*mockNamespaceMetadata) ListDataServer() map[string]commonobject.Borrowed[*proto.DataServer] {

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -173,6 +173,10 @@ func (*mockNamespaceMetadata) GetLoadBalancer() commonobject.Borrowed[*proto.Loa
 	return commonobject.Borrowed[*proto.LoadBalancer]{}
 }
 
+func (*mockNamespaceMetadata) CreateDataServer(*proto.DataServer) (bool, error) {
+	return false, nil
+}
+
 func (*mockNamespaceMetadata) ListDataServer() map[string]commonobject.Borrowed[*proto.DataServer] {
 	return map[string]commonobject.Borrowed[*proto.DataServer]{}
 }

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -105,8 +105,8 @@ func (m *mockMetadata) GetLoadBalancer() commonobject.Borrowed[*proto.LoadBalanc
 	})
 }
 
-func (*mockMetadata) CreateDataServer(*proto.DataServer) (bool, error) {
-	return false, nil
+func (*mockMetadata) CreateDataServer(*proto.DataServer) error {
+	return nil
 }
 
 func (m *mockMetadata) ListDataServer() map[string]commonobject.Borrowed[*proto.DataServer] {

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -105,6 +105,10 @@ func (m *mockMetadata) GetLoadBalancer() commonobject.Borrowed[*proto.LoadBalanc
 	})
 }
 
+func (*mockMetadata) CreateDataServer(*proto.DataServer) (bool, error) {
+	return false, nil
+}
+
 func (m *mockMetadata) ListDataServer() map[string]commonobject.Borrowed[*proto.DataServer] {
 	dataServers := make(map[string]commonobject.Borrowed[*proto.DataServer], m.nodes.Size())
 	for _, id := range m.nodes.Values() {


### PR DESCRIPTION
## Motivation
- add an admin API for creating data servers through coordinator-managed cluster configuration
- expose the same capability through the Go admin client and CLI
- return provider/config conflicts as normal errors so the management server can map them to standard gRPC codes

## Modifications
- added `CreateDataServer` to the admin gRPC API and regenerated the admin protobuf bindings
- added a metadata config mutation for creating data servers and updated provider store paths to return `ErrBadVersion` instead of panicking
- implemented coordinator `CreateDataServer` request validation and response/error mapping
- added `CreateDataServer` to the Go admin client and mock client support
- added `oxia admin dataserver create <name> --public ... --internal ... [--label key=value]`

## Testing
- `go test ./oxiad/coordinator ./oxiad/coordinator/metadata ./oxia ./cmd/admin/...`
- `make lint`
