### PR TITLE
refactor: scope metadata status updates

### DIFF
--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -39,17 +39,13 @@ type Metadata interface {
 	io.Closer
 
 	GetStatus() commonobject.Borrowed[*commonproto.ClusterStatus]
-	UpdateStatus(newStatus *commonproto.ClusterStatus)
 	ReserveShardIDs(count uint32) int64
 
 	CreateNamespaceStatus(name string, status *commonproto.NamespaceStatus) bool
 	ListNamespaceStatus() map[string]commonobject.Borrowed[*commonproto.NamespaceStatus]
 	GetNamespaceStatus(namespace string) (commonobject.Borrowed[*commonproto.NamespaceStatus], bool)
+	UpdateNamespaceStatus(name string, status *commonproto.NamespaceStatus)
 	DeleteNamespaceStatus(name string) commonobject.Borrowed[*commonproto.NamespaceStatus]
-	CreateNamespace(namespace *commonproto.Namespace) error
-	PatchNamespace(namespace *commonproto.Namespace) (*commonproto.Namespace, error)
-	DeleteNamespace(name string) (*commonproto.Namespace, error)
-	GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool)
 
 	UpdateShardStatus(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata)
 	DeleteShardStatus(namespace string, shard int64)
@@ -57,6 +53,11 @@ type Metadata interface {
 	GetConfig() commonobject.Borrowed[*commonproto.ClusterConfiguration]
 	SubscribeConfig() *commonwatch.Receiver[provider.Versioned[*commonproto.ClusterConfiguration]]
 	GetLoadBalancer() commonobject.Borrowed[*commonproto.LoadBalancer]
+
+	CreateNamespace(namespace *commonproto.Namespace) error
+	PatchNamespace(namespace *commonproto.Namespace) (*commonproto.Namespace, error)
+	DeleteNamespace(name string) (*commonproto.Namespace, error)
+	GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool)
 
 	CreateDataServer(dataServer *commonproto.DataServer) error
 	PatchDataServer(dataServer *commonproto.DataServer) (*commonproto.DataServer, error)
@@ -169,20 +170,6 @@ func (m *coordinatorMetadata) GetStatus() commonobject.Borrowed[*commonproto.Clu
 	return commonobject.Borrow(m.statusProvider.Watch().Load().Value)
 }
 
