### PR TITLE
refactor: add metadata namespace listing

### DIFF
--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -166,10 +166,14 @@ func (management *managementServer) DeleteDataServer(_ context.Context, req *pro
 }
 
 func (management *managementServer) ListNamespaces(context.Context, *proto.ListNamespacesRequest) (*proto.ListNamespacesResponse, error) {
-	cnf := management.metadata.GetConfig().UnsafeBorrow()
+	namespaces := management.metadata.ListNamespace()
+	responseNamespaces := make([]*proto.Namespace, 0, len(namespaces))
+	for _, namespace := range namespaces {
+		responseNamespaces = append(responseNamespaces, namespace.UnsafeBorrow())
+	}
 
 	return &proto.ListNamespacesResponse{
-		Namespaces: cnf.GetNamespaces(),
+		Namespaces: responseNamespaces,
 	}, nil
 }
 

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -57,6 +57,7 @@ type Metadata interface {
 	CreateNamespace(namespace *commonproto.Namespace) error
 	PatchNamespace(namespace *commonproto.Namespace) (*commonproto.Namespace, error)
 	DeleteNamespace(name string) (*commonproto.Namespace, error)
+	ListNamespace() map[string]commonobject.Borrowed[*commonproto.Namespace]
 	GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool)
 
 	CreateDataServer(dataServer *commonproto.DataServer) error
@@ -529,12 +530,17 @@ func (m *coordinatorMetadata) ListDataServer() map[string]commonobject.Borrowed[
 }
 
 func (m *coordinatorMetadata) GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool) {
-	for _, ns := range m.GetConfig().UnsafeBorrow().GetNamespaces() {
-		if ns.GetName() == namespace {
-			return commonobject.Borrow(ns), true
-		}
+	ns, exists := m.ListNamespace()[namespace]
+	return ns, exists
+}
+
+func (m *coordinatorMetadata) ListNamespace() map[string]commonobject.Borrowed[*commonproto.Namespace] {
+	configNamespaces := m.GetConfig().UnsafeBorrow().GetNamespaces()
+	namespaces := make(map[string]commonobject.Borrowed[*commonproto.Namespace], len(configNamespaces))
+	for _, namespace := range configNamespaces {
+		namespaces[namespace.GetName()] = commonobject.Borrow(namespace)
 	}
-	return commonobject.Borrowed[*commonproto.Namespace]{}, false
+	return namespaces
 }
 
 func (m *coordinatorMetadata) GetDataServer(name string) (commonobject.Borrowed[*commonproto.DataServer], bool) {

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -185,6 +185,14 @@ func (*mockNamespaceMetadata) DeleteNamespace(string) (*proto.Namespace, error) 
 	return &proto.Namespace{}, nil
 }
 
+func (m *mockNamespaceMetadata) ListNamespace() map[string]commonobject.Borrowed[*proto.Namespace] {
+	namespaces := make(map[string]commonobject.Borrowed[*proto.Namespace], len(m.configNS))
+	for name, namespace := range m.configNS {
+		namespaces[name] = commonobject.Borrow(namespace)
+	}
+	return namespaces
+}
+
 func (*mockNamespaceMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterConfiguration] {
 	return commonobject.Borrowed[*proto.ClusterConfiguration]{}
 }

--- a/oxiad/coordinator/runtime/balancer/scheduler.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler.go
@@ -340,12 +340,12 @@ func (r *nodeBasedBalancer) IsNodeQuarantined(highestLoadRatioNode *model.NodeLo
 }
 
 func (r *nodeBasedBalancer) IsBalanced() bool {
-	configNamespaces := r.metadata.GetConfig().UnsafeBorrow().GetNamespaces()
+	configNamespaces := r.metadata.ListNamespace()
 	if len(configNamespaces) != len(r.metadata.ListNamespaceStatus()) {
 		return false
 	}
-	for _, namespace := range configNamespaces {
-		if _, exists := r.metadata.GetNamespaceStatus(namespace.GetName()); !exists {
+	for namespace := range configNamespaces {
+		if _, exists := r.metadata.GetNamespaceStatus(namespace); !exists {
 			return false
 		}
 	}

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -110,6 +110,14 @@ func (*mockMetadata) DeleteNamespace(string) (*proto.Namespace, error) {
 	return &proto.Namespace{}, nil
 }
 
+func (m *mockMetadata) ListNamespace() map[string]commonobject.Borrowed[*proto.Namespace] {
+	namespaces := make(map[string]commonobject.Borrowed[*proto.Namespace], len(m.nsConfigs))
+	for name, namespace := range m.nsConfigs {
+		namespaces[name] = commonobject.Borrow(namespace)
+	}
+	return namespaces
+}
+
 func (m *mockMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterConfiguration] {
 	namespaces := make([]*proto.Namespace, 0, len(m.nsConfigs))
 	for _, namespace := range m.nsConfigs {


### PR DESCRIPTION
## Motivation
- Keep namespace configuration access behind the coordinator metadata domain API instead of requiring callers to inspect the full cluster config.
- Pair the existing `GetNamespace` method with a matching list operation, similar to data server accessors.

## Modifications
- Added `Metadata.ListNamespace()` returning borrowed namespace configs keyed by name.
- Updated management namespace listing and balancer readiness checks to use `ListNamespace()` instead of reaching through `GetConfig()`.
- Updated metadata test doubles to implement the new interface method.

## Testing
- `go test ./oxiad/coordinator/...`
- `make lint`
