### PR TITLE
feat: add CLI auth token flags

### DIFF
--- a/cmd/admin/cmd.go
+++ b/cmd/admin/cmd.go
@@ -37,6 +37,8 @@ var (
 func init() {
 	defaultAdminClientAddress := fmt.Sprintf("localhost:%d", oxiacommon.DefaultAdminPort)
 	Cmd.PersistentFlags().StringVar(&commons.AdminConfig.AdminAddress, "admin-address", defaultAdminClientAddress, "Admin client address")
+	Cmd.PersistentFlags().StringVar(&commons.AdminConfig.Auth.Token, "auth-token", "", "Bearer token for authenticated requests")
+	Cmd.PersistentFlags().StringVar(&commons.AdminConfig.Auth.TokenFile, "auth-token-file", "", "Path to bearer token file for authenticated requests")
 	Cmd.PersistentFlags().StringP("output", "o", "", "Output format. One of: json|yaml|name|table")
 
 	Cmd.AddCommand(dataserver.Cmd)

--- a/cmd/admin/commons/admin_client.go
+++ b/cmd/admin/commons/admin_client.go
@@ -17,6 +17,8 @@ package commons
 import (
 	"time"
 
+	"github.com/oxia-db/oxia/cmd/common/clientauth"
+	"github.com/oxia-db/oxia/common/auth"
 	"github.com/oxia-db/oxia/oxia"
 )
 
@@ -28,11 +30,22 @@ var (
 type AdminClientConfig struct {
 	AdminAddress   string
 	RequestTimeout time.Duration
+	Auth           clientauth.Config
 }
 
-func (AdminClientConfig) NewAdminClient() (oxia.AdminClient, error) {
+func (config AdminClientConfig) NewAdminClient() (oxia.AdminClient, error) {
 	if MockedAdminClient != nil {
 		return MockedAdminClient, nil
 	}
-	return oxia.NewAdminClient(AdminConfig.AdminAddress, nil, nil)
+
+	var authentication auth.Authentication
+	if config.Auth.Enabled() {
+		var err error
+		authentication, err = config.Auth.GetAuthentication()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return oxia.NewAdminClient(config.AdminAddress, nil, authentication)
 }

--- a/cmd/client/cmd.go
+++ b/cmd/client/cmd.go
@@ -46,6 +46,8 @@ func init() {
 	Cmd.PersistentFlags().StringVarP(&common.Config.ServiceAddr, "service-address", "a", defaultServiceAddress, "Service address")
 	Cmd.PersistentFlags().StringVarP(&common.Config.Namespace, "namespace", "n", oxia.DefaultNamespace, "The Oxia namespace to use")
 	Cmd.PersistentFlags().DurationVar(&common.Config.RequestTimeout, "request-timeout", oxia.DefaultRequestTimeout, "Requests timeout")
+	Cmd.PersistentFlags().StringVar(&common.Config.Auth.Token, "auth-token", "", "Bearer token for authenticated requests")
+	Cmd.PersistentFlags().StringVar(&common.Config.Auth.TokenFile, "auth-token-file", "", "Path to bearer token file for authenticated requests")
 
 	Cmd.AddCommand(put.Cmd)
 	Cmd.AddCommand(del.Cmd)

--- a/cmd/client/common/client.go
+++ b/cmd/client/common/client.go
@@ -18,6 +18,7 @@ package common
 import (
 	"time"
 
+	"github.com/oxia-db/oxia/cmd/common/clientauth"
 	"github.com/oxia-db/oxia/oxia"
 )
 
@@ -30,15 +31,25 @@ type ClientConfig struct {
 	ServiceAddr    string
 	Namespace      string
 	RequestTimeout time.Duration
+	Auth           clientauth.Config
 }
 
-func (ClientConfig) NewClient() (oxia.SyncClient, error) {
+func (config ClientConfig) NewClient() (oxia.SyncClient, error) {
 	if MockedClient != nil {
 		return MockedClient, nil
 	}
 
-	return oxia.NewSyncClient(Config.ServiceAddr,
-		oxia.WithRequestTimeout(Config.RequestTimeout),
-		oxia.WithNamespace(Config.Namespace),
-	)
+	options := []oxia.ClientOption{
+		oxia.WithRequestTimeout(config.RequestTimeout),
+		oxia.WithNamespace(config.Namespace),
+	}
+	if config.Auth.Enabled() {
+		authentication, err := config.Auth.GetAuthentication()
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, oxia.WithAuthentication(authentication))
+	}
+
+	return oxia.NewSyncClient(config.ServiceAddr, options...)
 }

--- a/cmd/common/clientauth/auth.go
+++ b/cmd/common/clientauth/auth.go
@@ -1,0 +1,65 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clientauth turns CLI auth options into Oxia client credentials.
+package clientauth
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/oxia-db/oxia/common/auth"
+)
+
+var (
+	// ErrAuthTokenRequired is returned when auth is enabled without a token value.
+	ErrAuthTokenRequired = errors.New("auth token must be configured")
+	// ErrAuthTokenConflict is returned when more than one token source is configured.
+	ErrAuthTokenConflict = errors.New("only one of auth-token or auth-token-file can be configured")
+)
+
+// Config contains CLI authentication options.
+type Config struct {
+	Token     string
+	TokenFile string
+}
+
+// Enabled reports whether the CLI auth options should create credentials.
+func (c Config) Enabled() bool {
+	return c.Token != "" || c.TokenFile != ""
+}
+
+// GetAuthentication creates Oxia token credentials from the CLI auth options.
+func (c Config) GetAuthentication() (auth.Authentication, error) {
+	if c.Token != "" && c.TokenFile != "" {
+		return nil, ErrAuthTokenConflict
+	}
+
+	token := strings.TrimSpace(c.Token)
+	if c.TokenFile != "" {
+		data, err := os.ReadFile(c.TokenFile)
+		if err != nil {
+			return nil, fmt.Errorf("read auth token file %q: %w", c.TokenFile, err)
+		}
+		token = strings.TrimSpace(string(data))
+	}
+
+	if token == "" {
+		return nil, ErrAuthTokenRequired
+	}
+
+	return auth.NewTokenAuthenticationWithToken(token, true), nil
+}

--- a/cmd/common/clientauth/auth_test.go
+++ b/cmd/common/clientauth/auth_test.go
@@ -1,0 +1,86 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientauth
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Enabled(t *testing.T) {
+	assert.False(t, Config{}.Enabled())
+	assert.True(t, Config{Token: "token"}.Enabled())
+	assert.True(t, Config{TokenFile: "token-file"}.Enabled())
+}
+
+func TestConfig_GetAuthenticationWithToken(t *testing.T) {
+	authentication, err := Config{Token: " token\n"}.GetAuthentication()
+	require.NoError(t, err)
+
+	metadata, err := authentication.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer token", metadata["authorization"])
+	assert.True(t, authentication.RequireTransportSecurity())
+}
+
+func TestConfig_GetAuthenticationWithTokenFile(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("file-token\n"), 0o600))
+
+	authentication, err := Config{TokenFile: tokenFile}.GetAuthentication()
+	require.NoError(t, err)
+
+	metadata, err := authentication.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer file-token", metadata["authorization"])
+	assert.True(t, authentication.RequireTransportSecurity())
+}
+
+func TestConfig_GetAuthenticationWithoutToken(t *testing.T) {
+	_, err := Config{}.GetAuthentication()
+	require.ErrorIs(t, err, ErrAuthTokenRequired)
+}
+
+func TestConfig_GetAuthenticationWithConflictingTokenSources(t *testing.T) {
+	_, err := Config{Token: "token", TokenFile: "token-file"}.GetAuthentication()
+	require.ErrorIs(t, err, ErrAuthTokenConflict)
+}
+
+func TestConfig_GetAuthenticationWithEmptyToken(t *testing.T) {
+	_, err := Config{Token: " \n"}.GetAuthentication()
+	require.ErrorIs(t, err, ErrAuthTokenRequired)
+}
+
+func TestConfig_GetAuthenticationWithEmptyTokenFile(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("\n"), 0o600))
+
+	_, err := Config{TokenFile: tokenFile}.GetAuthentication()
+	require.ErrorIs(t, err, ErrAuthTokenRequired)
+}
+
+func TestConfig_GetAuthenticationWithMissingTokenFile(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "missing")
+	_, err := Config{TokenFile: tokenFile}.GetAuthentication()
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrAuthTokenRequired))
+	assert.Contains(t, err.Error(), tokenFile)
+}


### PR DESCRIPTION
## Motivation
- The CLI already supports address selection through existing flags, but there was no way for `oxia client` or `oxia admin` to pass authentication credentials into the SDK clients.
- Keeping this as CLI parameters avoids introducing local client config or context management in this PR.

## Modifications
- Add shared CLI auth parsing for bearer tokens from `--auth-token` or `--auth-token-file`.
- Trim token values from both CLI arguments and token files, and include the token-file path in read errors.
- Require transport security for token credentials, so authenticated CLI requests should use `tls://` addresses.
- Wire auth credentials into both `oxia.NewSyncClient` and `oxia.NewAdminClient` while preserving the existing address flags.
- Add unit coverage for token parsing, token-file parsing, empty token validation, and conflicting token sources.

## Testing
- `go test ./cmd/common/clientauth ./cmd/client/common ./cmd/admin/commons ./cmd/client ./cmd/admin`
- `golangci-lint run ./cmd/...`
- `go test ./cmd/...`
