### PR TITLE
fix: monitor pooled grpc connections

### DIFF
--- a/cmd/health/cmd.go
+++ b/cmd/health/cmd.go
@@ -68,11 +68,10 @@ func exec(*cobra.Command, []string) error {
 
 	serverAddress := fmt.Sprintf("%s:%d", config.Host, config.Port)
 
-	client, closer, err := clientPool.GetHealthRpc(serverAddress)
+	client, err := clientPool.GetHealthRpc(serverAddress)
 	if err != nil {
 		return err
 	}
-	defer closer.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 	defer cancel()

--- a/common/rpc/client_pool.go
+++ b/common/rpc/client_pool.go
@@ -19,17 +19,11 @@ import (
 	"crypto/tls"
 	"io"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
-	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
 
 	"github.com/oxia-db/oxia/common/auth"
@@ -47,7 +41,7 @@ const (
 type ClientPool interface {
 	io.Closer
 	GetClientRpc(target string) (proto.OxiaClientClient, error)
-	GetHealthRpc(target string) (grpc_health_v1.HealthClient, io.Closer, error)
+	GetHealthRpc(target string) (grpc_health_v1.HealthClient, error)
 	GetCoordinationRpc(target string) (proto.OxiaCoordinationClient, error)
 	GetReplicationRpc(target string) (proto.OxiaLogReplicationClient, error)
 	GetAminRpc(target string) (proto.OxiaAdminClient, error)
@@ -58,7 +52,7 @@ type ClientPool interface {
 
 type clientPool struct {
 	sync.RWMutex
-	connections map[string]*grpc.ClientConn
+	connections map[string]*connection
 
 	tls            *tls.Config
 	authentication auth.Authentication
@@ -76,7 +70,7 @@ func (cp *clientPool) GetAminRpc(target string) (proto.OxiaAdminClient, error) {
 
 func NewClientPool(tlsConf *tls.Config, authentication auth.Authentication, dialOptions ...grpc.DialOption) ClientPool {
 	return &clientPool{
-		connections:    make(map[string]*grpc.ClientConn),
+		connections:    make(map[string]*connection),
 		tls:            tlsConf,
 		authentication: authentication,
 		dialOptions:    dialOptions,
@@ -88,29 +82,22 @@ func NewClientPool(tlsConf *tls.Config, authentication auth.Authentication, dial
 
 func (cp *clientPool) Close() error {
 	cp.Lock()
-	defer cp.Unlock()
-
-	for target, cnx := range cp.connections {
-		err := cnx.Close()
-		if err != nil {
-			cp.log.Warn(
-				"Failed to close GRPC connection",
-				slog.String("server_address", target),
-				slog.Any("error", err),
-			)
-		}
+	connections := cp.connections
+	cp.connections = make(map[string]*connection)
+	cp.Unlock()
+	for target, cnx := range connections {
+		cp.closeConnection(target, cnx)
 	}
 	return nil
 }
 
-func (cp *clientPool) GetHealthRpc(target string) (grpc_health_v1.HealthClient, io.Closer, error) {
-	// Skip the pooling for health-checks
-	cnx, err := cp.newConnection(target)
+func (cp *clientPool) GetHealthRpc(target string) (grpc_health_v1.HealthClient, error) {
+	cnx, err := cp.getConnectionFromPool(target)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return grpc_health_v1.NewHealthClient(cnx), cnx, nil
+	return grpc_health_v1.NewHealthClient(cnx), nil
 }
 
 func (cp *clientPool) GetClientRpc(target string) (proto.OxiaClientClient, error) {
@@ -141,19 +128,34 @@ func (cp *clientPool) GetReplicationRpc(target string) (proto.OxiaLogReplication
 }
 
 func (cp *clientPool) Clear(target string) {
+	cp.removeAndCloseConnection(target)
+}
+
+func (cp *clientPool) onNotHealthy(target string) {
+	cp.removeAndCloseConnection(target)
+}
+
+func (cp *clientPool) removeAndCloseConnection(target string) {
 	cp.Lock()
-	defer cp.Unlock()
+	var conn *connection
+	var ok bool
+	if conn, ok = cp.connections[target]; !ok {
+		cp.Unlock()
+		return
+	}
+	delete(cp.connections, target)
+	cp.Unlock()
 
-	if cnx, ok := cp.connections[target]; ok {
-		if err := cnx.Close(); err != nil {
-			cp.log.Warn(
-				"Failed to close GRPC connection",
-				slog.String("server_address", target),
-				slog.Any("error", err),
-			)
-		}
+	cp.closeConnection(target, conn)
+}
 
-		delete(cp.connections, target)
+func (cp *clientPool) closeConnection(target string, conn *connection) {
+	if err := conn.Close(); err != nil {
+		cp.log.Warn(
+			"Failed to close the stale GRPC connection",
+			slog.String("server_address", target),
+			slog.Any("error", err),
+		)
 	}
 }
 
@@ -161,74 +163,36 @@ func (cp *clientPool) getConnectionFromPool(target string) (grpc.ClientConnInter
 	cp.RLock()
 	cnx, ok := cp.connections[target]
 	cp.RUnlock()
-	if ok {
-		return cnx, nil
+	if ok && cnx.ctx.Err() == nil {
+		return cnx.conn, nil
 	}
 
 	cp.Lock()
-	defer cp.Unlock()
 
 	cnx, ok = cp.connections[target]
+	if ok && cnx.ctx.Err() == nil {
+		cp.Unlock()
+		return cnx.conn, nil
+	}
+	var staleConnection *connection
 	if ok {
-		return cnx, nil
+		staleConnection = cnx
+		delete(cp.connections, target)
 	}
 
-	cnx, err := cp.newConnection(target)
+	cnx, err := newConnection(context.Background(), target, cp.tls, cp.authentication, cp.dialOptions, cp)
+	if err == nil {
+		cp.connections[target] = cnx
+	}
+	cp.Unlock()
+
+	if staleConnection != nil {
+		cp.closeConnection(target, staleConnection)
+	}
 	if err != nil {
 		return nil, err
 	}
-	cp.connections[target] = cnx
-	return cnx, nil
-}
-
-func (cp *clientPool) newConnection(target string) (*grpc.ClientConn, error) {
-	cp.log.Debug(
-		"Creating new GRPC connection",
-		slog.String("server_address", target),
-	)
-
-	tcs := cp.getTransportCredential(target)
-
-	options := []grpc.DialOption{
-		grpc.WithTransportCredentials(tcs),
-		grpc.WithChainStreamInterceptor(grpcprometheus.StreamClientInterceptor),
-		grpc.WithChainUnaryInterceptor(grpcprometheus.UnaryClientInterceptor),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			PermitWithoutStream: defaultGrpcClientPermitWithoutStream,
-			Time:                defaultGrpcClientKeepAliveTime,
-			Timeout:             defaultGrpcClientKeepAliveTimeout,
-		}),
-	}
-	if cp.authentication != nil {
-		options = append(options, grpc.WithPerRPCCredentials(cp.authentication))
-	}
-	options = append(options, cp.dialOptions...)
-
-	cnx, err := grpc.NewClient(cp.getActualAddress(target), options...)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error connecting to %s", target)
-	}
-
-	return cnx, nil
-}
-
-func (*clientPool) getActualAddress(target string) string {
-	if strings.HasPrefix(target, AddressSchemaTLS) {
-		after, _ := strings.CutPrefix(target, AddressSchemaTLS)
-		return after
-	}
-	return target
-}
-
-func (cp *clientPool) getTransportCredential(target string) credentials.TransportCredentials {
-	tcs := insecure.NewCredentials()
-	if strings.HasPrefix(target, AddressSchemaTLS) {
-		tcs = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
-	}
-	if cp.tls != nil {
-		tcs = credentials.NewTLS(cp.tls)
-	}
-	return tcs
+	return cnx.conn, nil
 }
 
 func GetPeer(ctx context.Context) string {

--- a/common/rpc/client_pool_test.go
+++ b/common/rpc/client_pool_test.go
@@ -15,29 +15,110 @@
 package rpc
 
 import (
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-func TestClientPool_GetActualAddress(t *testing.T) {
+func TestClientPoolClearsPooledConnectionWhenHealthCheckFails(t *testing.T) {
+	setHealthProbeTimingForTest(t, 20*time.Millisecond, 100*time.Millisecond)
+
+	healthServer := health.NewServer()
+	target := startTestGrpcServer(t, func(registrar grpc.ServiceRegistrar) {
+		grpc_health_v1.RegisterHealthServer(registrar, healthServer)
+	})
+
 	pool := NewClientPool(nil, nil)
+	defer pool.Close()
 	poolInstance := pool.(*clientPool)
 
-	address := poolInstance.getActualAddress("tls://xxxxaa:6648")
-	assert.Equal(t, "xxxxaa:6648", address)
+	_, err := pool.GetClientRpc(target)
+	require.NoError(t, err)
 
-	actualAddress := poolInstance.getActualAddress("xxxxaaa:6649")
-	assert.Equal(t, "xxxxaaa:6649", actualAddress)
+	var first *connection
+	require.Eventually(t, func() bool {
+		poolInstance.RLock()
+		defer poolInstance.RUnlock()
+		first = poolInstance.connections[target]
+		return first != nil
+	}, time.Second, 10*time.Millisecond)
+
+	healthServer.Shutdown()
+	require.Eventually(t, func() bool {
+		poolInstance.RLock()
+		defer poolInstance.RUnlock()
+		return poolInstance.connections[target] == nil
+	}, 3*time.Second, 10*time.Millisecond)
+
+	healthServer.Resume()
+	_, err = pool.GetClientRpc(target)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		poolInstance.RLock()
+		defer poolInstance.RUnlock()
+		return poolInstance.connections[target] != nil && poolInstance.connections[target] != first
+	}, time.Second, 10*time.Millisecond)
 }
 
-func TestClientPool_GetTransportCredential(t *testing.T) {
+func TestClientPoolKeepsPooledConnectionWhenHealthServiceUnsupported(t *testing.T) {
+	target := startTestGrpcServer(t, nil)
+
 	pool := NewClientPool(nil, nil)
+	defer pool.Close()
 	poolInstance := pool.(*clientPool)
 
-	credential := poolInstance.getTransportCredential("tls://xxxxaa:6648")
-	assert.Equal(t, "tls", credential.Info().SecurityProtocol)
+	_, err := pool.GetClientRpc(target)
+	require.NoError(t, err)
 
-	credential = poolInstance.getTransportCredential("xxxxaaa:6649")
-	assert.Equal(t, "insecure", credential.Info().SecurityProtocol)
+	require.Eventually(t, func() bool {
+		poolInstance.RLock()
+		defer poolInstance.RUnlock()
+		return poolInstance.connections[target] != nil
+	}, time.Second, 10*time.Millisecond)
+
+	time.Sleep(200 * time.Millisecond)
+	poolInstance.RLock()
+	defer poolInstance.RUnlock()
+	assert.NotNil(t, poolInstance.connections[target])
+}
+
+func setHealthProbeTimingForTest(t *testing.T, interval time.Duration, timeout time.Duration) {
+	t.Helper()
+
+	previousInterval := defaultGrpcClientHealthProbeInterval
+	previousTimeout := defaultGrpcClientHealthProbeTimeout
+	defaultGrpcClientHealthProbeInterval = interval
+	defaultGrpcClientHealthProbeTimeout = timeout
+	t.Cleanup(func() {
+		defaultGrpcClientHealthProbeInterval = previousInterval
+		defaultGrpcClientHealthProbeTimeout = previousTimeout
+	})
+}
+
+func startTestGrpcServer(t *testing.T, register func(grpc.ServiceRegistrar)) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	if register != nil {
+		register(server)
+	}
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+
+	return listener.Addr().String()
 }

--- a/common/rpc/connection.go
+++ b/common/rpc/connection.go
@@ -1,0 +1,178 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/oxia-db/oxia/common/auth"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
+	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/oxia-db/oxia/common/process"
+)
+
+var (
+	defaultGrpcClientHealthProbeInterval = defaultGrpcClientKeepAliveTime
+	defaultGrpcClientHealthProbeTimeout  = defaultGrpcClientKeepAliveTimeout
+)
+
+type connection struct {
+	io.Closer
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	logger slog.Logger
+
+	target         string
+	conn           *grpc.ClientConn
+	healthClient   grpc_health_v1.HealthClient
+	healthListener connectionHealthListener
+}
+
+type connectionHealthListener interface {
+	onNotHealthy(target string)
+}
+
+func newConnection(
+	ctx context.Context,
+	target string,
+	tlsOptions *tls.Config,
+	auth auth.Authentication,
+	extraOptions []grpc.DialOption,
+	healthListener connectionHealthListener,
+) (*connection, error) {
+	logger := *slog.With("server_address", target)
+	logger.Debug("Creating new GRPC connection", slog.String("server_address", target))
+
+	actualAddress := target
+	tcs := insecure.NewCredentials()
+	if strings.HasPrefix(target, AddressSchemaTLS) {
+		actualAddress, _ = strings.CutPrefix(target, AddressSchemaTLS)
+		tcs = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
+	}
+	if tlsOptions != nil {
+		tcs = credentials.NewTLS(tlsOptions)
+	}
+
+	options := []grpc.DialOption{
+		grpc.WithTransportCredentials(tcs),
+		grpc.WithChainStreamInterceptor(grpcprometheus.StreamClientInterceptor),
+		grpc.WithChainUnaryInterceptor(grpcprometheus.UnaryClientInterceptor),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			PermitWithoutStream: defaultGrpcClientPermitWithoutStream,
+			Time:                defaultGrpcClientKeepAliveTime,
+			Timeout:             defaultGrpcClientKeepAliveTimeout,
+		}),
+	}
+	if auth != nil {
+		options = append(options, grpc.WithPerRPCCredentials(auth))
+	}
+	options = append(options, extraOptions...)
+
+	client, err := grpc.NewClient(actualAddress, options...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error connecting to %s", target)
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	cnx := &connection{
+		Closer:         client,
+		ctx:            ctx,
+		cancel:         cancel,
+		wg:             sync.WaitGroup{},
+		logger:         logger,
+		target:         target,
+		conn:           client,
+		healthClient:   grpc_health_v1.NewHealthClient(client),
+		healthListener: healthListener,
+	}
+	cnx.wg.Add(1)
+	go func() {
+		notifyNotHealthy := false
+		defer func() {
+			if notifyNotHealthy && cnx.healthListener != nil {
+				cnx.healthListener.onNotHealthy(cnx.target)
+			}
+		}()
+		defer cnx.wg.Done()
+		process.DoWithLabels(
+			cnx.ctx,
+			map[string]string{"oxia": "connection-health-ping"},
+			func() {
+				notifyNotHealthy = cnx.monitorHealth()
+			},
+		)
+	}()
+	return cnx, nil
+}
+
+func (c *connection) monitorHealth() bool {
+	var failureStart time.Time
+	ticker := time.NewTicker(defaultGrpcClientHealthProbeInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return false
+		case <-ticker.C:
+			checkStartedAt := time.Now()
+			ctx, cancel := context.WithTimeout(c.ctx, defaultGrpcClientHealthProbeTimeout)
+			response, err := c.healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: ""})
+			cancel()
+
+			if err == nil && response.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+				err = errors.Errorf("health status is %s", response.Status)
+			}
+
+			switch {
+			case err == nil:
+				failureStart = time.Time{}
+			case grpcstatus.Code(err) == codes.Unimplemented:
+				c.logger.Info("GRPC health service is not available; skipping connection health monitoring", slog.Any("error", err))
+				return false
+			default:
+				if failureStart.IsZero() {
+					failureStart = checkStartedAt
+				}
+				if time.Since(failureStart) >= defaultGrpcClientHealthProbeTimeout {
+					c.logger.Warn("GRPC health monitor failed", slog.Any("error", err))
+					c.cancel()
+					return true
+				}
+			}
+		}
+	}
+}
+
+func (c *connection) Close() error {
+	c.cancel()
+	err := c.Closer.Close()
+	c.wg.Wait()
+	return err
+}

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -17,7 +17,6 @@ package oxia
 import (
 	"context"
 	"errors"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,8 +116,8 @@ func (m *mockAdminClientPool) GetClientRpc(string) (proto.OxiaClientClient, erro
 	return nil, errors.New("unexpected GetClientRpc call")
 }
 
-func (m *mockAdminClientPool) GetHealthRpc(string) (grpc_health_v1.HealthClient, io.Closer, error) {
-	return nil, nil, errors.New("unexpected GetHealthRpc call")
+func (m *mockAdminClientPool) GetHealthRpc(string) (grpc_health_v1.HealthClient, error) {
+	return nil, errors.New("unexpected GetHealthRpc call")
 }
 
 func (m *mockAdminClientPool) GetCoordinationRpc(string) (proto.OxiaCoordinationClient, error) {

--- a/oxiad/coordinator/rpc/rpc_provider.go
+++ b/oxiad/coordinator/rpc/rpc_provider.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/tls"
 	"io"
-	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -31,8 +30,6 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 )
 
-const rpcTimeout = 30 * time.Second
-
 type Provider interface {
 	io.Closer
 
@@ -44,10 +41,7 @@ type Provider interface {
 	DeleteShard(ctx context.Context, node *proto.DataServerIdentity, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error)
 	Handshake(ctx context.Context, node *proto.DataServerIdentity, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error)
 	RemoveObserver(ctx context.Context, node *proto.DataServerIdentity, req *proto.RemoveObserverRequest) (*proto.RemoveObserverResponse, error)
-
-	GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, io.Closer, error)
-
-	ClearPooledConnections(node *proto.DataServerIdentity)
+	GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, error)
 }
 
 type rpcProvider struct {
@@ -83,7 +77,7 @@ func (r *rpcProvider) NewTerm(ctx context.Context, node *proto.DataServerIdentit
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, commonrpc.DefaultRpcTimeout)
 	defer cancel()
 
 	return client.NewTerm(ctx, req)
@@ -95,7 +89,7 @@ func (r *rpcProvider) BecomeLeader(ctx context.Context, node *proto.DataServerId
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, commonrpc.DefaultRpcTimeout)
 	defer cancel()
 
 	return client.BecomeLeader(ctx, req)
@@ -107,7 +101,7 @@ func (r *rpcProvider) AddFollower(ctx context.Context, node *proto.DataServerIde
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, commonrpc.DefaultRpcTimeout)
 	defer cancel()
 
 	return client.AddFollower(ctx, req)
@@ -119,7 +113,7 @@ func (r *rpcProvider) GetStatus(ctx context.Context, node *proto.DataServerIdent
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, commonrpc.DefaultRpcTimeout)
 	defer cancel()
 
 	return client.GetStatus(ctx, req)
@@ -131,7 +125,7 @@ func (r *rpcProvider) Handshake(ctx context.Context, node *proto.DataServerIdent
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, commonrpc.DefaultRpcTimeout)
 	defer cancel()
 
 	res, err := client.Handshake(ctx, &proto.HandshakeRequest{
@@ -160,7 +154,7 @@ func (r *rpcProvider) DeleteShard(ctx context.Context, node *proto.DataServerIde
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, commonrpc.DefaultRpcTimeout)
 	defer cancel()
 
 	return client.DeleteShard(ctx, req)
@@ -172,16 +166,12 @@ func (r *rpcProvider) RemoveObserver(ctx context.Context, node *proto.DataServer
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, commonrpc.DefaultRpcTimeout)
 	defer cancel()
 
 	return client.RemoveObserver(ctx, req)
 }
 
-func (r *rpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (r *rpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, error) {
 	return r.pool.GetHealthRpc(node.Internal)
-}
-
-func (r *rpcProvider) ClearPooledConnections(node *proto.DataServerIdentity) {
-	r.pool.Clear(node.Internal)
 }

--- a/oxiad/coordinator/runtime/controller/dataserver_controller.go
+++ b/oxiad/coordinator/runtime/controller/dataserver_controller.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 
-	"github.com/oxia-db/oxia/common/commonio"
 	commonobject "github.com/oxia-db/oxia/common/object"
 
 	"github.com/oxia-db/oxia/common/metric"
@@ -80,17 +79,16 @@ type dataServerController struct {
 	ctx        context.Context
 	ctxCancel  context.CancelFunc
 	dataServer *proto.DataServer
-	rpc        rpc.Provider
 	insID      string
 	closed     atomic.Bool
+
+	rpc rpc.Provider
 
 	statusLock        sync.RWMutex
 	status            DataServerStatus
 	supportedFeatures atomic.Value
 
-	healthClientOnce   sync.Once
-	healthClient       grpc_health_v1.HealthClient
-	healthClientCloser io.Closer
+	healthClient grpc_health_v1.HealthClient
 
 	healthCheckBackoff         *commontime.ConcurrentBackOff
 	dispatchAssignmentsBackoff backoff.BackOff
@@ -121,26 +119,6 @@ func (n *dataServerController) SetStatus(status DataServerStatus) {
 	n.logger.Info("Changed status", slog.Any("from", previous), slog.Any("to", status))
 }
 
-func (n *dataServerController) maybeInitHealthClient() {
-	n.healthClientOnce.Do(func() {
-		_ = backoff.RetryNotify(func() error {
-			health, closer, err := n.rpc.GetHealthClient(n.dataServer.GetIdentity())
-			if err != nil {
-				return err
-			}
-			n.healthClient = health
-			n.healthClientCloser = closer
-			return nil
-		}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
-			n.logger.Warn(
-				"Failed to create health client to storage data server",
-				slog.Duration("retry-after", duration),
-				slog.Any("error", err),
-			)
-		})
-	})
-}
-
 func (n *dataServerController) Close() error {
 	if !n.closed.CompareAndSwap(false, true) {
 		return nil
@@ -149,12 +127,8 @@ func (n *dataServerController) Close() error {
 	n.ctxCancel()
 	n.wg.Wait()
 
-	var err error
-	if err = n.healthClientCloser.Close(); err != nil {
-		n.logger.Warn("close data server controller health client failed", slog.Any("error", err))
-	}
 	n.logger.Info("Closed data server controller")
-	return err
+	return nil
 }
 
 func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
@@ -216,7 +190,6 @@ func (n *dataServerController) doHealthPing() error {
 
 func (n *dataServerController) healthPingWithRetries() {
 	_ = backoff.RetryNotify(func() error {
-		n.maybeInitHealthClient()
 		// Immediate check on startup instead of waiting for first tick
 		if err := n.doHealthPing(); err != nil {
 			return err
@@ -247,7 +220,6 @@ func (n *dataServerController) healthPingWithRetries() {
 func (n *dataServerController) healthWatchWithRetries() {
 	_ = backoff.RetryNotify(func() error {
 		n.logger.Debug("Start new health watch cycle")
-		n.maybeInitHealthClient()
 
 		watchStream, err := n.healthClient.Watch(n.ctx, &grpc_health_v1.HealthCheckRequest{Service: ""})
 		if err != nil {
@@ -298,9 +270,6 @@ func (n *dataServerController) becomeAvailable() {
 
 	n.logger.Info("Storage data server is back online")
 
-	// To avoid the send assignments stream to miss the notification about the current
-	// dataServer went down, we interrupt the current stream when the ping on the dataServer fails
-	n.rpc.ClearPooledConnections(n.dataServer.GetIdentity())
 	n.healthCheckBackoff.Reset()
 
 	// Bind the node before it can receive other internal traffic.
@@ -355,7 +324,7 @@ func NewDataServerController(ctx context.Context, dataServer *proto.DataServer,
 	shardAssignmentsProvider ShardAssignmentsProvider,
 	dataServerEventListener DataServerEventListener,
 	rpcProvider rpc.Provider,
-	insID string) DataServerController {
+	insID string) (DataServerController, error) {
 	return newDataServerController(ctx, dataServer, shardAssignmentsProvider, dataServerEventListener, rpcProvider, insID, defaultInitialRetryBackoff)
 }
 
@@ -364,13 +333,19 @@ func newDataServerController(ctx context.Context, dataServer *proto.DataServer,
 	dataServerEventListener DataServerEventListener,
 	rpcProvider rpc.Provider,
 	insID string,
-	initialRetryBackoff time.Duration) DataServerController {
+	initialRetryBackoff time.Duration) (DataServerController, error) {
 	dataServerCtx, cancel := context.WithCancel(ctx)
 	dataServerID := dataServer.GetIdentity().GetNameOrDefault()
 	labels := map[string]any{"data-server": dataServerID}
 
 	supportedFeatures := atomic.Value{}
 	supportedFeatures.Store(make([]proto.Feature, 0))
+
+	healthClient, err := rpcProvider.GetHealthClient(dataServer.GetIdentity())
+	if err != nil {
+		cancel()
+		return nil, err
+	}
 
 	nc := &dataServerController{
 		ctx:                      dataServerCtx,
@@ -387,9 +362,7 @@ func newDataServerController(ctx context.Context, dataServer *proto.DataServer,
 			slog.String("component", "data-server-controller"),
 			slog.Any("data-server", dataServerID),
 		),
-		healthClientOnce:           sync.Once{},
-		healthClient:               nil,
-		healthClientCloser:         &commonio.NopCloser{},
+		healthClient:               healthClient,
 		healthCheckBackoff:         commontime.NewConcurrentBackOff(commontime.NewBackOffWithInitialInterval(dataServerCtx, initialRetryBackoff)),
 		dispatchAssignmentsBackoff: commontime.NewBackOffWithInitialInterval(dataServerCtx, initialRetryBackoff),
 		failedHealthChecks: metric.NewCounter("oxia_coordinator_node_health_checks_failed",
@@ -437,5 +410,5 @@ func newDataServerController(ctx context.Context, dataServer *proto.DataServer,
 	})
 
 	nc.logger.Info("Started data server controller")
-	return nc
+	return nc, nil
 }

--- a/oxiad/coordinator/runtime/controller/dataserver_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/dataserver_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/oxia-db/oxia/common/constant"
@@ -37,9 +38,9 @@ func TestDataServerController_HealthCheck(t *testing.T) {
 	sap := newMockShardAssignmentsProvider()
 	nal := newMockNodeAvailabilityListener()
 	rpc := newMockRpcProvider()
-	nc := newDataServerController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 1*time.Second)
-
 	node := rpc.GetNode(addr)
+	nc, err := newDataServerController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 1*time.Second)
+	require.NoError(t, err)
 
 	// Controller starts as NotRunning and transitions to Running on first health check
 	assert.Eventually(t, func() bool {
@@ -79,9 +80,9 @@ func TestDataServerController_HandshakeOnlyCalledOnStateTransition(t *testing.T)
 	sap := newMockShardAssignmentsProvider()
 	nal := newMockNodeAvailabilityListener()
 	rpc := newMockRpcProvider()
-	nc := newDataServerController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 1*time.Second)
-
 	node := rpc.GetNode(addr)
+	nc, err := newDataServerController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 1*time.Second)
+	require.NoError(t, err)
 
 	// Wait for the initial Handshake call that happens when the controller starts
 	// (the controller starts in Running state, transitions through health check)
@@ -140,9 +141,9 @@ func TestDataServerController_ShardsAssignments(t *testing.T) {
 	sap := newMockShardAssignmentsProvider()
 	nal := newMockNodeAvailabilityListener()
 	rpc := newMockRpcProvider()
-	nc := newDataServerController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 1*time.Second)
-
 	node := rpc.GetNode(addr)
+	nc, err := newDataServerController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 1*time.Second)
+	require.NoError(t, err)
 
 	resp := &proto.ShardAssignments{
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{

--- a/oxiad/coordinator/runtime/controller/mock_test.go
+++ b/oxiad/coordinator/runtime/controller/mock_test.go
@@ -17,7 +17,6 @@ package controller
 import (
 	"context"
 	"errors"
-	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -374,9 +373,6 @@ func (r *mockRpcProvider) Close() error {
 	return nil
 }
 
-func (r *mockRpcProvider) ClearPooledConnections(node *proto.DataServerIdentity) {
-}
-
 func newMockRpcProvider() *mockRpcProvider {
 	return &mockRpcProvider{
 		channels: make(map[string]*mockPerNodeChannels),
@@ -595,9 +591,8 @@ func (r *mockRpcProvider) RemoveObserver(ctx context.Context, node *proto.DataSe
 	}
 }
 
-func (r *mockRpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, io.Closer, error) {
-	c := r.GetNode(node).healthClient
-	return c, c, nil
+func (r *mockRpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, error) {
+	return r.GetNode(node).healthClient, nil
 }
 
 type mockShardAssignmentClient struct {

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -116,7 +116,7 @@ func (c *runtime) CreateDataServer(name string, dataServer *proto.DataServer) bo
 		_ = nc.Close()
 		delete(c.drainingNodes, name)
 	}
-	c.dataServerControllers[name] = controller.NewDataServerController(
+	nc, err := controller.NewDataServerController(
 		c.ctx,
 		dataServer,
 		c,
@@ -124,6 +124,11 @@ func (c *runtime) CreateDataServer(name string, dataServer *proto.DataServer) bo
 		c.rpc,
 		c.insID,
 	)
+	if err != nil {
+		c.logger.Warn("Failed to create data server controller", slog.Any("server", identity), slog.Any("error", err))
+		return false
+	}
+	c.dataServerControllers[name] = nc
 	return true
 }
 
@@ -832,7 +837,7 @@ func New(
 	// init node controller
 	for _, node := range dataServersFromStatus(clusterStatus) {
 		dataServer := &proto.DataServer{Identity: node, Metadata: &proto.DataServerMetadata{}}
-		c.dataServerControllers[node.GetNameOrDefault()] = controller.NewDataServerController(
+		nc, err := controller.NewDataServerController(
 			c.ctx,
 			dataServer,
 			c,
@@ -840,6 +845,10 @@ func New(
 			c.rpc,
 			c.insID,
 		)
+		if err != nil {
+			return nil, err
+		}
+		c.dataServerControllers[node.GetNameOrDefault()] = nc
 	}
 
 	// init shard controller

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -63,15 +64,17 @@ type publicRpcServer struct {
 	assignmentDispatcher       assignment.ShardAssignmentsDispatcher
 	disableAuthorityValidation bool
 	grpcServer                 oxiadcommonrpc.GrpcServer
+	healthServer               oxiadcommonrpc.HealthServer
 	log                        *slog.Logger
 }
 
 func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector, assignmentDispatcher assignment.ShardAssignmentsDispatcher,
-	disableAuthorityValidation bool, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
+	healthServer oxiadcommonrpc.HealthServer, disableAuthorityValidation bool, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
 	server := &publicRpcServer{
 		shardsDirector:             shardsDirector,
 		assignmentDispatcher:       assignmentDispatcher,
 		disableAuthorityValidation: disableAuthorityValidation,
+		healthServer:               healthServer,
 		log: slog.With(
 			slog.String("component", "public-rpc-server"),
 		),
@@ -81,6 +84,7 @@ func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string
 	server.grpcServer, err = provider.StartGrpcServer("public", bindAddress, func(registrar grpc.ServiceRegistrar) {
 		proto.RegisterOxiaClientServer(registrar, server)
 		compat.RegisterOxiaClientServer(registrar, &compatPublicRpcServer{impl: server})
+		grpc_health_v1.RegisterHealthServer(registrar, server.healthServer)
 	}, tlsConf, options, nil)
 	if err != nil {
 		return nil, err

--- a/oxiad/dataserver/rpc/rpc_provider.go
+++ b/oxiad/dataserver/rpc/rpc_provider.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
 	"google.golang.org/grpc/metadata"
 
@@ -28,8 +27,6 @@ import (
 	"github.com/oxia-db/oxia/common/security"
 	manifestpkg "github.com/oxia-db/oxia/oxiad/dataserver/manifest"
 )
-
-const rpcTimeout = 30 * time.Second
 
 type ReplicateStreamProvider interface {
 	GetReplicateStream(ctx context.Context, follower string, namespace string, shard int64, term int64) (proto.OxiaLogReplication_ReplicateClient, error)
@@ -97,7 +94,7 @@ func (r *replicationRpcProvider) Truncate(follower string, req *proto.TruncateRe
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), rpcTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), commonrpc.DefaultRpcTimeout)
 	defer cancel()
 
 	return client.Truncate(ctx, req)

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -138,7 +138,7 @@ func NewWithGrpcProvider(parent context.Context, optionsWatch *commonwatch.Watch
 		return nil, err
 	}
 	s.publicRpcServer, err = newPublicRpcServer(provider, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, disableAuthorityValidation, publicServerTLS, &publicServer.Auth)
+		s.shardAssignmentDispatcher, s.healthServer, disableAuthorityValidation, publicServerTLS, &publicServer.Auth)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/server_test.go
+++ b/oxiad/dataserver/server_test.go
@@ -70,9 +70,8 @@ func TestNewServerClosableWithHealthWatch(t *testing.T) {
 
 	clientPool := rpc.NewClientPool(nil, nil)
 
-	client, closer, err := clientPool.GetHealthRpc(fmt.Sprintf("127.0.0.1:%v", server.InternalPort()))
+	client, err := clientPool.GetHealthRpc(fmt.Sprintf("127.0.0.1:%v", server.InternalPort()))
 	assert.NoError(t, err)
-	defer closer.Close()
 	watchStream, err := client.Watch(t.Context(), &grpc_health_v1.HealthCheckRequest{Service: ""})
 	assert.NoError(t, err)
 
@@ -80,4 +79,27 @@ func TestNewServerClosableWithHealthWatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, watchStream.CloseSend())
+}
+
+func TestNewServerExposesHealthOnPublicEndpoint(t *testing.T) {
+	options := option.NewDefaultOptions()
+	options.Server.Public.BindAddress = "localhost:0"
+	options.Server.Internal.BindAddress = "localhost:0"
+	options.Observability.Metric.BindAddress = "localhost:0"
+	options.Storage.Database.Dir = t.TempDir()
+	options.Storage.WAL.Dir = t.TempDir()
+
+	server, err := New(t.Context(), commonwatch.New(options))
+	assert.NoError(t, err)
+	defer server.Close()
+
+	clientPool := rpc.NewClientPool(nil, nil)
+	defer clientPool.Close()
+
+	client, err := clientPool.GetHealthRpc(fmt.Sprintf("127.0.0.1:%v", server.PublicPort()))
+	assert.NoError(t, err)
+
+	response, err := client.Check(t.Context(), &grpc_health_v1.HealthCheckRequest{Service: ""})
+	assert.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, response.Status)
 }

--- a/oxiad/dataserver/standalone.go
+++ b/oxiad/dataserver/standalone.go
@@ -56,6 +56,7 @@ type Standalone struct {
 	walFactory                wal.Factory
 	shardsDirector            controller.ShardsDirector
 	shardAssignmentDispatcher assignment.ShardAssignmentsDispatcher
+	healthServer              rpc2.HealthServer
 
 	metrics *metric.PrometheusMetrics
 }
@@ -80,7 +81,10 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 		slog.Any("config", config),
 	)
 
-	s := &Standalone{config: config}
+	s := &Standalone{
+		config:       config,
+		healthServer: rpc2.NewClosableHealthServer(context.Background()),
+	}
 
 	storageOptions := config.DataServerOptions.Storage
 	kvOptions := kvstore.FactoryOptions{
@@ -114,7 +118,7 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 		return nil, err
 	}
 	s.rpc, err = newPublicRpcServer(rpc2.Default, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, false, serverTLS, &auth.Disabled)
+		s.shardAssignmentDispatcher, s.healthServer, false, serverTLS, &auth.Disabled)
 	if err != nil {
 		return nil, err
 	}
@@ -183,6 +187,7 @@ func (s *Standalone) Close() error {
 
 	return multierr.Combine(
 		err,
+		s.healthServer.Close(),
 		s.shardsDirector.Close(),
 		s.shardAssignmentDispatcher.Close(),
 		s.rpc.Close(),

--- a/oxiad/maelstrom/coordinator_rpc_client.go
+++ b/oxiad/maelstrom/coordinator_rpc_client.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"sync"
 
@@ -45,9 +44,6 @@ type maelstromCoordinatorRpcProvider struct {
 
 func (m *maelstromCoordinatorRpcProvider) Close() error {
 	return nil
-}
-
-func (m *maelstromCoordinatorRpcProvider) ClearPooledConnections(node *proto.DataServerIdentity) {
 }
 
 func newRpcProvider(dispatcher *dispatcher) rpc.Provider {
@@ -116,13 +112,13 @@ func (m *maelstromCoordinatorRpcProvider) Handshake(ctx context.Context, node *p
 	}, nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (m *maelstromCoordinatorRpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, error) {
 	c := &maelstromHealthCheckClient{
 		provider: m,
 		node:     node.GetInternal(),
 	}
 
-	return c, c, nil
+	return c, nil
 }
 
 type maelstromShardAssignmentClient struct {


### PR DESCRIPTION
## Motivation
- Clients can sit behind proxies that keep broken sockets open, so pooled gRPC connections need active health probing and replacement.
- The dataserver public endpoint should expose the health service so clients can probe the reachable endpoint.

## Modifications
- Add a closeable pooled connection type that owns the gRPC connection, context cancellation, health ping loop, and graceful WaitGroup shutdown.
- Reuse pooled connections for Health RPC clients and remove the extra closer from GetHealthRpc.
- Register the health service on the public dataserver gRPC server and keep standalone shutdown closing its health server.
- Replace duplicate provider RPC timeouts with common/rpc.DefaultRpcTimeout.
- Add tests for public health exposure and connection replacement after health failures.

## Testing
- go test ./common/rpc
- go test ./cmd/health ./oxia ./oxiad/coordinator/rpc ./oxiad/coordinator/runtime/controller ./oxiad/dataserver ./oxiad/dataserver/rpc
- go test -race ./common/rpc