### PR TITLE
fix: align grpc connection health eviction with keepalive

### DIFF
--- a/common/rpc/client_pool_test.go
+++ b/common/rpc/client_pool_test.go
@@ -27,14 +27,14 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-func TestClientPool_RemovesConnectionAfterHealthTimeout(t *testing.T) {
+func TestClientPool_RemovesConnectionAfterHealthFailure(t *testing.T) {
 	_, _, target := newTestHealthServer(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 
 	pool := NewClientPool(nil, nil).(*clientPool)
 	defer pool.Close()
 
 	conn, err := newTestConnectionWithHealthConfig(pool, target,
-		10*time.Millisecond, 10*time.Millisecond, 50*time.Millisecond)
+		10*time.Millisecond, 10*time.Millisecond)
 	require.NoError(t, err)
 
 	pool.Lock()
@@ -56,7 +56,7 @@ func TestClientPool_RemovesConnectionWhenHealthPingHangs(t *testing.T) {
 	defer pool.Close()
 
 	conn, err := newTestConnectionWithHealthConfig(pool, target,
-		10*time.Millisecond, 10*time.Millisecond, 50*time.Millisecond)
+		10*time.Millisecond, 10*time.Millisecond)
 	require.NoError(t, err)
 
 	pool.Lock()
@@ -71,21 +71,20 @@ func TestClientPool_RemovesConnectionWhenHealthPingHangs(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
-func TestClientPool_KeepsConnectionWhenHealthRecoversBeforeTimeout(t *testing.T) {
-	_, healthServer, target := newTestHealthServer(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+func TestClientPool_KeepsConnectionWhenHealthIsServing(t *testing.T) {
+	_, _, target := newTestHealthServer(t, grpc_health_v1.HealthCheckResponse_SERVING)
 
 	pool := NewClientPool(nil, nil).(*clientPool)
 	defer pool.Close()
 
 	conn, err := newTestConnectionWithHealthConfig(pool, target,
-		10*time.Millisecond, 10*time.Millisecond, 200*time.Millisecond)
+		10*time.Millisecond, 10*time.Millisecond)
 	require.NoError(t, err)
 
 	pool.Lock()
 	pool.connections[target] = conn
 	pool.Unlock()
 
-	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 	require.Never(t, func() bool {
 		pool.RLock()
 		defer pool.RUnlock()
@@ -100,7 +99,7 @@ func TestClientPool_KeepsConnectionWhenHealthCheckIsUnsupported(t *testing.T) {
 	defer pool.Close()
 
 	conn, err := newTestConnectionWithHealthConfig(pool, target,
-		10*time.Millisecond, 10*time.Millisecond, 50*time.Millisecond)
+		10*time.Millisecond, 10*time.Millisecond)
 	require.NoError(t, err)
 
 	pool.Lock()
@@ -119,7 +118,6 @@ func newTestConnectionWithHealthConfig(
 	target string,
 	healthInterval time.Duration,
 	healthPingTimeout time.Duration,
-	healthTimeout time.Duration,
 ) (*connection, error) {
 	return newConnectionWithHealthConfig(
 		target,
@@ -129,7 +127,6 @@ func newTestConnectionWithHealthConfig(
 		pool.removeConnection,
 		healthInterval,
 		healthPingTimeout,
-		healthTimeout,
 	)
 }
 

--- a/common/rpc/connection.go
+++ b/common/rpc/connection.go
@@ -39,12 +39,9 @@ import (
 )
 
 const (
-	defaultGrpcClientKeepAliveTime            = 10 * time.Second
-	defaultGrpcClientKeepAliveTimeout         = 3 * time.Second
-	defaultGrpcConnectionHealthPingInterval   = defaultGrpcClientKeepAliveTime
-	defaultGrpcConnectionHealthPingTimeout    = defaultGrpcClientKeepAliveTimeout
-	defaultGrpcConnectionHealthFailureTimeout = 30 * time.Second
-	defaultGrpcClientPermitWithoutStream      = true
+	defaultGrpcClientKeepAliveTime       = 10 * time.Second
+	defaultGrpcClientKeepAliveTimeout    = 3 * time.Second
+	defaultGrpcClientPermitWithoutStream = true
 )
 
 type connectionFailureCallback func(target string)
@@ -60,7 +57,6 @@ type connection struct {
 	healthClient      grpc_health_v1.HealthClient
 	onFailure         connectionFailureCallback
 	healthPingTimeout time.Duration
-	healthTimeout     time.Duration
 	healthInterval    time.Duration
 	closeOnce         sync.Once
 	disconnected      atomic.Bool
@@ -83,9 +79,8 @@ func newConnection(
 		authentication,
 		dialOptions,
 		onFailure,
-		defaultGrpcConnectionHealthPingInterval,
-		defaultGrpcConnectionHealthPingTimeout,
-		defaultGrpcConnectionHealthFailureTimeout,
+		defaultGrpcClientKeepAliveTime,
+		defaultGrpcClientKeepAliveTimeout,
 	)
 }
 
@@ -97,7 +92,6 @@ func newConnectionWithHealthConfig(
 	onFailure connectionFailureCallback,
 	healthInterval time.Duration,
 	healthPingTimeout time.Duration,
-	healthTimeout time.Duration,
 ) (*connection, error) {
 	log := slog.With(slog.String("component", "rpc-connection"), slog.String("target", target))
 	log.Debug("Creating new GRPC connection")
@@ -139,7 +133,6 @@ func newConnectionWithHealthConfig(
 		healthClient:      grpc_health_v1.NewHealthClient(clientConn),
 		onFailure:         onFailure,
 		healthPingTimeout: healthPingTimeout,
-		healthTimeout:     healthTimeout,
 		healthInterval:    healthInterval,
 		ctx:               ctx,
 		cancel:            cancel,
@@ -159,7 +152,6 @@ func newConnectionWithHealthConfig(
 }
 
 func (c *connection) healthCheckLoop() {
-	var firstFailure time.Time
 	ticker := time.NewTicker(c.healthInterval)
 	defer ticker.Stop()
 
@@ -173,18 +165,13 @@ func (c *connection) healthCheckLoop() {
 			return
 		}
 
-		if err == nil && response.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING {
-			firstFailure = time.Time{}
-		} else {
+		if err != nil || response.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
 			if err != nil {
-				c.log.Debug("Connection health ping failed", slog.Any("error", err))
+				c.log.Warn("Connection health ping failed", slog.Any("error", err))
 			} else {
-				c.log.Debug("Connection health ping returned unhealthy status", slog.Any("status", response.GetStatus()))
+				c.log.Warn("Connection health ping returned unhealthy status", slog.Any("status", response.GetStatus()))
 			}
-			if firstFailure.IsZero() {
-				firstFailure = time.Now()
-			}
-			if time.Since(firstFailure) >= c.healthTimeout && c.disconnected.CompareAndSwap(false, true) {
+			if c.disconnected.CompareAndSwap(false, true) {
 				c.notifyDisconnect()
 				return
 			}
@@ -199,7 +186,6 @@ func (c *connection) healthCheckLoop() {
 }
 
 func (c *connection) notifyDisconnect() {
-	c.log.Warn("Connection health check timed out", slog.Duration("timeout", c.healthTimeout))
 	go process.DoWithLabels(
 		context.Background(),
 		map[string]string{


### PR DESCRIPTION
## Motivation
- Match TiKV-style gRPC keepalive behavior more closely for stale proxied connections.
- Avoid keeping a separate sustained health-failure window after a health probe has already failed or timed out.

## Modifications
- Removed redundant health ping interval/timeout alias constants.
- Removed the 30s connection health failure timeout.
- Evict pooled connections on the first failed or non-serving health probe, while still disabling connection health probing when the health service is unimplemented.
- Updated RPC pool tests for immediate health-failure eviction.

## Testing
- `go test ./common/rpc`
