### PR TITLE
feat: add patch namespace admin API

### DIFF
--- a/cmd/admin/commons/mock_admin_client.go
+++ b/cmd/admin/commons/mock_admin_client.go
@@ -93,6 +93,14 @@ func (m *MockAdminClient) CreateNamespace(namespace *proto.Namespace) (*proto.Na
 	return nil, errors.New("failed to create namespace")
 }
 
+func (m *MockAdminClient) PatchNamespace(namespace *proto.Namespace) (*proto.Namespace, error) {
+	args := m.MethodCalled("PatchNamespace", namespace)
+	if v, ok := args.Get(0).(*proto.Namespace); ok {
+		return v, args.Error(1)
+	}
+	return nil, errors.New("failed to patch namespace")
+}
+
 func (m *MockAdminClient) GetNamespace(namespace string) (*proto.Namespace, error) {
 	args := m.MethodCalled("GetNamespace", namespace)
 	if v, ok := args.Get(0).(*proto.Namespace); ok {

--- a/cmd/admin/namespace/cmd.go
+++ b/cmd/admin/namespace/cmd.go
@@ -17,6 +17,7 @@ package namespace
 import (
 	createcmd "github.com/oxia-db/oxia/cmd/admin/namespace/create"
 	getcmd "github.com/oxia-db/oxia/cmd/admin/namespace/get"
+	patchcmd "github.com/oxia-db/oxia/cmd/admin/namespace/patch"
 
 	"github.com/spf13/cobra"
 )
@@ -30,4 +31,5 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(createcmd.Cmd)
 	Cmd.AddCommand(getcmd.Cmd)
+	Cmd.AddCommand(patchcmd.Cmd)
 }

--- a/cmd/admin/namespace/create/cmd.go
+++ b/cmd/admin/namespace/create/cmd.go
@@ -20,20 +20,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
+	"github.com/oxia-db/oxia/cmd/admin/namespace/option"
 	namespaceoutput "github.com/oxia-db/oxia/cmd/admin/namespace/output"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/common/validation"
 	"github.com/oxia-db/oxia/oxia"
 )
 
