### PR TITLE
ci: run build workflow only for PRs

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -18,9 +18,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Motivation
- The repository requires changes to land through pull requests, so running the full Build workflow again on `main` pushes duplicates the PR validation.

## Modifications
- Removed the `push` trigger for `main` from the Build workflow.
- Kept the `pull_request` trigger for PRs targeting `main` unchanged.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr_build_and_test.yaml"); puts "yaml ok"'`
