### PR TITLE
fix: decouple CLI token auth from TLS

### DIFF
--- a/cmd/common/clientauth/auth.go
+++ b/cmd/common/clientauth/auth.go
@@ -61,5 +61,5 @@ func (c Config) GetAuthentication() (auth.Authentication, error) {
 		return nil, ErrAuthTokenRequired
 	}
 
-	return auth.NewTokenAuthenticationWithToken(token, true), nil
+	return auth.NewTokenAuthenticationWithToken(token, false), nil
 }

--- a/cmd/common/clientauth/auth_test.go
+++ b/cmd/common/clientauth/auth_test.go
@@ -38,7 +38,7 @@ func TestConfig_GetAuthenticationWithToken(t *testing.T) {
 	metadata, err := authentication.GetRequestMetadata(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer token", metadata["authorization"])
-	assert.True(t, authentication.RequireTransportSecurity())
+	assert.False(t, authentication.RequireTransportSecurity())
 }
 
 func TestConfig_GetAuthenticationWithTokenFile(t *testing.T) {
@@ -51,7 +51,7 @@ func TestConfig_GetAuthenticationWithTokenFile(t *testing.T) {
 	metadata, err := authentication.GetRequestMetadata(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer file-token", metadata["authorization"])
-	assert.True(t, authentication.RequireTransportSecurity())
+	assert.False(t, authentication.RequireTransportSecurity())
 }
 
 func TestConfig_GetAuthenticationWithoutToken(t *testing.T) {


### PR DESCRIPTION
## Motivation
- Authentication should not implicitly require TLS because transport security is selected independently by using `tls://` addresses.
- Allow CLI bearer-token authentication to work with the existing default plaintext addresses, while TLS remains available through the address scheme.

## Modifications
- Change CLI token credentials to not require transport security by default.
- Update token and token-file auth tests to assert transport security is not required.

## Testing
- `go test ./cmd/common/clientauth ./cmd/client/... ./cmd/admin/...`
