### PR TITLE
feat: add create namespace admin API

### DIFF
--- a/cmd/admin/commons/mock_admin_client.go
+++ b/cmd/admin/commons/mock_admin_client.go
@@ -85,6 +85,14 @@ func (m *MockAdminClient) DeleteDataServer(dataServer string) (*proto.DataServer
 	return nil, errors.New("failed to delete data server")
 }
 
+func (m *MockAdminClient) CreateNamespace(namespace *proto.Namespace) (*proto.Namespace, error) {
+	args := m.MethodCalled("CreateNamespace", namespace)
+	if v, ok := args.Get(0).(*proto.Namespace); ok {
+		return v, args.Error(1)
+	}
+	return nil, errors.New("failed to create namespace")
+}
+
 func (m *MockAdminClient) GetNamespace(namespace string) (*proto.Namespace, error) {
 	args := m.MethodCalled("GetNamespace", namespace)
 	if v, ok := args.Get(0).(*proto.Namespace); ok {

--- a/cmd/admin/namespace/cmd.go
+++ b/cmd/admin/namespace/cmd.go
@@ -15,6 +15,7 @@
 package namespace
 
 import (
+	createcmd "github.com/oxia-db/oxia/cmd/admin/namespace/create"
 	getcmd "github.com/oxia-db/oxia/cmd/admin/namespace/get"
 
 	"github.com/spf13/cobra"
@@ -27,5 +28,6 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
+	Cmd.AddCommand(createcmd.Cmd)
 	Cmd.AddCommand(getcmd.Cmd)
 }

--- a/cmd/admin/namespace/create/cmd.go
+++ b/cmd/admin/namespace/create/cmd.go
@@ -1,0 +1,131 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package create
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/oxia-db/oxia/cmd/admin/commons"
+	namespaceoutput "github.com/oxia-db/oxia/cmd/admin/namespace/output"
+	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/common/validation"
+	"github.com/oxia-db/oxia/oxia"
+)
+
+const (
+	initialShardsFlagName     = "initial-shards"
+	replicationFactorFlagName = "replication-factor"
+	notificationsFlagName     = "notifications"
+	keySortingFlagName        = "key-sorting"
+)
+
+var fields namespaceFields
+
+var Cmd = &cobra.Command{
+	Use:          "create <namespace> --initial-shards <count> --replication-factor <factor>",
+	Short:        "Create a namespace",
+	Long:         `Create a namespace`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         exec,
+	SilenceUsage: true,
+}
+
+func init() {
+	fields.addFlags(Cmd)
+	_ = Cmd.MarkFlagRequired(initialShardsFlagName)
+	_ = Cmd.MarkFlagRequired(replicationFactorFlagName)
+}
+
+type namespaceFields struct {
+	initialShardCount uint32
+	replicationFactor uint32
+	notifications     bool
+	keySorting        string
+}
+
+func (f *namespaceFields) addFlags(cmd *cobra.Command) {
+	f.notifications = true
+	f.keySorting = "hierarchical"
+	cmd.Flags().Uint32Var(&f.initialShardCount, initialShardsFlagName, 0, "Initial shard count for the namespace")
+	cmd.Flags().Uint32Var(&f.replicationFactor, replicationFactorFlagName, 0, "Replication factor for the namespace")
+	cmd.Flags().BoolVar(&f.notifications, notificationsFlagName, true, "Whether notifications are enabled")
+	cmd.Flags().StringVar(&f.keySorting, keySortingFlagName, f.keySorting, `Key sorting. allowed: "hierarchical", "natural"`)
+	_ = cmd.RegisterFlagCompletionFunc(keySortingFlagName, keySortingCompletion)
+}
+
+func (f *namespaceFields) reset() {
+	f.initialShardCount = 0
+	f.replicationFactor = 0
+	f.notifications = true
+	f.keySorting = "hierarchical"
+}
+
+func exec(cmd *cobra.Command, args []string) error {
+	outputFormat, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+	if err := commons.ValidateOutputFormat(outputFormat); err != nil {
+		return err
+	}
+
+	name := args[0]
+	if err := validation.ValidateNamespace(name); err != nil {
+		return err
+	}
+	if fields.initialShardCount == 0 {
+		return errors.New("namespace initial shard count must be greater than 0")
+	}
+	if fields.replicationFactor == 0 {
+		return errors.New("namespace replication factor must be greater than 0")
+	}
+	keySorting, err := proto.ParseKeySortingType(fields.keySorting)
+	if err != nil {
+		return err
+	}
+	if keySorting == proto.KeySortingType_UNKNOWN {
+		return errors.New(`key sorting must be one of "natural" or "hierarchical"`)
+	}
+
+	client, err := commons.AdminConfig.NewAdminClient()
+	if err != nil {
+		return err
+	}
+	defer func(client oxia.AdminClient) {
+		_ = client.Close()
+	}(client)
+
+	created, err := client.CreateNamespace(&proto.Namespace{
+		Name:                 name,
+		InitialShardCount:    fields.initialShardCount,
+		ReplicationFactor:    fields.replicationFactor,
+		NotificationsEnabled: &fields.notifications,
+		KeySorting:           fields.keySorting,
+	})
+	if err != nil {
+		return err
+	}
+
+	return namespaceoutput.WriteNamespace(cmd.OutOrStdout(), outputFormat, created)
+}
+
+func keySortingCompletion(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return []string{
+		"hierarchical\tUse file-system like hierarchical sorting based on `/`",
+		"natural\tUse natural, byte-wise sorting",
+	}, cobra.ShellCompDirectiveDefault
+}

--- a/cmd/admin/namespace/create/cmd_test.go
+++ b/cmd/admin/namespace/create/cmd_test.go
@@ -1,0 +1,197 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/cmd/admin/commons"
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+func runCmd(cmd *cobra.Command, args ...string) (string, error) {
+	actual := new(bytes.Buffer)
+	root := &cobra.Command{Use: "admin"}
+	root.PersistentFlags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
+	root.AddCommand(cmd)
+	root.SetOut(actual)
+	root.SetErr(actual)
+	root.SetArgs(append([]string{"create"}, args...))
+	err := root.Execute()
+	fields.reset()
+	return strings.TrimSpace(actual.String()), err
+}
+
+func Test_cmd_createNamespace(t *testing.T) {
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	notificationsEnabled := false
+	expected := &proto.Namespace{
+		Name:                 "ns-1",
+		InitialShardCount:    4,
+		ReplicationFactor:    3,
+		NotificationsEnabled: &notificationsEnabled,
+		KeySorting:           "natural",
+	}
+
+	commons.MockedAdminClient.On("Close").Return(nil)
+	commons.MockedAdminClient.On("CreateNamespace", mock.MatchedBy(func(namespace *proto.Namespace) bool {
+		return namespace.GetName() == "ns-1" &&
+			namespace.GetInitialShardCount() == 4 &&
+			namespace.GetReplicationFactor() == 3 &&
+			namespace.GetNotificationsEnabled() == notificationsEnabled &&
+			namespace.GetKeySorting() == "natural"
+	})).Return(expected, nil)
+
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	fields.addFlags(cmd)
+	_ = cmd.MarkFlagRequired(initialShardsFlagName)
+	_ = cmd.MarkFlagRequired(replicationFactorFlagName)
+	out, err := runCmd(cmd, "ns-1", "--initial-shards", "4", "--replication-factor", "3",
+		"--notifications=false", "--key-sorting", "natural", "-o", "json")
+
+	require.NoError(t, err)
+	var namespace proto.Namespace
+	require.NoError(t, json.Unmarshal([]byte(out), &namespace))
+	assert.Equal(t, "ns-1", namespace.GetName())
+	assert.EqualValues(t, 4, namespace.GetInitialShardCount())
+	assert.EqualValues(t, 3, namespace.GetReplicationFactor())
+	assert.False(t, namespace.NotificationsEnabledOrDefault())
+	assert.Equal(t, "natural", namespace.GetKeySorting())
+}
+
+func Test_cmd_createNamespace_DefaultTable(t *testing.T) {
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	commons.MockedAdminClient.On("Close").Return(nil)
+	commons.MockedAdminClient.On("CreateNamespace", mock.Anything).Return(&proto.Namespace{
+		Name:              "ns-1",
+		InitialShardCount: 4,
+		ReplicationFactor: 3,
+		KeySorting:        "hierarchical",
+	}, nil)
+
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	fields.addFlags(cmd)
+	_ = cmd.MarkFlagRequired(initialShardsFlagName)
+	_ = cmd.MarkFlagRequired(replicationFactorFlagName)
+	out, err := runCmd(cmd, "ns-1", "--initial-shards", "4", "--replication-factor", "3")
+
+	require.NoError(t, err)
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "INITIAL_SHARDS")
+	assert.Contains(t, out, "REPLICATION_FACTOR")
+	assert.Contains(t, out, "NOTIFICATIONS")
+	assert.Contains(t, out, "KEY_SORTING")
+	assert.Contains(t, out, "ns-1")
+	assert.Contains(t, out, "4")
+	assert.Contains(t, out, "3")
+	assert.Contains(t, out, "true")
+	assert.Contains(t, out, "hierarchical")
+}
+
+func Test_cmd_createNamespace_Name(t *testing.T) {
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	commons.MockedAdminClient.On("Close").Return(nil)
+	commons.MockedAdminClient.On("CreateNamespace", mock.Anything).Return(&proto.Namespace{
+		Name: "ns-1",
+	}, nil)
+
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	fields.addFlags(cmd)
+	_ = cmd.MarkFlagRequired(initialShardsFlagName)
+	_ = cmd.MarkFlagRequired(replicationFactorFlagName)
+	out, err := runCmd(cmd, "ns-1", "--initial-shards", "4", "--replication-factor", "3", "-o", "name")
+
+	require.NoError(t, err)
+	assert.Equal(t, "namespace/ns-1", out)
+}
+
+func Test_cmd_createNamespace_RejectsInvalidName(t *testing.T) {
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	fields.addFlags(cmd)
+	_ = cmd.MarkFlagRequired(initialShardsFlagName)
+	_ = cmd.MarkFlagRequired(replicationFactorFlagName)
+	out, err := runCmd(cmd, "../ns", "--initial-shards", "4", "--replication-factor", "3")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid path traversal sequence")
+	assert.Contains(t, out, "invalid path traversal sequence")
+}
+
+func Test_cmd_createNamespace_RejectsInvalidKeySorting(t *testing.T) {
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	fields.addFlags(cmd)
+	_ = cmd.MarkFlagRequired(initialShardsFlagName)
+	_ = cmd.MarkFlagRequired(replicationFactorFlagName)
+	out, err := runCmd(cmd, "ns-1", "--initial-shards", "4", "--replication-factor", "3", "--key-sorting", "unknown")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `key sorting must be one of "natural" or "hierarchical"`)
+	assert.Contains(t, out, `key sorting must be one of "natural" or "hierarchical"`)
+}

