### PR TITLE
fix: use default pebble memtable size

### DIFF
--- a/oxiad/dataserver/database/kvstore/kv_pebble.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble.go
@@ -239,12 +239,11 @@ func newKVPebble(factory *PebbleFactory, namespace string, shardId int64, keySor
 		slog.Int64("shard", shardId),
 	)
 	pbOptions := &pebble.Options{
-		Cache:        factory.cache,
-		MemTableSize: 32 * 1024 * 1024,
-		Levels:       levelOptions,
-		FS:           vfs.Default,
-		DisableWAL:   !factory.options.UseWAL,
-		Logger:       &pebbleLogger{log},
+		Cache:      factory.cache,
+		Levels:     levelOptions,
+		FS:         vfs.Default,
+		DisableWAL: !factory.options.UseWAL,
+		Logger:     &pebbleLogger{log},
 
 		FormatMajorVersion: pebble.FormatVirtualSSTables,
 	}


### PR DESCRIPTION
## Motivation
- Avoid wasting memory in multi-shard deployments where each shard owns a Pebble DB.
- A fixed 32 MiB memtable per shard can grow total memory usage quickly and risks OOM as shard count increases.
- Coordinator-driven memtable sizing can be added later as a separate rule-based configuration path.

## Modifications
- Remove the explicit 32 MiB Pebble `MemTableSize` override.
- Let Pebble use its default memtable size.

## Testing
- `go test ./oxiad/dataserver/database/kvstore`
