### PR TITLE
fix: keep raft snapshots rollback compatible

### DIFF
--- a/oxiad/coordinator/metadata/provider/raft/raft_fsm.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft_fsm.go
@@ -143,9 +143,17 @@ type documentContainer struct {
 }
 
 func marshalStateContainer(sc *stateContainer) ([]byte, error) {
-	return json.Marshal(persistedStateContainer{
-		Documents: cloneDocuments(sc.Documents),
-	})
+	persisted := persistedStateContainer{
+		Documents:      sc.Documents,
+		CurrentVersion: -1,
+	}
+
+	if statusDocument, ok := sc.Documents[metadatacodec.ClusterStatusCodec.GetKey()]; ok && statusDocument != nil {
+		persisted.State = statusDocument.State
+		persisted.CurrentVersion = statusDocument.CurrentVersion
+	}
+
+	return json.Marshal(persisted)
 }
 
 func (sc *stateContainer) document(key string) *documentContainer {

--- a/oxiad/coordinator/metadata/provider/raft/raft_fsm_test.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft_fsm_test.go
@@ -58,3 +58,49 @@ func TestStateContainerApplySupportsV0163StatusLog(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, status.GetInstanceId(), decoded.GetInstanceId())
 }
+
+func TestStateContainerSnapshotIncludesV0163StatusState(t *testing.T) {
+	sc := newStateContainer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+
+	status := &commonproto.ClusterStatus{
+		InstanceId: "v0163-snapshot",
+		Namespaces: map[string]*commonproto.NamespaceStatus{
+			"default": {
+				Shards: map[int64]*commonproto.ShardMetadata{
+					1: {
+						Status: commonproto.ShardStatusSteadyState,
+						Split: &commonproto.SplitMetadata{
+							Phase: commonproto.SplitPhaseCatchUp,
+						},
+					},
+				},
+			},
+		},
+	}
+	statusBytes, err := metadatacodec.ClusterStatusCodec.MarshalJSON(status)
+	require.NoError(t, err)
+
+	statusDocument := sc.document(metadatacodec.ClusterStatusCodec.GetKey())
+	statusDocument.State = statusBytes
+	statusDocument.CurrentVersion = 4
+
+	payload, err := marshalStateContainer(sc)
+	require.NoError(t, err)
+
+	var legacySnapshot struct {
+		State          json.RawMessage `json:"state"`
+		CurrentVersion int64           `json:"current_version"`
+	}
+	require.NoError(t, json.Unmarshal(payload, &legacySnapshot))
+	require.Equal(t, int64(4), legacySnapshot.CurrentVersion)
+
+	decoded, err := metadatacodec.ClusterStatusCodec.UnmarshalJSON(legacySnapshot.State)
+	require.NoError(t, err)
+	require.Equal(t, "v0163-snapshot", decoded.GetInstanceId())
+	require.Equal(t, commonproto.ShardStatusSteadyState, decoded.GetNamespaces()["default"].GetShards()[1].GetStatusOrDefault())
+	require.Equal(t, commonproto.SplitPhaseCatchUp, decoded.GetNamespaces()["default"].GetShards()[1].GetSplit().GetPhaseOrDefault())
+
+	var currentSnapshot persistedStateContainer
+	require.NoError(t, json.Unmarshal(payload, &currentSnapshot))
+	require.Contains(t, currentSnapshot.Documents, metadatacodec.ClusterStatusCodec.GetKey())
+}


### PR DESCRIPTION
## Motivation
- Preserve rollback compatibility for Raft metadata snapshots after the metadata provider moved to a multi-document snapshot envelope.
- Keep v0.16.3 readers able to recover the cluster status from the legacy top-level snapshot fields.

## Modifications
- Include legacy `state` and `current_version` fields in Raft snapshot payloads alongside the current `documents` map.
- Populate the legacy fields from the cluster status document only.
- Added coverage that verifies snapshots contain both the current document map and the legacy status snapshot shape.

## Testing
- `go test ./oxiad/coordinator/metadata/provider/raft`
- `go test ./common/proto ./oxiad/coordinator/metadata/...`
- `make lint`
- `make license-check`
- `git diff --check`