-const (
-	initialShardsFlagName     = "initial-shards"
-	replicationFactorFlagName = "replication-factor"
-	notificationsFlagName     = "notifications"
-	keySortingFlagName        = "key-sorting"
-)
-
-var fields namespaceFields
+var fields option.NamespaceFields
 
 var Cmd = &cobra.Command{
 	Use:          "create <namespace> --initial-shards <count> --replication-factor <factor>",
@@ -45,33 +39,9 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	fields.addFlags(Cmd)
-	_ = Cmd.MarkFlagRequired(initialShardsFlagName)
-	_ = Cmd.MarkFlagRequired(replicationFactorFlagName)
-}
-
-type namespaceFields struct {
-	initialShardCount uint32
-	replicationFactor uint32
-	notifications     bool
-	keySorting        string
-}
-
-func (f *namespaceFields) addFlags(cmd *cobra.Command) {
-	f.notifications = true
-	f.keySorting = "hierarchical"
-	cmd.Flags().Uint32Var(&f.initialShardCount, initialShardsFlagName, 0, "Initial shard count for the namespace")
-	cmd.Flags().Uint32Var(&f.replicationFactor, replicationFactorFlagName, 0, "Replication factor for the namespace")
-	cmd.Flags().BoolVar(&f.notifications, notificationsFlagName, true, "Whether notifications are enabled")
-	cmd.Flags().StringVar(&f.keySorting, keySortingFlagName, f.keySorting, `Key sorting. allowed: "hierarchical", "natural"`)
-	_ = cmd.RegisterFlagCompletionFunc(keySortingFlagName, keySortingCompletion)
-}
-
-func (f *namespaceFields) reset() {
-	f.initialShardCount = 0
-	f.replicationFactor = 0
-	f.notifications = true
-	f.keySorting = "hierarchical"
+	fields.AddFlags(Cmd)
+	_ = Cmd.MarkFlagRequired(option.InitialShardsFlagName)
+	_ = Cmd.MarkFlagRequired(option.ReplicationFactorFlagName)
 }
 
 func exec(cmd *cobra.Command, args []string) error {
@@ -87,13 +57,13 @@ func exec(cmd *cobra.Command, args []string) error {
 	if err := validation.ValidateNamespace(name); err != nil {
 		return err
 	}
-	if fields.initialShardCount == 0 {
+	if fields.InitialShardCount == 0 {
 		return errors.New("namespace initial shard count must be greater than 0")
 	}
-	if fields.replicationFactor == 0 {
+	if fields.ReplicationFactor == 0 {
 		return errors.New("namespace replication factor must be greater than 0")
 	}
-	keySorting, err := proto.ParseKeySortingType(fields.keySorting)
+	keySorting, err := proto.ParseKeySortingType(fields.KeySorting)
 	if err != nil {
 		return err
 	}
@@ -111,21 +81,14 @@ func exec(cmd *cobra.Command, args []string) error {
 
 	created, err := client.CreateNamespace(&proto.Namespace{
 		Name:                 name,
-		InitialShardCount:    fields.initialShardCount,
-		ReplicationFactor:    fields.replicationFactor,
-		NotificationsEnabled: &fields.notifications,
-		KeySorting:           fields.keySorting,
+		InitialShardCount:    fields.InitialShardCount,
+		ReplicationFactor:    fields.ReplicationFactor,
+		NotificationsEnabled: &fields.Notifications,
+		KeySorting:           fields.KeySorting,
 	})
 	if err != nil {
 		return err
 	}
 
 	return namespaceoutput.WriteNamespace(cmd.OutOrStdout(), outputFormat, created)
-}
-
-func keySortingCompletion(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-	return []string{
-		"hierarchical\tUse file-system like hierarchical sorting based on `/`",
-		"natural\tUse natural, byte-wise sorting",
-	}, cobra.ShellCompDirectiveDefault
 }

--- a/cmd/admin/namespace/option/option.go
+++ b/cmd/admin/namespace/option/option.go
@@ -31,13 +31,18 @@ type NamespaceFields struct {
 }
 
 func (f *NamespaceFields) AddFlags(cmd *cobra.Command) {
-	f.Notifications = true
-	f.KeySorting = "hierarchical"
+	f.Reset()
 	cmd.Flags().Uint32Var(&f.InitialShardCount, InitialShardsFlagName, 0, "Initial shard count for the namespace")
 	cmd.Flags().Uint32Var(&f.ReplicationFactor, ReplicationFactorFlagName, 0, "Replication factor for the namespace")
 	cmd.Flags().BoolVar(&f.Notifications, NotificationsFlagName, true, "Whether notifications are enabled")
 	cmd.Flags().StringVar(&f.KeySorting, KeySortingFlagName, f.KeySorting, `Key sorting. allowed: "hierarchical", "natural"`)
 	_ = cmd.RegisterFlagCompletionFunc(KeySortingFlagName, keySortingCompletion)
+}
+
+func (f *NamespaceFields) AddPatchFlags(cmd *cobra.Command) {
+	f.Reset()
+	cmd.Flags().Uint32Var(&f.ReplicationFactor, ReplicationFactorFlagName, 0, "Replication factor for the namespace")
+	cmd.Flags().BoolVar(&f.Notifications, NotificationsFlagName, true, "Whether notifications are enabled")
 }
 
 func (f *NamespaceFields) Reset() {

--- a/cmd/admin/namespace/option/option.go
+++ b/cmd/admin/namespace/option/option.go
@@ -1,0 +1,55 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package option
+
+import "github.com/spf13/cobra"
+
+const (
+	InitialShardsFlagName     = "initial-shards"
+	ReplicationFactorFlagName = "replication-factor"
+	NotificationsFlagName     = "notifications"
+	KeySortingFlagName        = "key-sorting"
+)
+
+type NamespaceFields struct {
+	InitialShardCount uint32
+	ReplicationFactor uint32
+	Notifications     bool
+	KeySorting        string
+}
+
+func (f *NamespaceFields) AddFlags(cmd *cobra.Command) {
+	f.Notifications = true
+	f.KeySorting = "hierarchical"
+	cmd.Flags().Uint32Var(&f.InitialShardCount, InitialShardsFlagName, 0, "Initial shard count for the namespace")
+	cmd.Flags().Uint32Var(&f.ReplicationFactor, ReplicationFactorFlagName, 0, "Replication factor for the namespace")
+	cmd.Flags().BoolVar(&f.Notifications, NotificationsFlagName, true, "Whether notifications are enabled")
+	cmd.Flags().StringVar(&f.KeySorting, KeySortingFlagName, f.KeySorting, `Key sorting. allowed: "hierarchical", "natural"`)
+	_ = cmd.RegisterFlagCompletionFunc(KeySortingFlagName, keySortingCompletion)
+}
+
+func (f *NamespaceFields) Reset() {
+	f.InitialShardCount = 0
+	f.ReplicationFactor = 0
+	f.Notifications = true
+	f.KeySorting = "hierarchical"
+}
+
+func keySortingCompletion(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return []string{
+		"hierarchical\tUse file-system like hierarchical sorting based on `/`",
+		"natural\tUse natural, byte-wise sorting",
+	}, cobra.ShellCompDirectiveDefault
+}

--- a/cmd/admin/namespace/patch/cmd.go
+++ b/cmd/admin/namespace/patch/cmd.go
@@ -1,0 +1,121 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patch
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/oxia-db/oxia/cmd/admin/commons"
+	"github.com/oxia-db/oxia/cmd/admin/namespace/option"
+	namespaceoutput "github.com/oxia-db/oxia/cmd/admin/namespace/output"
+	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/common/validation"
+	"github.com/oxia-db/oxia/oxia"
+)
+
+var fields option.NamespaceFields
+
+var Cmd = &cobra.Command{
+	Use:          "patch <namespace>",
+	Short:        "Patch a namespace",
+	Long:         `Patch a namespace`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         exec,
+	SilenceUsage: true,
+}
+
+func init() {
+	fields.AddFlags(Cmd)
+}
+
+func exec(cmd *cobra.Command, args []string) error {
+	outputFormat, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+	if err := commons.ValidateOutputFormat(outputFormat); err != nil {
+		return err
+	}
+
+	name := args[0]
+	if err := validation.ValidateNamespace(name); err != nil {
+		return err
+	}
+
+	namespace, err := namespaceFromFlags(cmd, name)
+	if err != nil {
+		return err
+	}
+
+	client, err := commons.AdminConfig.NewAdminClient()
+	if err != nil {
+		return err
+	}
+	defer func(client oxia.AdminClient) {
+		_ = client.Close()
+	}(client)
+
+	patched, err := client.PatchNamespace(namespace)
+	if err != nil {
+		return err
+	}
+
+	return namespaceoutput.WriteNamespace(cmd.OutOrStdout(), outputFormat, patched)
+}
+
+func namespaceFromFlags(cmd *cobra.Command, name string) (*proto.Namespace, error) {
+	initialShardCountChanged := cmd.Flags().Changed(option.InitialShardsFlagName)
+	replicationFactorChanged := cmd.Flags().Changed(option.ReplicationFactorFlagName)
+	notificationsChanged := cmd.Flags().Changed(option.NotificationsFlagName)
+	keySortingChanged := cmd.Flags().Changed(option.KeySortingFlagName)
+	if !initialShardCountChanged && !replicationFactorChanged && !notificationsChanged && !keySortingChanged {
+		return nil, errors.New("must specify at least one field to patch")
+	}
+	if initialShardCountChanged && fields.InitialShardCount == 0 {
+		return nil, errors.New("namespace initial shard count must be greater than 0")
+	}
+	if replicationFactorChanged && fields.ReplicationFactor == 0 {
+		return nil, errors.New("namespace replication factor must be greater than 0")
+	}
+	if keySortingChanged {
+		keySorting, err := proto.ParseKeySortingType(fields.KeySorting)
+		if err != nil {
+			return nil, err
+		}
+		if keySorting == proto.KeySortingType_UNKNOWN {
+			return nil, errors.New(`key sorting must be one of "natural" or "hierarchical"`)
+		}
+	}
+
+	namespace := &proto.Namespace{
+		Name: name,
+	}
+	if initialShardCountChanged {
+		namespace.InitialShardCount = fields.InitialShardCount
+	}
+	if replicationFactorChanged {
+		namespace.ReplicationFactor = fields.ReplicationFactor
+	}
+	if notificationsChanged {
+		namespace.NotificationsEnabled = &fields.Notifications
+	}
+	if keySortingChanged {
+		namespace.KeySorting = fields.KeySorting
+	}
+
+	return namespace, nil
+}

--- a/cmd/admin/namespace/patch/cmd.go
+++ b/cmd/admin/namespace/patch/cmd.go
@@ -39,7 +39,7 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	fields.AddFlags(Cmd)
+	fields.AddPatchFlags(Cmd)
 }
 
 func exec(cmd *cobra.Command, args []string) error {
@@ -56,9 +56,23 @@ func exec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	namespace, err := namespaceFromFlags(cmd, name)
-	if err != nil {
-		return err
+	replicationFactorChanged := cmd.Flags().Changed(option.ReplicationFactorFlagName)
+	notificationsChanged := cmd.Flags().Changed(option.NotificationsFlagName)
+	if !replicationFactorChanged && !notificationsChanged {
+		return errors.New("must specify at least one field to patch")
+	}
+	if replicationFactorChanged && fields.ReplicationFactor == 0 {
+		return errors.New("namespace replication factor must be greater than 0")
+	}
+
+	namespace := &proto.Namespace{
+		Name: name,
+	}
+	if replicationFactorChanged {
+		namespace.ReplicationFactor = fields.ReplicationFactor
+	}
+	if notificationsChanged {
+		namespace.NotificationsEnabled = &fields.Notifications
 	}
 
 	client, err := commons.AdminConfig.NewAdminClient()
@@ -75,47 +89,4 @@ func exec(cmd *cobra.Command, args []string) error {
 	}
 
 	return namespaceoutput.WriteNamespace(cmd.OutOrStdout(), outputFormat, patched)
-}
-
-func namespaceFromFlags(cmd *cobra.Command, name string) (*proto.Namespace, error) {
-	initialShardCountChanged := cmd.Flags().Changed(option.InitialShardsFlagName)
-	replicationFactorChanged := cmd.Flags().Changed(option.ReplicationFactorFlagName)
-	notificationsChanged := cmd.Flags().Changed(option.NotificationsFlagName)
-	keySortingChanged := cmd.Flags().Changed(option.KeySortingFlagName)
-	if !initialShardCountChanged && !replicationFactorChanged && !notificationsChanged && !keySortingChanged {
-		return nil, errors.New("must specify at least one field to patch")
-	}
-	if initialShardCountChanged && fields.InitialShardCount == 0 {
-		return nil, errors.New("namespace initial shard count must be greater than 0")
-	}
-	if replicationFactorChanged && fields.ReplicationFactor == 0 {
-		return nil, errors.New("namespace replication factor must be greater than 0")
-	}
-	if keySortingChanged {
-		keySorting, err := proto.ParseKeySortingType(fields.KeySorting)
-		if err != nil {
-			return nil, err
-		}
-		if keySorting == proto.KeySortingType_UNKNOWN {
-			return nil, errors.New(`key sorting must be one of "natural" or "hierarchical"`)
-		}
-	}
-
-	namespace := &proto.Namespace{
-		Name: name,
-	}
-	if initialShardCountChanged {
-		namespace.InitialShardCount = fields.InitialShardCount
-	}
-	if replicationFactorChanged {
-		namespace.ReplicationFactor = fields.ReplicationFactor
-	}
-	if notificationsChanged {
-		namespace.NotificationsEnabled = &fields.Notifications
-	}
-	if keySortingChanged {
-		namespace.KeySorting = fields.KeySorting
-	}
-
-	return namespace, nil
 }

--- a/cmd/admin/namespace/patch/cmd_test.go
+++ b/cmd/admin/namespace/patch/cmd_test.go
@@ -61,7 +61,7 @@ func Test_cmd_patchNamespace(t *testing.T) {
 			namespace.GetInitialShardCount() == 0 &&
 			namespace.GetReplicationFactor() == 2 &&
 			namespace.GetNotificationsEnabled() == notificationsEnabled &&
-			namespace.GetKeySorting() == "natural"
+			namespace.GetKeySorting() == ""
 	})).Return(expected, nil)
 
 	cmd := &cobra.Command{
@@ -72,9 +72,9 @@ func Test_cmd_patchNamespace(t *testing.T) {
 		RunE:         Cmd.RunE,
 		SilenceUsage: Cmd.SilenceUsage,
 	}
-	fields.AddFlags(cmd)
+	fields.AddPatchFlags(cmd)
 	out, err := runCmd(cmd, "ns-1", "--replication-factor", "2",
-		"--notifications=false", "--key-sorting", "natural", "-o", "json")
+		"--notifications=false", "-o", "json")
 
 	require.NoError(t, err)
 	var namespace proto.Namespace
@@ -106,8 +106,8 @@ func Test_cmd_patchNamespace_DefaultTable(t *testing.T) {
 		RunE:         Cmd.RunE,
 		SilenceUsage: Cmd.SilenceUsage,
 	}
-	fields.AddFlags(cmd)
-	out, err := runCmd(cmd, "ns-1", "--key-sorting", "natural")
+	fields.AddPatchFlags(cmd)
+	out, err := runCmd(cmd, "ns-1", "--replication-factor", "2")
 
 	require.NoError(t, err)
 	assert.Contains(t, out, "NAME")
@@ -139,7 +139,7 @@ func Test_cmd_patchNamespace_Name(t *testing.T) {
 		RunE:         Cmd.RunE,
 		SilenceUsage: Cmd.SilenceUsage,
 	}
-	fields.AddFlags(cmd)
+	fields.AddPatchFlags(cmd)
 	out, err := runCmd(cmd, "ns-1", "--notifications=false", "-o", "name")
 
 	require.NoError(t, err)
@@ -155,7 +155,7 @@ func Test_cmd_patchNamespace_RejectsEmptyPatch(t *testing.T) {
 		RunE:         Cmd.RunE,
 		SilenceUsage: Cmd.SilenceUsage,
 	}
-	fields.AddFlags(cmd)
+	fields.AddPatchFlags(cmd)
 	out, err := runCmd(cmd, "ns-1")
 
 	require.Error(t, err)
@@ -172,15 +172,44 @@ func Test_cmd_patchNamespace_RejectsInvalidName(t *testing.T) {
 		RunE:         Cmd.RunE,
 		SilenceUsage: Cmd.SilenceUsage,
 	}
-	fields.AddFlags(cmd)
-	out, err := runCmd(cmd, "../ns", "--key-sorting", "natural")
+	fields.AddPatchFlags(cmd)
+	out, err := runCmd(cmd, "../ns", "--notifications=false")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid path traversal sequence")
 	assert.Contains(t, out, "invalid path traversal sequence")
 }
 
-func Test_cmd_patchNamespace_RejectsInvalidKeySorting(t *testing.T) {
+func Test_cmd_patchNamespace_RejectsUnsupportedFlags(t *testing.T) {
+	testCases := []struct {
+		name string
+		flag string
+	}{
+		{name: "initial shard count", flag: "--initial-shards"},
+		{name: "key sorting", flag: "--key-sorting"},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{
+				Use:          Cmd.Use,
+				Short:        Cmd.Short,
+				Long:         Cmd.Long,
+				Args:         Cmd.Args,
+				RunE:         Cmd.RunE,
+				SilenceUsage: Cmd.SilenceUsage,
+			}
+			fields.AddPatchFlags(cmd)
+			out, err := runCmd(cmd, "ns-1", tt.flag, "1")
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unknown flag")
+			assert.Contains(t, out, "unknown flag")
+		})
+	}
+}
+
+func Test_cmd_patchNamespace_RejectsInvalidReplicationFactor(t *testing.T) {
 	cmd := &cobra.Command{
 		Use:          Cmd.Use,
 		Short:        Cmd.Short,
@@ -189,10 +218,10 @@ func Test_cmd_patchNamespace_RejectsInvalidKeySorting(t *testing.T) {
 		RunE:         Cmd.RunE,
 		SilenceUsage: Cmd.SilenceUsage,
 	}
-	fields.AddFlags(cmd)
-	out, err := runCmd(cmd, "ns-1", "--key-sorting", "unknown")
+	fields.AddPatchFlags(cmd)
+	out, err := runCmd(cmd, "ns-1", "--replication-factor", "0")
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `key sorting must be one of "natural" or "hierarchical"`)
-	assert.Contains(t, out, `key sorting must be one of "natural" or "hierarchical"`)
+	assert.Contains(t, err.Error(), "namespace replication factor must be greater than 0")
+	assert.Contains(t, out, "namespace replication factor must be greater than 0")
 }

--- a/cmd/admin/namespace/patch/cmd_test.go
+++ b/cmd/admin/namespace/patch/cmd_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package create
+package patch
 
 import (
 	"bytes"
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	"github.com/oxia-db/oxia/cmd/admin/namespace/option"
 	"github.com/oxia-db/oxia/common/proto"
 )
 
