### PR TITLE
feat: add delete data server admin API

### DIFF
--- a/cmd/admin/commons/mock_admin_client.go
+++ b/cmd/admin/commons/mock_admin_client.go
@@ -79,6 +79,14 @@ func (m *MockAdminClient) PatchDataServer(dataServer *proto.DataServer) (*proto.
 	return nil, errors.New("failed to patch data server")
 }
 
+func (m *MockAdminClient) DeleteDataServer(dataServer string) (*proto.DataServer, error) {
+	args := m.MethodCalled("DeleteDataServer", dataServer)
+	if v, ok := args.Get(0).(*proto.DataServer); ok {
+		return v, args.Error(1)
+	}
+	return nil, errors.New("failed to delete data server")
+}
+
 func (m *MockAdminClient) SplitShard(namespace string, shardId int64, splitPoint *uint32) *oxia.SplitShardResult {
 	args := m.MethodCalled("SplitShard", namespace, shardId, splitPoint)
 	if v, ok := args.Get(0).(*oxia.SplitShardResult); ok {

--- a/cmd/admin/dataserver/cmd.go
+++ b/cmd/admin/dataserver/cmd.go
@@ -16,6 +16,7 @@ package dataserver
 
 import (
 	createcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/create"
+	"github.com/oxia-db/oxia/cmd/admin/dataserver/deletecmd"
 	getcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/get"
 	patchcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/patch"
 
@@ -32,6 +33,7 @@ var (
 
 func init() {
 	Cmd.AddCommand(createcmd.Cmd)
+	Cmd.AddCommand(deletecmd.Cmd)
 	Cmd.AddCommand(getcmd.Cmd)
 	Cmd.AddCommand(patchcmd.Cmd)
 }

--- a/cmd/admin/dataserver/deletecmd/cmd.go
+++ b/cmd/admin/dataserver/deletecmd/cmd.go
@@ -1,0 +1,65 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deletecmd
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/oxia-db/oxia/cmd/admin/commons"
+	dataserveroutput "github.com/oxia-db/oxia/cmd/admin/dataserver/output"
+	"github.com/oxia-db/oxia/oxia"
+)
+
+var Cmd = &cobra.Command{
+	Use:          "delete <name>",
+	Short:        "Delete a data server",
+	Long:         `Delete a data server`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         exec,
+	SilenceUsage: true,
+}
+
+func exec(cmd *cobra.Command, args []string) error {
+	outputFormat, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+	if err := commons.ValidateOutputFormat(outputFormat); err != nil {
+		return err
+	}
+
+	name := strings.TrimSpace(args[0])
+	if name == "" {
+		return errors.New("data server name must not be empty")
+	}
+
+	client, err := commons.AdminConfig.NewAdminClient()
+	if err != nil {
+		return err
+	}
+	defer func(client oxia.AdminClient) {
+		_ = client.Close()
+	}(client)
+
+	deleted, err := client.DeleteDataServer(name)
+	if err != nil {
+		return err
+	}
+
+	return dataserveroutput.WriteDataServer(cmd.OutOrStdout(), outputFormat, deleted)
+}

--- a/cmd/admin/dataserver/deletecmd/cmd_test.go
+++ b/cmd/admin/dataserver/deletecmd/cmd_test.go
@@ -1,0 +1,97 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deletecmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/cmd/admin/commons"
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+func runCmd(cmd *cobra.Command, args ...string) (string, error) {
+	actual := new(bytes.Buffer)
+	root := &cobra.Command{Use: "admin"}
+	root.PersistentFlags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
+	root.AddCommand(cmd)
+	root.SetOut(actual)
+	root.SetErr(actual)
+	root.SetArgs(append([]string{"delete"}, args...))
+	err := root.Execute()
+	return strings.TrimSpace(actual.String()), err
+}
+
+func Test_cmd_deleteDataServer(t *testing.T) {
+	serverName := "server-1"
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	commons.MockedAdminClient.On("Close").Return(nil)
+	commons.MockedAdminClient.On("DeleteDataServer", serverName).Return(&proto.DataServer{
+		Identity: &proto.DataServerIdentity{
+			Name:     &serverName,
+			Public:   "public1",
+			Internal: "internal1",
+		},
+		Metadata: &proto.DataServerMetadata{
+			Labels: map[string]string{"rack": "rack-1"},
+		},
+	}, nil)
+
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	out, err := runCmd(cmd, serverName, "-o", "json")
+	require.NoError(t, err)
+
+	var dataServer proto.DataServer
+	require.NoError(t, json.Unmarshal([]byte(out), &dataServer))
+	require.NotNil(t, dataServer.Identity)
+	require.NotNil(t, dataServer.Identity.Name)
+	assert.Equal(t, serverName, *dataServer.Identity.Name)
+	assert.Equal(t, "public1", dataServer.Identity.GetPublic())
+	assert.Equal(t, "internal1", dataServer.Identity.GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-1"}, dataServer.GetMetadata().GetLabels())
+}
+
+func Test_cmd_deleteDataServer_RejectsEmptyName(t *testing.T) {
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	out, err := runCmd(cmd, "   ")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "data server name must not be empty")
+	assert.Contains(t, out, "data server name must not be empty")
+}

--- a/common/proto/admin.pb.go
+++ b/common/proto/admin.pb.go
@@ -382,6 +382,94 @@ func (x *PatchDataServerResponse) GetDataServer() *DataServer {
 	return nil
 }
 
+type DeleteDataServerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DataServer    string                 `protobuf:"bytes,1,opt,name=data_server,json=dataServer,proto3" json:"data_server,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteDataServerRequest) Reset() {
+	*x = DeleteDataServerRequest{}
+	mi := &file_admin_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteDataServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteDataServerRequest) ProtoMessage() {}
+
+func (x *DeleteDataServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteDataServerRequest.ProtoReflect.Descriptor instead.
+func (*DeleteDataServerRequest) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *DeleteDataServerRequest) GetDataServer() string {
+	if x != nil {
+		return x.DataServer
+	}
+	return ""
+}
+
+type DeleteDataServerResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DataServer    *DataServer            `protobuf:"bytes,1,opt,name=data_server,json=dataServer,proto3" json:"data_server,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteDataServerResponse) Reset() {
+	*x = DeleteDataServerResponse{}
+	mi := &file_admin_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteDataServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteDataServerResponse) ProtoMessage() {}
+
+func (x *DeleteDataServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteDataServerResponse.ProtoReflect.Descriptor instead.
+func (*DeleteDataServerResponse) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *DeleteDataServerResponse) GetDataServer() *DataServer {
+	if x != nil {
+		return x.DataServer
+	}
+	return nil
+}
+
 type ListNamespacesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -390,7 +478,7 @@ type ListNamespacesRequest struct {
 
 func (x *ListNamespacesRequest) Reset() {
 	*x = ListNamespacesRequest{}
-	mi := &file_admin_proto_msgTypes[8]
+	mi := &file_admin_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -402,7 +490,7 @@ func (x *ListNamespacesRequest) String() string {
 func (*ListNamespacesRequest) ProtoMessage() {}
 
 func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[8]
+	mi := &file_admin_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -415,7 +503,7 @@ func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListNamespacesRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{8}
+	return file_admin_proto_rawDescGZIP(), []int{10}
 }
 
 type ListNamespacesResponse struct {
@@ -427,7 +515,7 @@ type ListNamespacesResponse struct {
 
 func (x *ListNamespacesResponse) Reset() {
 	*x = ListNamespacesResponse{}
-	mi := &file_admin_proto_msgTypes[9]
+	mi := &file_admin_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -439,7 +527,7 @@ func (x *ListNamespacesResponse) String() string {
 func (*ListNamespacesResponse) ProtoMessage() {}
 
 func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[9]
+	mi := &file_admin_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -452,7 +540,7 @@ func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListNamespacesResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{9}
+	return file_admin_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ListNamespacesResponse) GetNamespaces() []string {
@@ -474,7 +562,7 @@ type SplitShardRequest struct {
 
 func (x *SplitShardRequest) Reset() {
 	*x = SplitShardRequest{}
-	mi := &file_admin_proto_msgTypes[10]
+	mi := &file_admin_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -486,7 +574,7 @@ func (x *SplitShardRequest) String() string {
 func (*SplitShardRequest) ProtoMessage() {}
 
 func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[10]
+	mi := &file_admin_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -499,7 +587,7 @@ func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardRequest.ProtoReflect.Descriptor instead.
 func (*SplitShardRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{10}
+	return file_admin_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *SplitShardRequest) GetNamespace() string {
@@ -533,7 +621,7 @@ type SplitShardResponse struct {
 
 func (x *SplitShardResponse) Reset() {
 	*x = SplitShardResponse{}
-	mi := &file_admin_proto_msgTypes[11]
+	mi := &file_admin_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -545,7 +633,7 @@ func (x *SplitShardResponse) String() string {
 func (*SplitShardResponse) ProtoMessage() {}
 
 func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[11]
+	mi := &file_admin_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -558,7 +646,7 @@ func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardResponse.ProtoReflect.Descriptor instead.
 func (*SplitShardResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{11}
+	return file_admin_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *SplitShardResponse) GetLeftChildShard() int64 {
@@ -600,6 +688,12 @@ const file_admin_proto_rawDesc = "" +
 	"dataServer\"X\n" +
 	"\x17PatchDataServerResponse\x12=\n" +
 	"\vdata_server\x18\x01 \x01(\v2\x1c.io.oxia.proto.v1.DataServerR\n" +
+	"dataServer\":\n" +
+	"\x17DeleteDataServerRequest\x12\x1f\n" +
+	"\vdata_server\x18\x01 \x01(\tR\n" +
+	"dataServer\"Y\n" +
+	"\x18DeleteDataServerResponse\x12=\n" +
+	"\vdata_server\x18\x01 \x01(\v2\x1c.io.oxia.proto.v1.DataServerR\n" +
 	"dataServer\"\x17\n" +
 	"\x15ListNamespacesRequest\"8\n" +
 	"\x16ListNamespacesResponse\x12\x1e\n" +
@@ -614,12 +708,13 @@ const file_admin_proto_rawDesc = "" +
 	"\f_split_point\"j\n" +
 	"\x12SplitShardResponse\x12(\n" +
 	"\x10left_child_shard\x18\x01 \x01(\x03R\x0eleftChildShard\x12*\n" +
-	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\xe6\x04\n" +
+	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\xd1\x05\n" +
 	"\tOxiaAdmin\x12f\n" +
 	"\x0fListDataServers\x12(.io.oxia.proto.v1.ListDataServersRequest\x1a).io.oxia.proto.v1.ListDataServersResponse\x12`\n" +
 	"\rGetDataServer\x12&.io.oxia.proto.v1.GetDataServerRequest\x1a'.io.oxia.proto.v1.GetDataServerResponse\x12i\n" +
 	"\x10CreateDataServer\x12).io.oxia.proto.v1.CreateDataServerRequest\x1a*.io.oxia.proto.v1.CreateDataServerResponse\x12f\n" +
-	"\x0fPatchDataServer\x12(.io.oxia.proto.v1.PatchDataServerRequest\x1a).io.oxia.proto.v1.PatchDataServerResponse\x12c\n" +
+	"\x0fPatchDataServer\x12(.io.oxia.proto.v1.PatchDataServerRequest\x1a).io.oxia.proto.v1.PatchDataServerResponse\x12i\n" +
+	"\x10DeleteDataServer\x12).io.oxia.proto.v1.DeleteDataServerRequest\x1a*.io.oxia.proto.v1.DeleteDataServerResponse\x12c\n" +
 	"\x0eListNamespaces\x12'.io.oxia.proto.v1.ListNamespacesRequest\x1a(.io.oxia.proto.v1.ListNamespacesResponse\x12W\n" +
 	"\n" +
 	"SplitShard\x12#.io.oxia.proto.v1.SplitShardRequest\x1a$.io.oxia.proto.v1.SplitShardResponseB(P\x01Z$github.com/oxia-db/oxia/common/protob\x06proto3"
@@ -636,7 +731,7 @@ func file_admin_proto_rawDescGZIP() []byte {
 	return file_admin_proto_rawDescData
 }
 
-var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_admin_proto_goTypes = []any{
 	(*ListDataServersRequest)(nil),   // 0: io.oxia.proto.v1.ListDataServersRequest
 	(*ListDataServersResponse)(nil),  // 1: io.oxia.proto.v1.ListDataServersResponse
@@ -646,36 +741,41 @@ var file_admin_proto_goTypes = []any{
 	(*CreateDataServerResponse)(nil), // 5: io.oxia.proto.v1.CreateDataServerResponse
 	(*PatchDataServerRequest)(nil),   // 6: io.oxia.proto.v1.PatchDataServerRequest
 	(*PatchDataServerResponse)(nil),  // 7: io.oxia.proto.v1.PatchDataServerResponse
-	(*ListNamespacesRequest)(nil),    // 8: io.oxia.proto.v1.ListNamespacesRequest
-	(*ListNamespacesResponse)(nil),   // 9: io.oxia.proto.v1.ListNamespacesResponse
-	(*SplitShardRequest)(nil),        // 10: io.oxia.proto.v1.SplitShardRequest
-	(*SplitShardResponse)(nil),       // 11: io.oxia.proto.v1.SplitShardResponse
-	(*DataServer)(nil),               // 12: io.oxia.proto.v1.DataServer
+	(*DeleteDataServerRequest)(nil),  // 8: io.oxia.proto.v1.DeleteDataServerRequest
+	(*DeleteDataServerResponse)(nil), // 9: io.oxia.proto.v1.DeleteDataServerResponse
+	(*ListNamespacesRequest)(nil),    // 10: io.oxia.proto.v1.ListNamespacesRequest
+	(*ListNamespacesResponse)(nil),   // 11: io.oxia.proto.v1.ListNamespacesResponse
+	(*SplitShardRequest)(nil),        // 12: io.oxia.proto.v1.SplitShardRequest
+	(*SplitShardResponse)(nil),       // 13: io.oxia.proto.v1.SplitShardResponse
+	(*DataServer)(nil),               // 14: io.oxia.proto.v1.DataServer
 }
 var file_admin_proto_depIdxs = []int32{
-	12, // 0: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
-	12, // 1: io.oxia.proto.v1.GetDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
-	12, // 2: io.oxia.proto.v1.CreateDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
-	12, // 3: io.oxia.proto.v1.CreateDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
-	12, // 4: io.oxia.proto.v1.PatchDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
-	12, // 5: io.oxia.proto.v1.PatchDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
-	0,  // 6: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
-	2,  // 7: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
-	4,  // 8: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:input_type -> io.oxia.proto.v1.CreateDataServerRequest
-	6,  // 9: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:input_type -> io.oxia.proto.v1.PatchDataServerRequest
-	8,  // 10: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
-	10, // 11: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
-	1,  // 12: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
-	3,  // 13: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.GetDataServerResponse
-	5,  // 14: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:output_type -> io.oxia.proto.v1.CreateDataServerResponse
-	7,  // 15: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:output_type -> io.oxia.proto.v1.PatchDataServerResponse
-	9,  // 16: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
-	11, // 17: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
-	12, // [12:18] is the sub-list for method output_type
-	6,  // [6:12] is the sub-list for method input_type
-	6,  // [6:6] is the sub-list for extension type_name
-	6,  // [6:6] is the sub-list for extension extendee
-	0,  // [0:6] is the sub-list for field type_name
+	14, // 0: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
+	14, // 1: io.oxia.proto.v1.GetDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	14, // 2: io.oxia.proto.v1.CreateDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
+	14, // 3: io.oxia.proto.v1.CreateDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	14, // 4: io.oxia.proto.v1.PatchDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
+	14, // 5: io.oxia.proto.v1.PatchDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	14, // 6: io.oxia.proto.v1.DeleteDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	0,  // 7: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
+	2,  // 8: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
+	4,  // 9: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:input_type -> io.oxia.proto.v1.CreateDataServerRequest
+	6,  // 10: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:input_type -> io.oxia.proto.v1.PatchDataServerRequest
+	8,  // 11: io.oxia.proto.v1.OxiaAdmin.DeleteDataServer:input_type -> io.oxia.proto.v1.DeleteDataServerRequest
+	10, // 12: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
+	12, // 13: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
+	1,  // 14: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
+	3,  // 15: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.GetDataServerResponse
+	5,  // 16: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:output_type -> io.oxia.proto.v1.CreateDataServerResponse
+	7,  // 17: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:output_type -> io.oxia.proto.v1.PatchDataServerResponse
+	9,  // 18: io.oxia.proto.v1.OxiaAdmin.DeleteDataServer:output_type -> io.oxia.proto.v1.DeleteDataServerResponse
+	11, // 19: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
+	13, // 20: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
+	14, // [14:21] is the sub-list for method output_type
+	7,  // [7:14] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_admin_proto_init() }
@@ -684,14 +784,14 @@ func file_admin_proto_init() {
 		return
 	}
 	file_metadata_proto_init()
-	file_admin_proto_msgTypes[10].OneofWrappers = []any{}
+	file_admin_proto_msgTypes[12].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_admin_proto_rawDesc), len(file_admin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/common/proto/admin.proto
+++ b/common/proto/admin.proto
@@ -30,6 +30,7 @@ service OxiaAdmin {
   rpc GetDataServer(GetDataServerRequest) returns (GetDataServerResponse);
   rpc CreateDataServer(CreateDataServerRequest) returns (CreateDataServerResponse);
   rpc PatchDataServer(PatchDataServerRequest) returns (PatchDataServerResponse);
+  rpc DeleteDataServer(DeleteDataServerRequest) returns (DeleteDataServerResponse);
 
   rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse);
 
@@ -69,6 +70,14 @@ message PatchDataServerRequest {
 }
 
 message PatchDataServerResponse {
+  DataServer data_server = 1;
+}
+
+message DeleteDataServerRequest {
+  string data_server = 1;
+}
+
+message DeleteDataServerResponse {
   DataServer data_server = 1;
 }
 

--- a/common/proto/admin_grpc.pb.go
+++ b/common/proto/admin_grpc.pb.go
@@ -40,6 +40,7 @@ const (
 	OxiaAdmin_GetDataServer_FullMethodName    = "/io.oxia.proto.v1.OxiaAdmin/GetDataServer"
 	OxiaAdmin_CreateDataServer_FullMethodName = "/io.oxia.proto.v1.OxiaAdmin/CreateDataServer"
 	OxiaAdmin_PatchDataServer_FullMethodName  = "/io.oxia.proto.v1.OxiaAdmin/PatchDataServer"
+	OxiaAdmin_DeleteDataServer_FullMethodName = "/io.oxia.proto.v1.OxiaAdmin/DeleteDataServer"
 	OxiaAdmin_ListNamespaces_FullMethodName   = "/io.oxia.proto.v1.OxiaAdmin/ListNamespaces"
 	OxiaAdmin_SplitShard_FullMethodName       = "/io.oxia.proto.v1.OxiaAdmin/SplitShard"
 )
@@ -52,6 +53,7 @@ type OxiaAdminClient interface {
 	GetDataServer(ctx context.Context, in *GetDataServerRequest, opts ...grpc.CallOption) (*GetDataServerResponse, error)
 	CreateDataServer(ctx context.Context, in *CreateDataServerRequest, opts ...grpc.CallOption) (*CreateDataServerResponse, error)
 	PatchDataServer(ctx context.Context, in *PatchDataServerRequest, opts ...grpc.CallOption) (*PatchDataServerResponse, error)
+	DeleteDataServer(ctx context.Context, in *DeleteDataServerRequest, opts ...grpc.CallOption) (*DeleteDataServerResponse, error)
 	ListNamespaces(ctx context.Context, in *ListNamespacesRequest, opts ...grpc.CallOption) (*ListNamespacesResponse, error)
 	// *
 	// Triggers a shard split. The specified shard is split into two child
@@ -107,6 +109,16 @@ func (c *oxiaAdminClient) PatchDataServer(ctx context.Context, in *PatchDataServ
 	return out, nil
 }
 
+func (c *oxiaAdminClient) DeleteDataServer(ctx context.Context, in *DeleteDataServerRequest, opts ...grpc.CallOption) (*DeleteDataServerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteDataServerResponse)
+	err := c.cc.Invoke(ctx, OxiaAdmin_DeleteDataServer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *oxiaAdminClient) ListNamespaces(ctx context.Context, in *ListNamespacesRequest, opts ...grpc.CallOption) (*ListNamespacesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListNamespacesResponse)
@@ -135,6 +147,7 @@ type OxiaAdminServer interface {
 	GetDataServer(context.Context, *GetDataServerRequest) (*GetDataServerResponse, error)
 	CreateDataServer(context.Context, *CreateDataServerRequest) (*CreateDataServerResponse, error)
 	PatchDataServer(context.Context, *PatchDataServerRequest) (*PatchDataServerResponse, error)
+	DeleteDataServer(context.Context, *DeleteDataServerRequest) (*DeleteDataServerResponse, error)
 	ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error)
 	// *
 	// Triggers a shard split. The specified shard is split into two child
@@ -161,6 +174,9 @@ func (UnimplementedOxiaAdminServer) CreateDataServer(context.Context, *CreateDat
 }
 func (UnimplementedOxiaAdminServer) PatchDataServer(context.Context, *PatchDataServerRequest) (*PatchDataServerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PatchDataServer not implemented")
+}
+func (UnimplementedOxiaAdminServer) DeleteDataServer(context.Context, *DeleteDataServerRequest) (*DeleteDataServerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteDataServer not implemented")
 }
 func (UnimplementedOxiaAdminServer) ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListNamespaces not implemented")
@@ -261,6 +277,24 @@ func _OxiaAdmin_PatchDataServer_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+func _OxiaAdmin_DeleteDataServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteDataServerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OxiaAdminServer).DeleteDataServer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OxiaAdmin_DeleteDataServer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OxiaAdminServer).DeleteDataServer(ctx, req.(*DeleteDataServerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _OxiaAdmin_ListNamespaces_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ListNamespacesRequest)
 	if err := dec(in); err != nil {
@@ -319,6 +353,10 @@ var OxiaAdmin_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "PatchDataServer",
 			Handler:    _OxiaAdmin_PatchDataServer_Handler,
+		},
+		{
+			MethodName: "DeleteDataServer",
+			Handler:    _OxiaAdmin_DeleteDataServer_Handler,
 		},
 		{
 			MethodName: "ListNamespaces",

--- a/common/proto/admin_vtproto.pb.go
+++ b/common/proto/admin_vtproto.pb.go
@@ -161,6 +161,40 @@ func (m *PatchDataServerResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *DeleteDataServerRequest) CloneVT() *DeleteDataServerRequest {
+	if m == nil {
+		return (*DeleteDataServerRequest)(nil)
+	}
+	r := new(DeleteDataServerRequest)
+	r.DataServer = m.DataServer
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *DeleteDataServerRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *DeleteDataServerResponse) CloneVT() *DeleteDataServerResponse {
+	if m == nil {
+		return (*DeleteDataServerResponse)(nil)
+	}
+	r := new(DeleteDataServerResponse)
+	r.DataServer = m.DataServer.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *DeleteDataServerResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *ListNamespacesRequest) CloneVT() *ListNamespacesRequest {
 	if m == nil {
 		return (*ListNamespacesRequest)(nil)
@@ -396,6 +430,44 @@ func (this *PatchDataServerResponse) EqualVT(that *PatchDataServerResponse) bool
 
 func (this *PatchDataServerResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*PatchDataServerResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *DeleteDataServerRequest) EqualVT(that *DeleteDataServerRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.DataServer != that.DataServer {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *DeleteDataServerRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DeleteDataServerRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *DeleteDataServerResponse) EqualVT(that *DeleteDataServerResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.DataServer.EqualVT(that.DataServer) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *DeleteDataServerResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DeleteDataServerResponse)
 	if !ok {
 		return false
 	}
@@ -822,6 +894,89 @@ func (m *PatchDataServerResponse) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 
+func (m *DeleteDataServerRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DeleteDataServerRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *DeleteDataServerRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.DataServer) > 0 {
+		i -= len(m.DataServer)
+		copy(dAtA[i:], m.DataServer)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DataServer)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *DeleteDataServerResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DeleteDataServerResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *DeleteDataServerResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.DataServer != nil {
+		size, err := m.DataServer.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ListNamespacesRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -1087,6 +1242,34 @@ func (m *PatchDataServerRequest) SizeVT() (n int) {
 }
 
 func (m *PatchDataServerResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.DataServer != nil {
+		l = m.DataServer.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *DeleteDataServerRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.DataServer)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *DeleteDataServerResponse) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1756,6 +1939,176 @@ func (m *PatchDataServerResponse) UnmarshalVT(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: PatchDataServerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DataServer == nil {
+				m.DataServer = &DataServer{}
+			}
+			if err := m.DataServer.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DeleteDataServerRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DeleteDataServerRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DeleteDataServerRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DataServer = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DeleteDataServerResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DeleteDataServerResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DeleteDataServerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -2759,6 +3112,180 @@ func (m *PatchDataServerResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: PatchDataServerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DataServer == nil {
+				m.DataServer = &DataServer{}
+			}
+			if err := m.DataServer.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DeleteDataServerRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DeleteDataServerRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DeleteDataServerRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.DataServer = stringValue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DeleteDataServerResponse) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DeleteDataServerResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DeleteDataServerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/oxia/admin.go
+++ b/oxia/admin.go
@@ -27,6 +27,7 @@ type AdminClient interface {
 	GetDataServer(dataServer string) (*proto.DataServer, error)
 	CreateDataServer(dataServer *proto.DataServer) (*proto.DataServer, error)
 	PatchDataServer(dataServer *proto.DataServer) (*proto.DataServer, error)
+	DeleteDataServer(dataServer string) (*proto.DataServer, error)
 
 	ListNamespaces() *ListNamespacesResult
 

--- a/oxia/admin_client_impl.go
+++ b/oxia/admin_client_impl.go
@@ -105,6 +105,25 @@ func (admin *adminClientImpl) PatchDataServer(dataServer *proto.DataServer) (*pr
 	return response.DataServer, nil
 }
 
+func (admin *adminClientImpl) DeleteDataServer(dataServer string) (*proto.DataServer, error) {
+	client, err := admin.clientPool.GetAminRpc(admin.adminAddr)
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+
+	if client == nil {
+		return nil, wrapAdminError(ErrUnknown, errors.New(errUnableToConnectToAdminServer))
+	}
+
+	response, err := client.DeleteDataServer(context.Background(), &proto.DeleteDataServerRequest{
+		DataServer: dataServer,
+	})
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+	return response.DataServer, nil
+}
+
 func (admin *adminClientImpl) Close() error {
 	return admin.clientPool.Close()
 }

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -40,6 +40,8 @@ type mockAdminRpcClient struct {
 	createDataServerErr     error
 	patchDataServerResp     *proto.PatchDataServerResponse
 	patchDataServerErr      error
+	deleteDataServerResp    *proto.DeleteDataServerResponse
+	deleteDataServerErr     error
 }
 
 func (m *mockAdminRpcClient) ListDataServers(context.Context, *proto.ListDataServersRequest, ...grpc.CallOption) (*proto.ListDataServersResponse, error) {
@@ -56,6 +58,10 @@ func (m *mockAdminRpcClient) CreateDataServer(context.Context, *proto.CreateData
 
 func (m *mockAdminRpcClient) PatchDataServer(context.Context, *proto.PatchDataServerRequest, ...grpc.CallOption) (*proto.PatchDataServerResponse, error) {
 	return m.patchDataServerResp, m.patchDataServerErr
+}
+
+func (m *mockAdminRpcClient) DeleteDataServer(context.Context, *proto.DeleteDataServerRequest, ...grpc.CallOption) (*proto.DeleteDataServerResponse, error) {
+	return m.deleteDataServerResp, m.deleteDataServerErr
 }
 
 func (*mockAdminRpcClient) ListNamespaces(context.Context, *proto.ListNamespacesRequest, ...grpc.CallOption) (*proto.ListNamespacesResponse, error) {
@@ -298,6 +304,39 @@ func TestAdminClientPatchDataServerReturnsResponse(t *testing.T) {
 	assert.Equal(t, "public-2", dataServer.Identity.GetPublic())
 	assert.Equal(t, "internal-1", dataServer.Identity.GetInternal())
 	assert.Equal(t, map[string]string{"rack": "rack-2"}, dataServer.Metadata.GetLabels())
+}
+
+func TestAdminClientDeleteDataServerReturnsResponse(t *testing.T) {
+	serverName := "server-1"
+	admin := &adminClientImpl{
+		adminAddr: "admin-addr",
+		clientPool: &mockAdminClientPool{
+			adminClient: &mockAdminRpcClient{
+				deleteDataServerResp: &proto.DeleteDataServerResponse{
+					DataServer: &proto.DataServer{
+						Identity: &proto.DataServerIdentity{
+							Name:     &serverName,
+							Public:   "public-1",
+							Internal: "internal-1",
+						},
+						Metadata: &proto.DataServerMetadata{
+							Labels: map[string]string{"rack": "rack-1"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dataServer, err := admin.DeleteDataServer(serverName)
+	require.NoError(t, err)
+	require.NotNil(t, dataServer)
+	require.NotNil(t, dataServer.Identity)
+	require.NotNil(t, dataServer.Identity.Name)
+	assert.Equal(t, serverName, *dataServer.Identity.Name)
+	assert.Equal(t, "public-1", dataServer.Identity.GetPublic())
+	assert.Equal(t, "internal-1", dataServer.Identity.GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-1"}, dataServer.Metadata.GetLabels())
 }
 
 func TestWrapAdminErrorPreservesCause(t *testing.T) {

--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -141,6 +141,27 @@ func (management *managementServer) PatchDataServer(_ context.Context, req *prot
 	}, nil
 }
 
+func (management *managementServer) DeleteDataServer(_ context.Context, req *proto.DeleteDataServerRequest) (*proto.DeleteDataServerResponse, error) {
+	if req == nil || req.DataServer == "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "data server must not be empty")
+	}
+
+	dataServer, err := management.metadata.DeleteDataServer(req.DataServer)
+	if err != nil {
+		if errors.Is(err, metadatacommon.ErrNotFound) {
+			return nil, grpcstatus.Errorf(codes.NotFound, "data server %q not found", req.DataServer)
+		}
+		if errors.Is(err, metadatacommon.ErrBadVersion) {
+			return nil, grpcstatus.Errorf(codes.Aborted, "failed to delete data server %q due to concurrent config update", req.DataServer)
+		}
+		return nil, grpcstatus.Errorf(codes.Internal, "failed to delete data server %q: %v", req.DataServer, err)
+	}
+
+	return &proto.DeleteDataServerResponse{
+		DataServer: dataServer,
+	}, nil
+}
+
 func (management *managementServer) ListNamespaces(context.Context, *proto.ListNamespacesRequest) (*proto.ListNamespacesResponse, error) {
 	cnf := management.metadata.GetConfig().UnsafeBorrow()
 

--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -154,6 +154,9 @@ func (management *managementServer) DeleteDataServer(_ context.Context, req *pro
 		if errors.Is(err, metadatacommon.ErrBadVersion) {
 			return nil, grpcstatus.Errorf(codes.Aborted, "failed to delete data server %q due to concurrent config update", req.DataServer)
 		}
+		if errors.Is(err, metadatacommon.ErrFailedPrecondition) {
+			return nil, grpcstatus.Errorf(codes.FailedPrecondition, "failed to delete data server %q: %v", req.DataServer, err)
+		}
 		return nil, grpcstatus.Errorf(codes.Internal, "failed to delete data server %q: %v", req.DataServer, err)
 	}
 

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -422,3 +422,29 @@ func TestManagementServerDeleteDataServerNotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.NotFound, grpcstatus.Code(err))
 }
+
+func TestManagementServerDeleteDataServerFailedPrecondition(t *testing.T) {
+	serverName1 := "server-1"
+	serverName2 := "server-2"
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{
+			Namespaces: []*proto.Namespace{{
+				Name:              "default",
+				ReplicationFactor: 2,
+				InitialShardCount: 1,
+			}},
+			Servers: []*proto.DataServerIdentity{
+				dataServer(&serverName1, "public-1", "internal-1"),
+				dataServer(&serverName2, "public-2", "internal-2"),
+			},
+		}),
+		nil,
+	)
+
+	_, err := management.DeleteDataServer(context.Background(), &proto.DeleteDataServerRequest{DataServer: serverName1})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, grpcstatus.Code(err))
+
+	_, found := management.metadata.GetDataServer(serverName1)
+	assert.True(t, found)
+}

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -362,3 +362,63 @@ func TestManagementServerPatchDataServerNotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.NotFound, grpcstatus.Code(err))
 }
+
+func TestManagementServerDeleteDataServer(t *testing.T) {
+	serverName := "server-1"
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{
+			Servers: []*proto.DataServerIdentity{
+				dataServer(&serverName, "public-1", "internal-1"),
+			},
+			ServerMetadata: map[string]*proto.DataServerMetadata{
+				serverName: {Labels: map[string]string{"rack": "rack-1"}},
+			},
+		}),
+		nil,
+	)
+
+	res, err := management.DeleteDataServer(context.Background(), &proto.DeleteDataServerRequest{DataServer: serverName})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, res.DataServer)
+	require.NotNil(t, res.DataServer.Identity)
+	require.NotNil(t, res.DataServer.Identity.Name)
+	assert.Equal(t, serverName, *res.DataServer.Identity.Name)
+	assert.Equal(t, "public-1", res.DataServer.Identity.GetPublic())
+	assert.Equal(t, "internal-1", res.DataServer.Identity.GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-1"}, res.DataServer.Metadata.GetLabels())
+
+	_, found := management.metadata.GetDataServer(serverName)
+	assert.False(t, found)
+}
+
+func TestManagementServerDeleteDataServerRejectsInvalidRequest(t *testing.T) {
+	management := newManagementServer(newTestMetadata(t, &proto.ClusterConfiguration{}), nil)
+
+	testCases := []struct {
+		name string
+		req  *proto.DeleteDataServerRequest
+	}{
+		{name: "nil request", req: nil},
+		{name: "empty name", req: &proto.DeleteDataServerRequest{}},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := management.DeleteDataServer(context.Background(), tt.req)
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, grpcstatus.Code(err))
+		})
+	}
+}
+
+func TestManagementServerDeleteDataServerNotFound(t *testing.T) {
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{}),
+		nil,
+	)
+
+	_, err := management.DeleteDataServer(context.Background(), &proto.DeleteDataServerRequest{DataServer: "missing"})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, grpcstatus.Code(err))
+}

--- a/oxiad/coordinator/metadata/common/error.go
+++ b/oxiad/coordinator/metadata/common/error.go
@@ -17,8 +17,9 @@ package common
 import "github.com/pkg/errors"
 
 var (
-	ErrNotInitialized = errors.New("metadata not initialized")
-	ErrBadVersion     = errors.New("metadata bad version")
-	ErrAlreadyExists  = errors.New("metadata already exists")
-	ErrNotFound       = errors.New("metadata not found")
+	ErrNotInitialized     = errors.New("metadata not initialized")
+	ErrBadVersion         = errors.New("metadata bad version")
+	ErrAlreadyExists      = errors.New("metadata already exists")
+	ErrNotFound           = errors.New("metadata not found")
+	ErrFailedPrecondition = errors.New("metadata failed precondition")
 )

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -17,6 +17,7 @@ package metadata
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -429,6 +430,17 @@ func (m *coordinatorMetadata) DeleteDataServer(name string) (*commonproto.DataSe
 
 			dataServer, _ := config.GetDataServer(name)
 			deleted = dataServer
+			remainingServerCount := len(config.GetServers()) - 1
+			for _, namespace := range config.GetNamespaces() {
+				if uint64(namespace.GetReplicationFactor()) > uint64(remainingServerCount) {
+					return nil, fmt.Errorf("%w: cannot delete data server %q because namespace %q replicationFactor=%d exceeds remaining data servers=%d",
+						metadatacommon.ErrFailedPrecondition,
+						name,
+						namespace.GetName(),
+						namespace.GetReplicationFactor(),
+						remainingServerCount)
+				}
+			}
 			config.Servers = append(config.Servers[:i], config.Servers[i+1:]...)
 			if config.ServerMetadata != nil {
 				delete(config.ServerMetadata, name)

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -55,6 +55,7 @@ type Metadata interface {
 
 	CreateDataServer(dataServer *commonproto.DataServer) error
 	PatchDataServer(dataServer *commonproto.DataServer) (*commonproto.DataServer, error)
+	DeleteDataServer(name string) (*commonproto.DataServer, error)
 	ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer]
 	GetDataServer(name string) (commonobject.Borrowed[*commonproto.DataServer], bool)
 }
@@ -416,6 +417,30 @@ func (m *coordinatorMetadata) PatchDataServer(desireDataServer *commonproto.Data
 	}
 
 	return updated, nil
+}
+
+func (m *coordinatorMetadata) DeleteDataServer(name string) (*commonproto.DataServer, error) {
+	var deleted *commonproto.DataServer
+	if err := m.computeConfig(func(config *commonproto.ClusterConfiguration, _ metadatacommon.Version) (*commonproto.ClusterConfiguration, error) {
+		for i, identity := range config.GetServers() {
+			if identity.GetNameOrDefault() != name {
+				continue
+			}
+
+			dataServer, _ := config.GetDataServer(name)
+			deleted = dataServer
+			config.Servers = append(config.Servers[:i], config.Servers[i+1:]...)
+			if config.ServerMetadata != nil {
+				delete(config.ServerMetadata, name)
+			}
+			return config, nil
+		}
+		return nil, metadatacommon.ErrNotFound
+	}); err != nil {
+		return nil, err
+	}
+
+	return deleted, nil
 }
 
 func (m *coordinatorMetadata) ListDataServer() map[string]commonobject.Borrowed[*commonproto.DataServer] {

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -181,6 +181,10 @@ func (*mockNamespaceMetadata) PatchDataServer(*proto.DataServer) (*proto.DataSer
 	return &proto.DataServer{}, nil
 }
 
+func (*mockNamespaceMetadata) DeleteDataServer(string) (*proto.DataServer, error) {
+	return &proto.DataServer{}, nil
+}
+
 func (*mockNamespaceMetadata) ListDataServer() map[string]commonobject.Borrowed[*proto.DataServer] {
 	return map[string]commonobject.Borrowed[*proto.DataServer]{}
 }

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -113,6 +113,10 @@ func (*mockMetadata) PatchDataServer(*proto.DataServer) (*proto.DataServer, erro
 	return &proto.DataServer{}, nil
 }
 
+func (*mockMetadata) DeleteDataServer(string) (*proto.DataServer, error) {
+	return &proto.DataServer{}, nil
+}
+
 func (m *mockMetadata) ListDataServer() map[string]commonobject.Borrowed[*proto.DataServer] {
 	dataServers := make(map[string]commonobject.Borrowed[*proto.DataServer], m.nodes.Size())
 	for _, id := range m.nodes.Values() {

--- a/tests/coordinator/admin_dataserver_e2e_test.go
+++ b/tests/coordinator/admin_dataserver_e2e_test.go
@@ -1,0 +1,138 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxia"
+	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
+	coordserver "github.com/oxia-db/oxia/oxiad/coordinator"
+	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	coordoption "github.com/oxia-db/oxia/oxiad/coordinator/option"
+)
+
+func TestAdminDataServerCRUD(t *testing.T) {
+	metadataDir := t.TempDir()
+
+	adminAddr := freeAddress(t)
+	options := coordoption.NewDefaultOptions()
+	options.Server.Internal.BindAddress = "127.0.0.1:0"
+	options.Server.Admin.BindAddress = adminAddr
+	options.Observability.Metric.Enabled = &constant.FlagFalse
+	options.Metadata.ProviderName = metadatacommon.NameFile
+	options.Metadata.File.Dir = metadataDir
+	options.Metadata.File.ConfigName = "cluster.yaml"
+
+	coordinatorServer, err := coordserver.NewGrpcServer(t.Context(), commonwatch.New(options))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, coordinatorServer.Close())
+	})
+
+	client, err := oxia.NewAdminClient(adminAddr, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	serverName := "server-1"
+	created, err := client.CreateDataServer(&proto.DataServer{
+		Identity: &proto.DataServerIdentity{
+			Name:     &serverName,
+			Public:   "localhost:19001",
+			Internal: "localhost:19002",
+		},
+		Metadata: &proto.DataServerMetadata{
+			Labels: map[string]string{"rack": "rack-1"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	assert.Equal(t, serverName, created.GetIdentity().GetName())
+	assert.Equal(t, "localhost:19001", created.GetIdentity().GetPublic())
+	assert.Equal(t, "localhost:19002", created.GetIdentity().GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-1"}, created.GetMetadata().GetLabels())
+
+	remainingServerName := "server-2"
+	_, err = client.CreateDataServer(&proto.DataServer{
+		Identity: &proto.DataServerIdentity{
+			Name:     &remainingServerName,
+			Public:   "localhost:19003",
+			Internal: "localhost:19004",
+		},
+		Metadata: &proto.DataServerMetadata{
+			Labels: map[string]string{"rack": "rack-2"},
+		},
+	})
+	require.NoError(t, err)
+
+	dataServers, err := client.ListDataServers()
+	require.NoError(t, err)
+	require.Len(t, dataServers, 2)
+
+	found, err := client.GetDataServer(serverName)
+	require.NoError(t, err)
+	assert.Equal(t, serverName, found.GetIdentity().GetName())
+	assert.Equal(t, "localhost:19001", found.GetIdentity().GetPublic())
+	assert.Equal(t, map[string]string{"rack": "rack-1"}, found.GetMetadata().GetLabels())
+
+	patched, err := client.PatchDataServer(&proto.DataServer{
+		Identity: &proto.DataServerIdentity{
+			Name:   &serverName,
+			Public: "localhost:19101",
+		},
+		Metadata: &proto.DataServerMetadata{
+			Labels: map[string]string{"rack": "rack-3"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, serverName, patched.GetIdentity().GetName())
+	assert.Equal(t, "localhost:19101", patched.GetIdentity().GetPublic())
+	assert.Equal(t, "localhost:19002", patched.GetIdentity().GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-3"}, patched.GetMetadata().GetLabels())
+
+	deleted, err := client.DeleteDataServer(serverName)
+	require.NoError(t, err)
+	require.NotNil(t, deleted)
+	require.NotNil(t, deleted.GetIdentity())
+	assert.Equal(t, serverName, deleted.GetIdentity().GetName())
+	assert.Equal(t, "localhost:19101", deleted.GetIdentity().GetPublic())
+	assert.Equal(t, "localhost:19002", deleted.GetIdentity().GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-3"}, deleted.GetMetadata().GetLabels())
+
+	dataServers, err = client.ListDataServers()
+	require.NoError(t, err)
+	require.Len(t, dataServers, 1)
+	require.NotNil(t, dataServers[0].GetIdentity())
+	assert.Equal(t, remainingServerName, dataServers[0].GetIdentity().GetName())
+	assert.Equal(t, map[string]string{"rack": "rack-2"}, dataServers[0].GetMetadata().GetLabels())
+}
+
+func freeAddress(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := listener.Addr().String()
+	require.NoError(t, listener.Close())
+	return addr
+}


### PR DESCRIPTION
## Motivation
- Add the admin dataserver delete operation so configured dataservers can be removed through the public management API and CLI.
- Keep this scoped to configuration deletion; decommission/drain readiness remains a separate lifecycle concern.

## Modifications
- Added DeleteDataServer to the admin proto, generated clients, public admin client, coordinator management server, and coordinator metadata.
- Added the `oxia admin dataserver delete <name>` CLI command.
- Added unit coverage plus a coordinator integration test that starts from an empty file-backed cluster and exercises create, read, patch, and delete via the admin API.

## Testing
- `go test ./cmd/admin/... ./oxia ./oxiad/coordinator/...`
- `go test ./tests/coordinator -run TestAdminDataServerCRUD -count=1`
- `go test ./tests/coordinator`
- `make lint`