### PR TITLE
refactor: move split shard command under shard

### DIFF
--- a/cmd/admin/cmd.go
+++ b/cmd/admin/cmd.go
@@ -20,7 +20,7 @@ import (
 	"github.com/oxia-db/oxia/cmd/admin/commons"
 	"github.com/oxia-db/oxia/cmd/admin/dataserver"
 	"github.com/oxia-db/oxia/cmd/admin/namespace"
-	"github.com/oxia-db/oxia/cmd/admin/splitshard"
+	"github.com/oxia-db/oxia/cmd/admin/shard"
 	oxiacommon "github.com/oxia-db/oxia/common/constant"
 
 	"github.com/spf13/cobra"
@@ -41,5 +41,5 @@ func init() {
 
 	Cmd.AddCommand(dataserver.Cmd)
 	Cmd.AddCommand(namespace.Cmd)
-	Cmd.AddCommand(splitshard.Cmd)
+	Cmd.AddCommand(shard.Cmd)
 }

--- a/cmd/admin/cmd_test.go
+++ b/cmd/admin/cmd_test.go
@@ -1,0 +1,66 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/cmd/admin/commons"
+	"github.com/oxia-db/oxia/oxia"
+)
+
+func runCmd(args ...string) (string, error) {
+	actual := new(bytes.Buffer)
+	Cmd.SetOut(actual)
+	Cmd.SetErr(actual)
+	Cmd.SetArgs(args)
+	err := Cmd.Execute()
+	return strings.TrimSpace(actual.String()), err
+}
+
+func Test_cmd_adminShardSplit(t *testing.T) {
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() { commons.MockedAdminClient = nil })
+
+	commons.MockedAdminClient.On("Close").Return(nil)
+	commons.MockedAdminClient.On(
+		"SplitShard",
+		"tenant",
+		int64(7),
+		mock.MatchedBy(func(splitPoint *uint32) bool {
+			return splitPoint != nil && *splitPoint == 512
+		}),
+	).Return(&oxia.SplitShardResult{
+		LeftChildShardId:  8,
+		RightChildShardId: 9,
+	})
+
+	out, err := runCmd("shard", "split", "--namespace", "tenant", "--shard", "7", "--split-point", "512")
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.EqualValues(t, 8, result["LeftChildShardId"])
+	assert.EqualValues(t, 9, result["RightChildShardId"])
+	assert.Nil(t, result["Error"])
+	commons.MockedAdminClient.AssertExpectations(t)
+}

--- a/cmd/admin/shard/cmd.go
+++ b/cmd/admin/shard/cmd.go
@@ -1,0 +1,31 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shard
+
+import (
+	splitcmd "github.com/oxia-db/oxia/cmd/admin/shard/split"
+
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "shard",
+	Short: "Oxia admin operations on shards",
+	Long:  `Oxia admin operations on shards`,
+}
+
+func init() {
+	Cmd.AddCommand(splitcmd.Cmd)
+}

--- a/cmd/admin/shard/split/cmd.go
+++ b/cmd/admin/shard/split/cmd.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package splitshard
+package split
 
 import (
 	"github.com/spf13/cobra"
@@ -37,7 +37,7 @@ func init() {
 }
 
 var Cmd = &cobra.Command{
-	Use:          "split-shard",
+	Use:          "split",
 	Short:        "Split a shard into two children",
 	Long:         `Split a shard into two children at the specified split point (or midpoint if not specified)`,
 	Args:         cobra.ExactArgs(0),


### PR DESCRIPTION
## Motivation
- Align the shard split admin command with resource-oriented command grouping.
- Replace the top-level `split-shard` command with `shard split`.

## Modifications
- Added a new `admin shard` command group.
- Moved the split shard command implementation from `cmd/admin/splitshard` to `cmd/admin/shard/split`.
- Updated admin command registration so the command is now invoked as `admin shard split`.

## Testing
- `go test ./cmd/admin/...`
- `make lint`
- `make license-check`
- `git diff --check`
