### PR TITLE
fix: derive CLI auth transport security

### DIFF
--- a/cmd/admin/commons/admin_client.go
+++ b/cmd/admin/commons/admin_client.go
@@ -41,7 +41,7 @@ func (config AdminClientConfig) NewAdminClient() (oxia.AdminClient, error) {
 	var authentication auth.Authentication
 	if config.Auth.Enabled() {
 		var err error
-		authentication, err = config.Auth.GetAuthentication()
+		authentication, err = config.Auth.GetAuthentication(config.AdminAddress)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/client/common/client.go
+++ b/cmd/client/common/client.go
@@ -44,7 +44,7 @@ func (config ClientConfig) NewClient() (oxia.SyncClient, error) {
 		oxia.WithNamespace(config.Namespace),
 	}
 	if config.Auth.Enabled() {
-		authentication, err := config.Auth.GetAuthentication()
+		authentication, err := config.Auth.GetAuthentication(config.ServiceAddr)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/common/clientauth/auth.go
+++ b/cmd/common/clientauth/auth.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/oxia-db/oxia/common/auth"
+	clientrpc "github.com/oxia-db/oxia/common/rpc"
 )
 
 var (
@@ -43,7 +44,7 @@ func (c Config) Enabled() bool {
 }
 
 // GetAuthentication creates Oxia token credentials from the CLI auth options.
-func (c Config) GetAuthentication() (auth.Authentication, error) {
+func (c Config) GetAuthentication(address string) (auth.Authentication, error) {
 	if c.Token != "" && c.TokenFile != "" {
 		return nil, ErrAuthTokenConflict
 	}
@@ -61,5 +62,5 @@ func (c Config) GetAuthentication() (auth.Authentication, error) {
 		return nil, ErrAuthTokenRequired
 	}
 
-	return auth.NewTokenAuthenticationWithToken(token, true), nil
+	return auth.NewTokenAuthenticationWithToken(token, strings.HasPrefix(address, clientrpc.AddressSchemaTLS)), nil
 }

--- a/cmd/common/clientauth/auth_test.go
+++ b/cmd/common/clientauth/auth_test.go
@@ -32,12 +32,19 @@ func TestConfig_Enabled(t *testing.T) {
 }
 
 func TestConfig_GetAuthenticationWithToken(t *testing.T) {
-	authentication, err := Config{Token: " token\n"}.GetAuthentication()
+	authentication, err := Config{Token: " token\n"}.GetAuthentication("localhost:6648")
 	require.NoError(t, err)
 
 	metadata, err := authentication.GetRequestMetadata(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer token", metadata["authorization"])
+	assert.False(t, authentication.RequireTransportSecurity())
+}
+
+func TestConfig_GetAuthenticationWithTLSAddress(t *testing.T) {
+	authentication, err := Config{Token: "token"}.GetAuthentication("tls://localhost:6648")
+	require.NoError(t, err)
+
 	assert.True(t, authentication.RequireTransportSecurity())
 }
 
@@ -45,27 +52,27 @@ func TestConfig_GetAuthenticationWithTokenFile(t *testing.T) {
 	tokenFile := filepath.Join(t.TempDir(), "token")
 	require.NoError(t, os.WriteFile(tokenFile, []byte("file-token\n"), 0o600))
 
-	authentication, err := Config{TokenFile: tokenFile}.GetAuthentication()
+	authentication, err := Config{TokenFile: tokenFile}.GetAuthentication("localhost:6648")
 	require.NoError(t, err)
 
 	metadata, err := authentication.GetRequestMetadata(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer file-token", metadata["authorization"])
-	assert.True(t, authentication.RequireTransportSecurity())
+	assert.False(t, authentication.RequireTransportSecurity())
 }
 
 func TestConfig_GetAuthenticationWithoutToken(t *testing.T) {
-	_, err := Config{}.GetAuthentication()
+	_, err := Config{}.GetAuthentication("localhost:6648")
 	require.ErrorIs(t, err, ErrAuthTokenRequired)
 }
 
 func TestConfig_GetAuthenticationWithConflictingTokenSources(t *testing.T) {
-	_, err := Config{Token: "token", TokenFile: "token-file"}.GetAuthentication()
+	_, err := Config{Token: "token", TokenFile: "token-file"}.GetAuthentication("localhost:6648")
 	require.ErrorIs(t, err, ErrAuthTokenConflict)
 }
 
 func TestConfig_GetAuthenticationWithEmptyToken(t *testing.T) {
-	_, err := Config{Token: " \n"}.GetAuthentication()
+	_, err := Config{Token: " \n"}.GetAuthentication("localhost:6648")
 	require.ErrorIs(t, err, ErrAuthTokenRequired)
 }
 
@@ -73,13 +80,13 @@ func TestConfig_GetAuthenticationWithEmptyTokenFile(t *testing.T) {
 	tokenFile := filepath.Join(t.TempDir(), "token")
 	require.NoError(t, os.WriteFile(tokenFile, []byte("\n"), 0o600))
 
-	_, err := Config{TokenFile: tokenFile}.GetAuthentication()
+	_, err := Config{TokenFile: tokenFile}.GetAuthentication("localhost:6648")
 	require.ErrorIs(t, err, ErrAuthTokenRequired)
 }
 
 func TestConfig_GetAuthenticationWithMissingTokenFile(t *testing.T) {
 	tokenFile := filepath.Join(t.TempDir(), "missing")
-	_, err := Config{TokenFile: tokenFile}.GetAuthentication()
+	_, err := Config{TokenFile: tokenFile}.GetAuthentication("localhost:6648")
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, ErrAuthTokenRequired))
 	assert.Contains(t, err.Error(), tokenFile)


### PR DESCRIPTION
## Motivation
- The CLI auth token support should not require transport security unconditionally.
- The RPC client already uses the `tls://` address prefix to select TLS credentials, so the auth credential requirement should follow the same address scheme.

## Modifications
- Pass the configured client/admin address into CLI auth credential creation.
- Set token credential `RequireTransportSecurity` only when the address starts with `tls://`.
- Add unit coverage for plaintext and `tls://` address behavior.

## Testing
- `go test ./cmd/common/clientauth ./cmd/client/common ./cmd/admin/commons ./cmd/client ./cmd/admin`
- `golangci-lint run ./cmd/...`
- `go test ./cmd/...`
