### PR TITLE
refactor: consolidate admin resource command helpers

### DIFF
--- a/cmd/admin/dataserver/cli/option.go
+++ b/cmd/admin/dataserver/cli/option.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package option
+package cli
 
 import "github.com/spf13/pflag"
 

--- a/cmd/admin/dataserver/cli/output.go
+++ b/cmd/admin/dataserver/cli/output.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package output
+package cli
 
 import (
 	"fmt"

--- a/cmd/admin/dataserver/cmd.go
+++ b/cmd/admin/dataserver/cmd.go
@@ -16,7 +16,7 @@ package dataserver
 
 import (
 	createcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/create"
-	"github.com/oxia-db/oxia/cmd/admin/dataserver/deletecmd"
+	deletecmd "github.com/oxia-db/oxia/cmd/admin/dataserver/delete"
 	getcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/get"
 	patchcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/patch"
 

--- a/cmd/admin/dataserver/create/cmd.go
+++ b/cmd/admin/dataserver/create/cmd.go
@@ -21,14 +21,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	"github.com/oxia-db/oxia/cmd/admin/dataserver/option"
-	dataserveroutput "github.com/oxia-db/oxia/cmd/admin/dataserver/output"
+	dataservercli "github.com/oxia-db/oxia/cmd/admin/dataserver/cli"
 	cmdparse "github.com/oxia-db/oxia/cmd/common/parse"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxia"
 )
 
-var fields option.DataServerFields
+var fields dataservercli.DataServerFields
 
 var Cmd = &cobra.Command{
 	Use:          "create <name> --public <address> --internal <address>",
@@ -41,8 +40,8 @@ var Cmd = &cobra.Command{
 
 func init() {
 	fields.AddFlags(Cmd.Flags())
-	_ = Cmd.MarkFlagRequired(option.PublicFlagName)
-	_ = Cmd.MarkFlagRequired(option.InternalFlagName)
+	_ = Cmd.MarkFlagRequired(dataservercli.PublicFlagName)
+	_ = Cmd.MarkFlagRequired(dataservercli.InternalFlagName)
 }
 
 func exec(cmd *cobra.Command, args []string) error {
@@ -92,5 +91,5 @@ func exec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return dataserveroutput.WriteDataServer(cmd.OutOrStdout(), outputFormat, created)
+	return dataservercli.WriteDataServer(cmd.OutOrStdout(), outputFormat, created)
 }

--- a/cmd/admin/dataserver/create/cmd_test.go
+++ b/cmd/admin/dataserver/create/cmd_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	"github.com/oxia-db/oxia/cmd/admin/dataserver/option"
+	dataservercli "github.com/oxia-db/oxia/cmd/admin/dataserver/cli"
 	"github.com/oxia-db/oxia/common/proto"
 )
 
@@ -76,8 +76,8 @@ func Test_cmd_createDataServer(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd.Flags())
-	_ = cmd.MarkFlagRequired(option.PublicFlagName)
-	_ = cmd.MarkFlagRequired(option.InternalFlagName)
+	_ = cmd.MarkFlagRequired(dataservercli.PublicFlagName)
+	_ = cmd.MarkFlagRequired(dataservercli.InternalFlagName)
 	out, err := runCmd(cmd, serverName, "--public", "public1", "--internal", "internal1", "--label", "rack=rack-1", "-o", "json")
 
 	assert.NoError(t, err)
@@ -117,8 +117,8 @@ func Test_cmd_createDataServer_DefaultTable(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd.Flags())
-	_ = cmd.MarkFlagRequired(option.PublicFlagName)
-	_ = cmd.MarkFlagRequired(option.InternalFlagName)
+	_ = cmd.MarkFlagRequired(dataservercli.PublicFlagName)
+	_ = cmd.MarkFlagRequired(dataservercli.InternalFlagName)
 	out, err := runCmd(cmd, serverName, "--public", "public1", "--internal", "internal1")
 
 	assert.NoError(t, err)
@@ -154,8 +154,8 @@ func Test_cmd_createDataServer_Name(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd.Flags())
-	_ = cmd.MarkFlagRequired(option.PublicFlagName)
-	_ = cmd.MarkFlagRequired(option.InternalFlagName)
+	_ = cmd.MarkFlagRequired(dataservercli.PublicFlagName)
+	_ = cmd.MarkFlagRequired(dataservercli.InternalFlagName)
 	out, err := runCmd(cmd, serverName, "--public", "public1", "--internal", "internal1", "-o", "name")
 
 	assert.NoError(t, err)
@@ -175,8 +175,8 @@ func Test_cmd_createDataServer_InvalidLabel(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd.Flags())
-	_ = cmd.MarkFlagRequired(option.PublicFlagName)
-	_ = cmd.MarkFlagRequired(option.InternalFlagName)
+	_ = cmd.MarkFlagRequired(dataservercli.PublicFlagName)
+	_ = cmd.MarkFlagRequired(dataservercli.InternalFlagName)
 	out, err := runCmd(cmd, "server-1", "--public", "public1", "--internal", "internal1", "--label", "rack")
 
 	assert.Error(t, err)
@@ -197,8 +197,8 @@ func Test_cmd_createDataServer_RejectsEmptyName(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd.Flags())
-	_ = cmd.MarkFlagRequired(option.PublicFlagName)
-	_ = cmd.MarkFlagRequired(option.InternalFlagName)
+	_ = cmd.MarkFlagRequired(dataservercli.PublicFlagName)
+	_ = cmd.MarkFlagRequired(dataservercli.InternalFlagName)
 	out, err := runCmd(cmd, "   ", "--public", "public1", "--internal", "internal1")
 
 	assert.Error(t, err)

--- a/cmd/admin/dataserver/delete/cmd.go
+++ b/cmd/admin/dataserver/delete/cmd.go
@@ -12,23 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:revive // delete is a Go keyword, so this package keeps the command suffix.
 package deletecmd
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	namespaceoutput "github.com/oxia-db/oxia/cmd/admin/namespace/output"
-	"github.com/oxia-db/oxia/common/validation"
+	dataservercli "github.com/oxia-db/oxia/cmd/admin/dataserver/cli"
 	"github.com/oxia-db/oxia/oxia"
 )
 
 var Cmd = &cobra.Command{
-	Use:          "delete <namespace>",
-	Short:        "Delete a namespace",
-	Long:         `Delete a namespace`,
+	Use:          "delete <name>",
+	Short:        "Delete a data server",
+	Long:         `Delete a data server`,
 	Args:         cobra.ExactArgs(1),
 	RunE:         exec,
 	SilenceUsage: true,
@@ -44,8 +45,8 @@ func exec(cmd *cobra.Command, args []string) error {
 	}
 
 	name := strings.TrimSpace(args[0])
-	if err := validation.ValidateNamespace(name); err != nil {
-		return err
+	if name == "" {
+		return errors.New("data server name must not be empty")
 	}
 
 	client, err := commons.AdminConfig.NewAdminClient()
@@ -56,10 +57,10 @@ func exec(cmd *cobra.Command, args []string) error {
 		_ = client.Close()
 	}(client)
 
-	deleted, err := client.DeleteNamespace(name)
+	deleted, err := client.DeleteDataServer(name)
 	if err != nil {
 		return err
 	}
 
-	return namespaceoutput.WriteNamespace(cmd.OutOrStdout(), outputFormat, deleted)
+	return dataservercli.WriteDataServer(cmd.OutOrStdout(), outputFormat, deleted)
 }

--- a/cmd/admin/dataserver/delete/cmd_test.go
+++ b/cmd/admin/dataserver/delete/cmd_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:revive // delete is a Go keyword, so this package keeps the command suffix.
 package deletecmd
 
 import (
@@ -40,18 +41,21 @@ func runCmd(cmd *cobra.Command, args ...string) (string, error) {
 	return strings.TrimSpace(actual.String()), err
 }
 
-func Test_cmd_deleteNamespace(t *testing.T) {
+func Test_cmd_deleteDataServer(t *testing.T) {
+	serverName := "server-1"
 	commons.MockedAdminClient = commons.NewMockAdminClient()
 	t.Cleanup(func() { commons.MockedAdminClient = nil })
 
-	notificationsEnabled := false
 	commons.MockedAdminClient.On("Close").Return(nil)
-	commons.MockedAdminClient.On("DeleteNamespace", "ns-1").Return(&proto.Namespace{
-		Name:                 "ns-1",
-		InitialShardCount:    4,
-		ReplicationFactor:    3,
-		NotificationsEnabled: &notificationsEnabled,
-		KeySorting:           "natural",
+	commons.MockedAdminClient.On("DeleteDataServer", serverName).Return(&proto.DataServer{
+		Identity: &proto.DataServerIdentity{
+			Name:     &serverName,
+			Public:   "public1",
+			Internal: "internal1",
+		},
+		Metadata: &proto.DataServerMetadata{
+			Labels: map[string]string{"rack": "rack-1"},
+		},
 	}, nil)
 
 	cmd := &cobra.Command{
@@ -62,54 +66,23 @@ func Test_cmd_deleteNamespace(t *testing.T) {
 		RunE:         Cmd.RunE,
 		SilenceUsage: Cmd.SilenceUsage,
 	}
-	out, err := runCmd(cmd, "ns-1", "-o", "json")
+	out, err := runCmd(cmd, serverName, "-o", "json")
 	require.NoError(t, err)
 
-	var namespace proto.Namespace
-	require.NoError(t, json.Unmarshal([]byte(out), &namespace))
-	assert.Equal(t, "ns-1", namespace.GetName())
-	assert.EqualValues(t, 4, namespace.GetInitialShardCount())
-	assert.EqualValues(t, 3, namespace.GetReplicationFactor())
-	assert.False(t, namespace.NotificationsEnabledOrDefault())
-	assert.Equal(t, "natural", namespace.GetKeySorting())
+	var dataServer proto.DataServer
+	require.NoError(t, json.Unmarshal([]byte(out), &dataServer))
+	require.NotNil(t, dataServer.Identity)
+	require.NotNil(t, dataServer.Identity.Name)
+	assert.Equal(t, serverName, *dataServer.Identity.Name)
+	assert.Equal(t, "public1", dataServer.Identity.GetPublic())
+	assert.Equal(t, "internal1", dataServer.Identity.GetInternal())
+	assert.Equal(t, map[string]string{"rack": "rack-1"}, dataServer.GetMetadata().GetLabels())
 }
 
-func Test_cmd_deleteNamespace_Name(t *testing.T) {
+func Test_cmd_deleteDataServer_RejectsEmptyName(t *testing.T) {
 	commons.MockedAdminClient = commons.NewMockAdminClient()
 	t.Cleanup(func() { commons.MockedAdminClient = nil })
 
-	commons.MockedAdminClient.On("Close").Return(nil)
-	commons.MockedAdminClient.On("DeleteNamespace", "ns-1").Return(&proto.Namespace{Name: "ns-1"}, nil)
-
-	cmd := &cobra.Command{
-		Use:          Cmd.Use,
-		Short:        Cmd.Short,
-		Long:         Cmd.Long,
-		Args:         Cmd.Args,
-		RunE:         Cmd.RunE,
-		SilenceUsage: Cmd.SilenceUsage,
-	}
-	out, err := runCmd(cmd, "ns-1", "-o", "name")
-	require.NoError(t, err)
-	assert.Equal(t, "namespace/ns-1", out)
-}
-
-func Test_cmd_deleteNamespace_RejectsInvalidName(t *testing.T) {
-	cmd := &cobra.Command{
-		Use:          Cmd.Use,
-		Short:        Cmd.Short,
-		Long:         Cmd.Long,
-		Args:         Cmd.Args,
-		RunE:         Cmd.RunE,
-		SilenceUsage: Cmd.SilenceUsage,
-	}
-	out, err := runCmd(cmd, "../ns")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid path traversal sequence")
-	assert.Contains(t, out, "invalid path traversal sequence")
-}
-
-func Test_cmd_deleteNamespace_RejectsEmptyName(t *testing.T) {
 	cmd := &cobra.Command{
 		Use:          Cmd.Use,
 		Short:        Cmd.Short,
@@ -120,6 +93,6 @@ func Test_cmd_deleteNamespace_RejectsEmptyName(t *testing.T) {
 	}
 	out, err := runCmd(cmd, "   ")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "namespace must not be empty")
-	assert.Contains(t, out, "namespace must not be empty")
+	assert.Contains(t, err.Error(), "data server name must not be empty")
+	assert.Contains(t, out, "data server name must not be empty")
 }

--- a/cmd/admin/dataserver/get/cmd.go
+++ b/cmd/admin/dataserver/get/cmd.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	dataserveroutput "github.com/oxia-db/oxia/cmd/admin/dataserver/output"
+	dataservercli "github.com/oxia-db/oxia/cmd/admin/dataserver/cli"
 	"github.com/oxia-db/oxia/oxia"
 )
 
@@ -53,12 +53,12 @@ func exec(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		return dataserveroutput.WriteDataServers(cmd.OutOrStdout(), outputFormat, dataServers)
+		return dataservercli.WriteDataServers(cmd.OutOrStdout(), outputFormat, dataServers)
 	}
 
 	dataServer, err := client.GetDataServer(args[0])
 	if err != nil {
 		return err
 	}
-	return dataserveroutput.WriteDataServer(cmd.OutOrStdout(), outputFormat, dataServer)
+	return dataservercli.WriteDataServer(cmd.OutOrStdout(), outputFormat, dataServer)
 }

--- a/cmd/admin/dataserver/patch/cmd.go
+++ b/cmd/admin/dataserver/patch/cmd.go
@@ -21,15 +21,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	"github.com/oxia-db/oxia/cmd/admin/dataserver/option"
-	dataserveroutput "github.com/oxia-db/oxia/cmd/admin/dataserver/output"
+	dataservercli "github.com/oxia-db/oxia/cmd/admin/dataserver/cli"
 	cmdparse "github.com/oxia-db/oxia/cmd/common/parse"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxia"
 )
 
 var (
-	fields option.DataServerFields
+	fields dataservercli.DataServerFields
 )
 
 var Cmd = &cobra.Command{
@@ -61,9 +60,9 @@ func exec(cmd *cobra.Command, args []string) error {
 
 	publicAddress := strings.TrimSpace(fields.PublicAddress)
 	internalAddress := strings.TrimSpace(fields.InternalAddress)
-	publicChanged := cmd.Flags().Changed(option.PublicFlagName)
-	internalChanged := cmd.Flags().Changed(option.InternalFlagName)
-	labelChanged := cmd.Flags().Changed(option.LabelFlagName)
+	publicChanged := cmd.Flags().Changed(dataservercli.PublicFlagName)
+	internalChanged := cmd.Flags().Changed(dataservercli.InternalFlagName)
+	labelChanged := cmd.Flags().Changed(dataservercli.LabelFlagName)
 
 	if !publicChanged && !internalChanged && !labelChanged {
 		return errors.New("must specify at least one field to patch")
@@ -110,5 +109,5 @@ func exec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return dataserveroutput.WriteDataServer(cmd.OutOrStdout(), outputFormat, patched)
+	return dataservercli.WriteDataServer(cmd.OutOrStdout(), outputFormat, patched)
 }

--- a/cmd/admin/namespace/cli/option.go
+++ b/cmd/admin/namespace/cli/option.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package option
+package cli
 
 import "github.com/spf13/cobra"
 

--- a/cmd/admin/namespace/cli/output.go
+++ b/cmd/admin/namespace/cli/output.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package output
+package cli
 
 import (
 	"fmt"

--- a/cmd/admin/namespace/cmd.go
+++ b/cmd/admin/namespace/cmd.go
@@ -16,7 +16,7 @@ package namespace
 
 import (
 	createcmd "github.com/oxia-db/oxia/cmd/admin/namespace/create"
-	"github.com/oxia-db/oxia/cmd/admin/namespace/deletecmd"
+	deletecmd "github.com/oxia-db/oxia/cmd/admin/namespace/delete"
 	getcmd "github.com/oxia-db/oxia/cmd/admin/namespace/get"
 	patchcmd "github.com/oxia-db/oxia/cmd/admin/namespace/patch"
 

--- a/cmd/admin/namespace/create/cmd.go
+++ b/cmd/admin/namespace/create/cmd.go
@@ -20,14 +20,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	"github.com/oxia-db/oxia/cmd/admin/namespace/option"
-	namespaceoutput "github.com/oxia-db/oxia/cmd/admin/namespace/output"
+	namespacecli "github.com/oxia-db/oxia/cmd/admin/namespace/cli"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/common/validation"
 	"github.com/oxia-db/oxia/oxia"
 )
 
-var fields option.NamespaceFields
+var fields namespacecli.NamespaceFields
 
 var Cmd = &cobra.Command{
 	Use:          "create <namespace> --initial-shards <count> --replication-factor <factor>",
@@ -40,8 +39,8 @@ var Cmd = &cobra.Command{
 
 func init() {
 	fields.AddFlags(Cmd)
-	_ = Cmd.MarkFlagRequired(option.InitialShardsFlagName)
-	_ = Cmd.MarkFlagRequired(option.ReplicationFactorFlagName)
+	_ = Cmd.MarkFlagRequired(namespacecli.InitialShardsFlagName)
+	_ = Cmd.MarkFlagRequired(namespacecli.ReplicationFactorFlagName)
 }
 
 func exec(cmd *cobra.Command, args []string) error {
@@ -90,5 +89,5 @@ func exec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return namespaceoutput.WriteNamespace(cmd.OutOrStdout(), outputFormat, created)
+	return namespacecli.WriteNamespace(cmd.OutOrStdout(), outputFormat, created)
 }

--- a/cmd/admin/namespace/create/cmd_test.go
+++ b/cmd/admin/namespace/create/cmd_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	"github.com/oxia-db/oxia/cmd/admin/namespace/option"
+	namespacecli "github.com/oxia-db/oxia/cmd/admin/namespace/cli"
 	"github.com/oxia-db/oxia/common/proto"
 )
 
@@ -75,8 +75,8 @@ func Test_cmd_createNamespace(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd)
-	_ = cmd.MarkFlagRequired(option.InitialShardsFlagName)
-	_ = cmd.MarkFlagRequired(option.ReplicationFactorFlagName)
+	_ = cmd.MarkFlagRequired(namespacecli.InitialShardsFlagName)
+	_ = cmd.MarkFlagRequired(namespacecli.ReplicationFactorFlagName)
 	out, err := runCmd(cmd, "ns-1", "--initial-shards", "4", "--replication-factor", "3",
 		"--notifications=false", "--key-sorting", "natural", "-o", "json")
 
@@ -112,8 +112,8 @@ func Test_cmd_createNamespace_DefaultTable(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd)
-	_ = cmd.MarkFlagRequired(option.InitialShardsFlagName)
-	_ = cmd.MarkFlagRequired(option.ReplicationFactorFlagName)
+	_ = cmd.MarkFlagRequired(namespacecli.InitialShardsFlagName)
+	_ = cmd.MarkFlagRequired(namespacecli.ReplicationFactorFlagName)
 	out, err := runCmd(cmd, "ns-1", "--initial-shards", "4", "--replication-factor", "3")
 
 	require.NoError(t, err)
@@ -147,8 +147,8 @@ func Test_cmd_createNamespace_Name(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd)
-	_ = cmd.MarkFlagRequired(option.InitialShardsFlagName)
-	_ = cmd.MarkFlagRequired(option.ReplicationFactorFlagName)
+	_ = cmd.MarkFlagRequired(namespacecli.InitialShardsFlagName)
+	_ = cmd.MarkFlagRequired(namespacecli.ReplicationFactorFlagName)
 	out, err := runCmd(cmd, "ns-1", "--initial-shards", "4", "--replication-factor", "3", "-o", "name")
 
 	require.NoError(t, err)
@@ -168,8 +168,8 @@ func Test_cmd_createNamespace_RejectsInvalidName(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd)
-	_ = cmd.MarkFlagRequired(option.InitialShardsFlagName)
-	_ = cmd.MarkFlagRequired(option.ReplicationFactorFlagName)
+	_ = cmd.MarkFlagRequired(namespacecli.InitialShardsFlagName)
+	_ = cmd.MarkFlagRequired(namespacecli.ReplicationFactorFlagName)
 	out, err := runCmd(cmd, "../ns", "--initial-shards", "4", "--replication-factor", "3")
 
 	require.Error(t, err)
@@ -190,8 +190,8 @@ func Test_cmd_createNamespace_RejectsInvalidKeySorting(t *testing.T) {
 		SilenceUsage: Cmd.SilenceUsage,
 	}
 	fields.AddFlags(cmd)
-	_ = cmd.MarkFlagRequired(option.InitialShardsFlagName)
-	_ = cmd.MarkFlagRequired(option.ReplicationFactorFlagName)
+	_ = cmd.MarkFlagRequired(namespacecli.InitialShardsFlagName)
+	_ = cmd.MarkFlagRequired(namespacecli.ReplicationFactorFlagName)
 	out, err := runCmd(cmd, "ns-1", "--initial-shards", "4", "--replication-factor", "3", "--key-sorting", "unknown")
 
 	require.Error(t, err)

--- a/cmd/admin/namespace/delete/cmd.go
+++ b/cmd/admin/namespace/delete/cmd.go
@@ -12,23 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:revive // delete is a Go keyword, so this package keeps the command suffix.
 package deletecmd
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	dataserveroutput "github.com/oxia-db/oxia/cmd/admin/dataserver/output"
+	namespacecli "github.com/oxia-db/oxia/cmd/admin/namespace/cli"
+	"github.com/oxia-db/oxia/common/validation"
 	"github.com/oxia-db/oxia/oxia"
 )
 
 var Cmd = &cobra.Command{
-	Use:          "delete <name>",
-	Short:        "Delete a data server",
-	Long:         `Delete a data server`,
+	Use:          "delete <namespace>",
+	Short:        "Delete a namespace",
+	Long:         `Delete a namespace`,
 	Args:         cobra.ExactArgs(1),
 	RunE:         exec,
 	SilenceUsage: true,
@@ -44,8 +45,8 @@ func exec(cmd *cobra.Command, args []string) error {
 	}
 
 	name := strings.TrimSpace(args[0])
-	if name == "" {
-		return errors.New("data server name must not be empty")
+	if err := validation.ValidateNamespace(name); err != nil {
+		return err
 	}
 
 	client, err := commons.AdminConfig.NewAdminClient()
@@ -56,10 +57,10 @@ func exec(cmd *cobra.Command, args []string) error {
 		_ = client.Close()
 	}(client)
 
-	deleted, err := client.DeleteDataServer(name)
+	deleted, err := client.DeleteNamespace(name)
 	if err != nil {
 		return err
 	}
 
-	return dataserveroutput.WriteDataServer(cmd.OutOrStdout(), outputFormat, deleted)
+	return namespacecli.WriteNamespace(cmd.OutOrStdout(), outputFormat, deleted)
 }

--- a/cmd/admin/namespace/delete/cmd_test.go
+++ b/cmd/admin/namespace/delete/cmd_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:revive // delete is a Go keyword, so this package keeps the command suffix.
 package deletecmd
 
 import (
@@ -40,21 +41,18 @@ func runCmd(cmd *cobra.Command, args ...string) (string, error) {
 	return strings.TrimSpace(actual.String()), err
 }
 
-func Test_cmd_deleteDataServer(t *testing.T) {
-	serverName := "server-1"
+func Test_cmd_deleteNamespace(t *testing.T) {
 	commons.MockedAdminClient = commons.NewMockAdminClient()
 	t.Cleanup(func() { commons.MockedAdminClient = nil })
 
+	notificationsEnabled := false
 	commons.MockedAdminClient.On("Close").Return(nil)
-	commons.MockedAdminClient.On("DeleteDataServer", serverName).Return(&proto.DataServer{
-		Identity: &proto.DataServerIdentity{
-			Name:     &serverName,
-			Public:   "public1",
-			Internal: "internal1",
-		},
-		Metadata: &proto.DataServerMetadata{
-			Labels: map[string]string{"rack": "rack-1"},
-		},
+	commons.MockedAdminClient.On("DeleteNamespace", "ns-1").Return(&proto.Namespace{
+		Name:                 "ns-1",
+		InitialShardCount:    4,
+		ReplicationFactor:    3,
+		NotificationsEnabled: &notificationsEnabled,
+		KeySorting:           "natural",
 	}, nil)
 
 	cmd := &cobra.Command{
@@ -65,23 +63,54 @@ func Test_cmd_deleteDataServer(t *testing.T) {
 		RunE:         Cmd.RunE,
 		SilenceUsage: Cmd.SilenceUsage,
 	}
-	out, err := runCmd(cmd, serverName, "-o", "json")
+	out, err := runCmd(cmd, "ns-1", "-o", "json")
 	require.NoError(t, err)
 
-	var dataServer proto.DataServer
-	require.NoError(t, json.Unmarshal([]byte(out), &dataServer))
-	require.NotNil(t, dataServer.Identity)
-	require.NotNil(t, dataServer.Identity.Name)
-	assert.Equal(t, serverName, *dataServer.Identity.Name)
-	assert.Equal(t, "public1", dataServer.Identity.GetPublic())
-	assert.Equal(t, "internal1", dataServer.Identity.GetInternal())
-	assert.Equal(t, map[string]string{"rack": "rack-1"}, dataServer.GetMetadata().GetLabels())
+	var namespace proto.Namespace
+	require.NoError(t, json.Unmarshal([]byte(out), &namespace))
+	assert.Equal(t, "ns-1", namespace.GetName())
+	assert.EqualValues(t, 4, namespace.GetInitialShardCount())
+	assert.EqualValues(t, 3, namespace.GetReplicationFactor())
+	assert.False(t, namespace.NotificationsEnabledOrDefault())
+	assert.Equal(t, "natural", namespace.GetKeySorting())
 }
 
-func Test_cmd_deleteDataServer_RejectsEmptyName(t *testing.T) {
+func Test_cmd_deleteNamespace_Name(t *testing.T) {
 	commons.MockedAdminClient = commons.NewMockAdminClient()
 	t.Cleanup(func() { commons.MockedAdminClient = nil })
 
+	commons.MockedAdminClient.On("Close").Return(nil)
+	commons.MockedAdminClient.On("DeleteNamespace", "ns-1").Return(&proto.Namespace{Name: "ns-1"}, nil)
+
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	out, err := runCmd(cmd, "ns-1", "-o", "name")
+	require.NoError(t, err)
+	assert.Equal(t, "namespace/ns-1", out)
+}
+
+func Test_cmd_deleteNamespace_RejectsInvalidName(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:          Cmd.Use,
+		Short:        Cmd.Short,
+		Long:         Cmd.Long,
+		Args:         Cmd.Args,
+		RunE:         Cmd.RunE,
+		SilenceUsage: Cmd.SilenceUsage,
+	}
+	out, err := runCmd(cmd, "../ns")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid path traversal sequence")
+	assert.Contains(t, out, "invalid path traversal sequence")
+}
+
+func Test_cmd_deleteNamespace_RejectsEmptyName(t *testing.T) {
 	cmd := &cobra.Command{
 		Use:          Cmd.Use,
 		Short:        Cmd.Short,
@@ -92,6 +121,6 @@ func Test_cmd_deleteDataServer_RejectsEmptyName(t *testing.T) {
 	}
 	out, err := runCmd(cmd, "   ")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "data server name must not be empty")
-	assert.Contains(t, out, "data server name must not be empty")
+	assert.Contains(t, err.Error(), "namespace must not be empty")
+	assert.Contains(t, out, "namespace must not be empty")
 }

--- a/cmd/admin/namespace/get/cmd.go
+++ b/cmd/admin/namespace/get/cmd.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	namespaceoutput "github.com/oxia-db/oxia/cmd/admin/namespace/output"
+	namespacecli "github.com/oxia-db/oxia/cmd/admin/namespace/cli"
 	"github.com/oxia-db/oxia/oxia"
 )
 
@@ -53,12 +53,12 @@ func exec(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		return namespaceoutput.WriteNamespaces(cmd.OutOrStdout(), outputFormat, namespaces)
+		return namespacecli.WriteNamespaces(cmd.OutOrStdout(), outputFormat, namespaces)
 	}
 
 	namespace, err := client.GetNamespace(args[0])
 	if err != nil {
 		return err
 	}
-	return namespaceoutput.WriteNamespace(cmd.OutOrStdout(), outputFormat, namespace)
+	return namespacecli.WriteNamespace(cmd.OutOrStdout(), outputFormat, namespace)
 }

--- a/cmd/admin/namespace/get/cmd_test.go
+++ b/cmd/admin/namespace/get/cmd_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	namespaceoutput "github.com/oxia-db/oxia/cmd/admin/namespace/output"
+	namespacecli "github.com/oxia-db/oxia/cmd/admin/namespace/cli"
 	"github.com/oxia-db/oxia/common/proto"
 )
 
@@ -209,7 +209,7 @@ func Test_cmd_getNamespace_InvalidOutput(t *testing.T) {
 }
 
 func TestWriteNamespaceRejectsNilNamespace(t *testing.T) {
-	err := namespaceoutput.WriteNamespace(new(bytes.Buffer), "", nil)
+	err := namespacecli.WriteNamespace(new(bytes.Buffer), "", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "namespace must not be nil")
 }

--- a/cmd/admin/namespace/patch/cmd.go
+++ b/cmd/admin/namespace/patch/cmd.go
@@ -20,14 +20,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	"github.com/oxia-db/oxia/cmd/admin/namespace/option"
-	namespaceoutput "github.com/oxia-db/oxia/cmd/admin/namespace/output"
+	namespacecli "github.com/oxia-db/oxia/cmd/admin/namespace/cli"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/common/validation"
 	"github.com/oxia-db/oxia/oxia"
 )
 
-var fields option.NamespaceFields
+var fields namespacecli.NamespaceFields
 
 var Cmd = &cobra.Command{
 	Use:          "patch <namespace>",
@@ -56,8 +55,8 @@ func exec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	replicationFactorChanged := cmd.Flags().Changed(option.ReplicationFactorFlagName)
-	notificationsChanged := cmd.Flags().Changed(option.NotificationsFlagName)
+	replicationFactorChanged := cmd.Flags().Changed(namespacecli.ReplicationFactorFlagName)
+	notificationsChanged := cmd.Flags().Changed(namespacecli.NotificationsFlagName)
 	if !replicationFactorChanged && !notificationsChanged {
 		return errors.New("must specify at least one field to patch")
 	}
@@ -88,5 +87,5 @@ func exec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return namespaceoutput.WriteNamespace(cmd.OutOrStdout(), outputFormat, patched)
+	return namespacecli.WriteNamespace(cmd.OutOrStdout(), outputFormat, patched)
 }


### PR DESCRIPTION
## Motivation
- Keep admin command resource layouts consistent now that dataserver and namespace commands both have create, get, patch, and delete operations.
- Avoid splitting resource-local CLI flag helpers and output helpers across separate small packages.

## Modifications
- Renamed dataserver and namespace delete command directories from `deletecmd` to `delete`, while keeping the Go package name as `deletecmd` because `delete` is a Go keyword.
- Merged each resource's `option` and `output` packages into a single resource-local `cli` package.
- Updated admin command imports and tests to use the new `dataserver/cli`, `namespace/cli`, and `delete` paths.

## Testing
- `go test ./cmd/admin/dataserver/... ./cmd/admin/namespace/...`
- `make lint`
- `make license-check`
- `git diff --check`
