### PR TITLE
chore: align metadata provider mutex fields

### DIFF
--- a/oxiad/coordinator/metadata/provider/file/provider.go
+++ b/oxiad/coordinator/metadata/provider/file/provider.go
@@ -42,6 +42,7 @@ var _ provider.Provider[*commonproto.ClusterConfiguration] = (*Provider[*commonp
 const parentDirectoryMode = 0o755
 
 type Provider[T gproto.Message] struct {
+	mu           sync.Mutex
 	path         string
 	codec        metadatacommon.Codec[T]
 	fileLock     *fslock.Lock
@@ -120,7 +121,7 @@ func (m *Provider[T]) WaitToBecomeLeader() error {
 func (m *Provider[T]) loadLatest() (snapshot provider.Versioned[T], err error) {
 	err = backoff.RetryNotify(func() error {
 		var readErr error
-		snapshot, readErr = m.loadLatestOnce()
+		snapshot, readErr = m.loadLatestOnceLocked()
 		return readErr
 	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
 		m.logger.Warn("Failed to read file metadata, retrying",
@@ -130,7 +131,14 @@ func (m *Provider[T]) loadLatest() (snapshot provider.Versioned[T], err error) {
 	return snapshot, err
 }
 
-func (m *Provider[T]) loadLatestOnce() (snapshot provider.Versioned[T], err error) {
+func (m *Provider[T]) loadLatestOnceLocked() (snapshot provider.Versioned[T], err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.loadLatestOnceWithoutLock()
+}
+
+func (m *Provider[T]) loadLatestOnceWithoutLock() (snapshot provider.Versioned[T], err error) {
 	content, err := os.ReadFile(m.path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -159,7 +167,10 @@ func (m *Provider[T]) loadLatestOnce() (snapshot provider.Versioned[T], err erro
 }
 
 func (m *Provider[T]) Store(snapshot provider.Versioned[T]) (newVersion metadatacommon.Version, err error) {
-	existingSnapshot, err := m.loadLatest()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	existingSnapshot, err := m.loadLatestOnceWithoutLock()
 	if err != nil {
 		return metadatacommon.NotExists, err
 	}

--- a/oxiad/coordinator/metadata/provider/kubernetes/provider.go
+++ b/oxiad/coordinator/metadata/provider/kubernetes/provider.go
@@ -61,7 +61,7 @@ const (
 )
 
 type Provider[T gproto.Message] struct {
-	sync.Mutex
+	mu              sync.Mutex
 	kubernetes      kubernetes.Interface
 	namespace, name string
 	codec           metadatacommon.Codec[T]
@@ -141,8 +141,8 @@ func (m *Provider[T]) loadLatest() (snapshot provider.Versioned[T], err error) {
 	timer := m.getLatencyHisto.Timer()
 	defer timer.Done()
 
-	m.Lock()
-	defer m.Unlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	err = backoff.RetryNotify(func() error {
 		var getErr error
 		snapshot, getErr = m.loadLatestWithoutLock()
@@ -196,8 +196,8 @@ func (m *Provider[T]) Store(snapshot provider.Versioned[T]) (metadatacommon.Vers
 	timer := m.storeLatencyHisto.Timer()
 	defer timer.Done()
 
-	m.Lock()
-	defer m.Unlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	data, err := m.codec.MarshalYAML(snapshot.Value)
 	if err != nil {

--- a/oxiad/coordinator/metadata/provider/memory/provider.go
+++ b/oxiad/coordinator/metadata/provider/memory/provider.go
@@ -29,8 +29,7 @@ var _ provider.Provider[*proto.ClusterStatus] = (*Provider[*proto.ClusterStatus]
 var _ provider.Provider[*proto.ClusterConfiguration] = (*Provider[*proto.ClusterConfiguration])(nil)
 
 type Provider[T gproto.Message] struct {
-	sync.Mutex
-
+	mu           sync.Mutex
 	codec        metadatacommon.Codec[T]
 	value        T
 	version      metadatacommon.Version
@@ -61,8 +60,8 @@ func (*Provider[T]) Close() error {
 }
 
 func (m *Provider[T]) Store(snapshot provider.Versioned[T]) (newVersion metadatacommon.Version, err error) {
-	m.Lock()
-	defer m.Unlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	if snapshot.Version != m.version {
 		return metadatacommon.NotExists, metadatacommon.ErrBadVersion

--- a/oxiad/coordinator/metadata/provider/raft/provider.go
+++ b/oxiad/coordinator/metadata/provider/raft/provider.go
@@ -95,8 +95,8 @@ func fromVersion(v metadatacommon.Version) int64 {
 }
 
 func (mpr *Provider[T]) loadLatest() provider.Versioned[T] {
-	mpr.raft.Lock()
-	defer mpr.raft.Unlock()
+	mpr.raft.mu.Lock()
+	defer mpr.raft.mu.Unlock()
 
 	document := mpr.raft.sc.document(mpr.codec.GetKey())
 
@@ -121,8 +121,8 @@ func (mpr *Provider[T]) loadLatest() provider.Versioned[T] {
 }
 
 func (mpr *Provider[T]) Store(snapshot provider.Versioned[T]) (newVersion metadatacommon.Version, err error) {
-	mpr.raft.Lock()
-	defer mpr.raft.Unlock()
+	mpr.raft.mu.Lock()
+	defer mpr.raft.mu.Unlock()
 
 	if err = mpr.raft.node.VerifyLeader().Error(); err != nil {
 		return metadatacommon.NotExists, err

--- a/oxiad/coordinator/metadata/provider/raft/raft.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft.go
@@ -30,7 +30,7 @@ import (
 )
 
 type Raft struct {
-	sync.Mutex
+	mu          sync.Mutex
 	sc          *stateContainer
 	node        *hashicorpraft.Raft
 	store       *kvRaftStore


### PR DESCRIPTION
## Motivation
- Keep metadata provider mutex fields consistently named and avoid embedding mutexes into provider APIs.
- Preserve the raft mutex on the shared Raft state because config and status providers use the same raft instance.

## Modifications
- Changed memory and Kubernetes providers from embedded `sync.Mutex` to named `mu sync.Mutex` fields.
- Kept the raft lock on `Raft`, renamed it to `mu`, and updated provider call sites to use the named field.
- Added file-provider locking around load/store paths so file metadata reads and writes serialize consistently.

## Testing
- `go test ./oxiad/coordinator/metadata/provider/...`