@@ -37,13 +36,13 @@ func runCmd(cmd *cobra.Command, args ...string) (string, error) {
 	root.AddCommand(cmd)
 	root.SetOut(actual)
 	root.SetErr(actual)
-	root.SetArgs(append([]string{"create"}, args...))
+	root.SetArgs(append([]string{"patch"}, args...))
 	err := root.Execute()
 	fields.Reset()
 	return strings.TrimSpace(actual.String()), err
 }
 
-func Test_cmd_createNamespace(t *testing.T) {
+func Test_cmd_patchNamespace(t *testing.T) {
 	commons.MockedAdminClient = commons.NewMockAdminClient()
 	t.Cleanup(func() { commons.MockedAdminClient = nil })
 
@@ -51,16 +50,16 @@ func Test_cmd_createNamespace(t *testing.T) {
 	expected := &proto.Namespace{
 		Name:                 "ns-1",
 		InitialShardCount:    4,
-		ReplicationFactor:    3,
+		ReplicationFactor:    2,
 		NotificationsEnabled: &notificationsEnabled,
 		KeySorting:           "natural",
 	}
 
 	commons.MockedAdminClient.On("Close").Return(nil)
-	commons.MockedAdminClient.On("CreateNamespace", mock.MatchedBy(func(namespace *proto.Namespace) bool {
+	commons.MockedAdminClient.On("PatchNamespace", mock.MatchedBy(func(namespace *proto.Namespace) bool {
 		return namespace.GetName() == "ns-1" &&
-			namespace.GetInitialShardCount() == 4 &&
-			namespace.GetReplicationFactor() == 3 &&
+			namespace.GetInitialShardCount() == 0 &&
+			namespace.GetReplicationFactor() == 2 &&
 			namespace.GetNotificationsEnabled() == notificationsEnabled &&
 			namespace.GetKeySorting() == "natural"
 	})).Return(expected, nil)
@@ -74,9 +73,7 @@ func Test_cmd_createNamespace(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd)
-	_ = cmd.MarkFlagRequired(option.InitialShardsFlagName)
-	_ = cmd.MarkFlagRequired(option.ReplicationFactorFlagName)
-	out, err := runCmd(cmd, "ns-1", "--initial-shards", "4", "--replication-factor", "3",
+	out, err := runCmd(cmd, "ns-1", "--replication-factor", "2",
 		"--notifications=false", "--key-sorting", "natural", "-o", "json")
 
 	require.NoError(t, err)
@@ -84,21 +81,21 @@ func Test_cmd_createNamespace(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(out), &namespace))
 	assert.Equal(t, "ns-1", namespace.GetName())
 	assert.EqualValues(t, 4, namespace.GetInitialShardCount())
-	assert.EqualValues(t, 3, namespace.GetReplicationFactor())
+	assert.EqualValues(t, 2, namespace.GetReplicationFactor())
 	assert.False(t, namespace.NotificationsEnabledOrDefault())
 	assert.Equal(t, "natural", namespace.GetKeySorting())
 }
 
-func Test_cmd_createNamespace_DefaultTable(t *testing.T) {
+func Test_cmd_patchNamespace_DefaultTable(t *testing.T) {
 	commons.MockedAdminClient = commons.NewMockAdminClient()
 	t.Cleanup(func() { commons.MockedAdminClient = nil })
 
 	commons.MockedAdminClient.On("Close").Return(nil)
-	commons.MockedAdminClient.On("CreateNamespace", mock.Anything).Return(&proto.Namespace{
+	commons.MockedAdminClient.On("PatchNamespace", mock.Anything).Return(&proto.Namespace{
 		Name:              "ns-1",
 		InitialShardCount: 4,
-		ReplicationFactor: 3,
-		KeySorting:        "hierarchical",
+		ReplicationFactor: 2,
+		KeySorting:        "natural",
 	}, nil)
 
 	cmd := &cobra.Command{
@@ -110,9 +107,7 @@ func Test_cmd_createNamespace_DefaultTable(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd)
-	_ = cmd.MarkFlagRequired(option.InitialShardsFlagName)
-	_ = cmd.MarkFlagRequired(option.ReplicationFactorFlagName)
-	out, err := runCmd(cmd, "ns-1", "--initial-shards", "4", "--replication-factor", "3")
+	out, err := runCmd(cmd, "ns-1", "--key-sorting", "natural")
 
 	require.NoError(t, err)
 	assert.Contains(t, out, "NAME")
@@ -122,17 +117,17 @@ func Test_cmd_createNamespace_DefaultTable(t *testing.T) {
 	assert.Contains(t, out, "KEY_SORTING")
 	assert.Contains(t, out, "ns-1")
 	assert.Contains(t, out, "4")
-	assert.Contains(t, out, "3")
+	assert.Contains(t, out, "2")
 	assert.Contains(t, out, "true")
-	assert.Contains(t, out, "hierarchical")
+	assert.Contains(t, out, "natural")
 }
 
-func Test_cmd_createNamespace_Name(t *testing.T) {
+func Test_cmd_patchNamespace_Name(t *testing.T) {
 	commons.MockedAdminClient = commons.NewMockAdminClient()
 	t.Cleanup(func() { commons.MockedAdminClient = nil })
 
 	commons.MockedAdminClient.On("Close").Return(nil)
-	commons.MockedAdminClient.On("CreateNamespace", mock.Anything).Return(&proto.Namespace{
+	commons.MockedAdminClient.On("PatchNamespace", mock.Anything).Return(&proto.Namespace{
 		Name: "ns-1",
 	}, nil)
 
@@ -145,18 +140,13 @@ func Test_cmd_createNamespace_Name(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd)
-	_ = cmd.MarkFlagRequired(option.InitialShardsFlagName)
-	_ = cmd.MarkFlagRequired(option.ReplicationFactorFlagName)
-	out, err := runCmd(cmd, "ns-1", "--initial-shards", "4", "--replication-factor", "3", "-o", "name")
+	out, err := runCmd(cmd, "ns-1", "--notifications=false", "-o", "name")
 
 	require.NoError(t, err)
 	assert.Equal(t, "namespace/ns-1", out)
 }
 
-func Test_cmd_createNamespace_RejectsInvalidName(t *testing.T) {
-	commons.MockedAdminClient = commons.NewMockAdminClient()
-	t.Cleanup(func() { commons.MockedAdminClient = nil })
-
+func Test_cmd_patchNamespace_RejectsEmptyPatch(t *testing.T) {
 	cmd := &cobra.Command{
 		Use:          Cmd.Use,
 		Short:        Cmd.Short,
@@ -166,19 +156,31 @@ func Test_cmd_createNamespace_RejectsInvalidName(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd)
-	_ = cmd.MarkFlagRequired(option.InitialShardsFlagName)
-	_ = cmd.MarkFlagRequired(option.ReplicationFactorFlagName)
-	out, err := runCmd(cmd, "../ns", "--initial-shards", "4", "--replication-factor", "3")
+	out, err := runCmd(cmd, "ns-1")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must specify at least one field to patch")
+	assert.Contains(t, out, "must specify at least one field to patch")
+}
+
+func Test_cmd_patchNamespace_RejectsInvalidName(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	fields.AddFlags(cmd)
+	out, err := runCmd(cmd, "../ns", "--key-sorting", "natural")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid path traversal sequence")
 	assert.Contains(t, out, "invalid path traversal sequence")
 }
 
-func Test_cmd_createNamespace_RejectsInvalidKeySorting(t *testing.T) {
-	commons.MockedAdminClient = commons.NewMockAdminClient()
-	t.Cleanup(func() { commons.MockedAdminClient = nil })
-
+func Test_cmd_patchNamespace_RejectsInvalidKeySorting(t *testing.T) {
 	cmd := &cobra.Command{
 		Use:          Cmd.Use,
 		Short:        Cmd.Short,
@@ -188,9 +190,7 @@ func Test_cmd_createNamespace_RejectsInvalidKeySorting(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd)
-	_ = cmd.MarkFlagRequired(option.InitialShardsFlagName)
-	_ = cmd.MarkFlagRequired(option.ReplicationFactorFlagName)
-	out, err := runCmd(cmd, "ns-1", "--initial-shards", "4", "--replication-factor", "3", "--key-sorting", "unknown")
+	out, err := runCmd(cmd, "ns-1", "--key-sorting", "unknown")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `key sorting must be one of "natural" or "hierarchical"`)

--- a/common/proto/admin.pb.go
+++ b/common/proto/admin.pb.go
@@ -558,6 +558,94 @@ func (x *CreateNamespaceResponse) GetNamespace() *Namespace {
 	return nil
 }
 
+type PatchNamespaceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Namespace     *Namespace             `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PatchNamespaceRequest) Reset() {
+	*x = PatchNamespaceRequest{}
+	mi := &file_admin_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PatchNamespaceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PatchNamespaceRequest) ProtoMessage() {}
+
+func (x *PatchNamespaceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PatchNamespaceRequest.ProtoReflect.Descriptor instead.
+func (*PatchNamespaceRequest) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *PatchNamespaceRequest) GetNamespace() *Namespace {
+	if x != nil {
+		return x.Namespace
+	}
+	return nil
+}
+
+type PatchNamespaceResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Namespace     *Namespace             `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PatchNamespaceResponse) Reset() {
+	*x = PatchNamespaceResponse{}
+	mi := &file_admin_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PatchNamespaceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PatchNamespaceResponse) ProtoMessage() {}
+
+func (x *PatchNamespaceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PatchNamespaceResponse.ProtoReflect.Descriptor instead.
+func (*PatchNamespaceResponse) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *PatchNamespaceResponse) GetNamespace() *Namespace {
+	if x != nil {
+		return x.Namespace
+	}
+	return nil
+}
+
 type ListNamespacesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -566,7 +654,7 @@ type ListNamespacesRequest struct {
 
 func (x *ListNamespacesRequest) Reset() {
 	*x = ListNamespacesRequest{}
-	mi := &file_admin_proto_msgTypes[12]
+	mi := &file_admin_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -578,7 +666,7 @@ func (x *ListNamespacesRequest) String() string {
 func (*ListNamespacesRequest) ProtoMessage() {}
 
 func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[12]
+	mi := &file_admin_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -591,7 +679,7 @@ func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListNamespacesRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{12}
+	return file_admin_proto_rawDescGZIP(), []int{14}
 }
 
 type ListNamespacesResponse struct {
@@ -603,7 +691,7 @@ type ListNamespacesResponse struct {
 
 func (x *ListNamespacesResponse) Reset() {
 	*x = ListNamespacesResponse{}
-	mi := &file_admin_proto_msgTypes[13]
+	mi := &file_admin_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -615,7 +703,7 @@ func (x *ListNamespacesResponse) String() string {
 func (*ListNamespacesResponse) ProtoMessage() {}
 
 func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[13]
+	mi := &file_admin_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -628,7 +716,7 @@ func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListNamespacesResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{13}
+	return file_admin_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ListNamespacesResponse) GetNamespaces() []*Namespace {
@@ -647,7 +735,7 @@ type GetNamespaceRequest struct {
 
 func (x *GetNamespaceRequest) Reset() {
 	*x = GetNamespaceRequest{}
-	mi := &file_admin_proto_msgTypes[14]
+	mi := &file_admin_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -659,7 +747,7 @@ func (x *GetNamespaceRequest) String() string {
 func (*GetNamespaceRequest) ProtoMessage() {}
 
 func (x *GetNamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[14]
+	mi := &file_admin_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -672,7 +760,7 @@ func (x *GetNamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNamespaceRequest.ProtoReflect.Descriptor instead.
 func (*GetNamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{14}
+	return file_admin_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetNamespaceRequest) GetNamespace() string {
@@ -691,7 +779,7 @@ type GetNamespaceResponse struct {
 
 func (x *GetNamespaceResponse) Reset() {
 	*x = GetNamespaceResponse{}
-	mi := &file_admin_proto_msgTypes[15]
+	mi := &file_admin_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -703,7 +791,7 @@ func (x *GetNamespaceResponse) String() string {
 func (*GetNamespaceResponse) ProtoMessage() {}
 
 func (x *GetNamespaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[15]
+	mi := &file_admin_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -716,7 +804,7 @@ func (x *GetNamespaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNamespaceResponse.ProtoReflect.Descriptor instead.
 func (*GetNamespaceResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{15}
+	return file_admin_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetNamespaceResponse) GetNamespace() *Namespace {
@@ -738,7 +826,7 @@ type SplitShardRequest struct {
 
 func (x *SplitShardRequest) Reset() {
 	*x = SplitShardRequest{}
-	mi := &file_admin_proto_msgTypes[16]
+	mi := &file_admin_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -750,7 +838,7 @@ func (x *SplitShardRequest) String() string {
 func (*SplitShardRequest) ProtoMessage() {}
 
 func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[16]
+	mi := &file_admin_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -763,7 +851,7 @@ func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardRequest.ProtoReflect.Descriptor instead.
 func (*SplitShardRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{16}
+	return file_admin_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SplitShardRequest) GetNamespace() string {
@@ -797,7 +885,7 @@ type SplitShardResponse struct {
 
 func (x *SplitShardResponse) Reset() {
 	*x = SplitShardResponse{}
-	mi := &file_admin_proto_msgTypes[17]
+	mi := &file_admin_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -809,7 +897,7 @@ func (x *SplitShardResponse) String() string {
 func (*SplitShardResponse) ProtoMessage() {}
 
 func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[17]
+	mi := &file_admin_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -822,7 +910,7 @@ func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardResponse.ProtoReflect.Descriptor instead.
 func (*SplitShardResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{17}
+	return file_admin_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SplitShardResponse) GetLeftChildShard() int64 {
@@ -874,6 +962,10 @@ const file_admin_proto_rawDesc = "" +
 	"\x16CreateNamespaceRequest\x129\n" +
 	"\tnamespace\x18\x01 \x01(\v2\x1b.io.oxia.proto.v1.NamespaceR\tnamespace\"T\n" +
 	"\x17CreateNamespaceResponse\x129\n" +
+	"\tnamespace\x18\x01 \x01(\v2\x1b.io.oxia.proto.v1.NamespaceR\tnamespace\"R\n" +
+	"\x15PatchNamespaceRequest\x129\n" +
+	"\tnamespace\x18\x01 \x01(\v2\x1b.io.oxia.proto.v1.NamespaceR\tnamespace\"S\n" +
+	"\x16PatchNamespaceResponse\x129\n" +
 	"\tnamespace\x18\x01 \x01(\v2\x1b.io.oxia.proto.v1.NamespaceR\tnamespace\"\x17\n" +
 	"\x15ListNamespacesRequest\"U\n" +
 	"\x16ListNamespacesResponse\x12;\n" +
@@ -892,14 +984,15 @@ const file_admin_proto_rawDesc = "" +
 	"\f_split_point\"j\n" +
 	"\x12SplitShardResponse\x12(\n" +
 	"\x10left_child_shard\x18\x01 \x01(\x03R\x0eleftChildShard\x12*\n" +
-	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\x98\a\n" +
+	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\xfd\a\n" +
 	"\tOxiaAdmin\x12f\n" +
 	"\x0fListDataServers\x12(.io.oxia.proto.v1.ListDataServersRequest\x1a).io.oxia.proto.v1.ListDataServersResponse\x12`\n" +
 	"\rGetDataServer\x12&.io.oxia.proto.v1.GetDataServerRequest\x1a'.io.oxia.proto.v1.GetDataServerResponse\x12i\n" +
 	"\x10CreateDataServer\x12).io.oxia.proto.v1.CreateDataServerRequest\x1a*.io.oxia.proto.v1.CreateDataServerResponse\x12f\n" +
 	"\x0fPatchDataServer\x12(.io.oxia.proto.v1.PatchDataServerRequest\x1a).io.oxia.proto.v1.PatchDataServerResponse\x12i\n" +
 	"\x10DeleteDataServer\x12).io.oxia.proto.v1.DeleteDataServerRequest\x1a*.io.oxia.proto.v1.DeleteDataServerResponse\x12f\n" +
-	"\x0fCreateNamespace\x12(.io.oxia.proto.v1.CreateNamespaceRequest\x1a).io.oxia.proto.v1.CreateNamespaceResponse\x12]\n" +
+	"\x0fCreateNamespace\x12(.io.oxia.proto.v1.CreateNamespaceRequest\x1a).io.oxia.proto.v1.CreateNamespaceResponse\x12c\n" +
+	"\x0ePatchNamespace\x12'.io.oxia.proto.v1.PatchNamespaceRequest\x1a(.io.oxia.proto.v1.PatchNamespaceResponse\x12]\n" +
 	"\fGetNamespace\x12%.io.oxia.proto.v1.GetNamespaceRequest\x1a&.io.oxia.proto.v1.GetNamespaceResponse\x12c\n" +
 	"\x0eListNamespaces\x12'.io.oxia.proto.v1.ListNamespacesRequest\x1a(.io.oxia.proto.v1.ListNamespacesResponse\x12W\n" +
 	"\n" +
@@ -917,7 +1010,7 @@ func file_admin_proto_rawDescGZIP() []byte {
 	return file_admin_proto_rawDescData
 }
 
-var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_admin_proto_goTypes = []any{
 	(*ListDataServersRequest)(nil),   // 0: io.oxia.proto.v1.ListDataServersRequest
 	(*ListDataServersResponse)(nil),  // 1: io.oxia.proto.v1.ListDataServersResponse
@@ -931,50 +1024,56 @@ var file_admin_proto_goTypes = []any{
 	(*DeleteDataServerResponse)(nil), // 9: io.oxia.proto.v1.DeleteDataServerResponse
 	(*CreateNamespaceRequest)(nil),   // 10: io.oxia.proto.v1.CreateNamespaceRequest
 	(*CreateNamespaceResponse)(nil),  // 11: io.oxia.proto.v1.CreateNamespaceResponse
-	(*ListNamespacesRequest)(nil),    // 12: io.oxia.proto.v1.ListNamespacesRequest
-	(*ListNamespacesResponse)(nil),   // 13: io.oxia.proto.v1.ListNamespacesResponse
-	(*GetNamespaceRequest)(nil),      // 14: io.oxia.proto.v1.GetNamespaceRequest
-	(*GetNamespaceResponse)(nil),     // 15: io.oxia.proto.v1.GetNamespaceResponse
-	(*SplitShardRequest)(nil),        // 16: io.oxia.proto.v1.SplitShardRequest
-	(*SplitShardResponse)(nil),       // 17: io.oxia.proto.v1.SplitShardResponse
-	(*DataServer)(nil),               // 18: io.oxia.proto.v1.DataServer
-	(*Namespace)(nil),                // 19: io.oxia.proto.v1.Namespace
+	(*PatchNamespaceRequest)(nil),    // 12: io.oxia.proto.v1.PatchNamespaceRequest
+	(*PatchNamespaceResponse)(nil),   // 13: io.oxia.proto.v1.PatchNamespaceResponse
+	(*ListNamespacesRequest)(nil),    // 14: io.oxia.proto.v1.ListNamespacesRequest
+	(*ListNamespacesResponse)(nil),   // 15: io.oxia.proto.v1.ListNamespacesResponse
+	(*GetNamespaceRequest)(nil),      // 16: io.oxia.proto.v1.GetNamespaceRequest
+	(*GetNamespaceResponse)(nil),     // 17: io.oxia.proto.v1.GetNamespaceResponse
+	(*SplitShardRequest)(nil),        // 18: io.oxia.proto.v1.SplitShardRequest
+	(*SplitShardResponse)(nil),       // 19: io.oxia.proto.v1.SplitShardResponse
+	(*DataServer)(nil),               // 20: io.oxia.proto.v1.DataServer
+	(*Namespace)(nil),                // 21: io.oxia.proto.v1.Namespace
 }
 var file_admin_proto_depIdxs = []int32{
-	18, // 0: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
-	18, // 1: io.oxia.proto.v1.GetDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
-	18, // 2: io.oxia.proto.v1.CreateDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
-	18, // 3: io.oxia.proto.v1.CreateDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
-	18, // 4: io.oxia.proto.v1.PatchDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
-	18, // 5: io.oxia.proto.v1.PatchDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
-	18, // 6: io.oxia.proto.v1.DeleteDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
-	19, // 7: io.oxia.proto.v1.CreateNamespaceRequest.namespace:type_name -> io.oxia.proto.v1.Namespace
-	19, // 8: io.oxia.proto.v1.CreateNamespaceResponse.namespace:type_name -> io.oxia.proto.v1.Namespace
-	19, // 9: io.oxia.proto.v1.ListNamespacesResponse.namespaces:type_name -> io.oxia.proto.v1.Namespace
-	19, // 10: io.oxia.proto.v1.GetNamespaceResponse.namespace:type_name -> io.oxia.proto.v1.Namespace
-	0,  // 11: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
-	2,  // 12: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
-	4,  // 13: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:input_type -> io.oxia.proto.v1.CreateDataServerRequest
-	6,  // 14: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:input_type -> io.oxia.proto.v1.PatchDataServerRequest
-	8,  // 15: io.oxia.proto.v1.OxiaAdmin.DeleteDataServer:input_type -> io.oxia.proto.v1.DeleteDataServerRequest
-	10, // 16: io.oxia.proto.v1.OxiaAdmin.CreateNamespace:input_type -> io.oxia.proto.v1.CreateNamespaceRequest
-	14, // 17: io.oxia.proto.v1.OxiaAdmin.GetNamespace:input_type -> io.oxia.proto.v1.GetNamespaceRequest
-	12, // 18: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
-	16, // 19: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
-	1,  // 20: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
-	3,  // 21: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.GetDataServerResponse
-	5,  // 22: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:output_type -> io.oxia.proto.v1.CreateDataServerResponse
-	7,  // 23: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:output_type -> io.oxia.proto.v1.PatchDataServerResponse
-	9,  // 24: io.oxia.proto.v1.OxiaAdmin.DeleteDataServer:output_type -> io.oxia.proto.v1.DeleteDataServerResponse
-	11, // 25: io.oxia.proto.v1.OxiaAdmin.CreateNamespace:output_type -> io.oxia.proto.v1.CreateNamespaceResponse
-	15, // 26: io.oxia.proto.v1.OxiaAdmin.GetNamespace:output_type -> io.oxia.proto.v1.GetNamespaceResponse
-	13, // 27: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
-	17, // 28: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
-	20, // [20:29] is the sub-list for method output_type
-	11, // [11:20] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	20, // 0: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
+	20, // 1: io.oxia.proto.v1.GetDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	20, // 2: io.oxia.proto.v1.CreateDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
+	20, // 3: io.oxia.proto.v1.CreateDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	20, // 4: io.oxia.proto.v1.PatchDataServerRequest.data_server:type_name -> io.oxia.proto.v1.DataServer
+	20, // 5: io.oxia.proto.v1.PatchDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	20, // 6: io.oxia.proto.v1.DeleteDataServerResponse.data_server:type_name -> io.oxia.proto.v1.DataServer
+	21, // 7: io.oxia.proto.v1.CreateNamespaceRequest.namespace:type_name -> io.oxia.proto.v1.Namespace
+	21, // 8: io.oxia.proto.v1.CreateNamespaceResponse.namespace:type_name -> io.oxia.proto.v1.Namespace
+	21, // 9: io.oxia.proto.v1.PatchNamespaceRequest.namespace:type_name -> io.oxia.proto.v1.Namespace
+	21, // 10: io.oxia.proto.v1.PatchNamespaceResponse.namespace:type_name -> io.oxia.proto.v1.Namespace
+	21, // 11: io.oxia.proto.v1.ListNamespacesResponse.namespaces:type_name -> io.oxia.proto.v1.Namespace
+	21, // 12: io.oxia.proto.v1.GetNamespaceResponse.namespace:type_name -> io.oxia.proto.v1.Namespace
+	0,  // 13: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
+	2,  // 14: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
+	4,  // 15: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:input_type -> io.oxia.proto.v1.CreateDataServerRequest
+	6,  // 16: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:input_type -> io.oxia.proto.v1.PatchDataServerRequest
+	8,  // 17: io.oxia.proto.v1.OxiaAdmin.DeleteDataServer:input_type -> io.oxia.proto.v1.DeleteDataServerRequest
+	10, // 18: io.oxia.proto.v1.OxiaAdmin.CreateNamespace:input_type -> io.oxia.proto.v1.CreateNamespaceRequest
+	12, // 19: io.oxia.proto.v1.OxiaAdmin.PatchNamespace:input_type -> io.oxia.proto.v1.PatchNamespaceRequest
+	16, // 20: io.oxia.proto.v1.OxiaAdmin.GetNamespace:input_type -> io.oxia.proto.v1.GetNamespaceRequest
+	14, // 21: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
+	18, // 22: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
+	1,  // 23: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
+	3,  // 24: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.GetDataServerResponse
+	5,  // 25: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:output_type -> io.oxia.proto.v1.CreateDataServerResponse
+	7,  // 26: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:output_type -> io.oxia.proto.v1.PatchDataServerResponse
+	9,  // 27: io.oxia.proto.v1.OxiaAdmin.DeleteDataServer:output_type -> io.oxia.proto.v1.DeleteDataServerResponse
+	11, // 28: io.oxia.proto.v1.OxiaAdmin.CreateNamespace:output_type -> io.oxia.proto.v1.CreateNamespaceResponse
+	13, // 29: io.oxia.proto.v1.OxiaAdmin.PatchNamespace:output_type -> io.oxia.proto.v1.PatchNamespaceResponse
+	17, // 30: io.oxia.proto.v1.OxiaAdmin.GetNamespace:output_type -> io.oxia.proto.v1.GetNamespaceResponse
+	15, // 31: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
+	19, // 32: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
+	23, // [23:33] is the sub-list for method output_type
+	13, // [13:23] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_admin_proto_init() }
@@ -983,14 +1082,14 @@ func file_admin_proto_init() {
 		return
 	}
 	file_metadata_proto_init()
-	file_admin_proto_msgTypes[16].OneofWrappers = []any{}
+	file_admin_proto_msgTypes[18].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_admin_proto_rawDesc), len(file_admin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   18,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/common/proto/admin.proto
+++ b/common/proto/admin.proto
@@ -33,6 +33,7 @@ service OxiaAdmin {
   rpc DeleteDataServer(DeleteDataServerRequest) returns (DeleteDataServerResponse);
 
   rpc CreateNamespace(CreateNamespaceRequest) returns (CreateNamespaceResponse);
+  rpc PatchNamespace(PatchNamespaceRequest) returns (PatchNamespaceResponse);
   rpc GetNamespace(GetNamespaceRequest) returns (GetNamespaceResponse);
   rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse);
 
@@ -88,6 +89,14 @@ message CreateNamespaceRequest {
 }
 
 message CreateNamespaceResponse {
+  Namespace namespace = 1;
+}
+
+message PatchNamespaceRequest {
+  Namespace namespace = 1;
+}
+
+message PatchNamespaceResponse {
   Namespace namespace = 1;
 }
 

--- a/common/proto/admin_grpc.pb.go
+++ b/common/proto/admin_grpc.pb.go
@@ -42,6 +42,7 @@ const (
 	OxiaAdmin_PatchDataServer_FullMethodName  = "/io.oxia.proto.v1.OxiaAdmin/PatchDataServer"
 	OxiaAdmin_DeleteDataServer_FullMethodName = "/io.oxia.proto.v1.OxiaAdmin/DeleteDataServer"
 	OxiaAdmin_CreateNamespace_FullMethodName  = "/io.oxia.proto.v1.OxiaAdmin/CreateNamespace"
+	OxiaAdmin_PatchNamespace_FullMethodName   = "/io.oxia.proto.v1.OxiaAdmin/PatchNamespace"
 	OxiaAdmin_GetNamespace_FullMethodName     = "/io.oxia.proto.v1.OxiaAdmin/GetNamespace"
 	OxiaAdmin_ListNamespaces_FullMethodName   = "/io.oxia.proto.v1.OxiaAdmin/ListNamespaces"
 	OxiaAdmin_SplitShard_FullMethodName       = "/io.oxia.proto.v1.OxiaAdmin/SplitShard"
@@ -57,6 +58,7 @@ type OxiaAdminClient interface {
 	PatchDataServer(ctx context.Context, in *PatchDataServerRequest, opts ...grpc.CallOption) (*PatchDataServerResponse, error)
 	DeleteDataServer(ctx context.Context, in *DeleteDataServerRequest, opts ...grpc.CallOption) (*DeleteDataServerResponse, error)
 	CreateNamespace(ctx context.Context, in *CreateNamespaceRequest, opts ...grpc.CallOption) (*CreateNamespaceResponse, error)
+	PatchNamespace(ctx context.Context, in *PatchNamespaceRequest, opts ...grpc.CallOption) (*PatchNamespaceResponse, error)
 	GetNamespace(ctx context.Context, in *GetNamespaceRequest, opts ...grpc.CallOption) (*GetNamespaceResponse, error)
 	ListNamespaces(ctx context.Context, in *ListNamespacesRequest, opts ...grpc.CallOption) (*ListNamespacesResponse, error)
 	// *
@@ -133,6 +135,16 @@ func (c *oxiaAdminClient) CreateNamespace(ctx context.Context, in *CreateNamespa
 	return out, nil
 }
 
+func (c *oxiaAdminClient) PatchNamespace(ctx context.Context, in *PatchNamespaceRequest, opts ...grpc.CallOption) (*PatchNamespaceResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PatchNamespaceResponse)
+	err := c.cc.Invoke(ctx, OxiaAdmin_PatchNamespace_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *oxiaAdminClient) GetNamespace(ctx context.Context, in *GetNamespaceRequest, opts ...grpc.CallOption) (*GetNamespaceResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetNamespaceResponse)
@@ -173,6 +185,7 @@ type OxiaAdminServer interface {
 	PatchDataServer(context.Context, *PatchDataServerRequest) (*PatchDataServerResponse, error)
 	DeleteDataServer(context.Context, *DeleteDataServerRequest) (*DeleteDataServerResponse, error)
 	CreateNamespace(context.Context, *CreateNamespaceRequest) (*CreateNamespaceResponse, error)
+	PatchNamespace(context.Context, *PatchNamespaceRequest) (*PatchNamespaceResponse, error)
 	GetNamespace(context.Context, *GetNamespaceRequest) (*GetNamespaceResponse, error)
 	ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error)
 	// *
@@ -206,6 +219,9 @@ func (UnimplementedOxiaAdminServer) DeleteDataServer(context.Context, *DeleteDat
 }
 func (UnimplementedOxiaAdminServer) CreateNamespace(context.Context, *CreateNamespaceRequest) (*CreateNamespaceResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateNamespace not implemented")
+}
+func (UnimplementedOxiaAdminServer) PatchNamespace(context.Context, *PatchNamespaceRequest) (*PatchNamespaceResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PatchNamespace not implemented")
 }
 func (UnimplementedOxiaAdminServer) GetNamespace(context.Context, *GetNamespaceRequest) (*GetNamespaceResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetNamespace not implemented")
@@ -345,6 +361,24 @@ func _OxiaAdmin_CreateNamespace_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+func _OxiaAdmin_PatchNamespace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PatchNamespaceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OxiaAdminServer).PatchNamespace(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OxiaAdmin_PatchNamespace_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OxiaAdminServer).PatchNamespace(ctx, req.(*PatchNamespaceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _OxiaAdmin_GetNamespace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetNamespaceRequest)
 	if err := dec(in); err != nil {
@@ -429,6 +463,10 @@ var OxiaAdmin_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CreateNamespace",
 			Handler:    _OxiaAdmin_CreateNamespace_Handler,
+		},
+		{
+			MethodName: "PatchNamespace",
+			Handler:    _OxiaAdmin_PatchNamespace_Handler,
 		},
 		{
 			MethodName: "GetNamespace",

--- a/common/proto/admin_vtproto.pb.go
+++ b/common/proto/admin_vtproto.pb.go
@@ -229,6 +229,40 @@ func (m *CreateNamespaceResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *PatchNamespaceRequest) CloneVT() *PatchNamespaceRequest {
+	if m == nil {
+		return (*PatchNamespaceRequest)(nil)
+	}
+	r := new(PatchNamespaceRequest)
+	r.Namespace = m.Namespace.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *PatchNamespaceRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *PatchNamespaceResponse) CloneVT() *PatchNamespaceResponse {
+	if m == nil {
+		return (*PatchNamespaceResponse)(nil)
+	}
+	r := new(PatchNamespaceResponse)
+	r.Namespace = m.Namespace.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *PatchNamespaceResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *ListNamespacesRequest) CloneVT() *ListNamespacesRequest {
 	if m == nil {
 		return (*ListNamespacesRequest)(nil)
@@ -576,6 +610,44 @@ func (this *CreateNamespaceResponse) EqualVT(that *CreateNamespaceResponse) bool
 
 func (this *CreateNamespaceResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*CreateNamespaceResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *PatchNamespaceRequest) EqualVT(that *PatchNamespaceRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.Namespace.EqualVT(that.Namespace) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *PatchNamespaceRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*PatchNamespaceRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *PatchNamespaceResponse) EqualVT(that *PatchNamespaceResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.Namespace.EqualVT(that.Namespace) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *PatchNamespaceResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*PatchNamespaceResponse)
 	if !ok {
 		return false
 	}
@@ -1217,6 +1289,92 @@ func (m *CreateNamespaceResponse) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 
+func (m *PatchNamespaceRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *PatchNamespaceRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *PatchNamespaceRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Namespace != nil {
+		size, err := m.Namespace.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *PatchNamespaceResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *PatchNamespaceResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *PatchNamespaceResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Namespace != nil {
+		size, err := m.Namespace.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ListNamespacesRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -1624,6 +1782,34 @@ func (m *CreateNamespaceRequest) SizeVT() (n int) {
 }
 
 func (m *CreateNamespaceResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Namespace != nil {
+		l = m.Namespace.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *PatchNamespaceRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Namespace != nil {
+		l = m.Namespace.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *PatchNamespaceResponse) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -2665,6 +2851,180 @@ func (m *CreateNamespaceResponse) UnmarshalVT(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: CreateNamespaceResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Namespace == nil {
+				m.Namespace = &Namespace{}
+			}
+			if err := m.Namespace.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *PatchNamespaceRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PatchNamespaceRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PatchNamespaceRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Namespace == nil {
+				m.Namespace = &Namespace{}
+			}
+			if err := m.Namespace.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *PatchNamespaceResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PatchNamespaceResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PatchNamespaceResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -4188,6 +4548,180 @@ func (m *CreateNamespaceResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: CreateNamespaceResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Namespace == nil {
+				m.Namespace = &Namespace{}
+			}
+			if err := m.Namespace.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *PatchNamespaceRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PatchNamespaceRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PatchNamespaceRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Namespace == nil {
+				m.Namespace = &Namespace{}
+			}
+			if err := m.Namespace.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *PatchNamespaceResponse) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PatchNamespaceResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PatchNamespaceResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/oxia/admin.go
+++ b/oxia/admin.go
@@ -30,6 +30,7 @@ type AdminClient interface {
 	DeleteDataServer(dataServer string) (*proto.DataServer, error)
 
 	CreateNamespace(namespace *proto.Namespace) (*proto.Namespace, error)
+	PatchNamespace(namespace *proto.Namespace) (*proto.Namespace, error)
 	ListNamespaces() ([]*proto.Namespace, error)
 	GetNamespace(namespace string) (*proto.Namespace, error)
 

--- a/oxia/admin_client_impl.go
+++ b/oxia/admin_client_impl.go
@@ -147,6 +147,25 @@ func (admin *adminClientImpl) CreateNamespace(namespace *proto.Namespace) (*prot
 	return response.Namespace, nil
 }
 
+func (admin *adminClientImpl) PatchNamespace(namespace *proto.Namespace) (*proto.Namespace, error) {
+	client, err := admin.clientPool.GetAminRpc(admin.adminAddr)
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+
+	if client == nil {
+		return nil, wrapAdminError(ErrUnknown, errors.New(errUnableToConnectToAdminServer))
+	}
+
+	response, err := client.PatchNamespace(context.Background(), &proto.PatchNamespaceRequest{
+		Namespace: namespace,
+	})
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+	return response.Namespace, nil
+}
+
 func (admin *adminClientImpl) ListNamespaces() ([]*proto.Namespace, error) {
 	client, err := admin.clientPool.GetAminRpc(admin.adminAddr)
 	if err != nil {

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -44,6 +44,8 @@ type mockAdminRpcClient struct {
 	deleteDataServerErr     error
 	createNamespaceResp     *proto.CreateNamespaceResponse
 	createNamespaceErr      error
+	patchNamespaceResp      *proto.PatchNamespaceResponse
+	patchNamespaceErr       error
 	listNamespacesResp      *proto.ListNamespacesResponse
 	listNamespacesErr       error
 	getNamespaceResp        *proto.GetNamespaceResponse
@@ -72,6 +74,10 @@ func (m *mockAdminRpcClient) DeleteDataServer(context.Context, *proto.DeleteData
 
 func (m *mockAdminRpcClient) CreateNamespace(context.Context, *proto.CreateNamespaceRequest, ...grpc.CallOption) (*proto.CreateNamespaceResponse, error) {
 	return m.createNamespaceResp, m.createNamespaceErr
+}
+
+func (m *mockAdminRpcClient) PatchNamespace(context.Context, *proto.PatchNamespaceRequest, ...grpc.CallOption) (*proto.PatchNamespaceResponse, error) {
+	return m.patchNamespaceResp, m.patchNamespaceErr
 }
 
 func (m *mockAdminRpcClient) GetNamespace(context.Context, *proto.GetNamespaceRequest, ...grpc.CallOption) (*proto.GetNamespaceResponse, error) {
@@ -377,6 +383,32 @@ func TestAdminClientCreateNamespaceReturnsResponse(t *testing.T) {
 	assert.EqualValues(t, 4, namespace.GetInitialShardCount())
 	assert.EqualValues(t, 3, namespace.GetReplicationFactor())
 	assert.Equal(t, proto.KeySortingType_NATURAL.String(), namespace.GetKeySorting())
+}
+
+func TestAdminClientPatchNamespaceReturnsResponse(t *testing.T) {
+	admin := &adminClientImpl{
+		adminAddr: "admin-addr",
+		clientPool: &mockAdminClientPool{
+			adminClient: &mockAdminRpcClient{
+				patchNamespaceResp: &proto.PatchNamespaceResponse{
+					Namespace: &proto.Namespace{
+						Name:              "ns-1",
+						InitialShardCount: 4,
+						ReplicationFactor: 3,
+						KeySorting:        "natural",
+					},
+				},
+			},
+		},
+	}
+
+	namespace, err := admin.PatchNamespace(&proto.Namespace{Name: "ns-1", KeySorting: "natural"})
+	require.NoError(t, err)
+	require.NotNil(t, namespace)
+	assert.Equal(t, "ns-1", namespace.GetName())
+	assert.EqualValues(t, 4, namespace.GetInitialShardCount())
+	assert.EqualValues(t, 3, namespace.GetReplicationFactor())
+	assert.Equal(t, "natural", namespace.GetKeySorting())
 }
 
 func TestAdminClientListNamespacesReturnsResponse(t *testing.T) {

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -386,28 +386,31 @@ func TestAdminClientCreateNamespaceReturnsResponse(t *testing.T) {
 }
 
 func TestAdminClientPatchNamespaceReturnsResponse(t *testing.T) {
+	notificationsEnabled := false
 	admin := &adminClientImpl{
 		adminAddr: "admin-addr",
 		clientPool: &mockAdminClientPool{
 			adminClient: &mockAdminRpcClient{
 				patchNamespaceResp: &proto.PatchNamespaceResponse{
 					Namespace: &proto.Namespace{
-						Name:              "ns-1",
-						InitialShardCount: 4,
-						ReplicationFactor: 3,
-						KeySorting:        "natural",
+						Name:                 "ns-1",
+						InitialShardCount:    4,
+						ReplicationFactor:    3,
+						NotificationsEnabled: &notificationsEnabled,
+						KeySorting:           "natural",
 					},
 				},
 			},
 		},
 	}
 
-	namespace, err := admin.PatchNamespace(&proto.Namespace{Name: "ns-1", KeySorting: "natural"})
+	namespace, err := admin.PatchNamespace(&proto.Namespace{Name: "ns-1", NotificationsEnabled: &notificationsEnabled})
 	require.NoError(t, err)
 	require.NotNil(t, namespace)
 	assert.Equal(t, "ns-1", namespace.GetName())
 	assert.EqualValues(t, 4, namespace.GetInitialShardCount())
 	assert.EqualValues(t, 3, namespace.GetReplicationFactor())
+	assert.False(t, namespace.NotificationsEnabledOrDefault())
 	assert.Equal(t, "natural", namespace.GetKeySorting())
 }
 

--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -220,14 +220,11 @@ func (management *managementServer) PatchNamespace(_ context.Context, req *proto
 	if err := validation.ValidateNamespace(req.Namespace.GetName()); err != nil {
 		return nil, grpcstatus.Error(codes.InvalidArgument, err.Error())
 	}
-	if keySorting := req.Namespace.GetKeySorting(); keySorting != "" {
-		parsedKeySorting, err := req.Namespace.GetKeySortingType()
-		if err != nil {
-			return nil, grpcstatus.Errorf(codes.InvalidArgument, "namespace key sorting is invalid: %v", err)
-		}
-		if parsedKeySorting == proto.KeySortingType_UNKNOWN {
-			return nil, grpcstatus.Error(codes.InvalidArgument, `namespace key sorting must be one of "natural" or "hierarchical"`)
-		}
+	if req.Namespace.GetInitialShardCount() != 0 {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "namespace initial shard count cannot be patched")
+	}
+	if req.Namespace.GetKeySorting() != "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "namespace key sorting cannot be patched")
 	}
 
 	namespace, err := management.metadata.PatchNamespace(req.Namespace)

--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -213,6 +213,42 @@ func (management *managementServer) CreateNamespace(_ context.Context, req *prot
 	}, nil
 }
 
+func (management *managementServer) PatchNamespace(_ context.Context, req *proto.PatchNamespaceRequest) (*proto.PatchNamespaceResponse, error) {
+	if req == nil || req.Namespace == nil {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "namespace must not be nil")
+	}
+	if err := validation.ValidateNamespace(req.Namespace.GetName()); err != nil {
+		return nil, grpcstatus.Error(codes.InvalidArgument, err.Error())
+	}
+	if keySorting := req.Namespace.GetKeySorting(); keySorting != "" {
+		parsedKeySorting, err := req.Namespace.GetKeySortingType()
+		if err != nil {
+			return nil, grpcstatus.Errorf(codes.InvalidArgument, "namespace key sorting is invalid: %v", err)
+		}
+		if parsedKeySorting == proto.KeySortingType_UNKNOWN {
+			return nil, grpcstatus.Error(codes.InvalidArgument, `namespace key sorting must be one of "natural" or "hierarchical"`)
+		}
+	}
+
+	namespace, err := management.metadata.PatchNamespace(req.Namespace)
+	if err != nil {
+		if errors.Is(err, metadatacommon.ErrNotFound) {
+			return nil, grpcstatus.Errorf(codes.NotFound, "namespace %q not found", req.Namespace.GetName())
+		}
+		if errors.Is(err, metadatacommon.ErrBadVersion) {
+			return nil, grpcstatus.Errorf(codes.Aborted, "failed to patch namespace %q due to concurrent config update", req.Namespace.GetName())
+		}
+		if errors.Is(err, metadatacommon.ErrFailedPrecondition) {
+			return nil, grpcstatus.Errorf(codes.FailedPrecondition, "failed to patch namespace %q: %v", req.Namespace.GetName(), err)
+		}
+		return nil, grpcstatus.Errorf(codes.Internal, "failed to patch namespace %q: %v", req.Namespace.GetName(), err)
+	}
+
+	return &proto.PatchNamespaceResponse{
+		Namespace: namespace,
+	}, nil
+}
+
 func (management *managementServer) GetNamespace(_ context.Context, req *proto.GetNamespaceRequest) (*proto.GetNamespaceResponse, error) {
 	if req == nil || req.Namespace == "" {
 		return nil, grpcstatus.Error(codes.InvalidArgument, "namespace must not be empty")

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -414,6 +414,164 @@ func TestManagementServerCreateNamespaceFailedPrecondition(t *testing.T) {
 	assert.Equal(t, codes.FailedPrecondition, grpcstatus.Code(err))
 }
 
+func TestManagementServerPatchNamespace(t *testing.T) {
+	serverName1 := "server-1"
+	serverName2 := "server-2"
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{
+			Namespaces: []*proto.Namespace{{
+				Name:              "ns-1",
+				InitialShardCount: 1,
+				ReplicationFactor: 1,
+				KeySorting:        "hierarchical",
+			}},
+			Servers: []*proto.DataServerIdentity{
+				dataServer(&serverName1, "public-1", "internal-1"),
+				dataServer(&serverName2, "public-2", "internal-2"),
+			},
+		}),
+		nil,
+	)
+
+	notificationsEnabled := false
+	res, err := management.PatchNamespace(context.Background(), &proto.PatchNamespaceRequest{
+		Namespace: &proto.Namespace{
+			Name:                 "ns-1",
+			InitialShardCount:    2,
+			ReplicationFactor:    2,
+			NotificationsEnabled: &notificationsEnabled,
+			KeySorting:           "natural",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, res.Namespace)
+	assert.Equal(t, "ns-1", res.Namespace.GetName())
+	assert.EqualValues(t, 2, res.Namespace.GetInitialShardCount())
+	assert.EqualValues(t, 2, res.Namespace.GetReplicationFactor())
+	assert.False(t, res.Namespace.NotificationsEnabledOrDefault())
+	assert.Equal(t, "natural", res.Namespace.GetKeySorting())
+
+	namespace, found := management.metadata.GetNamespace("ns-1")
+	require.True(t, found)
+	assert.EqualValues(t, 2, namespace.UnsafeBorrow().GetInitialShardCount())
+	assert.EqualValues(t, 2, namespace.UnsafeBorrow().GetReplicationFactor())
+	assert.False(t, namespace.UnsafeBorrow().NotificationsEnabledOrDefault())
+	assert.Equal(t, "natural", namespace.UnsafeBorrow().GetKeySorting())
+}
+
+func TestManagementServerPatchNamespacePreservesUnspecifiedFields(t *testing.T) {
+	serverName := "server-1"
+	notificationsEnabled := true
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{
+			Namespaces: []*proto.Namespace{{
+				Name:                 "ns-1",
+				InitialShardCount:    4,
+				ReplicationFactor:    1,
+				NotificationsEnabled: &notificationsEnabled,
+				KeySorting:           "hierarchical",
+			}},
+			Servers: []*proto.DataServerIdentity{
+				dataServer(&serverName, "public-1", "internal-1"),
+			},
+		}),
+		nil,
+	)
+
+	res, err := management.PatchNamespace(context.Background(), &proto.PatchNamespaceRequest{
+		Namespace: &proto.Namespace{
+			Name:       "ns-1",
+			KeySorting: "natural",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.EqualValues(t, 4, res.Namespace.GetInitialShardCount())
+	assert.EqualValues(t, 1, res.Namespace.GetReplicationFactor())
+	assert.True(t, res.Namespace.NotificationsEnabledOrDefault())
+	assert.Equal(t, "natural", res.Namespace.GetKeySorting())
+}
+
+func TestManagementServerPatchNamespaceRejectsInvalidRequest(t *testing.T) {
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{}),
+		nil,
+	)
+
+	testCases := []struct {
+		name string
+		req  *proto.PatchNamespaceRequest
+	}{
+		{name: "nil request", req: nil},
+		{name: "nil namespace", req: &proto.PatchNamespaceRequest{}},
+		{name: "empty name", req: &proto.PatchNamespaceRequest{Namespace: &proto.Namespace{}}},
+		{name: "invalid name", req: &proto.PatchNamespaceRequest{Namespace: &proto.Namespace{
+			Name:       "../ns",
+			KeySorting: "natural",
+		}}},
+		{name: "invalid key sorting", req: &proto.PatchNamespaceRequest{Namespace: &proto.Namespace{
+			Name:       "ns-1",
+			KeySorting: "invalid",
+		}}},
+		{name: "unknown key sorting", req: &proto.PatchNamespaceRequest{Namespace: &proto.Namespace{
+			Name:       "ns-1",
+			KeySorting: proto.KeySortingType_UNKNOWN.String(),
+		}}},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := management.PatchNamespace(context.Background(), tt.req)
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, grpcstatus.Code(err))
+		})
+	}
+}
+
+func TestManagementServerPatchNamespaceNotFound(t *testing.T) {
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{}),
+		nil,
+	)
+
+	_, err := management.PatchNamespace(context.Background(), &proto.PatchNamespaceRequest{
+		Namespace: &proto.Namespace{
+			Name:       "missing",
+			KeySorting: "natural",
+		},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, grpcstatus.Code(err))
+}
+
+func TestManagementServerPatchNamespaceFailedPrecondition(t *testing.T) {
+	serverName := "server-1"
+	management := newManagementServer(
+		newTestMetadata(t, &proto.ClusterConfiguration{
+			Namespaces: []*proto.Namespace{{
+				Name:              "ns-1",
+				InitialShardCount: 1,
+				ReplicationFactor: 1,
+				KeySorting:        "natural",
+			}},
+			Servers: []*proto.DataServerIdentity{
+				dataServer(&serverName, "public-1", "internal-1"),
+			},
+		}),
+		nil,
+	)
+
+	_, err := management.PatchNamespace(context.Background(), &proto.PatchNamespaceRequest{
+		Namespace: &proto.Namespace{
+			Name:              "ns-1",
+			ReplicationFactor: 2,
+		},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, grpcstatus.Code(err))
+}
+
 func TestManagementServerGetNamespaceRejectsEmptyLookup(t *testing.T) {
 	management := newManagementServer(
 		newTestMetadata(t, &proto.ClusterConfiguration{}),

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -437,27 +437,25 @@ func TestManagementServerPatchNamespace(t *testing.T) {
 	res, err := management.PatchNamespace(context.Background(), &proto.PatchNamespaceRequest{
 		Namespace: &proto.Namespace{
 			Name:                 "ns-1",
-			InitialShardCount:    2,
 			ReplicationFactor:    2,
 			NotificationsEnabled: &notificationsEnabled,
-			KeySorting:           "natural",
 		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.NotNil(t, res.Namespace)
 	assert.Equal(t, "ns-1", res.Namespace.GetName())
-	assert.EqualValues(t, 2, res.Namespace.GetInitialShardCount())
+	assert.EqualValues(t, 1, res.Namespace.GetInitialShardCount())
 	assert.EqualValues(t, 2, res.Namespace.GetReplicationFactor())
 	assert.False(t, res.Namespace.NotificationsEnabledOrDefault())
-	assert.Equal(t, "natural", res.Namespace.GetKeySorting())
+	assert.Equal(t, "hierarchical", res.Namespace.GetKeySorting())
 
 	namespace, found := management.metadata.GetNamespace("ns-1")
 	require.True(t, found)
-	assert.EqualValues(t, 2, namespace.UnsafeBorrow().GetInitialShardCount())
+	assert.EqualValues(t, 1, namespace.UnsafeBorrow().GetInitialShardCount())
 	assert.EqualValues(t, 2, namespace.UnsafeBorrow().GetReplicationFactor())
 	assert.False(t, namespace.UnsafeBorrow().NotificationsEnabledOrDefault())
-	assert.Equal(t, "natural", namespace.UnsafeBorrow().GetKeySorting())
+	assert.Equal(t, "hierarchical", namespace.UnsafeBorrow().GetKeySorting())
 }
 
 func TestManagementServerPatchNamespacePreservesUnspecifiedFields(t *testing.T) {
@@ -481,8 +479,8 @@ func TestManagementServerPatchNamespacePreservesUnspecifiedFields(t *testing.T) 
 
 	res, err := management.PatchNamespace(context.Background(), &proto.PatchNamespaceRequest{
 		Namespace: &proto.Namespace{
-			Name:       "ns-1",
-			KeySorting: "natural",
+			Name:                 "ns-1",
+			NotificationsEnabled: &notificationsEnabled,
 		},
 	})
 	require.NoError(t, err)
@@ -490,7 +488,7 @@ func TestManagementServerPatchNamespacePreservesUnspecifiedFields(t *testing.T) 
 	assert.EqualValues(t, 4, res.Namespace.GetInitialShardCount())
 	assert.EqualValues(t, 1, res.Namespace.GetReplicationFactor())
 	assert.True(t, res.Namespace.NotificationsEnabledOrDefault())
-	assert.Equal(t, "natural", res.Namespace.GetKeySorting())
+	assert.Equal(t, "hierarchical", res.Namespace.GetKeySorting())
 }
 
 func TestManagementServerPatchNamespaceRejectsInvalidRequest(t *testing.T) {
@@ -507,16 +505,16 @@ func TestManagementServerPatchNamespaceRejectsInvalidRequest(t *testing.T) {
 		{name: "nil namespace", req: &proto.PatchNamespaceRequest{}},
 		{name: "empty name", req: &proto.PatchNamespaceRequest{Namespace: &proto.Namespace{}}},
 		{name: "invalid name", req: &proto.PatchNamespaceRequest{Namespace: &proto.Namespace{
-			Name:       "../ns",
-			KeySorting: "natural",
+			Name:              "../ns",
+			ReplicationFactor: 1,
 		}}},
-		{name: "invalid key sorting", req: &proto.PatchNamespaceRequest{Namespace: &proto.Namespace{
+		{name: "initial shard count", req: &proto.PatchNamespaceRequest{Namespace: &proto.Namespace{
+			Name:              "ns-1",
+			InitialShardCount: 1,
+		}}},
+		{name: "key sorting", req: &proto.PatchNamespaceRequest{Namespace: &proto.Namespace{
 			Name:       "ns-1",
 			KeySorting: "invalid",
-		}}},
-		{name: "unknown key sorting", req: &proto.PatchNamespaceRequest{Namespace: &proto.Namespace{
-			Name:       "ns-1",
-			KeySorting: proto.KeySortingType_UNKNOWN.String(),
 		}}},
 	}
 
@@ -537,8 +535,8 @@ func TestManagementServerPatchNamespaceNotFound(t *testing.T) {
 
 	_, err := management.PatchNamespace(context.Background(), &proto.PatchNamespaceRequest{
 		Namespace: &proto.Namespace{
-			Name:       "missing",
-			KeySorting: "natural",
+			Name:              "missing",
+			ReplicationFactor: 1,
 		},
 	})
 	require.Error(t, err)

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -387,9 +387,6 @@ func (m *coordinatorMetadata) PatchNamespace(desiredNamespace *commonproto.Names
 			if namespace.GetName() != desiredNamespace.GetName() {
 				continue
 			}
-			if initialShardCount := desiredNamespace.GetInitialShardCount(); initialShardCount != 0 {
-				namespace.InitialShardCount = initialShardCount
-			}
 			if replicationFactor := desiredNamespace.GetReplicationFactor(); replicationFactor != 0 {
 				if replicationFactor > uint32(len(config.GetServers())) {
 					return nil, fmt.Errorf("%w: namespace %q has replicationFactor=%d but only %d servers are configured",
@@ -400,9 +397,6 @@ func (m *coordinatorMetadata) PatchNamespace(desiredNamespace *commonproto.Names
 			if desiredNamespace.NotificationsEnabled != nil {
 				notificationsEnabled := desiredNamespace.GetNotificationsEnabled()
 				namespace.NotificationsEnabled = &notificationsEnabled
-			}
-			if keySorting := desiredNamespace.GetKeySorting(); keySorting != "" {
-				namespace.KeySorting = keySorting
 			}
 			if policy := desiredNamespace.GetPolicy(); policy != nil {
 				namespace.Policy = policy

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -46,6 +46,7 @@ type Metadata interface {
 	GetNamespaceStatus(namespace string) (commonobject.Borrowed[*commonproto.NamespaceStatus], bool)
 	DeleteNamespaceStatus(name string) commonobject.Borrowed[*commonproto.NamespaceStatus]
 	CreateNamespace(namespace *commonproto.Namespace) error
+	PatchNamespace(namespace *commonproto.Namespace) (*commonproto.Namespace, error)
 	GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool)
 
 	UpdateShardStatus(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata)
@@ -377,6 +378,45 @@ func (m *coordinatorMetadata) CreateNamespace(namespace *commonproto.Namespace) 
 		config.Namespaces = append(config.Namespaces, namespace)
 		return config, nil
 	})
+}
+
+func (m *coordinatorMetadata) PatchNamespace(desiredNamespace *commonproto.Namespace) (*commonproto.Namespace, error) {
+	var updated *commonproto.Namespace
+	if err := m.computeConfig(func(config *commonproto.ClusterConfiguration, _ metadatacommon.Version) (*commonproto.ClusterConfiguration, error) {
+		for _, namespace := range config.GetNamespaces() {
+			if namespace.GetName() != desiredNamespace.GetName() {
+				continue
+			}
+			if initialShardCount := desiredNamespace.GetInitialShardCount(); initialShardCount != 0 {
+				namespace.InitialShardCount = initialShardCount
+			}
+			if replicationFactor := desiredNamespace.GetReplicationFactor(); replicationFactor != 0 {
+				if replicationFactor > uint32(len(config.GetServers())) {
+					return nil, fmt.Errorf("%w: namespace %q has replicationFactor=%d but only %d servers are configured",
+						metadatacommon.ErrFailedPrecondition, namespace.GetName(), replicationFactor, len(config.GetServers()))
+				}
+				namespace.ReplicationFactor = replicationFactor
+			}
+			if desiredNamespace.NotificationsEnabled != nil {
+				notificationsEnabled := desiredNamespace.GetNotificationsEnabled()
+				namespace.NotificationsEnabled = &notificationsEnabled
+			}
+			if keySorting := desiredNamespace.GetKeySorting(); keySorting != "" {
+				namespace.KeySorting = keySorting
+			}
+			if policy := desiredNamespace.GetPolicy(); policy != nil {
+				namespace.Policy = policy
+			}
+
+			updated = namespace
+			return config, nil
+		}
+		return nil, metadatacommon.ErrNotFound
+	}); err != nil {
+		return nil, err
+	}
+
+	return updated, nil
 }
 
 func (m *coordinatorMetadata) CreateDataServer(dataServer *commonproto.DataServer) error {

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -162,6 +162,10 @@ func (*mockNamespaceMetadata) CreateNamespace(*proto.Namespace) error {
 	return nil
 }
 
+func (*mockNamespaceMetadata) PatchNamespace(*proto.Namespace) (*proto.Namespace, error) {
+	return &proto.Namespace{}, nil
+}
+
 func (*mockNamespaceMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterConfiguration] {
 	return commonobject.Borrowed[*proto.ClusterConfiguration]{}
 }

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -88,6 +88,10 @@ func (*mockMetadata) CreateNamespace(*proto.Namespace) error {
 	return nil
 }
 
+func (*mockMetadata) PatchNamespace(*proto.Namespace) (*proto.Namespace, error) {
+	return &proto.Namespace{}, nil
+}
+
 func (*mockMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterConfiguration] {
 	return commonobject.Borrowed[*proto.ClusterConfiguration]{}
 }

--- a/tests/coordinator/admin_namespace_e2e_test.go
+++ b/tests/coordinator/admin_namespace_e2e_test.go
@@ -86,6 +86,26 @@ func TestAdminNamespaceCreateAndGet(t *testing.T) {
 	assert.EqualValues(t, 2, found.GetInitialShardCount())
 	assert.False(t, found.NotificationsEnabledOrDefault())
 
+	notificationsEnabled = true
+	patched, err := client.PatchNamespace(&proto.Namespace{
+		Name:                 "ns-1",
+		NotificationsEnabled: &notificationsEnabled,
+		KeySorting:           "hierarchical",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, patched)
+	assert.Equal(t, "ns-1", patched.GetName())
+	assert.EqualValues(t, 2, patched.GetInitialShardCount())
+	assert.EqualValues(t, 1, patched.GetReplicationFactor())
+	assert.True(t, patched.NotificationsEnabledOrDefault())
+	assert.Equal(t, "hierarchical", patched.GetKeySorting())
+
+	found, err = client.GetNamespace("ns-1")
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	assert.True(t, found.NotificationsEnabledOrDefault())
+	assert.Equal(t, "hierarchical", found.GetKeySorting())
+
 	namespaces, err := client.ListNamespaces()
 	require.NoError(t, err)
 	require.Len(t, namespaces, 1)

--- a/tests/coordinator/admin_namespace_e2e_test.go
+++ b/tests/coordinator/admin_namespace_e2e_test.go
@@ -90,7 +90,6 @@ func TestAdminNamespaceCreateAndGet(t *testing.T) {
 	patched, err := client.PatchNamespace(&proto.Namespace{
 		Name:                 "ns-1",
 		NotificationsEnabled: &notificationsEnabled,
-		KeySorting:           "hierarchical",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, patched)
@@ -98,13 +97,13 @@ func TestAdminNamespaceCreateAndGet(t *testing.T) {
 	assert.EqualValues(t, 2, patched.GetInitialShardCount())
 	assert.EqualValues(t, 1, patched.GetReplicationFactor())
 	assert.True(t, patched.NotificationsEnabledOrDefault())
-	assert.Equal(t, "hierarchical", patched.GetKeySorting())
+	assert.Equal(t, "natural", patched.GetKeySorting())
 
 	found, err = client.GetNamespace("ns-1")
 	require.NoError(t, err)
 	require.NotNil(t, found)
 	assert.True(t, found.NotificationsEnabledOrDefault())
-	assert.Equal(t, "hierarchical", found.GetKeySorting())
+	assert.Equal(t, "natural", found.GetKeySorting())
 
 	namespaces, err := client.ListNamespaces()
 	require.NoError(t, err)


### PR DESCRIPTION
## Motivation
- Continue the namespace admin API rollout by supporting safe partial namespace configuration updates.
- Keep namespace create and patch CLI behavior aligned through shared field handling without exposing immutable patch fields.

## Modifications
- Added `PatchNamespace` to the admin proto, generated stubs, public admin client, coordinator metadata, and management server.
- Added `oxia admin namespace patch <namespace>` with partial update support for replication factor and notifications.
- Disallowed patching immutable namespace fields, including initial shard count and key sorting, at both CLI and RPC validation layers.
- Reused namespace CLI field definitions between create and patch commands.
- Added unit and integration coverage for the client, CLI, management server, and coordinator namespace admin flow.

## Testing
- `go test ./cmd/admin/namespace/... ./oxia ./oxiad/coordinator ./tests/coordinator -run 'Test_cmd_patchNamespace|TestAdminClientPatchNamespace|TestManagementServerPatchNamespace|TestAdminNamespaceCreateAndGet' -count=1`
- `go test ./cmd/admin/... ./oxia ./oxiad/coordinator/...`
- `go test ./tests/coordinator -count=1`
- `make lint`
- `make license-check`
