### PR TITLE
refactor: use standard grpc error codes

### DIFF
--- a/common/constant/grpc_errors.go
+++ b/common/constant/grpc_errors.go
@@ -15,61 +15,47 @@
 package constant
 
 import (
-	"fmt"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/proto"
 )
 
-const (
-	CodeNotInitialized          codes.Code = 100
-	CodeInvalidTerm             codes.Code = 101
-	CodeInvalidStatus           codes.Code = 102
-	CodeCancelled               codes.Code = 103
-	CodeAlreadyClosed           codes.Code = 104
-	CodeLeaderAlreadyConnected  codes.Code = 105
-	CodeNodeIsNotLeader         codes.Code = 106
-	CodeNodeIsNotFollower       codes.Code = 107
-	CodeSessionNotFound         codes.Code = 108
-	CodeInvalidSessionTimeout   codes.Code = 109
-	CodeNamespaceNotFound       codes.Code = 110
-	CodeNotificationsNotEnabled codes.Code = 111
-	CodeNodeIsNotMember         codes.Code = 112
-)
-
 var (
-	ErrNotInitialized          = status.Error(CodeNotInitialized, "oxia: server not initialized yet")
-	ErrCancelled               = status.Error(CodeCancelled, "oxia: operation was cancelled")
-	ErrInvalidTerm             = status.Error(CodeInvalidTerm, "oxia: invalid term")
-	ErrInvalidStatus           = status.Error(CodeInvalidStatus, "oxia: invalid status")
-	ErrLeaderAlreadyConnected  = status.Error(CodeLeaderAlreadyConnected, "oxia: leader is already connected")
-	ErrAlreadyClosed           = status.Error(CodeAlreadyClosed, "oxia: resource is already closed")
-	ErrSessionNotFound         = status.Error(CodeSessionNotFound, "oxia: session not found")
-	ErrInvalidSessionTimeout   = status.Error(CodeInvalidSessionTimeout, "oxia: invalid session timeout")
-	ErrNamespaceNotFound       = status.Error(CodeNamespaceNotFound, "oxia: namespace not found")
-	ErrNotificationsNotEnabled = status.Error(CodeNotificationsNotEnabled, "oxia: notifications not enabled on namespace")
-	ErrNodeIsNotMember         = status.Error(CodeNodeIsNotMember, "oxia: node is not a member")
+	ErrCancelled = status.Error(codes.Canceled, "oxia: operation was cancelled")
+
+	ErrInvalidSessionTimeout = status.Error(codes.InvalidArgument, "oxia: invalid session timeout")
+
+	ErrSessionNotFound   = status.Error(codes.NotFound, "oxia: session not found")
+	ErrNamespaceNotFound = status.Error(codes.NotFound, "oxia: namespace not found")
+
+	ErrInvalidTerm             = status.Error(codes.FailedPrecondition, "oxia: invalid term")
+	ErrInvalidStatus           = status.Error(codes.FailedPrecondition, "oxia: invalid status")
+	ErrNotificationsNotEnabled = status.Error(codes.FailedPrecondition, "oxia: notifications not enabled on namespace")
+
+	ErrNodeIsNotMember = status.Error(codes.Aborted, "oxia: node is not a member")
+	ErrNodeIsNotLeader = status.Error(codes.Aborted, "oxia: node is not leader")
+
+	ErrNotInitialized      = status.Error(codes.Unavailable, "oxia: server not initialized yet")
+	ErrResourceUnavailable = status.Error(codes.Unavailable, "oxia: resource unavailable")
 )
 