--- a/common/proto/admin.pb.go
+++ b/common/proto/admin.pb.go
@@ -470,6 +470,94 @@ func (x *DeleteDataServerResponse) GetDataServer() *DataServer {
 	return nil
 }
 
+type CreateNamespaceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Namespace     *Namespace             `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateNamespaceRequest) Reset() {
+	*x = CreateNamespaceRequest{}
+	mi := &file_admin_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateNamespaceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateNamespaceRequest) ProtoMessage() {}
+
+func (x *CreateNamespaceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateNamespaceRequest.ProtoReflect.Descriptor instead.
+func (*CreateNamespaceRequest) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *CreateNamespaceRequest) GetNamespace() *Namespace {
+	if x != nil {
+		return x.Namespace
+	}
+	return nil
+}
+
+type CreateNamespaceResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Namespace     *Namespace             `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateNamespaceResponse) Reset() {
+	*x = CreateNamespaceResponse{}
+	mi := &file_admin_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateNamespaceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateNamespaceResponse) ProtoMessage() {}
+
+func (x *CreateNamespaceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateNamespaceResponse.ProtoReflect.Descriptor instead.
+func (*CreateNamespaceResponse) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *CreateNamespaceResponse) GetNamespace() *Namespace {
+	if x != nil {
+		return x.Namespace
+	}
+	return nil
+}
+
 type ListNamespacesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -478,7 +566,7 @@ type ListNamespacesRequest struct {
 
 func (x *ListNamespacesRequest) Reset() {
 	*x = ListNamespacesRequest{}
-	mi := &file_admin_proto_msgTypes[10]
+	mi := &file_admin_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -490,7 +578,7 @@ func (x *ListNamespacesRequest) String() string {
 func (*ListNamespacesRequest) ProtoMessage() {}
 
 func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[10]
+	mi := &file_admin_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -503,7 +591,7 @@ func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListNamespacesRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{10}
+	return file_admin_proto_rawDescGZIP(), []int{12}
 }
 
 type ListNamespacesResponse struct {
@@ -515,7 +603,7 @@ type ListNamespacesResponse struct {
 
 func (x *ListNamespacesResponse) Reset() {
 	*x = ListNamespacesResponse{}
-	mi := &file_admin_proto_msgTypes[11]
+	mi := &file_admin_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -527,7 +615,7 @@ func (x *ListNamespacesResponse) String() string {
 func (*ListNamespacesResponse) ProtoMessage() {}
 
 func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[11]
+	mi := &file_admin_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -540,7 +628,7 @@ func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListNamespacesResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{11}
+	return file_admin_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ListNamespacesResponse) GetNamespaces() []*Namespace {
@@ -559,7 +647,7 @@ type GetNamespaceRequest struct {
 
 func (x *GetNamespaceRequest) Reset() {
 	*x = GetNamespaceRequest{}
-	mi := &file_admin_proto_msgTypes[12]
+	mi := &file_admin_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -571,7 +659,7 @@ func (x *GetNamespaceRequest) String() string {
 func (*GetNamespaceRequest) ProtoMessage() {}
 
 func (x *GetNamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[12]
+	mi := &file_admin_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -584,7 +672,7 @@ func (x *GetNamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNamespaceRequest.ProtoReflect.Descriptor instead.
 func (*GetNamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{12}
+	return file_admin_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GetNamespaceRequest) GetNamespace() string {
@@ -603,7 +691,7 @@ type GetNamespaceResponse struct {
 
 func (x *GetNamespaceResponse) Reset() {
 	*x = GetNamespaceResponse{}
-	mi := &file_admin_proto_msgTypes[13]
+	mi := &file_admin_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -615,7 +703,7 @@ func (x *GetNamespaceResponse) String() string {
 func (*GetNamespaceResponse) ProtoMessage() {}
 
 func (x *GetNamespaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[13]
+	mi := &file_admin_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -628,7 +716,7 @@ func (x *GetNamespaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNamespaceResponse.ProtoReflect.Descriptor instead.
 func (*GetNamespaceResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{13}
+	return file_admin_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GetNamespaceResponse) GetNamespace() *Namespace {
@@ -650,7 +738,7 @@ type SplitShardRequest struct {
 
 func (x *SplitShardRequest) Reset() {
 	*x = SplitShardRequest{}
-	mi := &file_admin_proto_msgTypes[14]
+	mi := &file_admin_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -662,7 +750,7 @@ func (x *SplitShardRequest) String() string {
 func (*SplitShardRequest) ProtoMessage() {}
 
 func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[14]
+	mi := &file_admin_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -675,7 +763,7 @@ func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardRequest.ProtoReflect.Descriptor instead.
 func (*SplitShardRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{14}
+	return file_admin_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SplitShardRequest) GetNamespace() string {
@@ -709,7 +797,7 @@ type SplitShardResponse struct {
 
 func (x *SplitShardResponse) Reset() {
 	*x = SplitShardResponse{}
-	mi := &file_admin_proto_msgTypes[15]
+	mi := &file_admin_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -721,7 +809,7 @@ func (x *SplitShardResponse) String() string {
 func (*SplitShardResponse) ProtoMessage() {}
 
 func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[15]
+	mi := &file_admin_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -734,7 +822,7 @@ func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardResponse.ProtoReflect.Descriptor instead.
 func (*SplitShardResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{15}
+	return file_admin_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SplitShardResponse) GetLeftChildShard() int64 {
@@ -782,7 +870,11 @@ const file_admin_proto_rawDesc = "" +
 	"dataServer\"Y\n" +
 	"\x18DeleteDataServerResponse\x12=\n" +
 	"\vdata_server\x18\x01 \x01(\v2\x1c.io.oxia.proto.v1.DataServerR\n" +
-	"dataServer\"\x17\n" +
+	"dataServer\"S\n" +
+	"\x16CreateNamespaceRequest\x129\n" +
+	"\tnamespace\x18\x01 \x01(\v2\x1b.io.oxia.proto.v1.NamespaceR\tnamespace\"T\n" +
+	"\x17CreateNamespaceResponse\x129\n" +
+	"\tnamespace\x18\x01 \x01(\v2\x1b.io.oxia.proto.v1.NamespaceR\tnamespace\"\x17\n" +
 	"\x15ListNamespacesRequest\"U\n" +
 	"\x16ListNamespacesResponse\x12;\n" +
 	"\n" +
@@ -800,13 +892,14 @@ const file_admin_proto_rawDesc = "" +
 	"\f_split_point\"j\n" +
 	"\x12SplitShardResponse\x12(\n" +
 	"\x10left_child_shard\x18\x01 \x01(\x03R\x0eleftChildShard\x12*\n" +
-	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\xb0\x06\n" +
+	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\x98\a\n" +
 	"\tOxiaAdmin\x12f\n" +
 	"\x0fListDataServers\x12(.io.oxia.proto.v1.ListDataServersRequest\x1a).io.oxia.proto.v1.ListDataServersResponse\x12`\n" +
 	"\rGetDataServer\x12&.io.oxia.proto.v1.GetDataServerRequest\x1a'.io.oxia.proto.v1.GetDataServerResponse\x12i\n" +
 	"\x10CreateDataServer\x12).io.oxia.proto.v1.CreateDataServerRequest\x1a*.io.oxia.proto.v1.CreateDataServerResponse\x12f\n" +
 	"\x0fPatchDataServer\x12(.io.oxia.proto.v1.PatchDataServerRequest\x1a).io.oxia.proto.v1.PatchDataServerResponse\x12i\n" +
-	"\x10DeleteDataServer\x12).io.oxia.proto.v1.DeleteDataServerRequest\x1a*.io.oxia.proto.v1.DeleteDataServerResponse\x12]\n" +
+	"\x10DeleteDataServer\x12).io.oxia.proto.v1.DeleteDataServerRequest\x1a*.io.oxia.proto.v1.DeleteDataServerResponse\x12f\n" +
+	"\x0fCreateNamespace\x12(.io.oxia.proto.v1.CreateNamespaceRequest\x1a).io.oxia.proto.v1.CreateNamespaceResponse\x12]\n" +
 	"\fGetNamespace\x12%.io.oxia.proto.v1.GetNamespaceRequest\x1a&.io.oxia.proto.v1.GetNamespaceResponse\x12c\n" +
 	"\x0eListNamespaces\x12'.io.oxia.proto.v1.ListNamespacesRequest\x1a(.io.oxia.proto.v1.ListNamespacesResponse\x12W\n" +
 	"\n" +
@@ -824,7 +917,7 @@ func file_admin_proto_rawDescGZIP() []byte {
 	return file_admin_proto_rawDescData
 }
 
-var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_admin_proto_goTypes = []any{
 	(*ListDataServersRequest)(nil),   // 0: io.oxia.proto.v1.ListDataServersRequest
 	(*ListDataServersResponse)(nil),  // 1: io.oxia.proto.v1.ListDataServersResponse
@@ -836,46 +929,52 @@ var file_admin_proto_goTypes = []any{
 	(*PatchDataServerResponse)(nil),  // 7: io.oxia.proto.v1.PatchDataServerResponse
 	(*DeleteDataServerRequest)(nil),  // 8: io.oxia.proto.v1.DeleteDataServerRequest
 	(*DeleteDataServerResponse)(nil), // 9: io.oxia.proto.v1.DeleteDataServerResponse
-	(*ListNamespacesRequest)(nil),    // 10: io.oxia.proto.v1.ListNamespacesRequest
-	(*ListNamespacesResponse)(nil),   // 11: io.oxia.proto.v1.ListNamespacesResponse
-	(*GetNamespaceRequest)(nil),      // 12: io.oxia.proto.v1.GetNamespaceRequest
-	(*GetNamespaceResponse)(nil),     // 13: io.oxia.proto.v1.GetNamespaceResponse
-	(*SplitShardRequest)(nil),        // 14: io.oxia.proto.v1.SplitShardRequest
-	(*SplitShardResponse)(nil),       // 15: io.oxia.proto.v1.SplitShardResponse
-	(*DataServer)(nil),               // 16: io.oxia.proto.v1.DataServer
-	(*Namespace)(nil),                // 17: io.oxia.proto.v1.Namespace
+	(*CreateNamespaceRequest)(nil),   // 10: io.oxia.proto.v1.CreateNamespaceRequest
+	(*CreateNamespaceResponse)(nil),  // 11: io.oxia.proto.v1.CreateNamespaceResponse
+	(*ListNamespacesRequest)(nil),    // 12: io.oxia.proto.v1.ListNamespacesRequest
+	(*ListNamespacesResponse)(nil),   // 13: io.oxia.proto.v1.ListNamespacesResponse
+	(*GetNamespaceRequest)(nil),      // 14: io.oxia.proto.v1.GetNamespaceRequest
+	(*GetNamespaceResponse)(nil),     // 15: io.oxia.proto.v1.GetNamespaceResponse
+	(*SplitShardRequest)(nil),        // 16: io.oxia.proto.v1.SplitShardRequest
+	(*SplitShardResponse)(nil),       // 17: io.oxia.proto.v1.SplitShardResponse
+	(*DataServer)(nil),               // 18: io.oxia.proto.v1.DataServer
+	(*Namespace)(nil),                // 19: io.oxia.proto.v1.Namespace
 }
 var file_admin_proto_depIdxs = []int32{
-	16, // 0: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
-	16, // 1: io.oxia.proto.v1.GetDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
-	16, // 2: io.oxia.proto.v1.CreateDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
-	16, // 3: io.oxia.proto.v1.CreateDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
-	16, // 4: io.oxia.proto.v1.PatchDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
-	16, // 5: io.oxia.proto.v1.PatchDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
-	16, // 6: io.oxia.proto.v1.DeleteDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
-	17, // 7: io.oxia.proto.v1.ListNamespacesResponse.namespaces:type_name -> io.oxia.proto.v1.Namespace
-	17, // 8: io.oxia.proto.v1.GetNamespaceResponse.namespace:type_name -> io.oxia.proto.v1.Namespace
-	0,  // 9: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
-	2,  // 10: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
-	4,  // 11: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:input_type -> io.oxia.proto.v1.CreateDataServerRequest
-	6,  // 12: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:input_type -> io.oxia.proto.v1.PatchDataServerRequest
-	8,  // 13: io.oxia.proto.v1.OxiaAdmin.DeleteDataServer:input_type -> io.oxia.proto.v1.DeleteDataServerRequest
-	12, // 14: io.oxia.proto.v1.OxiaAdmin.GetNamespace:input_type -> io.oxia.proto.v1.GetNamespaceRequest
-	10, // 15: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
-	14, // 16: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
-	1,  // 17: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
-	3,  // 18: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.GetDataServerResponse
-	5,  // 19: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:output_type -> io.oxia.proto.v1.CreateDataServerResponse
-	7,  // 20: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:output_type -> io.oxia.proto.v1.PatchDataServerResponse
-	9,  // 21: io.oxia.proto.v1.OxiaAdmin.DeleteDataServer:output_type -> io.oxia.proto.v1.DeleteDataServerResponse
-	13, // 22: io.oxia.proto.v1.OxiaAdmin.GetNamespace:output_type -> io.oxia.proto.v1.GetNamespaceResponse
-	11, // 23: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
-	15, // 24: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
-	17, // [17:25] is the sub-list for method output_type
-	9,  // [9:17] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	18, // 0: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
+	18, // 1: io.oxia.proto.v1.GetDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	18, // 2: io.oxia.proto.v1.CreateDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
+	18, // 3: io.oxia.proto.v1.CreateDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	18, // 4: io.oxia.proto.v1.PatchDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
+	18, // 5: io.oxia.proto.v1.PatchDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	18, // 6: io.oxia.proto.v1.DeleteDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	19, // 7: io.oxia.proto.v1.CreateNamespaceRequest.namespace:type_name -> io.oxia.proto.v1.Namespace
+	19, // 8: io.oxia.proto.v1.CreateNamespaceResponse.namespace:type_name -> io.oxia.proto.v1.Namespace
+	19, // 9: io.oxia.proto.v1.ListNamespacesResponse.namespaces:type_name -> io.oxia.proto.v1.Namespace
+	19, // 10: io.oxia.proto.v1.GetNamespaceResponse.namespace:type_name -> io.oxia.proto.v1.Namespace
+	0,  // 11: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
+	2,  // 12: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
+	4,  // 13: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:input_type -> io.oxia.proto.v1.CreateDataServerRequest
+	6,  // 14: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:input_type -> io.oxia.proto.v1.PatchDataServerRequest
+	8,  // 15: io.oxia.proto.v1.OxiaAdmin.DeleteDataServer:input_type -> io.oxia.proto.v1.DeleteDataServerRequest
+	10, // 16: io.oxia.proto.v1.OxiaAdmin.CreateNamespace:input_type -> io.oxia.proto.v1.CreateNamespaceRequest
+	14, // 17: io.oxia.proto.v1.OxiaAdmin.GetNamespace:input_type -> io.oxia.proto.v1.GetNamespaceRequest
+	12, // 18: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
+	16, // 19: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
+	1,  // 20: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
+	3,  // 21: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.GetDataServerResponse
+	5,  // 22: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:output_type -> io.oxia.proto.v1.CreateDataServerResponse
+	7,  // 23: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:output_type -> io.oxia.proto.v1.PatchDataServerResponse
+	9,  // 24: io.oxia.proto.v1.OxiaAdmin.DeleteDataServer:output_type -> io.oxia.proto.v1.DeleteDataServerResponse
+	11, // 25: io.oxia.proto.v1.OxiaAdmin.CreateNamespace:output_type -> io.oxia.proto.v1.CreateNamespaceResponse
+	15, // 26: io.oxia.proto.v1.OxiaAdmin.GetNamespace:output_type -> io.oxia.proto.v1.GetNamespaceResponse
+	13, // 27: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
+	17, // 28: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
+	20, // [20:29] is the sub-list for method output_type
+	11, // [11:20] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_admin_proto_init() }
@@ -884,14 +983,14 @@ func file_admin_proto_init() {
 		return
 	}
 	file_metadata_proto_init()
-	file_admin_proto_msgTypes[14].OneofWrappers = []any{}
+	file_admin_proto_msgTypes[16].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_admin_proto_rawDesc), len(file_admin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   16,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/common/proto/admin.proto
+++ b/common/proto/admin.proto
@@ -32,6 +32,7 @@ service OxiaAdmin {
   rpc PatchDataServer(PatchDataServerRequest) returns (PatchDataServerResponse);
   rpc DeleteDataServer(DeleteDataServerRequest) returns (DeleteDataServerResponse);
 
+  rpc CreateNamespace(CreateNamespaceRequest) returns (CreateNamespaceResponse);
   rpc GetNamespace(GetNamespaceRequest) returns (GetNamespaceResponse);
   rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse);
 
@@ -80,6 +81,14 @@ message DeleteDataServerRequest {
 
 message DeleteDataServerResponse {
   DataServer data_server = 1;
+}
+
+message CreateNamespaceRequest {
+  Namespace namespace = 1;
+}
+
+message CreateNamespaceResponse {
+  Namespace namespace = 1;
 }
 
 message ListNamespacesRequest {

--- a/common/proto/admin_grpc.pb.go
+++ b/common/proto/admin_grpc.pb.go
@@ -41,6 +41,7 @@ const (
 	OxiaAdmin_CreateDataServer_FullMethodName = "/io.oxia.proto.v1.OxiaAdmin/CreateDataServer"
 	OxiaAdmin_PatchDataServer_FullMethodName  = "/io.oxia.proto.v1.OxiaAdmin/PatchDataServer"
 	OxiaAdmin_DeleteDataServer_FullMethodName = "/io.oxia.proto.v1.OxiaAdmin/DeleteDataServer"
+	OxiaAdmin_CreateNamespace_FullMethodName  = "/io.oxia.proto.v1.OxiaAdmin/CreateNamespace"
 	OxiaAdmin_GetNamespace_FullMethodName     = "/io.oxia.proto.v1.OxiaAdmin/GetNamespace"
 	OxiaAdmin_ListNamespaces_FullMethodName   = "/io.oxia.proto.v1.OxiaAdmin/ListNamespaces"
 	OxiaAdmin_SplitShard_FullMethodName       = "/io.oxia.proto.v1.OxiaAdmin/SplitShard"
@@ -55,6 +56,7 @@ type OxiaAdminClient interface {
 	CreateDataServer(ctx context.Context, in *CreateDataServerRequest, opts ...grpc.CallOption) (*CreateDataServerResponse, error)
 	PatchDataServer(ctx context.Context, in *PatchDataServerRequest, opts ...grpc.CallOption) (*PatchDataServerResponse, error)
 	DeleteDataServer(ctx context.Context, in *DeleteDataServerRequest, opts ...grpc.CallOption) (*DeleteDataServerResponse, error)
+	CreateNamespace(ctx context.Context, in *CreateNamespaceRequest, opts ...grpc.CallOption) (*CreateNamespaceResponse, error)
 	GetNamespace(ctx context.Context, in *GetNamespaceRequest, opts ...grpc.CallOption) (*GetNamespaceResponse, error)
 	ListNamespaces(ctx context.Context, in *ListNamespacesRequest, opts ...grpc.CallOption) (*ListNamespacesResponse, error)
 	// *
@@ -121,6 +123,16 @@ func (c *oxiaAdminClient) DeleteDataServer(ctx context.Context, in *DeleteDataSe
 	return out, nil
 }
 
+func (c *oxiaAdminClient) CreateNamespace(ctx context.Context, in *CreateNamespaceRequest, opts ...grpc.CallOption) (*CreateNamespaceResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateNamespaceResponse)
+	err := c.cc.Invoke(ctx, OxiaAdmin_CreateNamespace_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *oxiaAdminClient) GetNamespace(ctx context.Context, in *GetNamespaceRequest, opts ...grpc.CallOption) (*GetNamespaceResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetNamespaceResponse)
@@ -160,6 +172,7 @@ type OxiaAdminServer interface {
 	CreateDataServer(context.Context, *CreateDataServerRequest) (*CreateDataServerResponse, error)
 	PatchDataServer(context.Context, *PatchDataServerRequest) (*PatchDataServerResponse, error)
 	DeleteDataServer(context.Context, *DeleteDataServerRequest) (*DeleteDataServerResponse, error)
+	CreateNamespace(context.Context, *CreateNamespaceRequest) (*CreateNamespaceResponse, error)
 	GetNamespace(context.Context, *GetNamespaceRequest) (*GetNamespaceResponse, error)
 	ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error)
 	// *
@@ -190,6 +203,9 @@ func (UnimplementedOxiaAdminServer) PatchDataServer(context.Context, *PatchDataS
 }
 func (UnimplementedOxiaAdminServer) DeleteDataServer(context.Context, *DeleteDataServerRequest) (*DeleteDataServerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteDataServer not implemented")
+}
+func (UnimplementedOxiaAdminServer) CreateNamespace(context.Context, *CreateNamespaceRequest) (*CreateNamespaceResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateNamespace not implemented")
 }
 func (UnimplementedOxiaAdminServer) GetNamespace(context.Context, *GetNamespaceRequest) (*GetNamespaceResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetNamespace not implemented")
@@ -311,6 +327,24 @@ func _OxiaAdmin_DeleteDataServer_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _OxiaAdmin_CreateNamespace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateNamespaceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OxiaAdminServer).CreateNamespace(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OxiaAdmin_CreateNamespace_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OxiaAdminServer).CreateNamespace(ctx, req.(*CreateNamespaceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _OxiaAdmin_GetNamespace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetNamespaceRequest)
 	if err := dec(in); err != nil {
@@ -391,6 +425,10 @@ var OxiaAdmin_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteDataServer",
 			Handler:    _OxiaAdmin_DeleteDataServer_Handler,
+		},
+		{
+			MethodName: "CreateNamespace",
+			Handler:    _OxiaAdmin_CreateNamespace_Handler,
 		},
 		{
 			MethodName: "GetNamespace",

--- a/common/proto/admin_vtproto.pb.go
+++ b/common/proto/admin_vtproto.pb.go
@@ -195,6 +195,40 @@ func (m *DeleteDataServerResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *CreateNamespaceRequest) CloneVT() *CreateNamespaceRequest {
+	if m == nil {
+		return (*CreateNamespaceRequest)(nil)
+	}
+	r := new(CreateNamespaceRequest)
+	r.Namespace = m.Namespace.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *CreateNamespaceRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *CreateNamespaceResponse) CloneVT() *CreateNamespaceResponse {
+	if m == nil {
+		return (*CreateNamespaceResponse)(nil)
+	}
+	r := new(CreateNamespaceResponse)
+	r.Namespace = m.Namespace.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *CreateNamespaceResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *ListNamespacesRequest) CloneVT() *ListNamespacesRequest {
 	if m == nil {
 		return (*ListNamespacesRequest)(nil)
@@ -504,6 +538,44 @@ func (this *DeleteDataServerResponse) EqualVT(that *DeleteDataServerResponse) bo
 
 func (this *DeleteDataServerResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*DeleteDataServerResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *CreateNamespaceRequest) EqualVT(that *CreateNamespaceRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.Namespace.EqualVT(that.Namespace) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *CreateNamespaceRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*CreateNamespaceRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *CreateNamespaceResponse) EqualVT(that *CreateNamespaceResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.Namespace.EqualVT(that.Namespace) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *CreateNamespaceResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*CreateNamespaceResponse)
 	if !ok {
 		return false
 	}
@@ -1059,6 +1131,92 @@ func (m *DeleteDataServerResponse) MarshalToSizedBufferVT(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 
+func (m *CreateNamespaceRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CreateNamespaceRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *CreateNamespaceRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Namespace != nil {
+		size, err := m.Namespace.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *CreateNamespaceResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CreateNamespaceResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *CreateNamespaceResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Namespace != nil {
+		size, err := m.Namespace.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ListNamespacesRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -1445,6 +1603,34 @@ func (m *DeleteDataServerResponse) SizeVT() (n int) {
 	_ = l
 	if m.DataServer != nil {
 		l = m.DataServer.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *CreateNamespaceRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Namespace != nil {
+		l = m.Namespace.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *CreateNamespaceResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Namespace != nil {
+		l = m.Namespace.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -2340,6 +2526,180 @@ func (m *DeleteDataServerResponse) UnmarshalVT(dAtA []byte) error {
 				m.DataServer = &DataServer{}
 			}
 			if err := m.DataServer.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateNamespaceRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateNamespaceRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateNamespaceRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Namespace == nil {
+				m.Namespace = &Namespace{}
+			}
+			if err := m.Namespace.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateNamespaceResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateNamespaceResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateNamespaceResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Namespace == nil {
+				m.Namespace = &Namespace{}
+			}
+			if err := m.Namespace.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -3689,6 +4049,180 @@ func (m *DeleteDataServerResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 				m.DataServer = &DataServer{}
 			}
 			if err := m.DataServer.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateNamespaceRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateNamespaceRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateNamespaceRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Namespace == nil {
+				m.Namespace = &Namespace{}
+			}
+			if err := m.Namespace.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateNamespaceResponse) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateNamespaceResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateNamespaceResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Namespace == nil {
+				m.Namespace = &Namespace{}
+			}
+			if err := m.Namespace.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/oxia/admin.go
+++ b/oxia/admin.go
@@ -29,6 +29,7 @@ type AdminClient interface {
 	PatchDataServer(dataServer *proto.DataServer) (*proto.DataServer, error)
 	DeleteDataServer(dataServer string) (*proto.DataServer, error)
 
+	CreateNamespace(namespace *proto.Namespace) (*proto.Namespace, error)
 	ListNamespaces() ([]*proto.Namespace, error)
 	GetNamespace(namespace string) (*proto.Namespace, error)
 

--- a/oxia/admin_client_impl.go
+++ b/oxia/admin_client_impl.go
@@ -128,6 +128,25 @@ func (admin *adminClientImpl) Close() error {
 	return admin.clientPool.Close()
 }
 
+func (admin *adminClientImpl) CreateNamespace(namespace *proto.Namespace) (*proto.Namespace, error) {
+	client, err := admin.clientPool.GetAminRpc(admin.adminAddr)
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+
+	if client == nil {
+		return nil, wrapAdminError(ErrUnknown, errors.New(errUnableToConnectToAdminServer))
+	}
+
+	response, err := client.CreateNamespace(context.Background(), &proto.CreateNamespaceRequest{
+		Namespace: namespace,
+	})
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+	return response.Namespace, nil
+}
+
 func (admin *adminClientImpl) ListNamespaces() ([]*proto.Namespace, error) {
 	client, err := admin.clientPool.GetAminRpc(admin.adminAddr)
 	if err != nil {

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -42,6 +42,8 @@ type mockAdminRpcClient struct {
 	patchDataServerErr      error
 	deleteDataServerResp    *proto.DeleteDataServerResponse
 	deleteDataServerErr     error
+	createNamespaceResp     *proto.CreateNamespaceResponse
+	createNamespaceErr      error
 	listNamespacesResp      *proto.ListNamespacesResponse
 	listNamespacesErr       error
 	getNamespaceResp        *proto.GetNamespaceResponse
@@ -66,6 +68,10 @@ func (m *mockAdminRpcClient) PatchDataServer(context.Context, *proto.PatchDataSe
 
 func (m *mockAdminRpcClient) DeleteDataServer(context.Context, *proto.DeleteDataServerRequest, ...grpc.CallOption) (*proto.DeleteDataServerResponse, error) {
 	return m.deleteDataServerResp, m.deleteDataServerErr
+}
+
+func (m *mockAdminRpcClient) CreateNamespace(context.Context, *proto.CreateNamespaceRequest, ...grpc.CallOption) (*proto.CreateNamespaceResponse, error) {
+	return m.createNamespaceResp, m.createNamespaceErr
 }
 
 func (m *mockAdminRpcClient) GetNamespace(context.Context, *proto.GetNamespaceRequest, ...grpc.CallOption) (*proto.GetNamespaceResponse, error) {
@@ -345,6 +351,32 @@ func TestAdminClientDeleteDataServerReturnsResponse(t *testing.T) {
 	assert.Equal(t, "public-1", dataServer.Identity.GetPublic())
 	assert.Equal(t, "internal-1", dataServer.Identity.GetInternal())
 	assert.Equal(t, map[string]string{"rack": "rack-1"}, dataServer.Metadata.GetLabels())
+}
+
+func TestAdminClientCreateNamespaceReturnsResponse(t *testing.T) {
+	admin := &adminClientImpl{
+		adminAddr: "admin-addr",
+		clientPool: &mockAdminClientPool{
+			adminClient: &mockAdminRpcClient{
+				createNamespaceResp: &proto.CreateNamespaceResponse{
+					Namespace: &proto.Namespace{
+						Name:              "ns-1",
+						InitialShardCount: 4,
+						ReplicationFactor: 3,
+						KeySorting:        proto.KeySortingType_NATURAL.String(),
+					},
+				},
+			},
+		},
+	}
+
+	namespace, err := admin.CreateNamespace(&proto.Namespace{Name: "ns-1"})
+	require.NoError(t, err)
+	require.NotNil(t, namespace)
+	assert.Equal(t, "ns-1", namespace.GetName())
+	assert.EqualValues(t, 4, namespace.GetInitialShardCount())
+	assert.EqualValues(t, 3, namespace.GetReplicationFactor())
+	assert.Equal(t, proto.KeySortingType_NATURAL.String(), namespace.GetKeySorting())
 }
 
 func TestAdminClientListNamespacesReturnsResponse(t *testing.T) {

--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -23,6 +23,7 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/common/validation"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
@@ -169,6 +170,42 @@ func (management *managementServer) ListNamespaces(context.Context, *proto.ListN
 
 	return &proto.ListNamespacesResponse{
 		Namespaces: cnf.GetNamespaces(),
+	}, nil
+}
+
+func (management *managementServer) CreateNamespace(_ context.Context, req *proto.CreateNamespaceRequest) (*proto.CreateNamespaceResponse, error) {
+	if req == nil || req.Namespace == nil {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "namespace must not be nil")
+	}
+	if err := validation.ValidateNamespace(req.Namespace.GetName()); err != nil {
+		return nil, grpcstatus.Error(codes.InvalidArgument, err.Error())
+	}
+	if req.Namespace.GetInitialShardCount() == 0 {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "namespace initial shard count must be greater than 0")
+	}
+	if req.Namespace.GetReplicationFactor() == 0 {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "namespace replication factor must be greater than 0")
+	}
+	if _, err := req.Namespace.GetKeySortingType(); err != nil {
+		return nil, grpcstatus.Errorf(codes.InvalidArgument, "namespace key sorting is invalid: %v", err)
+	}
+
+	err := management.metadata.CreateNamespace(req.Namespace)
+	if err != nil {
+		if errors.Is(err, metadatacommon.ErrAlreadyExists) {
+			return nil, grpcstatus.Errorf(codes.AlreadyExists, "namespace %q already exists", req.Namespace.GetName())
+		}
+		if errors.Is(err, metadatacommon.ErrBadVersion) {
+			return nil, grpcstatus.Errorf(codes.Aborted, "failed to create namespace %q due to concurrent config update", req.Namespace.GetName())
+		}
+		if errors.Is(err, metadatacommon.ErrFailedPrecondition) {
+			return nil, grpcstatus.Errorf(codes.FailedPrecondition, "failed to create namespace %q: %v", req.Namespace.GetName(), err)
+		}
+		return nil, grpcstatus.Errorf(codes.Internal, "failed to create namespace %q: %v", req.Namespace.GetName(), err)
+	}
+
+	return &proto.CreateNamespaceResponse{
+		Namespace: req.Namespace,
 	}, nil
 }
 

--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -186,11 +186,15 @@ func (management *managementServer) CreateNamespace(_ context.Context, req *prot
 	if req.Namespace.GetReplicationFactor() == 0 {
 		return nil, grpcstatus.Error(codes.InvalidArgument, "namespace replication factor must be greater than 0")
 	}
-	if _, err := req.Namespace.GetKeySortingType(); err != nil {
+	keySorting, err := req.Namespace.GetKeySortingType()
+	if err != nil {
 		return nil, grpcstatus.Errorf(codes.InvalidArgument, "namespace key sorting is invalid: %v", err)
 	}
+	if keySorting == proto.KeySortingType_UNKNOWN {
+		return nil, grpcstatus.Error(codes.InvalidArgument, `namespace key sorting must be one of "natural" or "hierarchical"`)
+	}
 
-	err := management.metadata.CreateNamespace(req.Namespace)
+	err = management.metadata.CreateNamespace(req.Namespace)
 	if err != nil {
 		if errors.Is(err, metadatacommon.ErrAlreadyExists) {
 			return nil, grpcstatus.Errorf(codes.AlreadyExists, "namespace %q already exists", req.Namespace.GetName())

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -268,7 +268,7 @@ func TestManagementServerCreateNamespace(t *testing.T) {
 			InitialShardCount:    4,
 			ReplicationFactor:    3,
 			NotificationsEnabled: &notificationsEnabled,
-			KeySorting:           proto.KeySortingType_NATURAL.String(),
+			KeySorting:           "natural",
 		},
 	})
 	require.NoError(t, err)
@@ -278,7 +278,7 @@ func TestManagementServerCreateNamespace(t *testing.T) {
 	assert.EqualValues(t, 4, res.Namespace.GetInitialShardCount())
 	assert.EqualValues(t, 3, res.Namespace.GetReplicationFactor())
 	assert.False(t, res.Namespace.NotificationsEnabledOrDefault())
-	assert.Equal(t, proto.KeySortingType_NATURAL.String(), res.Namespace.GetKeySorting())
+	assert.Equal(t, "natural", res.Namespace.GetKeySorting())
 
 	namespace, found := management.metadata.GetNamespace("ns-1")
 	require.True(t, found)
@@ -317,6 +317,17 @@ func TestManagementServerCreateNamespaceRejectsInvalidRequest(t *testing.T) {
 			ReplicationFactor: 1,
 			KeySorting:        "invalid",
 		}}},
+		{name: "empty key sorting", req: &proto.CreateNamespaceRequest{Namespace: &proto.Namespace{
+			Name:              "ns-1",
+			InitialShardCount: 1,
+			ReplicationFactor: 1,
+		}}},
+		{name: "unknown key sorting", req: &proto.CreateNamespaceRequest{Namespace: &proto.Namespace{
+			Name:              "ns-1",
+			InitialShardCount: 1,
+			ReplicationFactor: 1,
+			KeySorting:        proto.KeySortingType_UNKNOWN.String(),
+		}}},
 	}
 
 	for _, tt := range testCases {
@@ -326,6 +337,30 @@ func TestManagementServerCreateNamespaceRejectsInvalidRequest(t *testing.T) {
 			assert.Equal(t, codes.InvalidArgument, grpcstatus.Code(err))
 		})
 	}
+}
+
+func TestManagementServerCreateNamespacePreservesKeySorting(t *testing.T) {
+	serverName := "server-1"
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{
+			Servers: []*proto.DataServerIdentity{
+				dataServer(&serverName, "public-1", "internal-1"),
+			},
+		}),
+		nil,
+	)
+
+	res, err := management.CreateNamespace(context.Background(), &proto.CreateNamespaceRequest{
+		Namespace: &proto.Namespace{
+			Name:              "ns-1",
+			InitialShardCount: 1,
+			ReplicationFactor: 1,
+			KeySorting:        "NATURAL",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, "NATURAL", res.Namespace.GetKeySorting())
 }
 
 func TestManagementServerCreateNamespaceAlreadyExists(t *testing.T) {
@@ -349,6 +384,7 @@ func TestManagementServerCreateNamespaceAlreadyExists(t *testing.T) {
 			Name:              "ns-1",
 			InitialShardCount: 1,
 			ReplicationFactor: 1,
+			KeySorting:        "natural",
 		},
 	})
 	require.Error(t, err)
@@ -371,6 +407,7 @@ func TestManagementServerCreateNamespaceFailedPrecondition(t *testing.T) {
 			Name:              "ns-1",
 			InitialShardCount: 1,
 			ReplicationFactor: 2,
+			KeySorting:        "natural",
 		},
 	})
 	require.Error(t, err)

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -246,6 +246,137 @@ func TestManagementServerListNamespaces(t *testing.T) {
 	assert.Equal(t, "ns-2", res.Namespaces[1].GetName())
 }
 
+func TestManagementServerCreateNamespace(t *testing.T) {
+	serverName1 := "server-1"
+	serverName2 := "server-2"
+	serverName3 := "server-3"
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{
+			Servers: []*proto.DataServerIdentity{
+				dataServer(&serverName1, "public-1", "internal-1"),
+				dataServer(&serverName2, "public-2", "internal-2"),
+				dataServer(&serverName3, "public-3", "internal-3"),
+			},
+		}),
+		nil,
+	)
+
+	notificationsEnabled := false
+	res, err := management.CreateNamespace(context.Background(), &proto.CreateNamespaceRequest{
+		Namespace: &proto.Namespace{
+			Name:                 "ns-1",
+			InitialShardCount:    4,
+			ReplicationFactor:    3,
+			NotificationsEnabled: &notificationsEnabled,
+			KeySorting:           proto.KeySortingType_NATURAL.String(),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, res.Namespace)
+	assert.Equal(t, "ns-1", res.Namespace.GetName())
+	assert.EqualValues(t, 4, res.Namespace.GetInitialShardCount())
+	assert.EqualValues(t, 3, res.Namespace.GetReplicationFactor())
+	assert.False(t, res.Namespace.NotificationsEnabledOrDefault())
+	assert.Equal(t, proto.KeySortingType_NATURAL.String(), res.Namespace.GetKeySorting())
+
+	namespace, found := management.metadata.GetNamespace("ns-1")
+	require.True(t, found)
+	assert.Equal(t, "ns-1", namespace.UnsafeBorrow().GetName())
+}
+
+func TestManagementServerCreateNamespaceRejectsInvalidRequest(t *testing.T) {
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{}),
+		nil,
+	)
+
+	testCases := []struct {
+		name string
+		req  *proto.CreateNamespaceRequest
+	}{
+		{name: "nil request", req: nil},
+		{name: "nil namespace", req: &proto.CreateNamespaceRequest{}},
+		{name: "empty name", req: &proto.CreateNamespaceRequest{Namespace: &proto.Namespace{}}},
+		{name: "invalid name", req: &proto.CreateNamespaceRequest{Namespace: &proto.Namespace{
+			Name:              "../ns",
+			InitialShardCount: 1,
+			ReplicationFactor: 1,
+		}}},
+		{name: "empty initial shard count", req: &proto.CreateNamespaceRequest{Namespace: &proto.Namespace{
+			Name:              "ns-1",
+			ReplicationFactor: 1,
+		}}},
+		{name: "empty replication factor", req: &proto.CreateNamespaceRequest{Namespace: &proto.Namespace{
+			Name:              "ns-1",
+			InitialShardCount: 1,
+		}}},
+		{name: "invalid key sorting", req: &proto.CreateNamespaceRequest{Namespace: &proto.Namespace{
+			Name:              "ns-1",
+			InitialShardCount: 1,
+			ReplicationFactor: 1,
+			KeySorting:        "invalid",
+		}}},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := management.CreateNamespace(context.Background(), tt.req)
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, grpcstatus.Code(err))
+		})
+	}
+}
+
+func TestManagementServerCreateNamespaceAlreadyExists(t *testing.T) {
+	serverName := "server-1"
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{
+			Namespaces: []*proto.Namespace{{
+				Name:              "ns-1",
+				InitialShardCount: 1,
+				ReplicationFactor: 1,
+			}},
+			Servers: []*proto.DataServerIdentity{
+				dataServer(&serverName, "public-1", "internal-1"),
+			},
+		}),
+		nil,
+	)
+
+	_, err := management.CreateNamespace(context.Background(), &proto.CreateNamespaceRequest{
+		Namespace: &proto.Namespace{
+			Name:              "ns-1",
+			InitialShardCount: 1,
+			ReplicationFactor: 1,
+		},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, grpcstatus.Code(err))
+}
+
+func TestManagementServerCreateNamespaceFailedPrecondition(t *testing.T) {
+	serverName := "server-1"
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{
+			Servers: []*proto.DataServerIdentity{
+				dataServer(&serverName, "public-1", "internal-1"),
+			},
+		}),
+		nil,
+	)
+
+	_, err := management.CreateNamespace(context.Background(), &proto.CreateNamespaceRequest{
+		Namespace: &proto.Namespace{
+			Name:              "ns-1",
+			InitialShardCount: 1,
+			ReplicationFactor: 2,
+		},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, grpcstatus.Code(err))
+}
+
 func TestManagementServerGetNamespaceRejectsEmptyLookup(t *testing.T) {
 	management := newManagementServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{}),

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -45,6 +45,7 @@ type Metadata interface {
 	ListNamespaceStatus() map[string]commonobject.Borrowed[*commonproto.NamespaceStatus]
 	GetNamespaceStatus(namespace string) (commonobject.Borrowed[*commonproto.NamespaceStatus], bool)
 	DeleteNamespaceStatus(name string) commonobject.Borrowed[*commonproto.NamespaceStatus]
+	CreateNamespace(namespace *commonproto.Namespace) error
 	GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool)
 
 	UpdateShardStatus(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata)
@@ -357,6 +358,25 @@ func (m *coordinatorMetadata) SubscribeConfig() *commonwatch.Receiver[provider.V
 
 func (m *coordinatorMetadata) GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer] {
 	return commonobject.Borrow(m.GetConfig().UnsafeBorrow().GetLoadBalancerWithDefaults())
+}
+
+func (m *coordinatorMetadata) CreateNamespace(namespace *commonproto.Namespace) error {
+	name := namespace.GetName()
+
+	return m.computeConfig(func(config *commonproto.ClusterConfiguration, _ metadatacommon.Version) (*commonproto.ClusterConfiguration, error) {
+		for _, existing := range config.GetNamespaces() {
+			if existing.GetName() == name {
+				return nil, metadatacommon.ErrAlreadyExists
+			}
+		}
+		if namespace.GetReplicationFactor() > uint32(len(config.GetServers())) {
+			return nil, fmt.Errorf("%w: namespace %q has replicationFactor=%d but only %d servers are configured",
+				metadatacommon.ErrFailedPrecondition, name, namespace.GetReplicationFactor(), len(config.GetServers()))
+		}
+
+		config.Namespaces = append(config.Namespaces, namespace)
+		return config, nil
+	})
 }
 
 func (m *coordinatorMetadata) CreateDataServer(dataServer *commonproto.DataServer) error {

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -158,6 +158,10 @@ func (*mockNamespaceMetadata) UpdateShardStatus(string, int64, *proto.ShardMetad
 
 func (*mockNamespaceMetadata) DeleteShardStatus(string, int64) {}
 
+func (*mockNamespaceMetadata) CreateNamespace(*proto.Namespace) error {
+	return nil
+}
+
 func (*mockNamespaceMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterConfiguration] {
 	return commonobject.Borrowed[*proto.ClusterConfiguration]{}
 }

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -84,6 +84,10 @@ func (*mockMetadata) DeleteShardStatus(string, int64) {}
 
 func (*mockMetadata) IsReady(*proto.ClusterConfiguration) bool { return true }
 
+func (*mockMetadata) CreateNamespace(*proto.Namespace) error {
+	return nil
+}
+
 func (*mockMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterConfiguration] {
 	return commonobject.Borrowed[*proto.ClusterConfiguration]{}
 }

--- a/tests/coordinator/admin_namespace_e2e_test.go
+++ b/tests/coordinator/admin_namespace_e2e_test.go
@@ -1,0 +1,93 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxia"
+	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
+	coordserver "github.com/oxia-db/oxia/oxiad/coordinator"
+	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	coordoption "github.com/oxia-db/oxia/oxiad/coordinator/option"
+)
+
+func TestAdminNamespaceCreateAndGet(t *testing.T) {
+	metadataDir := t.TempDir()
+
+	adminAddr := freeAddress(t)
+	options := coordoption.NewDefaultOptions()
+	options.Server.Internal.BindAddress = "127.0.0.1:0"
+	options.Server.Admin.BindAddress = adminAddr
+	options.Observability.Metric.Enabled = &constant.FlagFalse
+	options.Metadata.ProviderName = metadatacommon.NameFile
+	options.Metadata.File.Dir = metadataDir
+	options.Metadata.File.ConfigName = "cluster.yaml"
+
+	coordinatorServer, err := coordserver.NewGrpcServer(t.Context(), commonwatch.New(options))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, coordinatorServer.Close())
+	})
+
+	client, err := oxia.NewAdminClient(adminAddr, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	serverName := "server-1"
+	_, err = client.CreateDataServer(&proto.DataServer{
+		Identity: &proto.DataServerIdentity{
+			Name:     &serverName,
+			Public:   "localhost:19001",
+			Internal: "localhost:19002",
+		},
+	})
+	require.NoError(t, err)
+
+	notificationsEnabled := false
+	created, err := client.CreateNamespace(&proto.Namespace{
+		Name:                 "ns-1",
+		InitialShardCount:    2,
+		ReplicationFactor:    1,
+		NotificationsEnabled: &notificationsEnabled,
+		KeySorting:           proto.KeySortingType_NATURAL.String(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	assert.Equal(t, "ns-1", created.GetName())
+	assert.EqualValues(t, 2, created.GetInitialShardCount())
+	assert.EqualValues(t, 1, created.GetReplicationFactor())
+	assert.False(t, created.NotificationsEnabledOrDefault())
+	assert.Equal(t, proto.KeySortingType_NATURAL.String(), created.GetKeySorting())
+
+	found, err := client.GetNamespace("ns-1")
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	assert.Equal(t, "ns-1", found.GetName())
+	assert.EqualValues(t, 2, found.GetInitialShardCount())
+	assert.False(t, found.NotificationsEnabledOrDefault())
+
+	namespaces, err := client.ListNamespaces()
+	require.NoError(t, err)
+	require.Len(t, namespaces, 1)
+	assert.Equal(t, "ns-1", namespaces[0].GetName())
+}

--- a/tests/coordinator/admin_namespace_e2e_test.go
+++ b/tests/coordinator/admin_namespace_e2e_test.go
@@ -69,7 +69,7 @@ func TestAdminNamespaceCreateAndGet(t *testing.T) {
 		InitialShardCount:    2,
 		ReplicationFactor:    1,
 		NotificationsEnabled: &notificationsEnabled,
-		KeySorting:           proto.KeySortingType_NATURAL.String(),
+		KeySorting:           "natural",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, created)
@@ -77,7 +77,7 @@ func TestAdminNamespaceCreateAndGet(t *testing.T) {
 	assert.EqualValues(t, 2, created.GetInitialShardCount())
 	assert.EqualValues(t, 1, created.GetReplicationFactor())
 	assert.False(t, created.NotificationsEnabledOrDefault())
-	assert.Equal(t, proto.KeySortingType_NATURAL.String(), created.GetKeySorting())
+	assert.Equal(t, "natural", created.GetKeySorting())
 
 	found, err := client.GetNamespace("ns-1")
 	require.NoError(t, err)


### PR DESCRIPTION
## Motivation
- Add the namespace create endpoint to continue the admin management API rollout.
- Align namespace creation with the existing dataserver create flow across proto, coordinator, public client, and CLI.

## Modifications
- Added `CreateNamespace` to the admin proto, generated stubs, and public `oxia.AdminClient`.
- Added coordinator metadata/server support with validation, duplicate detection, bad-version handling, and replication-factor precondition mapping.
- Added `oxia admin namespace create <namespace>` with required `--initial-shards` and `--replication-factor` flags plus notifications/key-sorting options.
- Added unit coverage for admin client, management server, namespace CLI, and an integration test for create/get/list through the admin client.

## Testing
- `go test ./cmd/admin/namespace/... ./oxia ./oxiad/coordinator ./oxiad/coordinator/reconciler ./oxiad/coordinator/runtime/balancer ./tests/coordinator` was interrupted after the full coordinator e2e package made no progress for several minutes; the preceding packages passed.
- `go test ./tests/coordinator -run TestAdminNamespaceCreateAndGet -count=1 -timeout=2m`
- `go test ./cmd/admin/... ./oxia ./oxiad/coordinator/...`
- `make lint`
