### PR TITLE
fix: refresh stale proxied grpc connections

### DIFF
--- a/cmd/health/cmd.go
+++ b/cmd/health/cmd.go
@@ -65,14 +65,14 @@ func init() {
 
 func exec(*cobra.Command, []string) error {
 	clientPool := rpc.NewClientPool(nil, nil)
+	defer clientPool.Close()
 
 	serverAddress := fmt.Sprintf("%s:%d", config.Host, config.Port)
 
-	client, closer, err := clientPool.GetHealthRpc(serverAddress)
+	client, err := clientPool.GetHealthRpc(serverAddress)
 	if err != nil {
 		return err
 	}
-	defer closer.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 	defer cancel()

--- a/common/rpc/client_pool.go
+++ b/common/rpc/client_pool.go
@@ -19,17 +19,11 @@ import (
 	"crypto/tls"
 	"io"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
-	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
 
 	"github.com/oxia-db/oxia/common/auth"
@@ -38,27 +32,19 @@ import (
 
 const DefaultRpcTimeout = 30 * time.Second
 const AddressSchemaTLS = "tls://"
-const (
-	defaultGrpcClientKeepAliveTime       = time.Second * 10
-	defaultGrpcClientKeepAliveTimeout    = time.Second * 5
-	defaultGrpcClientPermitWithoutStream = true
-)
 
 type ClientPool interface {
 	io.Closer
 	GetClientRpc(target string) (proto.OxiaClientClient, error)
-	GetHealthRpc(target string) (grpc_health_v1.HealthClient, io.Closer, error)
+	GetHealthRpc(target string) (grpc_health_v1.HealthClient, error)
 	GetCoordinationRpc(target string) (proto.OxiaCoordinationClient, error)
 	GetReplicationRpc(target string) (proto.OxiaLogReplicationClient, error)
 	GetAminRpc(target string) (proto.OxiaAdminClient, error)
-
-	// Clear all the pooled client instances for the given target
-	Clear(target string)
 }
 
 type clientPool struct {
 	sync.RWMutex
-	connections map[string]*grpc.ClientConn
+	connections map[string]*connection
 
 	tls            *tls.Config
 	authentication auth.Authentication
@@ -76,7 +62,7 @@ func (cp *clientPool) GetAminRpc(target string) (proto.OxiaAdminClient, error) {
 
 func NewClientPool(tlsConf *tls.Config, authentication auth.Authentication, dialOptions ...grpc.DialOption) ClientPool {
 	return &clientPool{
-		connections:    make(map[string]*grpc.ClientConn),
+		connections:    make(map[string]*connection),
 		tls:            tlsConf,
 		authentication: authentication,
 		dialOptions:    dialOptions,
@@ -103,14 +89,13 @@ func (cp *clientPool) Close() error {
 	return nil
 }
 
-func (cp *clientPool) GetHealthRpc(target string) (grpc_health_v1.HealthClient, io.Closer, error) {
-	// Skip the pooling for health-checks
-	cnx, err := cp.newConnection(target)
+func (cp *clientPool) GetHealthRpc(target string) (grpc_health_v1.HealthClient, error) {
+	cnx, err := cp.getConnectionFromPool(target)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return grpc_health_v1.NewHealthClient(cnx), cnx, nil
+	return grpc_health_v1.NewHealthClient(cnx), nil
 }
 
 func (cp *clientPool) GetClientRpc(target string) (proto.OxiaClientClient, error) {
@@ -140,23 +125,6 @@ func (cp *clientPool) GetReplicationRpc(target string) (proto.OxiaLogReplication
 	return proto.NewOxiaLogReplicationClient(cnx), nil
 }
 
-func (cp *clientPool) Clear(target string) {
-	cp.Lock()
-	defer cp.Unlock()
-
-	if cnx, ok := cp.connections[target]; ok {
-		if err := cnx.Close(); err != nil {
-			cp.log.Warn(
-				"Failed to close GRPC connection",
-				slog.String("server_address", target),
-				slog.Any("error", err),
-			)
-		}
-
-		delete(cp.connections, target)
-	}
-}
-
 func (cp *clientPool) getConnectionFromPool(target string) (grpc.ClientConnInterface, error) {
 	cp.RLock()
 	cnx, ok := cp.connections[target]
@@ -173,7 +141,13 @@ func (cp *clientPool) getConnectionFromPool(target string) (grpc.ClientConnInter
 		return cnx, nil
 	}
 
-	cnx, err := cp.newConnection(target)
+	cnx, err := newConnection(
+		target,
+		cp.tls,
+		cp.authentication,
+		cp.dialOptions,
+		cp.removeConnection,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -181,54 +155,25 @@ func (cp *clientPool) getConnectionFromPool(target string) (grpc.ClientConnInter
 	return cnx, nil
 }
 
-func (cp *clientPool) newConnection(target string) (*grpc.ClientConn, error) {
-	cp.log.Debug(
-		"Creating new GRPC connection",
-		slog.String("server_address", target),
-	)
-
-	tcs := cp.getTransportCredential(target)
-
-	options := []grpc.DialOption{
-		grpc.WithTransportCredentials(tcs),
-		grpc.WithChainStreamInterceptor(grpcprometheus.StreamClientInterceptor),
-		grpc.WithChainUnaryInterceptor(grpcprometheus.UnaryClientInterceptor),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			PermitWithoutStream: defaultGrpcClientPermitWithoutStream,
-			Time:                defaultGrpcClientKeepAliveTime,
-			Timeout:             defaultGrpcClientKeepAliveTimeout,
-		}),
+func (cp *clientPool) removeConnection(target string) {
+	cp.Lock()
+	cnx, ok := cp.connections[target]
+	if ok {
+		delete(cp.connections, target)
 	}
-	if cp.authentication != nil {
-		options = append(options, grpc.WithPerRPCCredentials(cp.authentication))
-	}
-	options = append(options, cp.dialOptions...)
+	cp.Unlock()
 
-	cnx, err := grpc.NewClient(cp.getActualAddress(target), options...)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error connecting to %s", target)
+	if !ok {
+		return
 	}
 
-	return cnx, nil
-}
-
-func (*clientPool) getActualAddress(target string) string {
-	if strings.HasPrefix(target, AddressSchemaTLS) {
-		after, _ := strings.CutPrefix(target, AddressSchemaTLS)
-		return after
+	if err := cnx.Close(); err != nil {
+		cp.log.Warn(
+			"Failed to close GRPC connection",
+			slog.String("server_address", target),
+			slog.Any("error", err),
+		)
 	}
-	return target
-}
-
-func (cp *clientPool) getTransportCredential(target string) credentials.TransportCredentials {
-	tcs := insecure.NewCredentials()
-	if strings.HasPrefix(target, AddressSchemaTLS) {
-		tcs = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
-	}
-	if cp.tls != nil {
-		tcs = credentials.NewTLS(cp.tls)
-	}
-	return tcs
 }
 
 func GetPeer(ctx context.Context) string {

--- a/common/rpc/client_pool_test.go
+++ b/common/rpc/client_pool_test.go
@@ -15,29 +15,168 @@
 package rpc
 
 import (
+	"context"
+	"net"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-func TestClientPool_GetActualAddress(t *testing.T) {
-	pool := NewClientPool(nil, nil)
-	poolInstance := pool.(*clientPool)
+func TestClientPool_RemovesConnectionAfterHealthTimeout(t *testing.T) {
+	_, _, target := newTestHealthServer(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 
-	address := poolInstance.getActualAddress("tls://xxxxaa:6648")
-	assert.Equal(t, "xxxxaa:6648", address)
+	pool := NewClientPool(nil, nil).(*clientPool)
+	defer pool.Close()
 
-	actualAddress := poolInstance.getActualAddress("xxxxaaa:6649")
-	assert.Equal(t, "xxxxaaa:6649", actualAddress)
+	conn, err := newTestConnectionWithHealthConfig(pool, target,
+		10*time.Millisecond, 10*time.Millisecond, 50*time.Millisecond)
+	require.NoError(t, err)
+
+	pool.Lock()
+	pool.connections[target] = conn
+	pool.Unlock()
+
+	require.Eventually(t, func() bool {
+		pool.RLock()
+		defer pool.RUnlock()
+		_, ok := pool.connections[target]
+		return !ok
+	}, time.Second, 10*time.Millisecond)
 }
 
-func TestClientPool_GetTransportCredential(t *testing.T) {
-	pool := NewClientPool(nil, nil)
-	poolInstance := pool.(*clientPool)
+func TestClientPool_RemovesConnectionWhenHealthPingHangs(t *testing.T) {
+	_, target := newTestBlockingHealthServer(t)
 
-	credential := poolInstance.getTransportCredential("tls://xxxxaa:6648")
-	assert.Equal(t, "tls", credential.Info().SecurityProtocol)
+	pool := NewClientPool(nil, nil).(*clientPool)
+	defer pool.Close()
 
-	credential = poolInstance.getTransportCredential("xxxxaaa:6649")
-	assert.Equal(t, "insecure", credential.Info().SecurityProtocol)
+	conn, err := newTestConnectionWithHealthConfig(pool, target,
+		10*time.Millisecond, 10*time.Millisecond, 50*time.Millisecond)
+	require.NoError(t, err)
+
+	pool.Lock()
+	pool.connections[target] = conn
+	pool.Unlock()
+
+	require.Eventually(t, func() bool {
+		pool.RLock()
+		defer pool.RUnlock()
+		_, ok := pool.connections[target]
+		return !ok
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestClientPool_KeepsConnectionWhenHealthRecoversBeforeTimeout(t *testing.T) {
+	_, healthServer, target := newTestHealthServer(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	pool := NewClientPool(nil, nil).(*clientPool)
+	defer pool.Close()
+
+	conn, err := newTestConnectionWithHealthConfig(pool, target,
+		10*time.Millisecond, 10*time.Millisecond, 200*time.Millisecond)
+	require.NoError(t, err)
+
+	pool.Lock()
+	pool.connections[target] = conn
+	pool.Unlock()
+
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	require.Never(t, func() bool {
+		pool.RLock()
+		defer pool.RUnlock()
+		return pool.connections[target] != conn
+	}, 250*time.Millisecond, 10*time.Millisecond)
+}
+
+func newTestConnectionWithHealthConfig(
+	pool *clientPool,
+	target string,
+	healthInterval time.Duration,
+	healthPingTimeout time.Duration,
+	healthTimeout time.Duration,
+) (*connection, error) {
+	return newConnectionWithHealthConfig(
+		target,
+		pool.tls,
+		pool.authentication,
+		pool.dialOptions,
+		pool.removeConnection,
+		healthInterval,
+		healthPingTimeout,
+		healthTimeout,
+	)
+}
+
+func newTestHealthServer(
+	t *testing.T,
+	status grpc_health_v1.HealthCheckResponse_ServingStatus,
+) (*grpc.Server, *health.Server, string) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", status)
+
+	server := grpc.NewServer()
+	grpc_health_v1.RegisterHealthServer(server, healthServer)
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		server.Stop()
+	})
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	healthClient := grpc_health_v1.NewHealthClient(conn)
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		_, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
+	require.NoError(t, conn.Close())
+
+	return server, healthServer, listener.Addr().String()
+}
+
+type blockingHealthServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+}
+
+func (*blockingHealthServer) Check(
+	ctx context.Context,
+	_ *grpc_health_v1.HealthCheckRequest,
+) (*grpc_health_v1.HealthCheckResponse, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func newTestBlockingHealthServer(t *testing.T) (*grpc.Server, string) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	grpc_health_v1.RegisterHealthServer(server, &blockingHealthServer{})
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		server.Stop()
+	})
+
+	return server, listener.Addr().String()
 }

--- a/common/rpc/client_pool_test.go
+++ b/common/rpc/client_pool_test.go
@@ -93,6 +93,27 @@ func TestClientPool_KeepsConnectionWhenHealthRecoversBeforeTimeout(t *testing.T)
 	}, 250*time.Millisecond, 10*time.Millisecond)
 }
 
+func TestClientPool_KeepsConnectionWhenHealthCheckIsUnsupported(t *testing.T) {
+	_, target := newTestGrpcServerWithoutHealth(t)
+
+	pool := NewClientPool(nil, nil).(*clientPool)
+	defer pool.Close()
+
+	conn, err := newTestConnectionWithHealthConfig(pool, target,
+		10*time.Millisecond, 10*time.Millisecond, 50*time.Millisecond)
+	require.NoError(t, err)
+
+	pool.Lock()
+	pool.connections[target] = conn
+	pool.Unlock()
+
+	require.Never(t, func() bool {
+		pool.RLock()
+		defer pool.RUnlock()
+		return pool.connections[target] != conn
+	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
 func newTestConnectionWithHealthConfig(
 	pool *clientPool,
 	target string,
@@ -170,6 +191,24 @@ func newTestBlockingHealthServer(t *testing.T) (*grpc.Server, string) {
 	server := grpc.NewServer()
 	grpc_health_v1.RegisterHealthServer(server, &blockingHealthServer{})
 
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		server.Stop()
+	})
+
+	return server, listener.Addr().String()
+}
+
+func newTestGrpcServerWithoutHealth(t *testing.T) (*grpc.Server, string) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
 	go func() {
 		_ = server.Serve(listener)
 	}()

--- a/common/rpc/connection.go
+++ b/common/rpc/connection.go
@@ -39,11 +39,11 @@ import (
 )
 
 const (
-	defaultGrpcConnectionHealthPingInterval   = 5 * time.Second
-	defaultGrpcConnectionHealthPingTimeout    = 5 * time.Second
+	defaultGrpcClientKeepAliveTime            = 10 * time.Second
+	defaultGrpcClientKeepAliveTimeout         = 3 * time.Second
+	defaultGrpcConnectionHealthPingInterval   = defaultGrpcClientKeepAliveTime
+	defaultGrpcConnectionHealthPingTimeout    = defaultGrpcClientKeepAliveTimeout
 	defaultGrpcConnectionHealthFailureTimeout = 30 * time.Second
-	defaultGrpcClientKeepAliveTime            = time.Second * 10
-	defaultGrpcClientKeepAliveTimeout         = time.Second * 5
 	defaultGrpcClientPermitWithoutStream      = true
 )
 

--- a/common/rpc/connection.go
+++ b/common/rpc/connection.go
@@ -27,10 +27,12 @@ import (
 	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/auth"
 	"github.com/oxia-db/oxia/common/process"
@@ -165,6 +167,11 @@ func (c *connection) healthCheckLoop() {
 		ctx, cancel := context.WithTimeout(c.ctx, c.healthPingTimeout)
 		response, err := c.healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: ""})
 		cancel()
+
+		if status.Code(err) == codes.Unimplemented {
+			c.log.Debug("Connection health ping is unsupported")
+			return
+		}
 
 		if err == nil && response.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING {
 			firstFailure = time.Time{}

--- a/common/rpc/connection.go
+++ b/common/rpc/connection.go
@@ -1,0 +1,216 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
+
+	"github.com/oxia-db/oxia/common/auth"
+	"github.com/oxia-db/oxia/common/process"
+)
+
+const (
+	defaultGrpcConnectionHealthPingInterval   = 5 * time.Second
+	defaultGrpcConnectionHealthPingTimeout    = 5 * time.Second
+	defaultGrpcConnectionHealthFailureTimeout = 30 * time.Second
+	defaultGrpcClientKeepAliveTime            = time.Second * 10
+	defaultGrpcClientKeepAliveTimeout         = time.Second * 5
+	defaultGrpcClientPermitWithoutStream      = true
+)
+
+type connectionFailureCallback func(target string)
+
+type connection struct {
+	*grpc.ClientConn
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	target            string
+	healthClient      grpc_health_v1.HealthClient
+	onFailure         connectionFailureCallback
+	healthPingTimeout time.Duration
+	healthTimeout     time.Duration
+	healthInterval    time.Duration
+	closeOnce         sync.Once
+	disconnected      atomic.Bool
+	log               *slog.Logger
+}
+
+var _ io.Closer = (*connection)(nil)
+var _ grpc.ClientConnInterface = (*connection)(nil)
+
+func newConnection(
+	target string,
+	tlsConf *tls.Config,
+	authentication auth.Authentication,
+	dialOptions []grpc.DialOption,
+	onFailure connectionFailureCallback,
+) (*connection, error) {
+	return newConnectionWithHealthConfig(
+		target,
+		tlsConf,
+		authentication,
+		dialOptions,
+		onFailure,
+		defaultGrpcConnectionHealthPingInterval,
+		defaultGrpcConnectionHealthPingTimeout,
+		defaultGrpcConnectionHealthFailureTimeout,
+	)
+}
+
+func newConnectionWithHealthConfig(
+	target string,
+	tlsConf *tls.Config,
+	authentication auth.Authentication,
+	dialOptions []grpc.DialOption,
+	onFailure connectionFailureCallback,
+	healthInterval time.Duration,
+	healthPingTimeout time.Duration,
+	healthTimeout time.Duration,
+) (*connection, error) {
+	log := slog.With(slog.String("component", "rpc-connection"), slog.String("target", target))
+	log.Debug("Creating new GRPC connection")
+
+	actualAddress := target
+	transportCredential := insecure.NewCredentials()
+	if strings.HasPrefix(target, AddressSchemaTLS) {
+		actualAddress, _ = strings.CutPrefix(target, AddressSchemaTLS)
+		transportCredential = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
+	}
+	if tlsConf != nil {
+		transportCredential = credentials.NewTLS(tlsConf)
+	}
+
+	options := []grpc.DialOption{
+		grpc.WithTransportCredentials(transportCredential),
+		grpc.WithChainStreamInterceptor(grpcprometheus.StreamClientInterceptor),
+		grpc.WithChainUnaryInterceptor(grpcprometheus.UnaryClientInterceptor),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			PermitWithoutStream: defaultGrpcClientPermitWithoutStream,
+			Time:                defaultGrpcClientKeepAliveTime,
+			Timeout:             defaultGrpcClientKeepAliveTimeout,
+		}),
+	}
+	if authentication != nil {
+		options = append(options, grpc.WithPerRPCCredentials(authentication))
+	}
+	options = append(options, dialOptions...)
+
+	clientConn, err := grpc.NewClient(actualAddress, options...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error connecting to %s", target)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &connection{
+		ClientConn:        clientConn,
+		target:            target,
+		healthClient:      grpc_health_v1.NewHealthClient(clientConn),
+		onFailure:         onFailure,
+		healthPingTimeout: healthPingTimeout,
+		healthTimeout:     healthTimeout,
+		healthInterval:    healthInterval,
+		ctx:               ctx,
+		cancel:            cancel,
+		log:               log,
+	}
+	c.wg.Go(func() {
+		process.DoWithLabels(
+			c.ctx,
+			map[string]string{
+				"component": "rpc-connection-health-ping",
+				"target":    c.target,
+			},
+			c.healthCheckLoop,
+		)
+	})
+	return c, nil
+}
+
+func (c *connection) healthCheckLoop() {
+	var firstFailure time.Time
+	ticker := time.NewTicker(c.healthInterval)
+	defer ticker.Stop()
+
+	for {
+		ctx, cancel := context.WithTimeout(c.ctx, c.healthPingTimeout)
+		response, err := c.healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: ""})
+		cancel()
+
+		if err == nil && response.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING {
+			firstFailure = time.Time{}
+		} else {
+			if err != nil {
+				c.log.Debug("Connection health ping failed", slog.Any("error", err))
+			} else {
+				c.log.Debug("Connection health ping returned unhealthy status", slog.Any("status", response.GetStatus()))
+			}
+			if firstFailure.IsZero() {
+				firstFailure = time.Now()
+			}
+			if time.Since(firstFailure) >= c.healthTimeout && c.disconnected.CompareAndSwap(false, true) {
+				c.notifyDisconnect()
+				return
+			}
+		}
+
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (c *connection) notifyDisconnect() {
+	c.log.Warn("Connection health check timed out", slog.Duration("timeout", c.healthTimeout))
+	go process.DoWithLabels(
+		context.Background(),
+		map[string]string{
+			"component": "rpc-connection-failure-callback",
+			"target":    c.target,
+		},
+		func() {
+			c.onFailure(c.target)
+		},
+	)
+}
+
+func (c *connection) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		c.cancel()
+		c.wg.Wait()
+		err = c.ClientConn.Close()
+	})
+	return err
+}

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -17,7 +17,6 @@ package oxia
 import (
 	"context"
 	"errors"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,8 +116,8 @@ func (m *mockAdminClientPool) GetClientRpc(string) (proto.OxiaClientClient, erro
 	return nil, errors.New("unexpected GetClientRpc call")
 }
 
-func (m *mockAdminClientPool) GetHealthRpc(string) (grpc_health_v1.HealthClient, io.Closer, error) {
-	return nil, nil, errors.New("unexpected GetHealthRpc call")
+func (m *mockAdminClientPool) GetHealthRpc(string) (grpc_health_v1.HealthClient, error) {
+	return nil, errors.New("unexpected GetHealthRpc call")
 }
 
 func (m *mockAdminClientPool) GetCoordinationRpc(string) (proto.OxiaCoordinationClient, error) {

--- a/oxiad/coordinator/grpc_server.go
+++ b/oxiad/coordinator/grpc_server.go
@@ -129,6 +129,7 @@ func NewGrpcServer(parent context.Context, optionsWatch *commonwatch.Watch[*opti
 	)
 	managementGrpcServer, err = commonrpc.Default.StartGrpcServer("admin", managementSv.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
 		proto.RegisterOxiaAdminServer(registrar, management)
+		grpc_health_v1.RegisterHealthServer(registrar, healthServer)
 	}, managementSvTLS, &managementSv.Auth, nil)
 	if err != nil {
 		return nil, err

--- a/oxiad/coordinator/rpc/rpc_provider.go
+++ b/oxiad/coordinator/rpc/rpc_provider.go
@@ -45,9 +45,7 @@ type Provider interface {
 	Handshake(ctx context.Context, node *proto.DataServerIdentity, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error)
 	RemoveObserver(ctx context.Context, node *proto.DataServerIdentity, req *proto.RemoveObserverRequest) (*proto.RemoveObserverResponse, error)
 
-	GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, io.Closer, error)
-
-	ClearPooledConnections(node *proto.DataServerIdentity)
+	GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, error)
 }
 
 type rpcProvider struct {
@@ -178,10 +176,6 @@ func (r *rpcProvider) RemoveObserver(ctx context.Context, node *proto.DataServer
 	return client.RemoveObserver(ctx, req)
 }
 
-func (r *rpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (r *rpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, error) {
 	return r.pool.GetHealthRpc(node.Internal)
-}
-
-func (r *rpcProvider) ClearPooledConnections(node *proto.DataServerIdentity) {
-	r.pool.Clear(node.Internal)
 }

--- a/oxiad/coordinator/runtime/controller/dataserver_controller.go
+++ b/oxiad/coordinator/runtime/controller/dataserver_controller.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 
-	"github.com/oxia-db/oxia/common/commonio"
 	commonobject "github.com/oxia-db/oxia/common/object"
 
 	"github.com/oxia-db/oxia/common/metric"
@@ -88,10 +87,6 @@ type dataServerController struct {
 	status            DataServerStatus
 	supportedFeatures atomic.Value
 
-	healthClientOnce   sync.Once
-	healthClient       grpc_health_v1.HealthClient
-	healthClientCloser io.Closer
-
 	healthCheckBackoff         *commontime.ConcurrentBackOff
 	dispatchAssignmentsBackoff backoff.BackOff
 
@@ -121,26 +116,6 @@ func (n *dataServerController) SetStatus(status DataServerStatus) {
 	n.logger.Info("Changed status", slog.Any("from", previous), slog.Any("to", status))
 }
 
-func (n *dataServerController) maybeInitHealthClient() {
-	n.healthClientOnce.Do(func() {
-		_ = backoff.RetryNotify(func() error {
-			health, closer, err := n.rpc.GetHealthClient(n.dataServer.GetIdentity())
-			if err != nil {
-				return err
-			}
-			n.healthClient = health
-			n.healthClientCloser = closer
-			return nil
-		}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
-			n.logger.Warn(
-				"Failed to create health client to storage data server",
-				slog.Duration("retry-after", duration),
-				slog.Any("error", err),
-			)
-		})
-	})
-}
-
 func (n *dataServerController) Close() error {
 	if !n.closed.CompareAndSwap(false, true) {
 		return nil
@@ -149,12 +124,8 @@ func (n *dataServerController) Close() error {
 	n.ctxCancel()
 	n.wg.Wait()
 
-	var err error
-	if err = n.healthClientCloser.Close(); err != nil {
-		n.logger.Warn("close data server controller health client failed", slog.Any("error", err))
-	}
 	n.logger.Info("Closed data server controller")
-	return err
+	return nil
 }
 
 func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
@@ -207,18 +178,22 @@ func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
 	})
 }
 
-func (n *dataServerController) doHealthPing() error {
+func (n *dataServerController) doHealthPing(healthClient grpc_health_v1.HealthClient) error {
 	pingCtx, pingCancel := context.WithTimeout(n.ctx, healthCheckProbeTimeout)
-	response, err := n.healthClient.Check(pingCtx, &grpc_health_v1.HealthCheckRequest{Service: ""})
+	response, err := healthClient.Check(pingCtx, &grpc_health_v1.HealthCheckRequest{Service: ""})
 	pingCancel()
 	return n.healthCheckHandler(response, err)
 }
 
 func (n *dataServerController) healthPingWithRetries() {
 	_ = backoff.RetryNotify(func() error {
-		n.maybeInitHealthClient()
+		healthClient, err := n.rpc.GetHealthClient(n.dataServer.GetIdentity())
+		if err != nil {
+			return err
+		}
+
 		// Immediate check on startup instead of waiting for first tick
-		if err := n.doHealthPing(); err != nil {
+		if err := n.doHealthPing(healthClient); err != nil {
 			return err
 		}
 		ticker := time.NewTicker(healthCheckProbeInterval)
@@ -228,7 +203,7 @@ func (n *dataServerController) healthPingWithRetries() {
 			case <-n.ctx.Done():
 				return nil
 			case <-ticker.C:
-				if err := n.doHealthPing(); err != nil {
+				if err := n.doHealthPing(healthClient); err != nil {
 					n.logger.Warn("Data server stopped responding to ping")
 					return err
 				}
@@ -247,9 +222,12 @@ func (n *dataServerController) healthPingWithRetries() {
 func (n *dataServerController) healthWatchWithRetries() {
 	_ = backoff.RetryNotify(func() error {
 		n.logger.Debug("Start new health watch cycle")
-		n.maybeInitHealthClient()
+		healthClient, err := n.rpc.GetHealthClient(n.dataServer.GetIdentity())
+		if err != nil {
+			return err
+		}
 
-		watchStream, err := n.healthClient.Watch(n.ctx, &grpc_health_v1.HealthCheckRequest{Service: ""})
+		watchStream, err := healthClient.Watch(n.ctx, &grpc_health_v1.HealthCheckRequest{Service: ""})
 		if err != nil {
 			return err
 		}
@@ -298,9 +276,6 @@ func (n *dataServerController) becomeAvailable() {
 
 	n.logger.Info("Storage data server is back online")
 
-	// To avoid the send assignments stream to miss the notification about the current
-	// dataServer went down, we interrupt the current stream when the ping on the dataServer fails
-	n.rpc.ClearPooledConnections(n.dataServer.GetIdentity())
 	n.healthCheckBackoff.Reset()
 
 	// Bind the node before it can receive other internal traffic.
@@ -368,28 +343,26 @@ func newDataServerController(ctx context.Context, dataServer *proto.DataServer,
 	dataServerCtx, cancel := context.WithCancel(ctx)
 	dataServerID := dataServer.GetIdentity().GetNameOrDefault()
 	labels := map[string]any{"data-server": dataServerID}
+	logger := slog.With(
+		slog.String("component", "data-server-controller"),
+		slog.Any("data-server", dataServerID),
+	)
 
 	supportedFeatures := atomic.Value{}
 	supportedFeatures.Store(make([]proto.Feature, 0))
 
 	nc := &dataServerController{
-		ctx:                      dataServerCtx,
-		ctxCancel:                cancel,
-		dataServer:               dataServer,
-		ShardAssignmentsProvider: shardAssignmentsProvider,
-		DataServerEventListener:  dataServerEventListener,
-		rpc:                      rpcProvider,
-		insID:                    insID,
-		statusLock:               sync.RWMutex{},
-		status:                   NotRunning,
-		supportedFeatures:        supportedFeatures,
-		logger: slog.With(
-			slog.String("component", "data-server-controller"),
-			slog.Any("data-server", dataServerID),
-		),
-		healthClientOnce:           sync.Once{},
-		healthClient:               nil,
-		healthClientCloser:         &commonio.NopCloser{},
+		ctx:                        dataServerCtx,
+		ctxCancel:                  cancel,
+		dataServer:                 dataServer,
+		ShardAssignmentsProvider:   shardAssignmentsProvider,
+		DataServerEventListener:    dataServerEventListener,
+		rpc:                        rpcProvider,
+		insID:                      insID,
+		statusLock:                 sync.RWMutex{},
+		status:                     NotRunning,
+		supportedFeatures:          supportedFeatures,
+		logger:                     logger,
 		healthCheckBackoff:         commontime.NewConcurrentBackOff(commontime.NewBackOffWithInitialInterval(dataServerCtx, initialRetryBackoff)),
 		dispatchAssignmentsBackoff: commontime.NewBackOffWithInitialInterval(dataServerCtx, initialRetryBackoff),
 		failedHealthChecks: metric.NewCounter("oxia_coordinator_node_health_checks_failed",

--- a/oxiad/coordinator/runtime/controller/mock_test.go
+++ b/oxiad/coordinator/runtime/controller/mock_test.go
@@ -17,7 +17,6 @@ package controller
 import (
 	"context"
 	"errors"
-	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -374,9 +373,6 @@ func (r *mockRpcProvider) Close() error {
 	return nil
 }
 
-func (r *mockRpcProvider) ClearPooledConnections(node *proto.DataServerIdentity) {
-}
-
 func newMockRpcProvider() *mockRpcProvider {
 	return &mockRpcProvider{
 		channels: make(map[string]*mockPerNodeChannels),
@@ -595,9 +591,9 @@ func (r *mockRpcProvider) RemoveObserver(ctx context.Context, node *proto.DataSe
 	}
 }
 
-func (r *mockRpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (r *mockRpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, error) {
 	c := r.GetNode(node).healthClient
-	return c, c, nil
+	return c, nil
 }
 
 type mockShardAssignmentClient struct {

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -63,15 +64,17 @@ type publicRpcServer struct {
 	assignmentDispatcher       assignment.ShardAssignmentsDispatcher
 	disableAuthorityValidation bool
 	grpcServer                 oxiadcommonrpc.GrpcServer
+	healthServer               oxiadcommonrpc.HealthServer
 	log                        *slog.Logger
 }
 
 func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector, assignmentDispatcher assignment.ShardAssignmentsDispatcher,
-	disableAuthorityValidation bool, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
+	disableAuthorityValidation bool, healthServer oxiadcommonrpc.HealthServer, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
 	server := &publicRpcServer{
 		shardsDirector:             shardsDirector,
 		assignmentDispatcher:       assignmentDispatcher,
 		disableAuthorityValidation: disableAuthorityValidation,
+		healthServer:               healthServer,
 		log: slog.With(
 			slog.String("component", "public-rpc-server"),
 		),
@@ -81,6 +84,7 @@ func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string
 	server.grpcServer, err = provider.StartGrpcServer("public", bindAddress, func(registrar grpc.ServiceRegistrar) {
 		proto.RegisterOxiaClientServer(registrar, server)
 		compat.RegisterOxiaClientServer(registrar, &compatPublicRpcServer{impl: server})
+		grpc_health_v1.RegisterHealthServer(registrar, server.healthServer)
 	}, tlsConf, options, nil)
 	if err != nil {
 		return nil, err

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/protoadapt"
@@ -33,6 +34,7 @@ import (
 	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/common/logging"
+	oxiadcommonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
 	"github.com/oxia-db/oxia/oxiad/dataserver/assignment"
 	"github.com/oxia-db/oxia/oxiad/dataserver/controller"
 	"github.com/oxia-db/oxia/oxiad/dataserver/controller/follow"
@@ -135,6 +137,23 @@ func TestWriteClientClose(t *testing.T) {
 	t.Logf("resp %v err %v", resp, err)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestPublicHealthCheck(t *testing.T) {
+	standaloneServer, err := NewStandalone(NewTestConfig(t.TempDir()))
+	require.NoError(t, err)
+	defer standaloneServer.Close()
+
+	conn, err := grpc.NewClient(standaloneServer.ServiceAddr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := grpc_health_v1.NewHealthClient(conn)
+	resp, err := client.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+		Service: oxiadcommonrpc.ReadinessProbeService,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
 }
 
 func TestValidateAuthorityRejectsWrongAuthority(t *testing.T) {

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -138,7 +138,7 @@ func NewWithGrpcProvider(parent context.Context, optionsWatch *commonwatch.Watch
 		return nil, err
 	}
 	s.publicRpcServer, err = newPublicRpcServer(provider, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, disableAuthorityValidation, publicServerTLS, &publicServer.Auth)
+		s.shardAssignmentDispatcher, disableAuthorityValidation, s.healthServer, publicServerTLS, &publicServer.Auth)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/server_test.go
+++ b/oxiad/dataserver/server_test.go
@@ -69,10 +69,10 @@ func TestNewServerClosableWithHealthWatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	clientPool := rpc.NewClientPool(nil, nil)
+	defer clientPool.Close()
 
-	client, closer, err := clientPool.GetHealthRpc(fmt.Sprintf("127.0.0.1:%v", server.InternalPort()))
+	client, err := clientPool.GetHealthRpc(fmt.Sprintf("127.0.0.1:%v", server.InternalPort()))
 	assert.NoError(t, err)
-	defer closer.Close()
 	watchStream, err := client.Watch(t.Context(), &grpc_health_v1.HealthCheckRequest{Service: ""})
 	assert.NoError(t, err)
 

--- a/oxiad/dataserver/standalone.go
+++ b/oxiad/dataserver/standalone.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"go.uber.org/multierr"
+	"google.golang.org/grpc/health/grpc_health_v1"
 
 	dataserveroption "github.com/oxia-db/oxia/oxiad/dataserver/option"
 
@@ -56,6 +57,7 @@ type Standalone struct {
 	walFactory                wal.Factory
 	shardsDirector            controller.ShardsDirector
 	shardAssignmentDispatcher assignment.ShardAssignmentsDispatcher
+	healthServer              rpc2.HealthServer
 
 	metrics *metric.PrometheusMetrics
 }
@@ -107,6 +109,8 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 	}
 
 	s.shardAssignmentDispatcher = assignment.NewStandaloneShardAssignmentDispatcher(config.NumShards)
+	s.healthServer = rpc2.NewClosableHealthServer(context.Background())
+	s.healthServer.SetServingStatus(rpc2.ReadinessProbeService, grpc_health_v1.HealthCheckResponse_SERVING)
 
 	publicServer := config.DataServerOptions.Server.Public
 	serverTLS, err := publicServer.TLS.TryIntoServerTLSConf()
@@ -114,7 +118,7 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 		return nil, err
 	}
 	s.rpc, err = newPublicRpcServer(rpc2.Default, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, false, serverTLS, &auth.Disabled)
+		s.shardAssignmentDispatcher, false, s.healthServer, serverTLS, &auth.Disabled)
 	if err != nil {
 		return nil, err
 	}
@@ -183,6 +187,7 @@ func (s *Standalone) Close() error {
 
 	return multierr.Combine(
 		err,
+		s.healthServer.Close(),
 		s.shardsDirector.Close(),
 		s.shardAssignmentDispatcher.Close(),
 		s.rpc.Close(),

--- a/oxiad/maelstrom/coordinator_rpc_client.go
+++ b/oxiad/maelstrom/coordinator_rpc_client.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"sync"
 
@@ -45,9 +44,6 @@ type maelstromCoordinatorRpcProvider struct {
 
 func (m *maelstromCoordinatorRpcProvider) Close() error {
 	return nil
-}
-
-func (m *maelstromCoordinatorRpcProvider) ClearPooledConnections(node *proto.DataServerIdentity) {
 }
 
 func newRpcProvider(dispatcher *dispatcher) rpc.Provider {
@@ -116,13 +112,13 @@ func (m *maelstromCoordinatorRpcProvider) Handshake(ctx context.Context, node *p
 	}, nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (m *maelstromCoordinatorRpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_health_v1.HealthClient, error) {
 	c := &maelstromHealthCheckClient{
 		provider: m,
 		node:     node.GetInternal(),
 	}
 
-	return c, c, nil
+	return c, nil
 }
 
 type maelstromShardAssignmentClient struct {


### PR DESCRIPTION
## Motivation
- Proxies between clients and servers can keep stale gRPC sockets open after a backend becomes unavailable.
- Reusing those pooled client connections can keep traffic pinned to an unhealthy path.

## Modifications
- Add health probing for pooled gRPC client connections and evict connections after repeated health failures.
- Register health services on public/admin RPC servers so pooled connections can verify liveness through proxies.
- Remove manual coordinator pool clearing now that failed pooled connections self-evict.
- Add tests for unhealthy, hanging, recovered, and stale-failure connection scenarios.

## Testing
- go test -count=1 ./common/rpc
- go test ./oxiad/dataserver ./oxiad/coordinator/...
- make lint