-func NewNodeIsNotLeaderWithHint(shard int64, leader string) error {
-	st := status.New(CodeNodeIsNotLeader, fmt.Sprintf("node is not leader for shard %d", shard))
-	if leader != "" {
-		redirect := &proto.LeaderHint{
-			Shard:         shard,
-			LeaderAddress: leader,
-		}
-		stWithDetails, err := st.WithDetails(redirect)
-		if err != nil {
-			return st.Err()
-		}
-		return stWithDetails.Err()
+func WithLeaderHint(st *status.Status, shard int64, leader string) error {
+	if leader == "" {
+		return st.Err()
 	}
-	return st.Err()
+	redirect := &proto.LeaderHint{
+		Shard:         shard,
+		LeaderAddress: leader,
+	}
+	stWithDetails, detailsErr := st.WithDetails(redirect)
+	if detailsErr != nil {
+		return st.Err()
+	}
+	return stWithDetails.Err()
 }
 
-func FindLeaderHint(err error) *proto.LeaderHint {
+func GetLeaderHint(err error) *proto.LeaderHint {
 	st := status.Convert(err)
 	if st == nil {
 		return nil

--- a/common/constant/grpc_errors_test.go
+++ b/common/constant/grpc_errors_test.go
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package batch
+package constant
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/oxia-db/oxia/common/constant"
+	"google.golang.org/grpc/status"
 )
 
-func TestIsRetriable_NotInitialized(t *testing.T) {
-	assert.True(t, IsRetriable(constant.ErrNotInitialized))
+func TestWithLeaderHint(t *testing.T) {
+	err := WithLeaderHint(status.Convert(ErrNodeIsNotLeader), 1, "leader:6648")
+	hint := GetLeaderHint(err)
+	assert.NotNil(t, hint)
+	assert.Equal(t, int64(1), hint.Shard)
+	assert.Equal(t, "leader:6648", hint.LeaderAddress)
 }

--- a/common/rpc/client_pool.go
+++ b/common/rpc/client_pool.go
@@ -104,7 +104,7 @@ func (cp *clientPool) GetClientRpc(target string) (proto.OxiaClientClient, error
 		return nil, err
 	}
 
-	return &loggingClientRpc{target, proto.NewOxiaClientClient(cnx)}, nil
+	return &loggingClientRpc{client: proto.NewOxiaClientClient(cnx)}, nil
 }
 
 func (cp *clientPool) GetCoordinationRpc(target string) (proto.OxiaCoordinationClient, error) {

--- a/common/rpc/logging_client_rpc.go
+++ b/common/rpc/logging_client_rpc.go
@@ -18,28 +18,18 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/proto"
 )
 
 type loggingClientRpc struct {
-	target string
 	client proto.OxiaClientClient
-}
-
-func (l *loggingClientRpc) decorateErr(err error) error {
-	if s, ok := status.FromError(err); ok {
-		return status.Errorf(s.Code(), "%s - target=%s", s.Message(), l.target)
-	}
-
-	return err
 }
 
 func (l *loggingClientRpc) GetShardAssignments(ctx context.Context, in *proto.ShardAssignmentsRequest, opts ...grpc.CallOption) (
 	res proto.OxiaClient_GetShardAssignmentsClient, err error) {
 	if res, err = l.client.GetShardAssignments(ctx, in, opts...); err != nil {
-		return nil, l.decorateErr(err)
+		return nil, err
 	}
 
 	return res, err
@@ -47,7 +37,7 @@ func (l *loggingClientRpc) GetShardAssignments(ctx context.Context, in *proto.Sh
 
 func (l *loggingClientRpc) WriteStream(ctx context.Context, opts ...grpc.CallOption) (res proto.OxiaClient_WriteStreamClient, err error) {
 	if res, err = l.client.WriteStream(ctx, opts...); err != nil {
-		return nil, l.decorateErr(err)
+		return nil, err
 	}
 
 	return res, err
@@ -56,7 +46,7 @@ func (l *loggingClientRpc) WriteStream(ctx context.Context, opts ...grpc.CallOpt
 func (l *loggingClientRpc) Write(ctx context.Context, in *proto.WriteRequest, opts ...grpc.CallOption) (
 	res *proto.WriteResponse, err error) {
 	if res, err = l.client.Write(ctx, in, opts...); err != nil {
-		return nil, l.decorateErr(err)
+		return nil, err
 	}
 
 	return res, err
@@ -65,7 +55,7 @@ func (l *loggingClientRpc) Write(ctx context.Context, in *proto.WriteRequest, op
 func (l *loggingClientRpc) Read(ctx context.Context, in *proto.ReadRequest, opts ...grpc.CallOption) (
 	res proto.OxiaClient_ReadClient, err error) {
 	if res, err = l.client.Read(ctx, in, opts...); err != nil {
-		return nil, l.decorateErr(err)
+		return nil, err
 	}
 
 	return res, err
@@ -74,7 +64,7 @@ func (l *loggingClientRpc) Read(ctx context.Context, in *proto.ReadRequest, opts
 func (l *loggingClientRpc) List(ctx context.Context, in *proto.ListRequest, opts ...grpc.CallOption) (
 	res proto.OxiaClient_ListClient, err error) {
 	if res, err = l.client.List(ctx, in, opts...); err != nil {
-		return nil, l.decorateErr(err)
+		return nil, err
 	}
 
 	return res, err
@@ -83,7 +73,7 @@ func (l *loggingClientRpc) List(ctx context.Context, in *proto.ListRequest, opts
 func (l *loggingClientRpc) RangeScan(ctx context.Context, in *proto.RangeScanRequest, opts ...grpc.CallOption) (
 	res proto.OxiaClient_RangeScanClient, err error) {
 	if res, err = l.client.RangeScan(ctx, in, opts...); err != nil {
-		return nil, l.decorateErr(err)
+		return nil, err
 	}
 
 	return res, err
@@ -92,7 +82,7 @@ func (l *loggingClientRpc) RangeScan(ctx context.Context, in *proto.RangeScanReq
 func (l *loggingClientRpc) GetNotifications(ctx context.Context, in *proto.NotificationsRequest, opts ...grpc.CallOption) (
 	res proto.OxiaClient_GetNotificationsClient, err error) {
 	if res, err = l.client.GetNotifications(ctx, in, opts...); err != nil {
-		return nil, l.decorateErr(err)
+		return nil, err
 	}
 
 	return res, err
@@ -101,7 +91,7 @@ func (l *loggingClientRpc) GetNotifications(ctx context.Context, in *proto.Notif
 func (l *loggingClientRpc) CreateSession(ctx context.Context, in *proto.CreateSessionRequest, opts ...grpc.CallOption) (
 	res *proto.CreateSessionResponse, err error) {
 	if res, err = l.client.CreateSession(ctx, in, opts...); err != nil {
-		return nil, l.decorateErr(err)
+		return nil, err
 	}
 
 	return res, err
@@ -110,7 +100,7 @@ func (l *loggingClientRpc) CreateSession(ctx context.Context, in *proto.CreateSe
 func (l *loggingClientRpc) KeepAlive(ctx context.Context, in *proto.SessionHeartbeat, opts ...grpc.CallOption) (
 	res *proto.KeepAliveResponse, err error) {
 	if res, err = l.client.KeepAlive(ctx, in, opts...); err != nil {
-		return nil, l.decorateErr(err)
+		return nil, err
 	}
 
 	return res, err
@@ -119,7 +109,7 @@ func (l *loggingClientRpc) KeepAlive(ctx context.Context, in *proto.SessionHeart
 func (l *loggingClientRpc) CloseSession(ctx context.Context, in *proto.CloseSessionRequest, opts ...grpc.CallOption) (
 	res *proto.CloseSessionResponse, err error) {
 	if res, err = l.client.CloseSession(ctx, in, opts...); err != nil {
-		return nil, l.decorateErr(err)
+		return nil, err
 	}
 
 	return res, err
@@ -127,7 +117,7 @@ func (l *loggingClientRpc) CloseSession(ctx context.Context, in *proto.CloseSess
 
 func (l *loggingClientRpc) GetSequenceUpdates(ctx context.Context, in *proto.GetSequenceUpdatesRequest, opts ...grpc.CallOption) (res proto.OxiaClient_GetSequenceUpdatesClient, err error) {
 	if res, err = l.client.GetSequenceUpdates(ctx, in, opts...); err != nil {
-		return nil, l.decorateErr(err)
+		return nil, err
 	}
 
 	return res, err

--- a/oxia/async_client_impl.go
+++ b/oxia/async_client_impl.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/concurrent"
 	"github.com/oxia-db/oxia/common/constant"
@@ -115,17 +117,12 @@ func NewAsyncClient(serviceAddress string, opts ...ClientOption) (AsyncClient, e
 	c.ctx, c.cancel = ctx, cancel
 	c.sessions = newSessions(c.ctx, c.shardManager, c.clientPool, c.options)
 
-	// Set up re-routing callbacks for shard splits. When a batch detects its
-	// target shard was deleted, these callbacks re-submit each operation through
-	// the normal path (which re-hashes keys and routes to the correct child shards).
 	batcherFactory.WriteRerouter = c.rerouteWrites
 	batcherFactory.ReadRerouter = c.rerouteReads
 
 	return c, nil
 }
 
-// rerouteWrites re-submits write operations to the correct child shards after
-// the original target shard was deleted (e.g. shard split).
 func (c *clientImpl) rerouteWrites(puts []model.PutCall, deletes []model.DeleteCall, deleteRanges []model.DeleteRangeCall) {
 	for _, put := range puts {
 		shardId := c.shardManager.Get(put.PartitionKeyOrKey())
@@ -136,15 +133,12 @@ func (c *clientImpl) rerouteWrites(puts []model.PutCall, deletes []model.DeleteC
 		c.writeBatchManager.Get(shardId).Add(del)
 	}
 	for _, dr := range deleteRanges {
-		// DeleteRanges without partition key are sent to all shards.
-		// Re-submit to all current shards.
 		for _, shardId := range c.shardManager.GetAll() {
 			c.writeBatchManager.Get(shardId).Add(dr)
 		}
 	}
 }
 
-// rerouteReads re-submits read operations to the correct child shards.
 func (c *clientImpl) rerouteReads(gets []model.GetCall) {
 	for _, get := range gets {
 		shardId := c.shardManager.Get(get.Key)
@@ -437,7 +431,7 @@ func (c *clientImpl) listFromShard(ctx context.Context, minKeyInclusive string, 
 			slog.Int64("shard", shardId),
 			slog.Duration("retry-after", duration),
 		)
-		if leaderHint := constant.FindLeaderHint(err); leaderHint != nil {
+		if leaderHint := constant.GetLeaderHint(err); leaderHint != nil {
 			hint = leaderHint
 		}
 	})
@@ -449,7 +443,7 @@ func (c *clientImpl) listFromShard(ctx context.Context, minKeyInclusive string, 
 func (c *clientImpl) doList(ctx context.Context, request *proto.ListRequest, hint *proto.LeaderHint, ch chan<- ListResult) error {
 	client, err := c.executor.ExecuteList(ctx, request, hint)
 	if err != nil {
-		if batch.IsRetriable(err) {
+		if status.Code(err) == codes.Unavailable || status.Code(err) == codes.Aborted {
 			return err
 		}
 		return backoff.Permanent(err)
@@ -464,7 +458,7 @@ func (c *clientImpl) doList(ctx context.Context, request *proto.ListRequest, hin
 			}
 			// Only retry if no data has been sent to the channel yet,
 			// to avoid sending duplicate keys.
-			if !dataSent && batch.IsRetriable(err) {
+			if !dataSent && (status.Code(err) == codes.Unavailable || status.Code(err) == codes.Aborted) {
 				return err
 			}
 			return backoff.Permanent(err)
@@ -535,7 +529,7 @@ func (c *clientImpl) rangeScanFromShard(ctx context.Context, minKeyInclusive str
 			slog.Int64("shard", shardId),
 			slog.Duration("retry-after", duration),
 		)
-		if leaderHint := constant.FindLeaderHint(err); leaderHint != nil {
+		if leaderHint := constant.GetLeaderHint(err); leaderHint != nil {
 			hint = leaderHint
 		}
 	})
@@ -549,7 +543,7 @@ func (c *clientImpl) rangeScanFromShard(ctx context.Context, minKeyInclusive str
 func (c *clientImpl) doRangeScan(ctx context.Context, request *proto.RangeScanRequest, hint *proto.LeaderHint, ch chan<- GetResult) error {
 	client, err := c.executor.ExecuteRangeScan(ctx, request, hint)
 	if err != nil {
-		if batch.IsRetriable(err) {
+		if status.Code(err) == codes.Unavailable || status.Code(err) == codes.Aborted {
 			return err
 		}
 		return backoff.Permanent(err)
@@ -564,7 +558,7 @@ func (c *clientImpl) doRangeScan(ctx context.Context, request *proto.RangeScanRe
 			}
 			// Only retry if no data has been sent to the channel yet,
 			// to avoid sending duplicate records.
-			if !dataSent && batch.IsRetriable(err) {
+			if !dataSent && (status.Code(err) == codes.Unavailable || status.Code(err) == codes.Aborted) {
 				return err
 			}
 			return backoff.Permanent(err)

--- a/oxia/internal/batch/batcher_factory.go
+++ b/oxia/internal/batch/batcher_factory.go
@@ -24,11 +24,8 @@ import (
 	"github.com/oxia-db/oxia/oxia/internal/model"
 )
 
-// WriteRerouter is called when a write batch detects its target shard was
-// deleted (e.g. after a split). It re-submits operations to the correct shards.
 type WriteRerouter func([]model.PutCall, []model.DeleteCall, []model.DeleteRangeCall)
 
-// ReadRerouter is called when a read batch detects its target shard was deleted.
 type ReadRerouter func([]model.GetCall)
 
 type BatcherFactory struct {

--- a/oxia/internal/batch/read_batch.go
+++ b/oxia/internal/batch/read_batch.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/constant"
 
@@ -92,7 +94,7 @@ func (b *readBatch) Complete() {
 	request := b.toProto()
 	response, err := b.doRequestWithRetries(request)
 
-	if errors.Is(err, ErrShardNotFound) && b.reroute != nil {
+	if errors.Is(err, errShardNotFound) && b.reroute != nil {
 		slog.Info("Shard was split/merged, re-routing read batch operations",
 			slog.Int64("shard", *b.shardId),
 			slog.Int("gets", len(b.gets)),
@@ -118,10 +120,13 @@ func (b *readBatch) doRequestWithRetries(request *proto.ReadRequest) (response *
 
 	err = backoff.RetryNotify(func() error {
 		if b.shardExists != nil && !b.shardExists(*b.shardId) {
-			return backoff.Permanent(ErrShardNotFound)
+			return backoff.Permanent(errShardNotFound)
 		}
 		response, err = b.doRequest(ctx, request, hint)
-		if !IsRetriable(err) {
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, io.EOF) && status.Code(err) != codes.Unavailable && status.Code(err) != codes.Aborted {
 			return backoff.Permanent(err)
 		}
 		return err
@@ -133,7 +138,7 @@ func (b *readBatch) doRequestWithRetries(request *proto.ReadRequest) (response *
 			slog.Int64("shard", *b.shardId),
 			slog.Duration("retry-after", duration),
 		)
-		if leaderHint := constant.FindLeaderHint(err); leaderHint != nil {
+		if leaderHint := constant.GetLeaderHint(err); leaderHint != nil {
 			hint = leaderHint
 		}
 	})

--- a/oxia/internal/batch/read_batch_test.go
+++ b/oxia/internal/batch/read_batch_test.go
@@ -145,14 +145,14 @@ func TestReadBatchRerouteOnShardDeleted(t *testing.T) {
 	execute := func(_ context.Context, _ *proto.ReadRequest, _ *proto.LeaderHint) (proto.OxiaClient_ReadClient, error) {
 		executeCount++
 		shardDeleted = true
-		return nil, status.Error(constant.CodeNodeIsNotLeader, "node is not leader for shard 1")
+		return nil, constant.WithLeaderHint(status.Convert(constant.ErrNodeIsNotLeader), 1, "")
 	}
 
 	var reroutedGets []model.GetCall
 
 	factory := &readBatchFactory{
 		execute: execute,
-		shardExists: func(id int64) bool {
+		shardExists: func(int64) bool {
 			return !shardDeleted
 		},
 		reroute: func(gets []model.GetCall) {

--- a/oxia/internal/batch/rpc_errors.go
+++ b/oxia/internal/batch/rpc_errors.go
@@ -14,40 +14,6 @@
 
 package batch
 
-import (
-	"errors"
-	"io"
+import "errors"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
-	"github.com/oxia-db/oxia/common/constant"
-)
-
-// ErrShardNotFound is returned when a batch's target shard no longer exists
-// in the shard manager (e.g. after a shard split). The batch should be broken
-// apart and individual operations re-routed to the correct child shards.
-var ErrShardNotFound = errors.New("shard not found in shard manager")
-
-func IsRetriable(err error) bool {
-	if errors.Is(err, io.EOF) {
-		// EOF can occur when a bidirectional write stream is closed by the
-		// server before delivering the gRPC status (e.g. the server returns
-		// an error from WriteStream before reading any messages).  This is a
-		// transient condition that should be retried.
-		return true
-	}
-	code := status.Code(err)
-	switch code {
-	case
-		codes.Unavailable,            // Failure to connect is ok to re-attempt
-		constant.CodeNotInitialized,  // Server is still warming up and should become ready shortly
-		constant.CodeInvalidStatus,   // Leader has fenced the shard, though we expect a new leader to be elected
-		constant.CodeAlreadyClosed,   // Leader is closing, though we expect a new leader to be elected
-		constant.CodeNodeIsNotLeader: /* We're making a request to a node that is not leader anymore. Retry to make
-		   the request to the new leader */
-		return true
-	default:
-		return false
-	}
-}
+var errShardNotFound = errors.New("shard not found in shard manager")

--- a/oxia/internal/batch/write_batch.go
+++ b/oxia/internal/batch/write_batch.go
@@ -17,10 +17,13 @@ package batch
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/constant"
 
@@ -110,10 +113,7 @@ func (b *writeBatch) Complete() {
 
 	response, err := b.doRequestWithRetries(request)
 
-	if errors.Is(err, ErrShardNotFound) && b.reroute != nil {
-		// The target shard was deleted (e.g. after a split). Re-submit
-		// each operation through the normal pipeline so keys get re-hashed
-		// and routed to the correct child shards.
+	if errors.Is(err, errShardNotFound) && b.reroute != nil {
 		slog.Info("Shard was split/merged, re-routing write batch operations",
 			slog.Int64("shard", *b.shardId),
 			slog.Int("puts", len(b.puts)),
@@ -141,14 +141,14 @@ func (b *writeBatch) doRequestWithRetries(request *proto.WriteRequest) (response
 
 	var hint *proto.LeaderHint
 	err = backoff.RetryNotify(func() error {
-		// Check if the shard still exists before each retry. If it was
-		// deleted (e.g. after a split), stop retrying so the batch can
-		// be re-routed to the correct child shards.
 		if b.shardExists != nil && !b.shardExists(*b.shardId) {
-			return backoff.Permanent(ErrShardNotFound)
+			return backoff.Permanent(errShardNotFound)
 		}
 		response, err = b.execute(ctx, request, hint)
-		if !IsRetriable(err) {
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, io.EOF) && status.Code(err) != codes.Unavailable && status.Code(err) != codes.Aborted {
 			return backoff.Permanent(err)
 		}
 		return err
@@ -160,7 +160,7 @@ func (b *writeBatch) doRequestWithRetries(request *proto.WriteRequest) (response
 			slog.Int64("shard", *b.shardId),
 			slog.Duration("retry-after", duration),
 		)
-		if leaderHint := constant.FindLeaderHint(err); leaderHint != nil {
+		if leaderHint := constant.GetLeaderHint(err); leaderHint != nil {
 			hint = leaderHint
 		}
 	})

--- a/oxia/internal/batch/write_batch_test.go
+++ b/oxia/internal/batch/write_batch_test.go
@@ -224,18 +224,13 @@ func TestWriteBatchComplete(t *testing.T) {
 }
 
 func TestWriteBatchRerouteOnShardDeleted(t *testing.T) {
-	// Simulate a shard that gets deleted after the first execute attempt
-	// (e.g. after a shard split). The batch should detect the deletion
-	// and invoke the reroute callback instead of retrying forever.
 	shardDeleted := false
 	executeCount := 0
 
 	execute := func(_ context.Context, _ *proto.WriteRequest, _ *proto.LeaderHint) (*proto.WriteResponse, error) {
 		executeCount++
-		// After first call, mark shard as deleted. Return a retriable
-		// error so the retry loop runs again and hits the shard check.
 		shardDeleted = true
-		return nil, status.Error(constant.CodeNodeIsNotLeader, "node is not leader for shard 1")
+		return nil, constant.WithLeaderHint(status.Convert(constant.ErrNodeIsNotLeader), 1, "")
 	}
 
 	var reroutedPuts []model.PutCall
@@ -244,7 +239,7 @@ func TestWriteBatchRerouteOnShardDeleted(t *testing.T) {
 
 	factory := &writeBatchFactory{
 		execute: execute,
-		shardExists: func(id int64) bool {
+		shardExists: func(int64) bool {
 			return !shardDeleted
 		},
 		reroute: func(puts []model.PutCall, deletes []model.DeleteCall, deleteRanges []model.DeleteRangeCall) {
@@ -269,26 +264,21 @@ func TestWriteBatchRerouteOnShardDeleted(t *testing.T) {
 
 	batch.Complete()
 
-	// Verify the reroute callback received all operations
 	assert.Equal(t, 2, len(reroutedPuts))
 	assert.Equal(t, "key-1", reroutedPuts[0].Key)
 	assert.Equal(t, "key-2", reroutedPuts[1].Key)
 	assert.Equal(t, 1, len(reroutedDeletes))
 	assert.Equal(t, "key-3", reroutedDeletes[0].Key)
 	assert.Equal(t, 1, len(reroutedDeleteRanges))
-
-	// Execute should only be called once (then shard check triggers reroute)
 	assert.Equal(t, 1, executeCount)
 }
 
 func TestWriteBatchNoRerouteWhenShardExists(t *testing.T) {
-	// When the shard still exists, retries should proceed normally
-	// (no reroute). We simulate a transient error followed by success.
 	callCount := 0
 	execute := func(_ context.Context, _ *proto.WriteRequest, _ *proto.LeaderHint) (*proto.WriteResponse, error) {
 		callCount++
 		if callCount == 1 {
-			return nil, status.Error(constant.CodeNodeIsNotLeader, "transient error")
+			return nil, constant.ErrNodeIsNotLeader
 		}
 		return &proto.WriteResponse{
 			Puts: []*proto.PutResponse{{Status: proto.Status_OK, Version: &proto.Version{VersionId: 1}}},
@@ -299,7 +289,7 @@ func TestWriteBatchNoRerouteWhenShardExists(t *testing.T) {
 	factory := &writeBatchFactory{
 		execute: execute,
 		shardExists: func(int64) bool {
-			return true // shard always exists
+			return true
 		},
 		reroute: func([]model.PutCall, []model.DeleteCall, []model.DeleteRangeCall) {
 			rerouted = true
@@ -325,8 +315,8 @@ func TestWriteBatchNoRerouteWhenShardExists(t *testing.T) {
 	batch.Complete()
 	wg.Wait()
 
-	assert.False(t, rerouted, "reroute should not be called when shard exists")
-	assert.Equal(t, 2, callCount, "should retry and succeed on second attempt")
+	assert.False(t, rerouted)
+	assert.Equal(t, 2, callCount)
 }
 
 func TestWriteBatchCanAdd(t *testing.T) {

--- a/oxia/internal/shard_manager.go
+++ b/oxia/internal/shard_manager.go
@@ -252,7 +252,7 @@ func overlap(a HashRange, b HashRange) bool {
 
 func isErrorRetryable(err error) bool {
 	switch status.Code(err) {
-	case constant.CodeNamespaceNotFound, codes.Unauthenticated:
+	case status.Code(constant.ErrNamespaceNotFound), codes.Unauthenticated:
 		return false
 	default:
 		return true

--- a/oxia/sessions.go
+++ b/oxia/sessions.go
@@ -197,7 +197,7 @@ func (cs *clientSession) createSession() error {
 			backOff := time2.NewBackOff(cs.sessions.ctx)
 			err := backoff.RetryNotify(func() error {
 				err := cs.keepAlive()
-				if status.Code(err) == constant.CodeSessionNotFound {
+				if status.Code(err) == status.Code(constant.ErrSessionNotFound) {
 					cs.log.Error(
 						"Session is no longer valid",
 						slog.Any("error", err),
@@ -250,6 +250,9 @@ func (cs *clientSession) Close() error {
 		Shard:     cs.shardId,
 		SessionId: cs.sessionId,
 	}); err != nil {
+		if status.Code(err) == status.Code(constant.ErrSessionNotFound) {
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/oxiad/coordinator/runtime/controller/shard_controller_election.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller_election.go
@@ -303,9 +303,10 @@ func (e *ShardElection) ensureFollowerCaught(ensemble []*proto.DataServerIdentit
 					)
 					return ErrFollowerNotCaughtUp
 				}, oxiatime.NewBackOff(e.ctx), func(err error, duration time.Duration) {
+					st := status.Convert(err)
 					switch {
 					case errors.Is(err, ErrFollowerNotCaughtUp):
-					case status.Code(err) == constant.CodeNodeIsNotMember:
+					case st.Code() == status.Code(constant.ErrNodeIsNotMember):
 						e.logger.Info("Follower has not been added by leader yet",
 							slog.Any("server", server),
 							slog.Int64("shard", e.shard),
@@ -385,9 +386,10 @@ func (e *ShardElection) fencingFailedFollowers(term int64, ensemble []*proto.Dat
 				},
 				func() {
 					bo := oxiatime.NewBackOffWithInitialInterval(e.ctx, 1*time.Second)
+					invalidTerm := status.Convert(constant.ErrInvalidTerm)
 					_ = backoff.RetryNotify(func() error {
 						var err error
-						if err = e.fenceNewTermAndAddFollower(e.ctx, term, leader, follower); status.Code(err) == constant.CodeInvalidTerm {
+						if err = e.fenceNewTermAndAddFollower(e.ctx, term, leader, follower); status.Convert(err).Code() == invalidTerm.Code() && status.Convert(err).Message() == invalidTerm.Message() {
 							// If we're receiving invalid term error, it would mean
 							// there's already a new term generated, and we don't have
 							// to keep trying with this old term

--- a/oxiad/dataserver/controller/lead/follower_cursor.go
+++ b/oxiad/dataserver/controller/lead/follower_cursor.go
@@ -291,7 +291,8 @@ func (fc *followerCursor) run() {
 			// If the follower reported that it's not a member (e.g. after a
 			// data clean-up and restart), reset the ack offset so that
 			// shouldSendSnapshot() will send a full snapshot on the next retry.
-			if status.Code(err) == constant.CodeNodeIsNotMember {
+			st := status.Convert(err)
+			if st.Code() == status.Code(constant.ErrNodeIsNotMember) {
 				fc.log.Warn("Follower reported not-member status, resetting ack offset to trigger snapshot")
 				fc.ackOffset.Store(wal.InvalidOffset)
 				fc.lastPushed.Store(wal.InvalidOffset)

--- a/oxiad/dataserver/controller/lead/leader_controller.go
+++ b/oxiad/dataserver/controller/lead/leader_controller.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
-	"google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/oxiad/common/crc"
 
@@ -264,7 +263,7 @@ func (lc *leaderController) NewTerm(req *proto.NewTermRequest) (*proto.NewTermRe
 	defer lc.Unlock()
 
 	if lc.isClosed() {
-		return nil, constant.ErrAlreadyClosed
+		return nil, constant.ErrResourceUnavailable
 	}
 
 	currentTerm := lc.term.Load()
@@ -346,7 +345,7 @@ func (lc *leaderController) becomeLeader(ctx context.Context, req *proto.BecomeL
 	defer lc.Unlock()
 
 	if lc.isClosed() {
-		return nil, constant.ErrAlreadyClosed
+		return nil, constant.ErrResourceUnavailable
 	}
 
 	if lc.status != proto.ServingStatus_FENCED {
@@ -1110,7 +1109,7 @@ func (lc *leaderController) GetNotifications(ctx context.Context, req *proto.Not
 			for {
 				select {
 				case <-lc.ctx.Done():
-					cb.OnComplete(constant.ErrAlreadyClosed)
+					cb.OnComplete(constant.ErrResourceUnavailable)
 					return
 				case <-ctx.Done():
 					cb.OnComplete(nil)
@@ -1293,7 +1292,7 @@ func (lc *leaderController) Checksum() crc.Checksum {
 
 func checkStatusIsLeader(actual proto.ServingStatus) error {
 	if actual != proto.ServingStatus_LEADER {
-		return status.Errorf(constant.CodeInvalidStatus, "Received message in the wrong state. In %+v, should be %+v.", actual, proto.ServingStatus_LEADER)
+		return constant.ErrInvalidStatus
 	}
 	return nil
 }

--- a/oxiad/dataserver/controller/lead/leader_controller_test.go
+++ b/oxiad/dataserver/controller/lead/leader_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	pb "google.golang.org/protobuf/proto"
@@ -79,7 +80,7 @@ func TestLeaderController_NotInitialized(t *testing.T) {
 	})
 
 	assert.Nil(t, res)
-	assert.Equal(t, constant.CodeInvalidStatus, status.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 
 	responses := make(chan *oentity.TWithError[*proto.GetResponse], 1000)
 	lc.Read(context.Background(), &proto.ReadRequest{
@@ -88,7 +89,7 @@ func TestLeaderController_NotInitialized(t *testing.T) {
 	}, concurrent.ReadFromStreamCallback(responses))
 
 	_, err = channel.ReadAll[*proto.GetResponse](context.Background(), responses)
-	assert.Equal(t, constant.CodeInvalidStatus, status.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, kvFactory.Close())
@@ -116,7 +117,7 @@ func TestLeaderController_Closed(t *testing.T) {
 	})
 
 	assert.Nil(t, res)
-	assert.Equal(t, constant.CodeAlreadyClosed, status.Code(err))
+	assert.Equal(t, codes.Unavailable, status.Code(err))
 
 	res2, err := lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		Shard:        shard,
@@ -125,7 +126,7 @@ func TestLeaderController_Closed(t *testing.T) {
 	})
 
 	assert.Nil(t, res2)
-	assert.Equal(t, constant.CodeAlreadyClosed, status.Code(err))
+	assert.Equal(t, codes.Unavailable, status.Code(err))
 
 	assert.NoError(t, kvFactory.Close())
 	assert.NoError(t, walFactory.Close())
@@ -150,7 +151,7 @@ func TestLeaderController_BecomeLeader_NoFencing(t *testing.T) {
 		FollowerMaps:      nil,
 	})
 	assert.Nil(t, resp)
-	assert.Equal(t, constant.CodeInvalidStatus, status.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, kvFactory.Close())
@@ -239,7 +240,7 @@ func TestLeaderController_BecomeLeader_RF1(t *testing.T) {
 	})
 
 	assert.Nil(t, res3)
-	assert.Equal(t, constant.CodeInvalidStatus, status.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 
 	responses = make(chan *oentity.TWithError[*proto.GetResponse], 1000)
 	lc.Read(context.Background(), &proto.ReadRequest{
@@ -248,7 +249,7 @@ func TestLeaderController_BecomeLeader_RF1(t *testing.T) {
 	}, concurrent.ReadFromStreamCallback(responses))
 
 	_, err = channel.ReadAll[*proto.GetResponse](context.Background(), responses)
-	assert.Equal(t, constant.CodeInvalidStatus, status.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, kvFactory.Close())
@@ -347,7 +348,7 @@ func TestLeaderController_BecomeLeader_RF2(t *testing.T) {
 	})
 
 	assert.Nil(t, res3)
-	assert.Equal(t, constant.CodeInvalidStatus, status.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 
 	responses = make(chan *oentity.TWithError[*proto.GetResponse], 1000)
 	lc.Read(context.Background(), &proto.ReadRequest{
@@ -356,7 +357,7 @@ func TestLeaderController_BecomeLeader_RF2(t *testing.T) {
 	}, concurrent.ReadFromStreamCallback(responses))
 
 	_, err = channel.ReadAll[*proto.GetResponse](context.Background(), responses)
-	assert.Equal(t, constant.CodeInvalidStatus, status.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 
 	close(provider.AckResps)
 	assert.NoError(t, lc.Close())
@@ -432,7 +433,7 @@ func TestLeaderController_FenceTerm(t *testing.T) {
 		Term:  4,
 	})
 	assert.Nil(t, fr)
-	assert.Equal(t, constant.CodeInvalidTerm, status.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 	assert.Equal(t, proto.ServingStatus_FENCED, lc.Status())
 
 	// Same term will succeed
@@ -478,7 +479,7 @@ func TestLeaderController_BecomeLeaderTerm(t *testing.T) {
 		FollowerMaps:      nil,
 	})
 	assert.Nil(t, resp)
-	assert.Equal(t, constant.CodeInvalidTerm, status.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 
 	// Higher term will fail
 	resp, err = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
@@ -488,7 +489,7 @@ func TestLeaderController_BecomeLeaderTerm(t *testing.T) {
 		FollowerMaps:      nil,
 	})
 	assert.Nil(t, resp)
-	assert.Equal(t, constant.CodeInvalidTerm, status.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 
 	// Same term will succeed
 	_, err = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
@@ -967,7 +968,7 @@ func TestLeaderController_AddFollowerCheckTerm(t *testing.T) {
 		FollowerHeadEntryId: constant2.InvalidEntryId,
 	})
 	assert.Nil(t, afRes)
-	assert.Equal(t, constant.CodeInvalidTerm, status.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 
 	afRes, err = lc.AddFollower(&proto.AddFollowerRequest{
 		Shard:               shard,
@@ -976,7 +977,7 @@ func TestLeaderController_AddFollowerCheckTerm(t *testing.T) {
 		FollowerHeadEntryId: constant2.InvalidEntryId,
 	})
 	assert.Nil(t, afRes)
-	assert.Equal(t, constant.CodeInvalidTerm, status.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, kvFactory.Close())
@@ -1160,7 +1161,7 @@ func TestLeaderController_NotificationsWhenNotReady(t *testing.T) {
 
 	adaptor := concurrent.NewStreamCallbackAdaptor[*proto.NotificationBatch]()
 	lc.GetNotifications(ctx, &proto.NotificationsRequest{Shard: shard, StartOffsetExclusive: &wal.InvalidOffset}, adaptor)
-	assert.Equal(t, status.Code(adaptor.Error()), constant.CodeInvalidStatus)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(adaptor.Error()))
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, kvFactory.Close())

--- a/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
+++ b/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
@@ -216,7 +216,7 @@ func (q *quorumAckTracker) WaitForCommitOffsetAsync(_ context.Context, offset in
 
 	if q.closed {
 		q.Unlock()
-		cb.OnCompleteError(constant.ErrAlreadyClosed)
+		cb.OnCompleteError(constant.ErrResourceUnavailable)
 		return
 	}
 
@@ -250,7 +250,7 @@ func (q *quorumAckTracker) Close() error {
 	q.Unlock()
 	// unblock waiting request
 	for _, r := range q.waitingRequests {
-		r.callback.OnCompleteError(constant.ErrAlreadyClosed)
+		r.callback.OnCompleteError(constant.ErrResourceUnavailable)
 	}
 	return nil
 }

--- a/oxiad/dataserver/controller/lead/quorum_ack_tracker_test.go
+++ b/oxiad/dataserver/controller/lead/quorum_ack_tracker_test.go
@@ -310,7 +310,7 @@ func TestQuorumAckTracker_ClearPending(t *testing.T) {
 	select {
 	case resErr := <-asyncRes:
 		// Ensure that we received the expected result (in this case, error should be nil)
-		assert.ErrorIs(t, resErr, constant.ErrAlreadyClosed)
+		assert.ErrorIs(t, resErr, constant.ErrResourceUnavailable)
 	case <-time.After(2 * time.Second): // Adding a timeout for safety
 		t.Fatal("Timed out waiting for async result")
 	}

--- a/oxiad/dataserver/controller/shards_director.go
+++ b/oxiad/dataserver/controller/shards_director.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"go.uber.org/multierr"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/option"
@@ -94,7 +95,7 @@ func (s *shardsDirector) GetLeader(shardId int64) (lead.LeaderController, error)
 	defer s.RUnlock()
 
 	if s.closed {
-		return nil, constant.ErrAlreadyClosed
+		return nil, constant.ErrResourceUnavailable
 	}
 
 	if leader, ok := s.leaders[shardId]; ok {
@@ -106,7 +107,7 @@ func (s *shardsDirector) GetLeader(shardId int64) (lead.LeaderController, error)
 		"This node is not hosting shard",
 		slog.Int64("shard", shardId),
 	)
-	return nil, status.Errorf(constant.CodeNodeIsNotLeader, "node is not leader for shard %d", shardId)
+	return nil, constant.ErrNodeIsNotLeader
 }
 
 func (s *shardsDirector) GetFollower(shardId int64) (follow.FollowerController, error) {
@@ -114,7 +115,7 @@ func (s *shardsDirector) GetFollower(shardId int64) (follow.FollowerController, 
 	defer s.RUnlock()
 
 	if s.closed {
-		return nil, constant.ErrAlreadyClosed
+		return nil, constant.ErrResourceUnavailable
 	}
 
 	if follower, ok := s.followers[shardId]; ok {
@@ -126,7 +127,7 @@ func (s *shardsDirector) GetFollower(shardId int64) (follow.FollowerController, 
 		"This node is not hosting shard",
 		slog.Int64("shard", shardId),
 	)
-	return nil, status.Errorf(constant.CodeNodeIsNotFollower, "node is not follower for shard %d", shardId)
+	return nil, status.Errorf(codes.NotFound, "oxia: node is not follower for shard %d", shardId)
 }
 
 func (s *shardsDirector) GetOrCreateLeader(namespace string, shardId int64, newTermOptions *proto.NewTermOptions) (lead.LeaderController, error) {
@@ -134,7 +135,7 @@ func (s *shardsDirector) GetOrCreateLeader(namespace string, shardId int64, newT
 	defer s.Unlock()
 
 	if s.closed {
-		return nil, constant.ErrAlreadyClosed
+		return nil, constant.ErrResourceUnavailable
 	}
 
 	if leader, ok := s.leaders[shardId]; ok {
@@ -170,7 +171,7 @@ func (s *shardsDirector) GetOrCreateFollower(namespace string, shardId int64, te
 	defer s.Unlock()
 
 	if s.closed {
-		return nil, constant.ErrAlreadyClosed
+		return nil, constant.ErrResourceUnavailable
 	}
 
 	if follower, ok := s.followers[shardId]; ok {

--- a/oxiad/dataserver/database/notifications_tracker.go
+++ b/oxiad/dataserver/database/notifications_tracker.go
@@ -172,7 +172,7 @@ func (nt *notificationsTracker) waitForNotifications(ctx context.Context, startO
 	}
 
 	if nt.closed.Load() {
-		return constant.ErrAlreadyClosed
+		return constant.ErrResourceUnavailable
 	}
 
 	return nil

--- a/oxiad/dataserver/errors/errors.go
+++ b/oxiad/dataserver/errors/errors.go
@@ -14,12 +14,43 @@
 
 package errors
 
-import "errors"
+import (
+	stderrors "errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/oxia-db/oxia/common/constant"
+)
 
 var (
-	ErrInvalidTerm          = errors.New("invalid term")
-	ErrResourceNotAvailable = errors.New("resource not available")
-	ErrResourceConflict     = errors.New("resource conflict")
-	ErrInvalidStatus        = errors.New("invalid status")
-	ErrNodeIsNotMember      = errors.New("node is not a member")
+	ErrInvalidTerm          = stderrors.New("invalid term")
+	ErrResourceNotAvailable = stderrors.New("resource not available")
+	ErrResourceConflict     = stderrors.New("resource conflict")
+	ErrInvalidStatus        = stderrors.New("invalid status")
+	ErrNodeIsNotMember      = stderrors.New("node is not a member")
 )
+
+// IntoGRPCError converts dataserver-internal errors into public gRPC errors.
+func IntoGRPCError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+	switch {
+	case stderrors.Is(err, ErrInvalidTerm):
+		return constant.ErrInvalidTerm
+	case stderrors.Is(err, ErrNodeIsNotMember):
+		return constant.ErrNodeIsNotMember
+	case stderrors.Is(err, ErrInvalidStatus):
+		return constant.ErrInvalidStatus
+	case stderrors.Is(err, ErrResourceConflict):
+		return constant.ErrResourceUnavailable
+	case stderrors.Is(err, ErrResourceNotAvailable):
+		return status.Error(codes.Unavailable, err.Error())
+	default:
+		return status.Error(codes.Unknown, err.Error())
+	}
+}

--- a/oxiad/dataserver/errors/errors_test.go
+++ b/oxiad/dataserver/errors/errors_test.go
@@ -1,0 +1,34 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIntoGRPCError(t *testing.T) {
+	assert.Equal(t, codes.FailedPrecondition, status.Code(IntoGRPCError(ErrInvalidTerm)))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(IntoGRPCError(ErrInvalidStatus)))
+	assert.Equal(t, codes.Aborted, status.Code(IntoGRPCError(ErrNodeIsNotMember)))
+	assert.Equal(t, codes.Unavailable, status.Code(IntoGRPCError(ErrResourceConflict)))
+	err := IntoGRPCError(fmt.Errorf("wrapped: %w", ErrResourceNotAvailable))
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+	assert.Equal(t, "wrapped: resource not available", status.Convert(err).Message())
+}

--- a/oxiad/dataserver/internal_rpc_server.go
+++ b/oxiad/dataserver/internal_rpc_server.go
@@ -17,7 +17,6 @@ package dataserver
 import (
 	"context"
 	"crypto/tls"
-	stderrors "errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -93,33 +92,6 @@ func (s *internalRpcServer) Close() error {
 	return s.grpcServer.Close()
 }
 
-// toGRPCError converts domain errors from the dataserver layer into gRPC
-// status errors so that remote callers (e.g. the coordinator) can match on
-// the expected gRPC error codes. If the error is already a gRPC status error,
-// it is returned as-is. Unknown domain errors are mapped to codes.Unknown.
-func toGRPCError(err error) error {
-	if err == nil {
-		return nil
-	}
-	if _, ok := status.FromError(err); ok {
-		return err
-	}
-	switch {
-	case stderrors.Is(err, dserror.ErrInvalidTerm):
-		return status.Error(constant.CodeInvalidTerm, err.Error())
-	case stderrors.Is(err, dserror.ErrNodeIsNotMember):
-		return status.Error(constant.CodeNodeIsNotMember, err.Error())
-	case stderrors.Is(err, dserror.ErrInvalidStatus):
-		return status.Error(constant.CodeInvalidStatus, err.Error())
-	case stderrors.Is(err, dserror.ErrResourceConflict):
-		return status.Error(constant.CodeAlreadyClosed, err.Error())
-	case stderrors.Is(err, dserror.ErrResourceNotAvailable):
-		return status.Error(codes.Unavailable, err.Error())
-	default:
-		return status.Error(codes.Unknown, err.Error())
-	}
-}
-
 func (s *internalRpcServer) PushShardAssignments(srv proto.OxiaCoordination_PushShardAssignmentsServer) error {
 	s.log.Info(
 		"Received shard assignment request from coordinator",
@@ -191,7 +163,7 @@ func (s *internalRpcServer) NewTerm(c context.Context, req *proto.NewTermRequest
 	// NewTerm applies to both followers and leaders
 	// First check if we have already a follower controller running
 	if follower, err := s.shardsDirector.GetFollower(req.Shard); err != nil { //nolint:revive
-		if status.Code(err) != constant.CodeNodeIsNotFollower {
+		if status.Code(err) != codes.NotFound {
 			log.Warn(
 				"NewTerm failed: could not get follower controller",
 				slog.Any("error", err),
@@ -216,7 +188,7 @@ func (s *internalRpcServer) NewTerm(c context.Context, req *proto.NewTermRequest
 				slog.Any("error", err2),
 			)
 		}
-		return res, toGRPCError(err2)
+		return res, dserror.IntoGRPCError(err2)
 	}
 
 	leader, err := s.shardsDirector.GetOrCreateLeader(req.Namespace, req.Shard, req.Options)
@@ -365,7 +337,7 @@ func (s *internalRpcServer) Truncate(c context.Context, req *proto.TruncateReque
 			slog.Any("error", err),
 		)
 	}
-	return res, toGRPCError(err)
+	return res, dserror.IntoGRPCError(err)
 }
 
 func (s *internalRpcServer) Replicate(srv proto.OxiaLogReplication_ReplicateServer) error {
@@ -424,7 +396,7 @@ func (s *internalRpcServer) Replicate(srv proto.OxiaLogReplication_ReplicateServ
 			slog.Any("error", err),
 		)
 	}
-	return toGRPCError(err)
+	return dserror.IntoGRPCError(err)
 }
 
 func (s *internalRpcServer) SendSnapshot(srv proto.OxiaLogReplication_SendSnapshotServer) error {
@@ -492,26 +464,26 @@ func (s *internalRpcServer) SendSnapshot(srv proto.OxiaLogReplication_SendSnapsh
 			slog.String("peer", rpc.GetPeer(srv.Context())),
 		)
 	}
-	return toGRPCError(err)
+	return dserror.IntoGRPCError(err)
 }
 
 func (s *internalRpcServer) GetStatus(_ context.Context, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
 	follower, err := s.shardsDirector.GetFollower(req.Shard)
 	if err == nil {
 		res, err := follower.GetStatus(req)
-		return res, toGRPCError(err)
+		return res, dserror.IntoGRPCError(err)
 	}
 
-	if status.Code(err) != constant.CodeNodeIsNotFollower {
+	if status.Code(err) != codes.NotFound {
 		return nil, err
 	}
 
 	// If we don't have a follower, fallback to checking the leader controller
 	leader, err := s.shardsDirector.GetLeader(req.Shard)
 	if err != nil {
-		if status.Code(err) == constant.CodeNodeIsNotLeader {
+		if status.Code(err) == status.Code(constant.ErrNodeIsNotLeader) {
 			// Node is neither follower nor leader for this shard
-			return nil, status.Errorf(constant.CodeNodeIsNotMember, "node is not a member for shard %d", req.Shard)
+			return nil, constant.ErrNodeIsNotMember
 		}
 		return nil, err
 	}
@@ -521,7 +493,7 @@ func (s *internalRpcServer) GetStatus(_ context.Context, req *proto.GetStatusReq
 
 func (s *internalRpcServer) DeleteShard(_ context.Context, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
 	res, err := s.shardsDirector.DeleteShard(req)
-	return res, toGRPCError(err)
+	return res, dserror.IntoGRPCError(err)
 }
 
 func readHeader(md metadata.MD, key string) (value string, err error) {

--- a/oxiad/dataserver/internal_rpc_server_test.go
+++ b/oxiad/dataserver/internal_rpc_server_test.go
@@ -133,7 +133,7 @@ func TestInternalGetInfoRejectedWhileUninitialized(t *testing.T) {
 	client := proto.NewOxiaCoordinationClient(cnx)
 	_, err := client.GetInfo(context.Background(), &proto.GetInfoRequest{}) //nolint:staticcheck // Deprecated endpoint coverage.
 	require.Error(t, err)
-	assert.Equal(t, constant.CodeNotInitialized, grpcstatus.Code(err))
+	assert.Equal(t, codes.Unavailable, grpcstatus.Code(err))
 }
 
 func TestInternalHandshakeBindsInstanceID(t *testing.T) {
@@ -158,7 +158,7 @@ func TestInternalProtectedRpcRejectedWhileUninitialized(t *testing.T) {
 
 	_, err = stream.CloseAndRecv()
 	require.Error(t, err)
-	assert.Equal(t, constant.CodeNotInitialized, grpcstatus.Code(err))
+	assert.Equal(t, codes.Unavailable, grpcstatus.Code(err))
 }
 
 func TestInternalReplicateRejectsWrongInstanceID(t *testing.T) {

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -459,7 +459,7 @@ func (s *publicRpcServer) CloseSession(ctx context.Context, req *proto.CloseSess
 	}
 	res, err := lc.CloseSession(req)
 	if err != nil {
-		if status.Code(err) != constant.CodeSessionNotFound {
+		if status.Code(err) != status.Code(constant.ErrSessionNotFound) {
 			s.log.Warn("Failed to close session", slog.Any("error", err))
 		}
 		return nil, err
@@ -513,8 +513,8 @@ func (s *publicRpcServer) resolveLeader(ctx context.Context, shardId *int64) (le
 	shardID := *shardId
 	lc, err := s.shardsDirector.GetLeader(shardID)
 	if err != nil {
-		if status.Code(err) == constant.CodeNodeIsNotLeader {
-			return nil, constant.NewNodeIsNotLeaderWithHint(shardID, s.assignmentDispatcher.GetLeader(shardID))
+		if status.Code(err) == status.Code(constant.ErrNodeIsNotLeader) {
+			return nil, constant.WithLeaderHint(status.Convert(err), shardID, s.assignmentDispatcher.GetLeader(shardID))
 		}
 		s.log.Warn("Failed to get the leader controller", slog.Any("error", err))
 		return nil, err

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -184,7 +184,7 @@ func TestValidateAuthorityReturnsNotInitializedBeforeAssignmentsReady(t *testing
 
 	err := server.validateAuthority(ctx)
 	require.Error(t, err)
-	assert.Equal(t, constant.CodeNotInitialized, grpcstatus.Code(err))
+	assert.Equal(t, codes.Unavailable, grpcstatus.Code(err))
 }
 
 func TestValidateAuthorityCanBeDisabled(t *testing.T) {
@@ -244,7 +244,7 @@ func TestResolveLeaderValidatesAuthorityBeforeLeaderLookup(t *testing.T) {
 		log: slog.Default(),
 		shardsDirector: &testShardsDirector{
 			getLeader: func(int64) (lead.LeaderController, error) {
-				return nil, constant.NewNodeIsNotLeaderWithHint(1, "leader:6648")
+				return nil, constant.WithLeaderHint(grpcstatus.Convert(constant.ErrNodeIsNotLeader), 1, "leader:6648")
 			},
 		},
 		assignmentDispatcher: &testAssignmentDispatcher{initialized: true, validAuthorities: map[string]bool{

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -291,7 +291,7 @@ func (t *wal) appendAsync0(entry *proto.LogEntry, previousCrc *uint32) error {
 	defer timer.Done()
 
 	if t.isClosed() {
-		return constant.ErrAlreadyClosed
+		return constant.ErrResourceUnavailable
 	}
 
 	if err := t.checkNextOffset(entry.Offset); err != nil {

--- a/tests/assignments/leader_hint_test.go
+++ b/tests/assignments/leader_hint_test.go
@@ -86,7 +86,7 @@ func TestLeaderHintWithoutClient(t *testing.T) {
 		if err == nil {
 			return false
 		}
-		hint := constant.FindLeaderHint(err)
+		hint := constant.GetLeaderHint(err)
 		if hint == nil {
 			return false
 		}
@@ -147,7 +147,7 @@ func TestLeaderHintListWithoutClient(t *testing.T) {
 		if err == nil {
 			return false
 		}
-		hint := constant.FindLeaderHint(err)
+		hint := constant.GetLeaderHint(err)
 		if hint == nil {
 			return false
 		}
@@ -260,7 +260,7 @@ func TestLeaderHintRangeScanWithoutClient(t *testing.T) {
 		if err == nil {
 			return false
 		}
-		hint := constant.FindLeaderHint(err)
+		hint := constant.GetLeaderHint(err)
 		if hint == nil {
 			return false
 		}


### PR DESCRIPTION
## Motivation
- Replace Oxia custom gRPC status codes with standard gRPC codes so clients and servers rely on portable gRPC semantics.
- Keep domain-specific matching available through shared errors and dataserver conversion logic.

## Modifications
- Map existing Oxia gRPC errors to standard `codes.Code` values.
- Update retry, redirect, and server-side checks to use the new status-code behavior.
- Adjust related tests for standard gRPC status codes.

## Testing
- `go test ./constant ./rpc` in `common`
- `go test ./internal/batch ./internal` in `oxia`
- `go test ./dataserver ./dataserver/controller/lead ./dataserver/controller/follow ./coordinator/runtime/controller` in `oxiad`
- `make lint`