-func (m *coordinatorMetadata) UpdateStatus(newStatus *commonproto.ClusterStatus) {
-	_ = backoff.RetryNotify(func() error {
-		return m.computeStatus(func(_ *commonproto.ClusterStatus, _ metadatacommon.Version) (*commonproto.ClusterStatus, bool) {
-			return newStatus, true
-		})
-	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
-		m.logger.Warn(
-			"failed to update status",
-			slog.Any("error", err),
-			slog.Duration("retry-after", duration),
-		)
-	})
-}
-
 func (m *coordinatorMetadata) ReserveShardIDs(count uint32) int64 {
 	var base int64
 	_ = backoff.RetryNotify(func() error {
@@ -241,6 +228,29 @@ func (m *coordinatorMetadata) GetNamespaceStatus(namespace string) (commonobject
 		return commonobject.Borrowed[*commonproto.NamespaceStatus]{}, false
 	}
 	return commonobject.Borrow(namespaceStatus), true
+}
+
+func (m *coordinatorMetadata) UpdateNamespaceStatus(name string, namespaceStatus *commonproto.NamespaceStatus) {
+	namespaceExists := true
+	_ = backoff.RetryNotify(func() error {
+		return m.computeStatus(func(clusterStatus *commonproto.ClusterStatus, _ metadatacommon.Version) (*commonproto.ClusterStatus, bool) {
+			if _, exists := clusterStatus.Namespaces[name]; !exists {
+				namespaceExists = false
+				return clusterStatus, false
+			}
+			clusterStatus.Namespaces[name] = namespaceStatus
+			return clusterStatus, true
+		})
+	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
+		m.logger.Warn(
+			"failed to update namespace status",
+			slog.Any("error", err),
+			slog.Duration("retry-after", duration),
+		)
+	})
+	if !namespaceExists {
+		m.logger.Warn("failed to update namespace status: namespace does not exist", slog.String("namespace", name))
+	}
 }
 
 func (m *coordinatorMetadata) DeleteNamespaceStatus(name string) commonobject.Borrowed[*commonproto.NamespaceStatus] {

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -93,8 +93,6 @@ func (m *mockNamespaceMetadata) GetStatus() commonobject.Borrowed[*proto.Cluster
 	return commonobject.Borrow(m.status)
 }
 
-func (m *mockNamespaceMetadata) UpdateStatus(newStatus *proto.ClusterStatus) { m.status = newStatus }
-
 func (m *mockNamespaceMetadata) ReserveShardIDs(count uint32) int64 {
 	cloned := gproto.Clone(m.status).(*proto.ClusterStatus)
 	base := cloned.ShardIdGenerator
@@ -121,6 +119,15 @@ func (m *mockNamespaceMetadata) CreateNamespaceStatus(
 
 	m.status = cloned
 	return true
+}
+
+func (m *mockNamespaceMetadata) UpdateNamespaceStatus(name string, status *proto.NamespaceStatus) {
+	cloned := gproto.Clone(m.status).(*proto.ClusterStatus)
+	if _, exists := cloned.Namespaces[name]; !exists {
+		return
+	}
+	cloned.Namespaces[name] = gproto.Clone(status).(*proto.NamespaceStatus)
+	m.status = cloned
 }
 
 func (m *mockNamespaceMetadata) ListNamespaceStatus() map[string]commonobject.Borrowed[*proto.NamespaceStatus] {
@@ -154,7 +161,15 @@ func (m *mockNamespaceMetadata) DeleteNamespaceStatus(name string) commonobject.
 	return commonobject.Borrow(namespaceStatus)
 }
 
-func (*mockNamespaceMetadata) UpdateShardStatus(string, int64, *proto.ShardMetadata) {}
+func (m *mockNamespaceMetadata) UpdateShardStatus(namespace string, shard int64, shardMetadata *proto.ShardMetadata) {
+	cloned := gproto.Clone(m.status).(*proto.ClusterStatus)
+	ns, exists := cloned.GetNamespaces()[namespace]
+	if !exists {
+		return
+	}
+	ns.Shards[shard] = shardMetadata
+	m.status = cloned
+}
 
 func (*mockNamespaceMetadata) DeleteShardStatus(string, int64) {}
 

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -58,13 +58,13 @@ func (m *mockMetadata) GetStatus() commonobject.Borrowed[*proto.ClusterStatus] {
 	return commonobject.Borrow(m.status)
 }
 
-func (m *mockMetadata) UpdateStatus(newStatus *proto.ClusterStatus) { m.status = newStatus }
-
 func (*mockMetadata) ReserveShardIDs(uint32) int64 { return 0 }
 
 func (*mockMetadata) CreateNamespaceStatus(string, *proto.NamespaceStatus) bool {
 	return false
 }
+
+func (*mockMetadata) UpdateNamespaceStatus(string, *proto.NamespaceStatus) {}
 
 func (m *mockMetadata) ListNamespaceStatus() map[string]commonobject.Borrowed[*proto.NamespaceStatus] {
 	statuses := make(map[string]commonobject.Borrowed[*proto.NamespaceStatus], len(m.status.GetNamespaces()))
@@ -86,7 +86,13 @@ func (*mockMetadata) DeleteNamespaceStatus(string) commonobject.Borrowed[*proto.
 	return commonobject.Borrowed[*proto.NamespaceStatus]{}
 }
 
-func (*mockMetadata) UpdateShardStatus(string, int64, *proto.ShardMetadata) {}
+func (m *mockMetadata) UpdateShardStatus(namespace string, shard int64, shardMetadata *proto.ShardMetadata) {
+	ns, exists := m.status.GetNamespaces()[namespace]
+	if !exists {
+		return
+	}
+	ns.Shards[shard] = shardMetadata
+}
 
 func (*mockMetadata) DeleteShardStatus(string, int64) {}
 

--- a/oxiad/coordinator/runtime/controller/split_controller.go
+++ b/oxiad/coordinator/runtime/controller/split_controller.go
@@ -220,23 +220,26 @@ func (sc *SplitController) currentPhase() (proto.SplitPhase, bool) {
 // updatePhase atomically updates the split phase on both parent and children.
 func (sc *SplitController) updatePhase(newPhase proto.SplitPhase) {
 	status := sc.metadata.GetStatus().UnsafeBorrow()
-	cloned := gproto.Clone(status).(*proto.ClusterStatus) //nolint:revive
-
-	ns := cloned.Namespaces[sc.namespace]
-
-	// Update parent
-	if parentMeta, exists := ns.Shards[sc.parentShardId]; exists && parentMeta.Split != nil {
-		parentMeta.Split.Phase = newPhase
+	currentNS, exists := status.Namespaces[sc.namespace]
+	if !exists {
+		sc.logger.Warn("namespace status not found while updating split phase",
+			slog.String("namespace", sc.namespace),
+			slog.String("phase", newPhase.String()))
+		return
 	}
-
-	// Update children
-	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		if childMeta, exists := ns.Shards[childId]; exists && childMeta.Split != nil {
-			childMeta.Split.Phase = newPhase
+	ns := gproto.Clone(currentNS).(*proto.NamespaceStatus) //nolint:revive
+	changed := false
+	for _, shardId := range []int64{sc.parentShardId, sc.leftChildId, sc.rightChildId} {
+		meta, exists := ns.Shards[shardId]
+		if !exists || meta.Split == nil {
+			continue
 		}
+		meta.Split.Phase = newPhase
+		changed = true
 	}
-
-	sc.metadata.UpdateStatus(cloned)
+	if changed {
+		sc.metadata.UpdateNamespaceStatus(sc.namespace, ns)
+	}
 }
 
 // runBootstrap validates preconditions, fences child ensemble members, elects
@@ -694,12 +697,23 @@ func (sc *SplitController) updateChildMeta(childId int64, fn func(meta *proto.Sh
 
 func (sc *SplitController) updateShardMeta(shardId int64, fn func(meta *proto.ShardMetadata)) {
 	status := sc.metadata.GetStatus().UnsafeBorrow()
-	cloned := gproto.Clone(status).(*proto.ClusterStatus) //nolint:revive
-	ns := cloned.Namespaces[sc.namespace]
-	if meta, exists := ns.Shards[shardId]; exists {
-		fn(meta)
-		sc.metadata.UpdateStatus(cloned)
+	ns, exists := status.Namespaces[sc.namespace]
+	if !exists {
+		sc.logger.Warn("namespace status not found while updating shard metadata",
+			slog.String("namespace", sc.namespace),
+			slog.Int64("shard", shardId))
+		return
 	}
+	meta, exists := ns.Shards[shardId]
+	if !exists {
+		sc.logger.Warn("shard metadata not found while updating shard metadata",
+			slog.String("namespace", sc.namespace),
+			slog.Int64("shard", shardId))
+		return
+	}
+	cloned := gproto.Clone(meta).(*proto.ShardMetadata) //nolint:revive
+	fn(cloned)
+	sc.metadata.UpdateShardStatus(sc.namespace, shardId, cloned)
 }
 
 // fenceEnsemble sends NewTerm to all ensemble members and returns the

--- a/oxiad/coordinator/runtime/controller/split_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/split_controller_test.go
@@ -173,10 +173,19 @@ func setupSplitTest(t *testing.T, phase proto.SplitPhase) (
 		ShardIdGenerator: 3,
 	}
 
-	metadata.UpdateStatus(clusterStatus)
+	require.Equal(t, int64(0), metadata.ReserveShardIDs(3))
+	metadata.CreateNamespaceStatus(constant.DefaultNamespace, clusterStatus.Namespaces[constant.DefaultNamespace])
 	listener := newMockSplitEventListener()
 
 	return rpcMock, metadata, listener
+}
+
+func updateTestStatusShards(t *testing.T, metadata coordmetadata.Metadata, status *proto.ClusterStatus, shardIDs ...int64) {
+	t.Helper()
+	ns := status.Namespaces[constant.DefaultNamespace]
+	for _, shardID := range shardIDs {
+		metadata.UpdateShardStatus(constant.DefaultNamespace, shardID, ns.Shards[shardID])
+	}
 }
 
 // queueBootstrapResponses queues all responses needed for the bootstrap phase.
@@ -320,7 +329,7 @@ func TestSplitController_ResumeFromCatchUp(t *testing.T) {
 	rightMeta.Leader = rs1
 	rightMeta.Term = 1
 	ns.Shards[2] = rightMeta
-	statusRes.UpdateStatus(cloned)
+	updateTestStatusShards(t, statusRes, cloned, 1, 2)
 
 	queueCatchUpResponses(rpcMock)
 	queueCutoverResponses(rpcMock)
@@ -443,7 +452,7 @@ func TestSplitController_TimeoutDuringCatchUp(t *testing.T) {
 	parentMeta.Split.ParentTermAtBootstrap = 5
 	ns.Shards[0] = parentMeta
 
-	statusRes.UpdateStatus(cloned)
+	updateTestStatusShards(t, statusRes, cloned, 0, 1, 2)
 
 	// Queue RemoveObserver responses (abort will call these)
 	rpcMock.GetNode(ps1).RemoveObserverResponse(nil)
@@ -508,7 +517,7 @@ func TestSplitController_ParentTermChangeDuringCatchUp(t *testing.T) {
 	parentMeta.Split.ParentTermAtBootstrap = 5 // Was 5 during Bootstrap
 	ns.Shards[0] = parentMeta
 
-	statusRes.UpdateStatus(cloned)
+	updateTestStatusShards(t, statusRes, cloned, 0, 1, 2)
 
 	// The controller should detect term change and reset to Bootstrap.
 	// Queue Bootstrap responses -- note: parent leader is now ps2 (after election)
@@ -713,7 +722,7 @@ func TestSplitController_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
 	parentMeta.Split.ParentTermAtBootstrap = 5
 	ns.Shards[0] = parentMeta
 
-	statusRes.UpdateStatus(cloned)
+	updateTestStatusShards(t, statusRes, cloned, 0, 1, 2)
 
 	// Queue RemoveObserver responses (abort will call these)
 	rpcMock.GetNode(ps1).RemoveObserverResponse(nil)
@@ -779,7 +788,7 @@ func TestSplitController_ChildFollowersDeadCommitStalls(t *testing.T) {
 	parentMeta.Split.ParentTermAtBootstrap = 5
 	ns.Shards[0] = parentMeta
 
-	statusRes.UpdateStatus(cloned)
+	updateTestStatusShards(t, statusRes, cloned, 0, 1, 2)
 
 	// Queue RemoveObserver responses (abort will call these)
 	rpcMock.GetNode(ps1).RemoveObserverResponse(nil)
@@ -856,7 +865,7 @@ func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 	}
 	ns.Shards[0] = parentMeta
 
-	statusRes.UpdateStatus(cloned)
+	updateTestStatusShards(t, statusRes, cloned, 0, 1, 2)
 
 	// CatchUp detects left child leader changed (ls1 -> ls2).
 	// It RemoveObserver(old leader) on parent, then falls back to Bootstrap.

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -573,10 +573,9 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 	}
 
 	// Allocate child shard IDs
+	leftChildId := c.metadata.ReserveShardIDs(2)
+	rightChildId := leftChildId + 1
 	cloned := pb.Clone(status).(*proto.ClusterStatus) //nolint:revive
-	leftChildId := cloned.ShardIdGenerator
-	rightChildId := cloned.ShardIdGenerator + 1
-	cloned.ShardIdGenerator += 2
 
 	// Select ensembles for children.
 	// After selecting the left child's ensemble, insert it into the cloned
@@ -645,7 +644,7 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 	}
 
 	// Persist
-	c.metadata.UpdateStatus(cloned)
+	c.metadata.UpdateNamespaceStatus(namespace, nsCloned)
 
 	c.logger.Info("Split initiated",
 		slog.Int64("parent-shard", parentShardId),

--- a/oxiad/coordinator/runtime/runtime_authority_test.go
+++ b/oxiad/coordinator/runtime/runtime_authority_test.go
@@ -83,20 +83,16 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 		},
 	}
 	metadata := newTestMetadata(t, clusterConfig)
-	metadata.UpdateStatus(&proto.ClusterStatus{
-		Namespaces: map[string]*proto.NamespaceStatus{
-			"default": {
-				ReplicationFactor: 1,
-				Shards: map[int64]*proto.ShardMetadata{
-					0: {
-						Status:   proto.ShardStatusUnknown,
-						Leader:   leader,
-						Ensemble: []*proto.DataServerIdentity{leader},
-						Int32HashRange: &proto.HashRange{
-							Min: 0,
-							Max: 100,
-						},
-					},
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		ReplicationFactor: 1,
+		Shards: map[int64]*proto.ShardMetadata{
+			0: {
+				Status:   proto.ShardStatusUnknown,
+				Leader:   leader,
+				Ensemble: []*proto.DataServerIdentity{leader},
+				Int32HashRange: &proto.HashRange{
+					Min: 0,
+					Max: 100,
 				},
 			},
 		},
@@ -141,21 +137,17 @@ func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
 		}},
 	}
 	metadata := newTestMetadata(t, clusterConfig)
-	metadata.UpdateStatus(&proto.ClusterStatus{
-		Namespaces: map[string]*proto.NamespaceStatus{
-			"default": {
-				ReplicationFactor: 1,
-				Shards: map[int64]*proto.ShardMetadata{
-					0: {
-						Status:       proto.ShardStatusUnknown,
-						Leader:       removed,
-						Ensemble:     []*proto.DataServerIdentity{removed},
-						RemovedNodes: []*proto.DataServerIdentity{removed},
-						Int32HashRange: &proto.HashRange{
-							Min: 0,
-							Max: 100,
-						},
-					},
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		ReplicationFactor: 1,
+		Shards: map[int64]*proto.ShardMetadata{
+			0: {
+				Status:       proto.ShardStatusUnknown,
+				Leader:       removed,
+				Ensemble:     []*proto.DataServerIdentity{removed},
+				RemovedNodes: []*proto.DataServerIdentity{removed},
+				Int32HashRange: &proto.HashRange{
+					Min: 0,
+					Max: 100,
 				},
 			},
 		},


### PR DESCRIPTION
## Motivation
- Remove the broad cluster status mutation API from coordinator metadata.
- Keep status writes scoped to the domain object being changed, while preserving atomic namespace-level split transitions.

## Modifications
- Removed `Metadata.UpdateStatus` and added `UpdateNamespaceStatus`.
- Reordered `Metadata` so namespace status, shard status, config, namespace config, and dataserver config APIs are grouped clearly.
- Updated split initiation and phase changes to persist namespace status atomically, and left single-shard changes on `UpdateShardStatus`.
- Updated tests and mocks to use namespace/shard status APIs directly.

## Testing
- `go test ./oxiad/coordinator/...`
- `go test ./tests/security/auth -run TestOIDCWithPerIssuerConfig -count=1`
- `go test ./common/... ./oxia/... ./oxiad/... ./cmd/... ./tests/...` mostly passed, but the full integration run hit a one-off timeout in `tests/security/auth/TestOIDCWithPerIssuerConfig`; rerunning that exact test passed.
