### PR TITLE
refactor: hide cluster status behind metadata APIs

### DIFF
--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -166,10 +166,14 @@ func (management *managementServer) DeleteDataServer(_ context.Context, req *pro
 }
 
 func (management *managementServer) ListNamespaces(context.Context, *proto.ListNamespacesRequest) (*proto.ListNamespacesResponse, error) {
-	cnf := management.metadata.GetConfig().UnsafeBorrow()
+	namespaces := management.metadata.ListNamespace()
+	responseNamespaces := make([]*proto.Namespace, 0, len(namespaces))
+	for _, namespace := range namespaces {
+		responseNamespaces = append(responseNamespaces, namespace.UnsafeBorrow())
+	}
 
 	return &proto.ListNamespacesResponse{
-		Namespaces: cnf.GetNamespaces(),
+		Namespaces: responseNamespaces,
 	}, nil
 }
 

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -38,7 +38,7 @@ import (
 type Metadata interface {
 	io.Closer
 
-	GetStatus() commonobject.Borrowed[*commonproto.ClusterStatus]
+	GetInstanceID() string
 	ReserveShardIDs(count uint32) int64
 
 	CreateNamespaceStatus(name string, status *commonproto.NamespaceStatus) bool
@@ -47,6 +47,7 @@ type Metadata interface {
 	UpdateNamespaceStatus(name string, status *commonproto.NamespaceStatus)
 	DeleteNamespaceStatus(name string) commonobject.Borrowed[*commonproto.NamespaceStatus]
 
+	GetShardStatus(namespace string, shard int64) (commonobject.Borrowed[*commonproto.ShardMetadata], bool)
 	UpdateShardStatus(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata)
 	DeleteShardStatus(namespace string, shard int64)
 
@@ -167,8 +168,8 @@ func (m *coordinatorMetadata) doStatusRecovery() {
 	}
 }
 
-func (m *coordinatorMetadata) GetStatus() commonobject.Borrowed[*commonproto.ClusterStatus] {
-	return commonobject.Borrow(m.statusProvider.Watch().Load().Value)
+func (m *coordinatorMetadata) GetInstanceID() string {
+	return m.statusProvider.Watch().Load().Value.GetInstanceId()
 }
 
 func (m *coordinatorMetadata) ReserveShardIDs(count uint32) int64 {
@@ -281,6 +282,18 @@ func (m *coordinatorMetadata) DeleteNamespaceStatus(name string) commonobject.Bo
 		)
 	})
 	return commonobject.Borrow(namespaceStatus)
+}
+
+func (m *coordinatorMetadata) GetShardStatus(namespace string, shard int64) (commonobject.Borrowed[*commonproto.ShardMetadata], bool) {
+	namespaceStatus, exists := m.GetNamespaceStatus(namespace)
+	if !exists {
+		return commonobject.Borrowed[*commonproto.ShardMetadata]{}, false
+	}
+	shardStatus, exists := namespaceStatus.UnsafeBorrow().GetShards()[shard]
+	if !exists {
+		return commonobject.Borrowed[*commonproto.ShardMetadata]{}, false
+	}
+	return commonobject.Borrow(shardStatus), true
 }
 
 func (m *coordinatorMetadata) UpdateShardStatus(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata) {

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -57,6 +57,7 @@ type Metadata interface {
 	CreateNamespace(namespace *commonproto.Namespace) error
 	PatchNamespace(namespace *commonproto.Namespace) (*commonproto.Namespace, error)
 	DeleteNamespace(name string) (*commonproto.Namespace, error)
+	ListNamespace() map[string]commonobject.Borrowed[*commonproto.Namespace]
 	GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool)
 
 	CreateDataServer(dataServer *commonproto.DataServer) error
@@ -529,12 +530,17 @@ func (m *coordinatorMetadata) ListDataServer() map[string]commonobject.Borrowed[
 }
 
 func (m *coordinatorMetadata) GetNamespace(namespace string) (commonobject.Borrowed[*commonproto.Namespace], bool) {
-	for _, ns := range m.GetConfig().UnsafeBorrow().GetNamespaces() {
-		if ns.GetName() == namespace {
-			return commonobject.Borrow(ns), true
-		}
+	ns, exists := m.ListNamespace()[namespace]
+	return ns, exists
+}
+
+func (m *coordinatorMetadata) ListNamespace() map[string]commonobject.Borrowed[*commonproto.Namespace] {
+	configNamespaces := m.GetConfig().UnsafeBorrow().GetNamespaces()
+	namespaces := make(map[string]commonobject.Borrowed[*commonproto.Namespace], len(configNamespaces))
+	for _, namespace := range configNamespaces {
+		namespaces[namespace.GetName()] = commonobject.Borrow(namespace)
 	}
-	return commonobject.Borrowed[*commonproto.Namespace]{}, false
+	return namespaces
 }
 
 func (m *coordinatorMetadata) GetDataServer(name string) (commonobject.Borrowed[*commonproto.DataServer], bool) {

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -89,9 +89,7 @@ type mockNamespaceMetadata struct {
 
 func (*mockNamespaceMetadata) Close() error { return nil }
 
-func (m *mockNamespaceMetadata) GetStatus() commonobject.Borrowed[*proto.ClusterStatus] {
-	return commonobject.Borrow(m.status)
-}
+func (m *mockNamespaceMetadata) GetInstanceID() string { return m.status.GetInstanceId() }
 
 func (m *mockNamespaceMetadata) ReserveShardIDs(count uint32) int64 {
 	cloned := gproto.Clone(m.status).(*proto.ClusterStatus)
@@ -144,6 +142,18 @@ func (m *mockNamespaceMetadata) GetNamespaceStatus(namespace string) (commonobje
 		return commonobject.Borrowed[*proto.NamespaceStatus]{}, false
 	}
 	return commonobject.Borrow(status), true
+}
+
+func (m *mockNamespaceMetadata) GetShardStatus(namespace string, shard int64) (commonobject.Borrowed[*proto.ShardMetadata], bool) {
+	namespaceStatus, exists := m.status.GetNamespaces()[namespace]
+	if !exists {
+		return commonobject.Borrowed[*proto.ShardMetadata]{}, false
+	}
+	shardStatus, exists := namespaceStatus.GetShards()[shard]
+	if !exists {
+		return commonobject.Borrowed[*proto.ShardMetadata]{}, false
+	}
+	return commonobject.Borrow(shardStatus), true
 }
 
 func (m *mockNamespaceMetadata) DeleteNamespaceStatus(name string) commonobject.Borrowed[*proto.NamespaceStatus] {
@@ -270,16 +280,15 @@ func (*mockNamespaceRuntime) SyncShardControllerServerAddresses() {}
 
 func (m *mockNamespaceRuntime) CreateNamespace(name string, namespaceConfig *proto.Namespace) bool {
 	baseShardID := m.metadata.ReserveShardIDs(namespaceConfig.GetInitialShardCount())
-	currentStatus := m.metadata.GetStatus().UnsafeBorrow()
 	namespaceStatus := &proto.NamespaceStatus{
 		Shards:            map[int64]*proto.ShardMetadata{},
 		ReplicationFactor: namespaceConfig.GetReplicationFactor(),
 	}
 	status := &proto.ClusterStatus{
-		Namespaces: make(map[string]*proto.NamespaceStatus, len(currentStatus.GetNamespaces())+1),
+		Namespaces: map[string]*proto.NamespaceStatus{},
 	}
-	for name, existingNamespaceStatus := range currentStatus.GetNamespaces() {
-		status.Namespaces[name] = existingNamespaceStatus
+	for name, existingNamespaceStatus := range m.metadata.ListNamespaceStatus() {
+		status.Namespaces[name] = existingNamespaceStatus.UnsafeBorrow()
 	}
 	status.Namespaces[name] = namespaceStatus
 

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -185,6 +185,14 @@ func (*mockNamespaceMetadata) DeleteNamespace(string) (*proto.Namespace, error) 
 	return &proto.Namespace{}, nil
 }
 
+func (m *mockNamespaceMetadata) ListNamespace() map[string]commonobject.Borrowed[*proto.Namespace] {
+	namespaces := make(map[string]commonobject.Borrowed[*proto.Namespace], len(m.configNS))
+	for name, namespace := range m.configNS {
+		namespaces[name] = commonobject.Borrow(namespace)
+	}
+	return namespaces
+}
+
 func (*mockNamespaceMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterConfiguration] {
 	return commonobject.Borrowed[*proto.ClusterConfiguration]{}
 }

--- a/oxiad/coordinator/runtime/balancer/scheduler.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler.go
@@ -116,7 +116,7 @@ func (r *nodeBasedBalancer) rebalanceEnsemble() bool {
 	r.checkQuarantineNodes()
 
 	swapGroup := &sync.WaitGroup{}
-	currentStatus := r.metadata.GetStatus().UnsafeBorrow()
+	currentStatus := r.metadata.ListNamespaceStatus()
 	dataServers := r.metadata.ListDataServer()
 	candidates, metadata := dataServersToCandidatesAndMetadata(dataServers)
 	groupedStatus, historyNodes := state.GroupingShardsNodeByStatus(candidates, currentStatus)
@@ -142,16 +142,16 @@ func (r *nodeBasedBalancer) rebalanceEnsemble() bool {
 		}
 	}()
 
-	r.cleanDeletedNode(loadRatios, candidates, metadata, currentStatus, swapGroup)
+	r.cleanDeletedNode(loadRatios, candidates, metadata, swapGroup)
 
 	if loadRatios.RatioGap() <= loadRatios.AvgShardLoadRatio() {
 		return true
 	}
-	r.balanceHighestNode(loadRatios, candidates, metadata, currentStatus, swapGroup)
+	r.balanceHighestNode(loadRatios, candidates, metadata, swapGroup)
 	return false
 }
 
-func (r *nodeBasedBalancer) balanceHighestNode(loadRatios *model.Ratio, candidates *linkedhashset.Set[string], metadata map[string]*commonproto.DataServerMetadata, currentStatus *commonproto.ClusterStatus, swapGroup *sync.WaitGroup) {
+func (r *nodeBasedBalancer) balanceHighestNode(loadRatios *model.Ratio, candidates *linkedhashset.Set[string], metadata map[string]*commonproto.DataServerMetadata, swapGroup *sync.WaitGroup) {
 	nodeIter := loadRatios.NodeIterator()
 	if !nodeIter.Last() {
 		return
@@ -180,7 +180,7 @@ func (r *nodeBasedBalancer) balanceHighestNode(loadRatios *model.Ratio, candidat
 		}
 		fromNodeID := highestLoadRatioNode.NodeID
 		fromNode := highestLoadRatioNode.Node
-		if _, err := r.swapShard(highestLoadRatioShard, fromNode, swapGroup, loadRatios, candidates, metadata, currentStatus); err != nil {
+		if _, err := r.swapShard(highestLoadRatioShard, fromNode, swapGroup, loadRatios, candidates, metadata); err != nil {
 			r.logger.Error("failed to select server when swap the node",
 				slog.String("namespace", highestLoadRatioShard.Namespace),
 				slog.Int64("shard", highestLoadRatioShard.ShardID),
@@ -203,7 +203,6 @@ func (r *nodeBasedBalancer) balanceHighestNode(loadRatios *model.Ratio, candidat
 func (r *nodeBasedBalancer) cleanDeletedNode(loadRatios *model.Ratio,
 	candidates *linkedhashset.Set[string],
 	metadata map[string]*commonproto.DataServerMetadata,
-	currentStatus *commonproto.ClusterStatus,
 	swapGroup *sync.WaitGroup) {
 	for nodeIter := loadRatios.NodeIterator(); nodeIter.Next(); {
 		nodeLoadRatio := nodeIter.Value()
@@ -214,7 +213,7 @@ func (r *nodeBasedBalancer) cleanDeletedNode(loadRatios *model.Ratio,
 		deletedNode := nodeLoadRatio.Node
 		for shardIter := nodeLoadRatio.ShardIterator(); shardIter.Next(); {
 			var shardRatio = shardIter.Value()
-			if swapped, err := r.swapShard(shardRatio, deletedNode, swapGroup, loadRatios, candidates, metadata, currentStatus); err != nil || !swapped {
+			if swapped, err := r.swapShard(shardRatio, deletedNode, swapGroup, loadRatios, candidates, metadata); err != nil || !swapped {
 				r.logger.Error("failed to select server when move ensemble out of deleted node",
 					slog.String("namespace", shardRatio.Namespace),
 					slog.Int64("shard", shardRatio.ShardID),
@@ -236,8 +235,7 @@ func (r *nodeBasedBalancer) swapShard(
 	swapGroup *sync.WaitGroup,
 	loadRatios *model.Ratio,
 	candidates *linkedhashset.Set[string],
-	metadata map[string]*commonproto.DataServerMetadata,
-	currentStatus *commonproto.ClusterStatus) (bool, error) {
+	metadata map[string]*commonproto.DataServerMetadata) (bool, error) {
 	var nsc *commonproto.Namespace
 	var exist bool
 	var err error
@@ -258,7 +256,6 @@ func (r *nodeBasedBalancer) swapShard(
 		Candidates:         candidates,
 		CandidatesMetadata: metadata,
 		AntiAffinities:     nsc.GetAntiAffinities(),
-		Status:             currentStatus,
 		Namespace:          candidateShard.Namespace,
 		Shard:              candidateShard.ShardID,
 		LoadRatioSupplier:  func() *model.Ratio { return loadRatios },
@@ -350,7 +347,7 @@ func (r *nodeBasedBalancer) IsBalanced() bool {
 		}
 	}
 
-	status := r.metadata.GetStatus().UnsafeBorrow()
+	status := r.metadata.ListNamespaceStatus()
 	candidates, _ := dataServersToCandidatesAndMetadata(r.metadata.ListDataServer())
 	groupedStatus, historyNodes := state.GroupingShardsNodeByStatus(candidates, status)
 	shardsBalanced := r.loadRatioAlgorithm(
@@ -366,7 +363,7 @@ func (r *nodeBasedBalancer) IsBalanced() bool {
 	return r.leaderBalanced(candidates, status)
 }
 
-func (*nodeBasedBalancer) leaderBalanced(candidates *linkedhashset.Set[string], status *commonproto.ClusterStatus) bool {
+func (*nodeBasedBalancer) leaderBalanced(candidates *linkedhashset.Set[string], status map[string]commonobject.Borrowed[*commonproto.NamespaceStatus]) bool {
 	totalShards, electedShards, nodeLeaders := state.NodeShardLeaders(candidates, status)
 	if totalShards == 0 {
 		return true
@@ -444,7 +441,7 @@ func (r *nodeBasedBalancer) startBackgroundNotifier() {
 func (r *nodeBasedBalancer) rebalanceLeader() {
 	r.checkQuarantineShards()
 
-	status := r.metadata.GetStatus().UnsafeBorrow()
+	status := r.metadata.ListNamespaceStatus()
 	candidates, _ := dataServersToCandidatesAndMetadata(r.metadata.ListDataServer())
 	totalShards, electedShards, nodeLeaders := state.NodeShardLeaders(candidates, status)
 
@@ -482,7 +479,7 @@ func (r *nodeBasedBalancer) rebalanceLeader() {
 		}
 		namespace := nsAndShard.Namespace
 		shard := nsAndShard.ShardID
-		shardStatus := status.Namespaces[namespace].Shards[shard]
+		shardStatus := status[namespace].UnsafeBorrow().Shards[shard]
 
 		minCandidateLeaders := -1
 		for _, candidate := range shardStatus.Ensemble {

--- a/oxiad/coordinator/runtime/balancer/scheduler.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler.go
@@ -340,12 +340,12 @@ func (r *nodeBasedBalancer) IsNodeQuarantined(highestLoadRatioNode *model.NodeLo
 }
 
 func (r *nodeBasedBalancer) IsBalanced() bool {
-	configNamespaces := r.metadata.GetConfig().UnsafeBorrow().GetNamespaces()
+	configNamespaces := r.metadata.ListNamespace()
 	if len(configNamespaces) != len(r.metadata.ListNamespaceStatus()) {
 		return false
 	}
-	for _, namespace := range configNamespaces {
-		if _, exists := r.metadata.GetNamespaceStatus(namespace.GetName()); !exists {
+	for namespace := range configNamespaces {
+		if _, exists := r.metadata.GetNamespaceStatus(namespace); !exists {
 			return false
 		}
 	}

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -54,9 +54,7 @@ var _ coordmetadata.Metadata = (*mockMetadata)(nil)
 
 func (*mockMetadata) Close() error { return nil }
 
-func (m *mockMetadata) GetStatus() commonobject.Borrowed[*proto.ClusterStatus] {
-	return commonobject.Borrow(m.status)
-}
+func (m *mockMetadata) GetInstanceID() string { return m.status.GetInstanceId() }
 
 func (*mockMetadata) ReserveShardIDs(uint32) int64 { return 0 }
 
@@ -80,6 +78,18 @@ func (m *mockMetadata) GetNamespaceStatus(namespace string) (commonobject.Borrow
 		return commonobject.Borrowed[*proto.NamespaceStatus]{}, false
 	}
 	return commonobject.Borrow(status), true
+}
+
+func (m *mockMetadata) GetShardStatus(namespace string, shard int64) (commonobject.Borrowed[*proto.ShardMetadata], bool) {
+	namespaceStatus, exists := m.status.GetNamespaces()[namespace]
+	if !exists {
+		return commonobject.Borrowed[*proto.ShardMetadata]{}, false
+	}
+	shardStatus, exists := namespaceStatus.GetShards()[shard]
+	if !exists {
+		return commonobject.Borrowed[*proto.ShardMetadata]{}, false
+	}
+	return commonobject.Borrow(shardStatus), true
 }
 
 func (*mockMetadata) DeleteNamespaceStatus(string) commonobject.Borrowed[*proto.NamespaceStatus] {
@@ -453,7 +463,6 @@ func TestSwapShardPassesNamespaceAndShardToSelector(t *testing.T) {
 		loadRatios,
 		candidates,
 		candidatesMetadata,
-		status,
 	)
 	assert.ErrorIs(t, err, selector.ErrUnsatisfiedAntiAffinity)
 

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -110,6 +110,14 @@ func (*mockMetadata) DeleteNamespace(string) (*proto.Namespace, error) {
 	return &proto.Namespace{}, nil
 }
 
+func (m *mockMetadata) ListNamespace() map[string]commonobject.Borrowed[*proto.Namespace] {
+	namespaces := make(map[string]commonobject.Borrowed[*proto.Namespace], len(m.nsConfigs))
+	for name, namespace := range m.nsConfigs {
+		namespaces[name] = commonobject.Borrow(namespace)
+	}
+	return namespaces
+}
+
 func (m *mockMetadata) GetConfig() commonobject.Borrowed[*proto.ClusterConfiguration] {
 	namespaces := make([]*proto.Namespace, 0, len(m.nsConfigs))
 	for _, namespace := range m.nsConfigs {

--- a/oxiad/coordinator/runtime/balancer/selector/ensemble/context.go
+++ b/oxiad/coordinator/runtime/balancer/selector/ensemble/context.go
@@ -25,7 +25,6 @@ type Context struct {
 	Candidates         *linkedhashset.Set[string]
 	CandidatesMetadata map[string]*commonproto.DataServerMetadata
 	AntiAffinities     []*commonproto.AntiAffinity
-	Status             *commonproto.ClusterStatus
 	Namespace          string
 	Shard              int64
 	Replicas           int

--- a/oxiad/coordinator/runtime/balancer/selector/ensemble/selector.go
+++ b/oxiad/coordinator/runtime/balancer/selector/ensemble/selector.go
@@ -33,7 +33,6 @@ func (ensemble *ensemble) Select(context *Context) ([]string, error) {
 	sServerContext := &single.Context{
 		Candidates:         context.Candidates,
 		CandidatesMetadata: context.CandidatesMetadata,
-		Status:             context.Status,
 		Namespace:          context.Namespace,
 		Shard:              context.Shard,
 		AntiAffinities:     context.AntiAffinities,

--- a/oxiad/coordinator/runtime/balancer/selector/leader/context.go
+++ b/oxiad/coordinator/runtime/balancer/selector/leader/context.go
@@ -14,9 +14,12 @@
 
 package leader
 
-import commonproto "github.com/oxia-db/oxia/common/proto"
+import (
+	commonobject "github.com/oxia-db/oxia/common/object"
+	commonproto "github.com/oxia-db/oxia/common/proto"
+)
 
 type Context struct {
 	Candidates []*commonproto.DataServerIdentity
-	Status     *commonproto.ClusterStatus
+	Namespaces map[string]commonobject.Borrowed[*commonproto.NamespaceStatus]
 }

--- a/oxiad/coordinator/runtime/balancer/selector/leader/lowerest_leaders_selector.go
+++ b/oxiad/coordinator/runtime/balancer/selector/leader/lowerest_leaders_selector.go
@@ -33,12 +33,11 @@ func (*leader) Select(context *Context) (*commonproto.DataServerIdentity, error)
 		return nil, selector.ErrNoCandidates
 	}
 
-	status := context.Status
 	candidates := linkedhashset.New[string]()
 	for _, candidate := range context.Candidates {
 		candidates.Add(candidate.GetNameOrDefault())
 	}
-	_, _, leaders := state.NodeShardLeaders(candidates, status)
+	_, _, leaders := state.NodeShardLeaders(candidates, context.Namespaces)
 
 	minLeaders := -1
 	var minLeadersNode *commonproto.DataServerIdentity

--- a/oxiad/coordinator/runtime/balancer/selector/leader/lowerest_leaders_selector_test.go
+++ b/oxiad/coordinator/runtime/balancer/selector/leader/lowerest_leaders_selector_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	commonobject "github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/selector"
 )
@@ -28,7 +29,7 @@ func TestSelect_NoCandidates(t *testing.T) {
 
 	_, err := s.Select(&Context{
 		Candidates: []*proto.DataServerIdentity{},
-		Status:     proto.NewClusterStatus(),
+		Namespaces: map[string]commonobject.Borrowed[*proto.NamespaceStatus]{},
 	})
 	assert.ErrorIs(t, err, selector.ErrNoCandidates)
 }
@@ -38,7 +39,7 @@ func TestSelect_NilCandidates(t *testing.T) {
 
 	_, err := s.Select(&Context{
 		Candidates: nil,
-		Status:     proto.NewClusterStatus(),
+		Namespaces: map[string]commonobject.Borrowed[*proto.NamespaceStatus]{},
 	})
 	assert.ErrorIs(t, err, selector.ErrNoCandidates)
 }
@@ -50,7 +51,7 @@ func TestSelect_SingleCandidate(t *testing.T) {
 		Candidates: []*proto.DataServerIdentity{
 			{Internal: "127.0.0.1:6601", Public: "127.0.0.1:6611"},
 		},
-		Status: proto.NewClusterStatus(),
+		Namespaces: map[string]commonobject.Borrowed[*proto.NamespaceStatus]{},
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "127.0.0.1:6601", server.Internal)

--- a/oxiad/coordinator/runtime/balancer/selector/single/context.go
+++ b/oxiad/coordinator/runtime/balancer/selector/single/context.go
@@ -28,7 +28,6 @@ type Context struct {
 	Candidates         *linkedhashset.Set[string]
 	CandidatesMetadata map[string]*commonproto.DataServerMetadata
 	AntiAffinities     []*commonproto.AntiAffinity
-	Status             *commonproto.ClusterStatus
 	Namespace          string
 	Shard              int64
 

--- a/oxiad/coordinator/runtime/balancer/state/grouping.go
+++ b/oxiad/coordinator/runtime/balancer/state/grouping.go
@@ -21,6 +21,7 @@ import (
 	"github.com/emirpasic/gods/v2/lists/arraylist"
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 
+	commonobject "github.com/oxia-db/oxia/common/object"
 	commonproto "github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/model"
 )
@@ -30,12 +31,16 @@ type NamespaceAndShard struct {
 	ShardID   int64
 }
 
-func NodeShardLeaders(candidates *linkedhashset.Set[string], status *commonproto.ClusterStatus) (totalShards int, electedShards int, result map[string]*arraylist.List[NamespaceAndShard]) {
+func NodeShardLeaders(candidates *linkedhashset.Set[string], namespaces map[string]commonobject.Borrowed[*commonproto.NamespaceStatus]) (totalShards int, electedShards int, result map[string]*arraylist.List[NamespaceAndShard]) {
 	result = make(map[string]*arraylist.List[NamespaceAndShard])
 	totalShards = 0
 	electedShards = 0
-	for na, ns := range status.Namespaces {
+	for namespace, borrowedNamespaceStatus := range namespaces {
+		ns := borrowedNamespaceStatus.UnsafeBorrow()
 		for shardID, shardStatus := range ns.Shards {
+			if !isBalancingCandidate(shardStatus) {
+				continue
+			}
 			totalShards++
 			if leader := shardStatus.Leader; leader != nil {
 				electedShards++
@@ -45,7 +50,7 @@ func NodeShardLeaders(candidates *linkedhashset.Set[string], status *commonproto
 					result[leaderNodeID] = arraylist.New[NamespaceAndShard]()
 				}
 				result[leaderNodeID].Add(NamespaceAndShard{
-					Namespace: na,
+					Namespace: namespace,
 					ShardID:   shardID,
 				})
 			}
@@ -66,28 +71,30 @@ func NodeShardLeaders(candidates *linkedhashset.Set[string], status *commonproto
 	return totalShards, electedShards, result
 }
 
-func GroupingShardsNodeByStatus(candidates *linkedhashset.Set[string], status *commonproto.ClusterStatus) (map[string][]model.ShardInfo, map[string]*commonproto.DataServerIdentity) {
+func GroupingShardsNodeByStatus(candidates *linkedhashset.Set[string], namespaces map[string]commonobject.Borrowed[*commonproto.NamespaceStatus]) (map[string][]model.ShardInfo, map[string]*commonproto.DataServerIdentity) {
 	groupingShardByNode := make(map[string][]model.ShardInfo)
 	historyNodes := make(map[string]*commonproto.DataServerIdentity)
-	if status != nil {
-		for namespace, namespaceStatus := range status.Namespaces {
-			for shard, shardStatus := range namespaceStatus.Shards {
-				for idx, node := range shardStatus.Ensemble {
-					nodeID := node.GetNameOrDefault()
-					var groupedShard []model.ShardInfo
-					var exist bool
-					if groupedShard, exist = groupingShardByNode[nodeID]; !exist {
-						tmp := make([]model.ShardInfo, 0)
-						groupedShard = tmp
-					}
-					groupedShard = append(groupedShard, model.ShardInfo{
-						Namespace: namespace,
-						ShardID:   shard,
-						Ensemble:  shardStatus.Ensemble,
-					})
-					groupingShardByNode[nodeID] = groupedShard
-					historyNodes[nodeID] = shardStatus.Ensemble[idx]
+	for namespace, borrowedNamespaceStatus := range namespaces {
+		namespaceStatus := borrowedNamespaceStatus.UnsafeBorrow()
+		for shard, shardStatus := range namespaceStatus.Shards {
+			if !isBalancingCandidate(shardStatus) {
+				continue
+			}
+			for idx, node := range shardStatus.Ensemble {
+				nodeID := node.GetNameOrDefault()
+				var groupedShard []model.ShardInfo
+				var exist bool
+				if groupedShard, exist = groupingShardByNode[nodeID]; !exist {
+					tmp := make([]model.ShardInfo, 0)
+					groupedShard = tmp
 				}
+				groupedShard = append(groupedShard, model.ShardInfo{
+					Namespace: namespace,
+					ShardID:   shard,
+					Ensemble:  shardStatus.Ensemble,
+				})
+				groupingShardByNode[nodeID] = groupedShard
+				historyNodes[nodeID] = shardStatus.Ensemble[idx]
 			}
 		}
 	}
@@ -99,6 +106,10 @@ func GroupingShardsNodeByStatus(candidates *linkedhashset.Set[string], status *c
 		}
 	}
 	return groupingShardByNode, historyNodes
+}
+
+func isBalancingCandidate(shardStatus *commonproto.ShardMetadata) bool {
+	return shardStatus.GetStatusOrDefault() == commonproto.ShardStatusSteadyState && shardStatus.Split == nil
 }
 
 func GroupingCandidatesWithLabelValue(candidates *linkedhashset.Set[string], candidatesMetadata map[string]*commonproto.DataServerMetadata) map[string]map[string]*linkedhashset.Set[string] {

--- a/oxiad/coordinator/runtime/controller/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller.go
@@ -258,15 +258,11 @@ func (s *shardController) waitForSplitComplete() {
 		case <-s.ctx.Done():
 			return
 		case <-ticker.C:
-			status := s.metadataStore.GetStatus().UnsafeBorrow()
-			ns, exists := status.Namespaces[s.namespace]
+			borrowedMeta, exists := s.metadataStore.GetShardStatus(s.namespace, s.shard)
 			if !exists {
 				continue
 			}
-			meta, exists := ns.Shards[s.shard]
-			if !exists {
-				continue
-			}
+			meta := borrowedMeta.UnsafeBorrow()
 			if meta.Split == nil {
 				s.logger.Info("Split complete, child shard entering normal operation",
 					slog.Any("leader", meta.Leader),

--- a/oxiad/coordinator/runtime/controller/shard_controller_election.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller_election.go
@@ -226,7 +226,7 @@ func (e *ShardElection) selectNewLeader(candidatesStatus map[*proto.DataServerId
 	candidates := chooseCandidates(candidatesStatus)
 	server, err := e.leaderSelector.Select(&leaderselector.Context{
 		Candidates: candidates,
-		Status:     e.metadataStore.GetStatus().UnsafeBorrow(),
+		Namespaces: e.metadataStore.ListNamespaceStatus(),
 	})
 	if err != nil {
 		return nil, nil, err

--- a/oxiad/coordinator/runtime/controller/split_controller.go
+++ b/oxiad/coordinator/runtime/controller/split_controller.go
@@ -111,21 +111,16 @@ func NewSplitController(cfg SplitControllerConfig) *SplitController {
 	sc.ctx, sc.ctxCancel = context.WithTimeout(context.Background(), splitTimeout)
 
 	// Load the current split metadata from cluster status
-	status := sc.metadata.GetStatus().UnsafeBorrow()
-	ns, exists := status.Namespaces[sc.namespace]
-	if !exists {
-		sc.logger.Error("Namespace not found in cluster status")
-		return sc
-	}
-	parentMeta, exists := ns.Shards[sc.parentShardId]
-	if !exists || parentMeta.Split == nil {
+	parentMeta, exists := sc.metadata.GetShardStatus(sc.namespace, sc.parentShardId)
+	if !exists || parentMeta.UnsafeBorrow().Split == nil {
 		sc.logger.Error("Parent shard or split metadata not found")
 		return sc
 	}
 
-	sc.leftChildId = parentMeta.Split.ChildShardIds[0]
-	sc.rightChildId = parentMeta.Split.ChildShardIds[1]
-	sc.splitPoint = parentMeta.Split.SplitPoint
+	split := parentMeta.UnsafeBorrow().Split
+	sc.leftChildId = split.ChildShardIds[0]
+	sc.rightChildId = split.ChildShardIds[1]
+	sc.splitPoint = split.SplitPoint
 
 	sc.wg.Go(func() {
 		process.DoWithLabels(
@@ -205,29 +200,23 @@ func (sc *SplitController) driveStateMachine() error {
 }
 
 func (sc *SplitController) currentPhase() (proto.SplitPhase, bool) {
-	status := sc.metadata.GetStatus().UnsafeBorrow()
-	ns, exists := status.Namespaces[sc.namespace]
-	if !exists {
+	parentMeta, exists := sc.metadata.GetShardStatus(sc.namespace, sc.parentShardId)
+	if !exists || parentMeta.UnsafeBorrow().Split == nil {
 		return proto.SplitPhaseBootstrap, false
 	}
-	parentMeta, exists := ns.Shards[sc.parentShardId]
-	if !exists || parentMeta.Split == nil {
-		return proto.SplitPhaseBootstrap, false
-	}
-	return parentMeta.Split.GetPhaseOrDefault(), true
+	return parentMeta.UnsafeBorrow().Split.GetPhaseOrDefault(), true
 }
 
 // updatePhase atomically updates the split phase on both parent and children.
 func (sc *SplitController) updatePhase(newPhase proto.SplitPhase) {
-	status := sc.metadata.GetStatus().UnsafeBorrow()
-	currentNS, exists := status.Namespaces[sc.namespace]
+	currentNS, exists := sc.metadata.GetNamespaceStatus(sc.namespace)
 	if !exists {
 		sc.logger.Warn("namespace status not found while updating split phase",
 			slog.String("namespace", sc.namespace),
 			slog.String("phase", newPhase.String()))
 		return
 	}
-	ns := gproto.Clone(currentNS).(*proto.NamespaceStatus) //nolint:revive
+	ns := gproto.Clone(currentNS.UnsafeBorrow()).(*proto.NamespaceStatus) //nolint:revive
 	changed := false
 	for _, shardId := range []int64{sc.parentShardId, sc.leftChildId, sc.rightChildId} {
 		meta, exists := ns.Shards[shardId]
@@ -675,16 +664,11 @@ func (sc *SplitController) loadParentMeta() *proto.ShardMetadata {
 }
 
 func (sc *SplitController) loadShardMeta(shardId int64) *proto.ShardMetadata {
-	status := sc.metadata.GetStatus().UnsafeBorrow()
-	ns, exists := status.Namespaces[sc.namespace]
+	meta, exists := sc.metadata.GetShardStatus(sc.namespace, shardId)
 	if !exists {
 		return nil
 	}
-	meta, exists := ns.Shards[shardId]
-	if !exists {
-		return nil
-	}
-	return gproto.Clone(meta).(*proto.ShardMetadata) //nolint:revive
+	return gproto.Clone(meta.UnsafeBorrow()).(*proto.ShardMetadata) //nolint:revive
 }
 
 func (sc *SplitController) updateParentMeta(fn func(meta *proto.ShardMetadata)) {
@@ -696,15 +680,14 @@ func (sc *SplitController) updateChildMeta(childId int64, fn func(meta *proto.Sh
 }
 
 func (sc *SplitController) updateShardMeta(shardId int64, fn func(meta *proto.ShardMetadata)) {
-	status := sc.metadata.GetStatus().UnsafeBorrow()
-	ns, exists := status.Namespaces[sc.namespace]
+	ns, exists := sc.metadata.GetNamespaceStatus(sc.namespace)
 	if !exists {
 		sc.logger.Warn("namespace status not found while updating shard metadata",
 			slog.String("namespace", sc.namespace),
 			slog.Int64("shard", shardId))
 		return
 	}
-	meta, exists := ns.Shards[shardId]
+	meta, exists := ns.UnsafeBorrow().Shards[shardId]
 	if !exists {
 		sc.logger.Warn("shard metadata not found while updating shard metadata",
 			slog.String("namespace", sc.namespace),

--- a/oxiad/coordinator/runtime/controller/split_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/split_controller_test.go
@@ -188,6 +188,17 @@ func updateTestStatusShards(t *testing.T, metadata coordmetadata.Metadata, statu
 	}
 }
 
+func loadTestStatus(t *testing.T, metadata coordmetadata.Metadata) *proto.ClusterStatus {
+	t.Helper()
+	status := &proto.ClusterStatus{
+		Namespaces: map[string]*proto.NamespaceStatus{},
+	}
+	for namespace, namespaceStatus := range metadata.ListNamespaceStatus() {
+		status.Namespaces[namespace] = gproto.Clone(namespaceStatus.UnsafeBorrow()).(*proto.NamespaceStatus)
+	}
+	return status
+}
+
 // queueBootstrapResponses queues all responses needed for the bootstrap phase.
 // The *1 nodes report a higher offset so pickLeader deterministically chooses them.
 func queueBootstrapResponses(rpcMock *mockRpcProvider) {
@@ -270,7 +281,7 @@ func TestSplitController_FullLifecycle(t *testing.T) {
 	}
 
 	// Verify final state: parent is Deleting, children have no split metadata
-	status := statusRes.GetStatus().UnsafeBorrow()
+	status := loadTestStatus(t, statusRes)
 	ns := status.Namespaces[constant.DefaultNamespace]
 
 	parentMeta, parentExists := ns.Shards[0]
@@ -318,7 +329,7 @@ func TestSplitController_ResumeFromCatchUp(t *testing.T) {
 
 	// For CatchUp, we need child leaders to already be set (they were set during bootstrap)
 	// Update child metadata to have leaders
-	status := statusRes.GetStatus().UnsafeBorrow()
+	status := loadTestStatus(t, statusRes)
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 	leftMeta := ns.Shards[1]
@@ -371,7 +382,7 @@ func TestSplitController_PhaseTransitions(t *testing.T) {
 	select {
 	case <-listener.completions:
 		// Verify final state: parent marked Deleting, children elected
-		status := statusRes.GetStatus().UnsafeBorrow()
+		status := loadTestStatus(t, statusRes)
 		ns := status.Namespaces[constant.DefaultNamespace]
 
 		parentMeta := ns.Shards[0]
@@ -416,7 +427,7 @@ func TestSplitController_TimeoutDuringBootstrap(t *testing.T) {
 	}
 
 	// Verify: parent.Split cleared, children deleted
-	status := statusRes.GetStatus().UnsafeBorrow()
+	status := loadTestStatus(t, statusRes)
 	ns := status.Namespaces[constant.DefaultNamespace]
 
 	parentMeta, parentExists := ns.Shards[0]
@@ -434,7 +445,7 @@ func TestSplitController_TimeoutDuringCatchUp(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders (as if Bootstrap completed) and ParentTermAtBootstrap
-	status := statusRes.GetStatus().UnsafeBorrow()
+	status := loadTestStatus(t, statusRes)
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -479,7 +490,7 @@ func TestSplitController_TimeoutDuringCatchUp(t *testing.T) {
 	}
 
 	// Verify: parent restored, children deleted
-	finalStatus := statusRes.GetStatus().UnsafeBorrow()
+	finalStatus := loadTestStatus(t, statusRes)
 	finalNs := finalStatus.Namespaces[constant.DefaultNamespace]
 
 	pm, exists := finalNs.Shards[0]
@@ -496,7 +507,7 @@ func TestSplitController_ParentTermChangeDuringCatchUp(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders and ParentTermAtBootstrap = 5
-	status := statusRes.GetStatus().UnsafeBorrow()
+	status := loadTestStatus(t, statusRes)
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -704,7 +715,7 @@ func TestSplitController_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders (as if Bootstrap completed) and ParentTermAtBootstrap
-	status := statusRes.GetStatus().UnsafeBorrow()
+	status := loadTestStatus(t, statusRes)
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -753,7 +764,7 @@ func TestSplitController_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
 	}
 
 	// Verify: parent restored, children deleted
-	finalStatus := statusRes.GetStatus().UnsafeBorrow()
+	finalStatus := loadTestStatus(t, statusRes)
 	finalNs := finalStatus.Namespaces[constant.DefaultNamespace]
 
 	pm, exists := finalNs.Shards[0]
@@ -770,7 +781,7 @@ func TestSplitController_ChildFollowersDeadCommitStalls(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders (as if Bootstrap completed) and ParentTermAtBootstrap
-	status := statusRes.GetStatus().UnsafeBorrow()
+	status := loadTestStatus(t, statusRes)
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -825,7 +836,7 @@ func TestSplitController_ChildFollowersDeadCommitStalls(t *testing.T) {
 	}
 
 	// Verify: parent restored, children deleted
-	finalStatus := statusRes.GetStatus().UnsafeBorrow()
+	finalStatus := loadTestStatus(t, statusRes)
 	finalNs := finalStatus.Namespaces[constant.DefaultNamespace]
 
 	pm, exists := finalNs.Shards[0]
@@ -843,7 +854,7 @@ func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 
 	// Set child leaders and ParentTermAtBootstrap as if Bootstrap completed.
 	// Also set ChildLeadersAtBootstrap with the ORIGINAL leaders.
-	status := statusRes.GetStatus().UnsafeBorrow()
+	status := loadTestStatus(t, statusRes)
 	cloned := gproto.Clone(status).(*proto.ClusterStatus)
 	ns := cloned.Namespaces[constant.DefaultNamespace]
 
@@ -920,7 +931,7 @@ func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 	}
 
 	// Verify parent is Deleting and children are healthy
-	finalStatus := statusRes.GetStatus().UnsafeBorrow()
+	finalStatus := loadTestStatus(t, statusRes)
 	finalNs := finalStatus.Namespaces[constant.DefaultNamespace]
 
 	pm := finalNs.Shards[0]

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -152,7 +152,7 @@ func (c *runtime) SyncShardControllerServerAddresses() {
 
 func (c *runtime) CreateNamespace(name string, namespaceConfig *proto.Namespace) bool {
 	baseShardID := c.metadata.ReserveShardIDs(namespaceConfig.GetInitialShardCount())
-	status := cloneNamespaceStatuses(c.metadata.ListNamespaceStatus())
+	status := c.metadata.ListNamespaceStatus()
 	namespaceStatus := &proto.NamespaceStatus{
 		Shards:            map[int64]*proto.ShardMetadata{},
 		ReplicationFactor: namespaceConfig.GetReplicationFactor(),

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -652,9 +652,6 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 
 	// Persist
 	c.metadata.UpdateNamespaceStatus(namespace, nsCloned)
-	if parentController, exists := c.shardControllers[parentShardId]; exists {
-		parentController.Metadata().Store(parentMetaCloned)
-	}
 
 	c.logger.Info("Split initiated",
 		slog.Int64("parent-shard", parentShardId),

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -152,18 +152,12 @@ func (c *runtime) SyncShardControllerServerAddresses() {
 
 func (c *runtime) CreateNamespace(name string, namespaceConfig *proto.Namespace) bool {
 	baseShardID := c.metadata.ReserveShardIDs(namespaceConfig.GetInitialShardCount())
-	currentStatus := c.metadata.GetStatus().UnsafeBorrow()
+	status := cloneNamespaceStatuses(c.metadata.ListNamespaceStatus())
 	namespaceStatus := &proto.NamespaceStatus{
 		Shards:            map[int64]*proto.ShardMetadata{},
 		ReplicationFactor: namespaceConfig.GetReplicationFactor(),
 	}
-	status := &proto.ClusterStatus{
-		Namespaces: make(map[string]*proto.NamespaceStatus, len(currentStatus.GetNamespaces())+1),
-	}
-	for name, existingNamespaceStatus := range currentStatus.GetNamespaces() {
-		status.Namespaces[name] = existingNamespaceStatus
-	}
-	status.Namespaces[name] = namespaceStatus
+	status[name] = commonobject.Borrow(namespaceStatus)
 
 	for _, shard := range sharding.GenerateShards(baseShardID, namespaceConfig.GetInitialShardCount()) {
 		esm, err := c.selectNewEnsemble(name, shard.Id, namespaceConfig, status)
@@ -259,16 +253,23 @@ func dataServersToCandidatesAndMetadata(dataServers map[string]commonobject.Borr
 	return candidates, metadata
 }
 
+func cloneNamespaceStatuses(namespaces map[string]commonobject.Borrowed[*proto.NamespaceStatus]) map[string]commonobject.Borrowed[*proto.NamespaceStatus] {
+	statuses := make(map[string]commonobject.Borrowed[*proto.NamespaceStatus], len(namespaces))
+	for namespace, status := range namespaces {
+		statuses[namespace] = commonobject.Borrow(pb.Clone(status.UnsafeBorrow()).(*proto.NamespaceStatus))
+	}
+	return statuses
+}
+
 // selectNewEnsemble select a new server ensemble based on namespace policy and current cluster status.
 // It uses the ensemble selector to choose appropriate servers and returns the selected server metadata or an error.
-func (c *runtime) selectNewEnsemble(namespace string, shard int64, ns *proto.Namespace, editingStatus *proto.ClusterStatus) ([]*proto.DataServerIdentity, error) {
+func (c *runtime) selectNewEnsemble(namespace string, shard int64, ns *proto.Namespace, editingStatus map[string]commonobject.Borrowed[*proto.NamespaceStatus]) ([]*proto.DataServerIdentity, error) {
 	dataServers := c.metadata.ListDataServer()
 	nodes, metadata := dataServersToCandidatesAndMetadata(dataServers)
 	ensembleContext := &ensemble.Context{
 		Candidates:         nodes,
 		CandidatesMetadata: metadata,
 		AntiAffinities:     ns.GetAntiAffinities(),
-		Status:             editingStatus,
 		Namespace:          namespace,
 		Shard:              shard,
 		Replicas:           int(ns.GetReplicationFactor()),
@@ -426,13 +427,14 @@ func (c *runtime) handleActionChangeEnsemble(ac action.Action) {
 // This is called while already holding the lock on the coordinator.
 func (c *runtime) computeNewAssignments() {
 	config := c.metadata.GetConfig().UnsafeBorrow()
-	status := c.metadata.GetStatus().UnsafeBorrow()
+	status := c.metadata.ListNamespaceStatus()
 	assignments := &proto.ShardAssignments{
 		Namespaces:         map[string]*proto.NamespaceShardsAssignment{},
 		AllowedAuthorities: mergedAuthorities(status, config.GetServers(), config.GetAllowExtraAuthorities()),
 	}
 	// Update the leader for the shards on all the namespaces
-	for name, ns := range status.Namespaces {
+	for name, borrowedNs := range status {
+		ns := borrowedNs.UnsafeBorrow()
 		nsAssignments := &proto.NamespaceShardsAssignment{
 			Assignments:    make([]*proto.ShardAssignment, 0),
 			ShardKeyRouter: proto.ShardKeyRouter_XXHASH3,
@@ -472,7 +474,7 @@ func (c *runtime) computeNewAssignments() {
 	c.assignmentsWatch.Publish(assignments)
 }
 
-func mergedAuthorities(status *proto.ClusterStatus, servers []*proto.DataServerIdentity, extraAuthorities []string) []string {
+func mergedAuthorities(status map[string]commonobject.Borrowed[*proto.NamespaceStatus], servers []*proto.DataServerIdentity, extraAuthorities []string) []string {
 	authorities := linkedhashset.New[string]()
 	addServerAuthorities := func(public string, internal string) {
 		authorities.Add(public)
@@ -481,7 +483,8 @@ func mergedAuthorities(status *proto.ClusterStatus, servers []*proto.DataServerI
 	for _, server := range servers {
 		addServerAuthorities(server.GetPublic(), server.GetInternal())
 	}
-	for _, namespace := range status.Namespaces {
+	for _, borrowedNamespace := range status {
+		namespace := borrowedNamespace.UnsafeBorrow()
 		for _, shard := range namespace.Shards {
 			for _, server := range shard.Ensemble {
 				addServerAuthorities(server.GetPublic(), server.GetInternal())
@@ -497,7 +500,7 @@ func mergedAuthorities(status *proto.ClusterStatus, servers []*proto.DataServerI
 	return authorities.Values()
 }
 
-func dataServersFromStatus(status *proto.ClusterStatus) []*proto.DataServerIdentity {
+func dataServersFromStatus(status map[string]commonobject.Borrowed[*proto.NamespaceStatus]) []*proto.DataServerIdentity {
 	servers := make(map[string]*proto.DataServerIdentity)
 	addServer := func(server *proto.DataServerIdentity) {
 		if server == nil {
@@ -506,7 +509,8 @@ func dataServersFromStatus(status *proto.ClusterStatus) []*proto.DataServerIdent
 		servers[server.GetNameOrDefault()] = server
 	}
 
-	for _, namespace := range status.Namespaces {
+	for _, borrowedNamespace := range status {
+		namespace := borrowedNamespace.UnsafeBorrow()
 		for _, shard := range namespace.Shards {
 			addServer(shard.Leader)
 			for _, server := range shard.Ensemble {
@@ -534,13 +538,14 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 	c.Lock()
 	defer c.Unlock()
 
-	status := c.metadata.GetStatus().UnsafeBorrow()
+	status := cloneNamespaceStatuses(c.metadata.ListNamespaceStatus())
 
 	// Validate namespace
-	ns, exists := status.Namespaces[namespace]
+	borrowedNs, exists := status[namespace]
 	if !exists {
 		return 0, 0, errors.Errorf("namespace %q not found", namespace)
 	}
+	ns := borrowedNs.UnsafeBorrow()
 
 	// Validate parent shard
 	parentMeta, exists := ns.Shards[parentShardId]
@@ -575,20 +580,18 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 	// Allocate child shard IDs
 	leftChildId := c.metadata.ReserveShardIDs(2)
 	rightChildId := leftChildId + 1
-	cloned := pb.Clone(status).(*proto.ClusterStatus) //nolint:revive
-
 	// Select ensembles for children.
 	// After selecting the left child's ensemble, insert it into the cloned
 	// status so the right child's selection sees the updated load distribution
 	// and picks a different server.
 	nsConfig := c.namespaceConfigForSplit(namespace)
-	leftEnsemble, err := c.selectNewEnsemble(namespace, leftChildId, nsConfig, cloned)
+	leftEnsemble, err := c.selectNewEnsemble(namespace, leftChildId, nsConfig, status)
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "failed to select ensemble for left child")
 	}
 
 	// Update cloned status with left child placement before selecting right child
-	cloned.Namespaces[namespace].Shards[leftChildId] = &proto.ShardMetadata{
+	status[namespace].UnsafeBorrow().Shards[leftChildId] = &proto.ShardMetadata{
 		Status:   proto.ShardStatusSteadyState,
 		Ensemble: leftEnsemble,
 		Int32HashRange: &proto.HashRange{
@@ -596,12 +599,12 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 			Max: sp,
 		},
 	}
-	rightEnsemble, err := c.selectNewEnsemble(namespace, rightChildId, nsConfig, cloned)
+	rightEnsemble, err := c.selectNewEnsemble(namespace, rightChildId, nsConfig, status)
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "failed to select ensemble for right child")
 	}
 
-	nsCloned := cloned.Namespaces[namespace]
+	nsCloned := status[namespace].UnsafeBorrow()
 
 	// Create split metadata for parent
 	parentMetaCloned := nsCloned.Shards[parentShardId]
@@ -645,6 +648,9 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 
 	// Persist
 	c.metadata.UpdateNamespaceStatus(namespace, nsCloned)
+	if parentController, exists := c.shardControllers[parentShardId]; exists {
+		parentController.Metadata().Store(parentMetaCloned)
+	}
 
 	c.logger.Info("Split initiated",
 		slog.Int64("parent-shard", parentShardId),
@@ -669,7 +675,7 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 		RpcProvider:   c.rpc,
 		EventListener: c,
 		EnsembleSelector: func(ns string) ([]*proto.DataServerIdentity, error) {
-			return c.selectNewEnsemble(ns, 0, c.namespaceConfigForSplit(ns), c.metadata.GetStatus().UnsafeBorrow())
+			return c.selectNewEnsemble(ns, 0, c.namespaceConfigForSplit(ns), c.metadata.ListNamespaceStatus())
 		},
 	})
 	c.splitControllers[parentShardId] = sc
@@ -710,9 +716,8 @@ func (c *runtime) SplitComplete(parentShard int64, leftChild int64, rightChild i
 	// during Cutover.
 	if sc, exists := c.shardControllers[parentShard]; exists {
 		// Sync shard controller metadata from the status resource.
-		status := c.metadata.GetStatus().UnsafeBorrow()
-		for _, ns := range status.Namespaces {
-			if parentMeta, ok := ns.Shards[parentShard]; ok {
+		for _, namespaceStatus := range c.metadata.ListNamespaceStatus() {
+			if parentMeta, ok := namespaceStatus.UnsafeBorrow().Shards[parentShard]; ok {
 				sc.Metadata().Store(parentMeta)
 				break
 			}
@@ -761,8 +766,9 @@ func (c *runtime) namespaceConfigForSplit(namespace string) *proto.Namespace {
 
 // restartInProgressSplits checks the cluster status for any shards that have
 // active SplitMetadata and creates SplitControllers to resume them.
-func (c *runtime) restartInProgressSplits(clusterStatus *proto.ClusterStatus) {
-	for ns, shards := range clusterStatus.Namespaces {
+func (c *runtime) restartInProgressSplits(clusterStatus map[string]commonobject.Borrowed[*proto.NamespaceStatus]) {
+	for ns, borrowedShards := range clusterStatus {
+		shards := borrowedShards.UnsafeBorrow()
 		for shardId, meta := range shards.Shards {
 			if meta.Split == nil {
 				continue
@@ -785,7 +791,7 @@ func (c *runtime) restartInProgressSplits(clusterStatus *proto.ClusterStatus) {
 				RpcProvider:   c.rpc,
 				EventListener: c,
 				EnsembleSelector: func(namespace string) ([]*proto.DataServerIdentity, error) {
-					return c.selectNewEnsemble(namespace, 0, c.namespaceConfigForSplit(namespace), c.metadata.GetStatus().UnsafeBorrow())
+					return c.selectNewEnsemble(namespace, 0, c.namespaceConfigForSplit(namespace), c.metadata.ListNamespaceStatus())
 				},
 			})
 			c.splitControllers[shardId] = sc
@@ -823,8 +829,8 @@ func New(
 		},
 	})
 
-	clusterStatus := c.metadata.GetStatus().UnsafeBorrow()
-	c.insID = clusterStatus.InstanceId
+	clusterStatus := c.metadata.ListNamespaceStatus()
+	c.insID = c.metadata.GetInstanceID()
 
 	c.rpc = rpcProvider(c.insID)
 
@@ -842,7 +848,8 @@ func New(
 	}
 
 	// init shard controller
-	for ns, shards := range clusterStatus.Namespaces {
+	for ns, borrowedShards := range clusterStatus {
+		shards := borrowedShards.UnsafeBorrow()
 		for shard := range shards.Shards {
 			shardMetadata := shards.Shards[shard]
 			var nsConfig *proto.Namespace

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -220,6 +220,9 @@ func (c *runtime) RecomputeAssignments() {
 }
 
 func (c *runtime) findDataServerFeatures(dataServers []*proto.DataServerIdentity) map[string][]proto.Feature {
+	c.RLock()
+	defer c.RUnlock()
+
 	features := make(map[string][]proto.Feature)
 	for _, dataServer := range dataServers {
 		dataServerID := dataServer.GetNameOrDefault()

--- a/tests/assignments/leader_hint_test.go
+++ b/tests/assignments/leader_hint_test.go
@@ -59,12 +59,12 @@ func TestLeaderHintWithoutClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow().Namespaces["default"].Shards[0]
+		shard := mock.StatusSnapshot(t, coordinatorInstance.Metadata()).Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 20*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, coordinatorInstance.Metadata())
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -121,12 +121,12 @@ func TestLeaderHintListWithoutClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow().Namespaces["default"].Shards[0]
+		shard := mock.StatusSnapshot(t, coordinatorInstance.Metadata()).Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, coordinatorInstance.Metadata())
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -183,12 +183,12 @@ func TestLeaderHintListWithClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow().Namespaces["default"].Shards[0]
+		shard := mock.StatusSnapshot(t, coordinatorInstance.Metadata()).Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, coordinatorInstance.Metadata())
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -235,12 +235,12 @@ func TestLeaderHintRangeScanWithoutClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow().Namespaces["default"].Shards[0]
+		shard := mock.StatusSnapshot(t, coordinatorInstance.Metadata()).Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, coordinatorInstance.Metadata())
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -297,12 +297,12 @@ func TestLeaderHintRangeScanWithClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow().Namespaces["default"].Shards[0]
+		shard := mock.StatusSnapshot(t, coordinatorInstance.Metadata()).Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, coordinatorInstance.Metadata())
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public
@@ -353,12 +353,12 @@ func TestLeaderHintWithClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		shard := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow().Namespaces["default"].Shards[0]
+		shard := mock.StatusSnapshot(t, coordinatorInstance.Metadata()).Namespaces["default"].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 20*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
-	status := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, coordinatorInstance.Metadata())
 	shard := status.Namespaces["default"].Shards[0]
 	if shard.Leader.GetNameOrDefault() == sa1.GetNameOrDefault() {
 		target = sa2.Public

--- a/tests/control/control_request_test.go
+++ b/tests/control/control_request_test.go
@@ -69,7 +69,7 @@ func TestControlRequestFeatureEnabled(t *testing.T) {
 	assert.NoError(t, err)
 	defer client.Close()
 
-	resource := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
+	resource := mock.StatusSnapshot(t, coordinatorInstance.Metadata())
 	shardMetadata := resource.Namespaces["default"].Shards[0]
 	leader := shardMetadata.Leader
 

--- a/tests/control/record_checksum_test.go
+++ b/tests/control/record_checksum_test.go
@@ -95,7 +95,7 @@ func TestControlRequestRecordChecksum(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Wait for the checksum feature to be enabled on all replicas
-	resource := coordinatorInstance.Metadata().GetStatus().UnsafeBorrow()
+	resource := mock.StatusSnapshot(t, coordinatorInstance.Metadata())
 	shardMetadata := resource.Namespaces["default"].Shards[0]
 	leader := shardMetadata.Leader
 	for _, dataServer := range shardMetadata.Ensemble {

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -38,6 +38,7 @@ import (
 
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	"github.com/oxia-db/oxia/oxiad/dataserver"
+	"github.com/oxia-db/oxia/tests/mock"
 
 	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/oxia"
@@ -87,7 +88,7 @@ func TestCoordinatorE2E(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, metadata)
 
 	assert.EqualValues(t, 1, len(status.Namespaces))
 	nsStatus := status.Namespaces[constant.DefaultNamespace]
@@ -95,7 +96,7 @@ func TestCoordinatorE2E(t *testing.T) {
 	assert.EqualValues(t, 3, nsStatus.ReplicationFactor)
 
 	assert.Eventually(t, func() bool {
-		shard := metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := mock.StatusSnapshot(t, metadata).Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 10*time.Second, 10*time.Millisecond)
 
@@ -127,7 +128,7 @@ func TestCoordinatorE2E_ShardsRanges(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, metadata)
 	nsStatus := status.Namespaces[constant.DefaultNamespace]
 	assert.EqualValues(t, 4, len(nsStatus.Shards))
 	assert.EqualValues(t, 3, nsStatus.ReplicationFactor)
@@ -181,18 +182,18 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, metadata)
 
 	nsStatus := status.Namespaces[constant.DefaultNamespace]
 	assert.EqualValues(t, 1, len(nsStatus.Shards))
 	assert.EqualValues(t, 3, nsStatus.ReplicationFactor)
 
 	assert.Eventually(t, func() bool {
-		shard := metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := mock.StatusSnapshot(t, metadata).Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 10*time.Second, 10*time.Millisecond)
 
-	nsStatus = metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace]
+	nsStatus = mock.StatusSnapshot(t, metadata).Namespaces[constant.DefaultNamespace]
 
 	leader := nsStatus.Shards[0].Leader
 	var follower *proto.DataServerIdentity
@@ -229,7 +230,7 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 	delete(servers, leader.GetNameOrDefault())
 
 	assert.Eventually(t, func() bool {
-		shard := metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := mock.StatusSnapshot(t, metadata).Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 10*time.Second, 10*time.Millisecond)
 
@@ -287,7 +288,7 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, metadata)
 	nsDefaultStatus := status.Namespaces[constant.DefaultNamespace]
 	assert.EqualValues(t, 1, len(nsDefaultStatus.Shards))
 	assert.EqualValues(t, 3, nsDefaultStatus.ReplicationFactor)
@@ -302,7 +303,7 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
+		for _, ns := range mock.StatusSnapshot(t, metadata).Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -380,14 +381,14 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, metadata)
 	ns1Status := status.Namespaces["my-ns-1"]
 	assert.EqualValues(t, 2, len(ns1Status.Shards))
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
+		for _, ns := range mock.StatusSnapshot(t, metadata).Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -398,12 +399,12 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	}, 10*time.Second, 10*time.Millisecond)
 
 	// Trigger new leader election in order to have a new term
-	ns1Status = metadata.GetStatus().UnsafeBorrow().Namespaces["my-ns-1"]
+	ns1Status = mock.StatusSnapshot(t, metadata).Namespaces["my-ns-1"]
 	coordinatorInstance.BecameUnavailable(ns1Status.Shards[0].Leader)
 
 	// Wait (again) for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
+		for _, ns := range mock.StatusSnapshot(t, metadata).Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -433,7 +434,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	metadata = coordinatorInstance.Metadata()
 	// Wait for all shards to be deleted
 	assert.Eventually(t, func() bool {
-		load := metadata.GetStatus().UnsafeBorrow()
+		load := mock.StatusSnapshot(t, metadata)
 		slog.Info("load", slog.Any("load", load))
 		return len(load.Namespaces) == 0
 	}, 10*time.Second, 10*time.Millisecond)
@@ -471,14 +472,14 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 	metadata := coordinatorInstance.Metadata()
-	status := metadata.GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, metadata)
 	ns1Status := status.Namespaces["my-ns-1"]
 	assert.EqualValues(t, 2, len(ns1Status.Shards))
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
+		for _, ns := range mock.StatusSnapshot(t, metadata).Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -505,7 +506,7 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
 		foundNS2 := false
-		for name, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
+		for name, ns := range mock.StatusSnapshot(t, metadata).Namespaces {
 			if name == "my-ns-2" {
 				foundNS2 = true
 			}
@@ -518,11 +519,11 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 		return foundNS2
 	}, 10*time.Second, 10*time.Millisecond)
 
-	ns1Status = metadata.GetStatus().UnsafeBorrow().Namespaces["my-ns-1"]
+	ns1Status = mock.StatusSnapshot(t, metadata).Namespaces["my-ns-1"]
 	assert.EqualValues(t, 2, len(ns1Status.Shards))
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
-	ns2Status := metadata.GetStatus().UnsafeBorrow().Namespaces["my-ns-2"]
+	ns2Status := mock.StatusSnapshot(t, metadata).Namespaces["my-ns-2"]
 	assert.EqualValues(t, 2, len(ns2Status.Shards))
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
@@ -631,7 +632,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
+		for _, ns := range mock.StatusSnapshot(t, metadata).Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -644,7 +645,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	assert.Equal(t, 4, len(c.ListDataServer()))
 
 	// Remove leader dataserver
-	leaderID := metadata.GetStatus().UnsafeBorrow().Namespaces["my-ns-1"].Shards[0].Leader.GetNameOrDefault()
+	leaderID := mock.StatusSnapshot(t, metadata).Namespaces["my-ns-1"].Shards[0].Leader.GetNameOrDefault()
 	d := make([]*proto.DataServerIdentity, 0)
 	for _, sv := range clusterConfig.Servers {
 		if sv.GetNameOrDefault() != leaderID {
@@ -665,7 +666,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 
 	// Wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
+		for _, ns := range mock.StatusSnapshot(t, metadata).Namespaces {
 			for _, shard := range ns.Shards {
 				return shard.Term > 0 && shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 			}
@@ -709,7 +710,7 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	metadata := c.Metadata()
 	// wait for all shards to be ready
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
+		for _, ns := range mock.StatusSnapshot(t, metadata).Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false
@@ -738,7 +739,7 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		for _, ns := range metadata.GetStatus().UnsafeBorrow().Namespaces {
+		for _, ns := range mock.StatusSnapshot(t, metadata).Namespaces {
 			for _, shard := range ns.Shards {
 				if shard.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 					return false

--- a/tests/coordinator/coordinator_test.go
+++ b/tests/coordinator/coordinator_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	metadata2 "github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
+	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func TestCoordinatorInitiateLeaderElection(t *testing.T) {
@@ -65,6 +66,6 @@ func TestCoordinatorInitiateLeaderElection(t *testing.T) {
 	metadataView := coordinatorInstance.Metadata()
 	metadataView.UpdateShardStatus("default", 1, shardMetadata)
 
-	status := metadataView.GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, metadataView)
 	assert.True(t, gproto.Equal(status.Namespaces["default"].Shards[1], shardMetadata))
 }

--- a/tests/coordinator/split_e2e_test.go
+++ b/tests/coordinator/split_e2e_test.go
@@ -45,6 +45,7 @@ import (
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
 	"github.com/oxia-db/oxia/oxiad/dataserver"
+	"github.com/oxia-db/oxia/tests/mock"
 )
 
 func TestCoordinator_ShardSplit(t *testing.T) {
@@ -77,7 +78,7 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 
 	// Wait for initial shard to be in steady state
 	require.Eventually(t, func() bool {
-		shard := metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := mock.StatusSnapshot(t, metadata).Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 30*time.Second, 100*time.Millisecond)
 
@@ -114,7 +115,7 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 	// Wait for split to complete: parent shard (0) should be removed,
 	// and both children should be in steady state with leaders.
 	require.Eventually(t, func() bool {
-		status := metadata.GetStatus().UnsafeBorrow()
+		status := mock.StatusSnapshot(t, metadata)
 		ns, ok := status.Namespaces[constant.DefaultNamespace]
 		if !ok {
 			t.Log("Namespace not found in status")
@@ -173,7 +174,7 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 	slog.Info("Split complete")
 
 	// Verify hash ranges: children should cover the entire original range
-	status := metadata.GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, metadata)
 	ns := status.Namespaces[constant.DefaultNamespace]
 	leftMeta := ns.Shards[leftChild]
 	rightMeta := ns.Shards[rightChild]
@@ -344,7 +345,7 @@ func setupSplitCluster(t *testing.T) *splitTestCluster {
 
 	metadata := coordinatorInstance.Metadata()
 	require.Eventually(t, func() bool {
-		shard := metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := mock.StatusSnapshot(t, metadata).Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 	}, 30*time.Second, 100*time.Millisecond)
 	slog.Info("Initial cluster is ready")
@@ -372,7 +373,7 @@ func (c *splitTestCluster) splitAndWait(t *testing.T) {
 	)
 
 	require.Eventually(t, func() bool {
-		status := c.metadata.GetStatus().UnsafeBorrow()
+		status := mock.StatusSnapshot(t, c.metadata)
 		ns := status.Namespaces[constant.DefaultNamespace]
 		if _, parentExists := ns.Shards[0]; parentExists {
 			return false
@@ -386,7 +387,7 @@ func (c *splitTestCluster) splitAndWait(t *testing.T) {
 		return true
 	}, 60*time.Second, 500*time.Millisecond)
 
-	status := c.metadata.GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, c.metadata)
 	ns := status.Namespaces[constant.DefaultNamespace]
 	c.leftMeta = ns.Shards[c.leftChild]
 	c.rightMeta = ns.Shards[c.rightChild]
@@ -900,7 +901,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 			coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
 
 			metadata := coordinatorInstance.Metadata()
-			status := metadata.GetStatus().UnsafeBorrow()
+			status := mock.StatusSnapshot(t, metadata)
 
 			assert.EqualValues(t, 1, len(status.Namespaces))
 			nsStatus := status.Namespaces[constant.DefaultNamespace]
@@ -908,7 +909,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 			assert.EqualValues(t, 1, nsStatus.ReplicationFactor)
 
 			assert.Eventually(t, func() bool {
-				shard := metadata.GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
+				shard := mock.StatusSnapshot(t, metadata).Namespaces[constant.DefaultNamespace].Shards[0]
 				return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 			}, 10*time.Second, 10*time.Millisecond)
 
@@ -943,7 +944,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 func waitForSplitPhase(t *testing.T, metadata coordmetadata.Metadata, parentShardId int64, phase proto.SplitPhase, timeout time.Duration) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		status := metadata.GetStatus().UnsafeBorrow()
+		status := mock.StatusSnapshot(t, metadata)
 		ns := status.Namespaces[constant.DefaultNamespace]
 		parentMeta, exists := ns.Shards[parentShardId]
 		if !exists || parentMeta.Split == nil {
@@ -971,7 +972,7 @@ func TestCoordinator_ShardSplit_ParentLeaderKillDuringSplit(t *testing.T) {
 	assert.NoError(t, client.Close())
 
 	// Find the parent leader before initiating the split
-	status := cluster.metadata.GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, cluster.metadata)
 	parentLeader := status.Namespaces[constant.DefaultNamespace].Shards[0].Leader
 	slog.Info("Parent leader identified", slog.Any("leader", parentLeader))
 
@@ -996,7 +997,7 @@ func TestCoordinator_ShardSplit_ParentLeaderKillDuringSplit(t *testing.T) {
 	slog.Info("Waiting for split to complete after parent leader kill")
 
 	require.Eventually(t, func() bool {
-		st := cluster.metadata.GetStatus().UnsafeBorrow()
+		st := mock.StatusSnapshot(t, cluster.metadata)
 		ns := st.Namespaces[constant.DefaultNamespace]
 		if _, parentExists := ns.Shards[0]; parentExists {
 			return false
@@ -1053,7 +1054,7 @@ func TestCoordinator_ShardSplit_FollowerKillDuringSplit(t *testing.T) {
 	assert.NoError(t, client.Close())
 
 	// Find a follower (non-leader) server
-	status := cluster.metadata.GetStatus().UnsafeBorrow()
+	status := mock.StatusSnapshot(t, cluster.metadata)
 	parentMeta := status.Namespaces[constant.DefaultNamespace].Shards[0]
 	parentLeader := parentMeta.Leader
 	follower := cluster.liveAddressExcluding(parentLeader.GetNameOrDefault())
@@ -1073,7 +1074,7 @@ func TestCoordinator_ShardSplit_FollowerKillDuringSplit(t *testing.T) {
 	// indefinitely (can't reach the dead node). So we accept the parent
 	// being either fully deleted OR marked Deleting with split metadata cleared.
 	require.Eventually(t, func() bool {
-		st := cluster.metadata.GetStatus().UnsafeBorrow()
+		st := mock.StatusSnapshot(t, cluster.metadata)
 		ns := st.Namespaces[constant.DefaultNamespace]
 		if parentMeta, parentExists := ns.Shards[0]; parentExists {
 			if parentMeta.GetStatusOrDefault() != proto.ShardStatusDeleting {
@@ -1135,7 +1136,7 @@ func TestCoordinator_ShardSplit_ConcurrentSplitRejected(t *testing.T) {
 
 	// First split should still complete
 	require.Eventually(t, func() bool {
-		st := cluster.metadata.GetStatus().UnsafeBorrow()
+		st := mock.StatusSnapshot(t, cluster.metadata)
 		ns := st.Namespaces[constant.DefaultNamespace]
 		if _, parentExists := ns.Shards[0]; parentExists {
 			return false

--- a/tests/mock/metadata.go
+++ b/tests/mock/metadata.go
@@ -89,6 +89,21 @@ func NewMetadataFromProviders(
 	return metadataFactory, metadata
 }
 
+func StatusSnapshot(t *testing.T, metadata coordmetadata.Metadata) *proto.ClusterStatus {
+	t.Helper()
+
+	status := &proto.ClusterStatus{
+		InstanceId: metadata.GetInstanceID(),
+		Namespaces: map[string]*proto.NamespaceStatus{},
+	}
+	for namespace, namespaceStatus := range metadata.ListNamespaceStatus() {
+		cloned, ok := gproto.Clone(namespaceStatus.UnsafeBorrow()).(*proto.NamespaceStatus)
+		require.True(t, ok)
+		status.Namespaces[namespace] = cloned
+	}
+	return status
+}
+
 func mirrorProviderToFile[T interface {
 	gproto.Message
 	*proto.ClusterStatus | *proto.ClusterConfiguration

--- a/tests/resolver/target_ip_flip_test.go
+++ b/tests/resolver/target_ip_flip_test.go
@@ -86,7 +86,7 @@ func newCoordinatorCluster(t *testing.T, prefix string, serverCount int) *testCl
 	cluster.coordinator = newCoordinatorInstance(t, metadataProvider, configProvider, coordinatorrpc.NewRpcProviderFactory(nil))
 
 	require.Eventually(t, func() bool {
-		shard := cluster.coordinator.Metadata().GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0]
+		shard := mock.StatusSnapshot(t, cluster.coordinator.Metadata()).Namespaces[constant.DefaultNamespace].Shards[0]
 		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState && shard.Leader != nil
 	}, 20*time.Second, 100*time.Millisecond)
 
@@ -112,7 +112,8 @@ func (c *testCluster) stopAllServers(t *testing.T) {
 }
 
 func (c *testCluster) leader() *proto.DataServerIdentity {
-	return c.coordinator.Metadata().GetStatus().UnsafeBorrow().Namespaces[constant.DefaultNamespace].Shards[0].Leader
+	shard, _ := c.coordinator.Metadata().GetShardStatus(constant.DefaultNamespace, 0)
+	return shard.UnsafeBorrow().Leader
 }
 
 func (c *testCluster) bootstrapTargetExcluding(excluded *proto.DataServerIdentity) *proto.DataServerIdentity {


### PR DESCRIPTION
## Motivation
- Keep coordinator metadata callers on domain-specific APIs instead of exposing the full borrowed cluster status object.
- Make status calculations consume namespace/shard level data, so callers do not need direct access to `ClusterStatus` for routine placement, leader, split, or assignment logic.

## Modifications
- Removed `Metadata.GetStatus()` and added focused accessors for instance ID and shard status lookup.
- Reworked runtime, split/shard controllers, balancer selectors, and assignment calculations to use namespace or shard status APIs instead of direct cluster status access.
- Kept test-only full-status reconstruction in `tests/mock.StatusSnapshot` for assertions that still need a cluster-shaped snapshot.
- Filtered balancer calculations to steady, non-splitting shards and synced parent shard controller metadata when a split starts to avoid clobbering split state.

## Testing
- `make lint`
- `go test ./oxiad/coordinator/...`
- `go test ./tests/resolver ./tests/assignments ./tests/balancer ./tests/control`
- Known pre-existing/adjacent issue observed while validating: `go test ./tests/coordinator -run TestCoordinator_ShardSplit_ConcurrentSplitRejected -count=1 -timeout 4m` times out waiting for split completion after parent cutover.
