### PR TITLE
fix: strip schemes from shard assignment authorities (release-0.16)

### DIFF
--- a/oxiad/common/rpc/authority.go
+++ b/oxiad/common/rpc/authority.go
@@ -36,6 +36,14 @@ func GetAuthority(ctx context.Context) (string, error) {
 	return "", errors.New("authority not identified")
 }
 
+func StripAuthorityScheme(authority string) string {
+	_, addr, found := strings.Cut(authority, "://")
+	if found {
+		return addr
+	}
+	return authority
+}
+
 func ValidateAuthorityAddress(addr string) error {
 	if strings.Contains(addr, "://") {
 		return errors.Errorf("authority address %q must not contain a scheme", addr)

--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -41,6 +41,7 @@ import (
 	"github.com/oxia-db/oxia/common/concurrent"
 	"github.com/oxia-db/oxia/common/process"
 	"github.com/oxia-db/oxia/common/proto"
+	oxiadcommonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
 )
 
 type Coordinator interface {
@@ -437,8 +438,8 @@ func (c *coordinator) computeNewAssignments() {
 func mergedAuthorities(status *model.ClusterStatus, servers []model.Server, extraAuthorities []string) []string {
 	authorities := linkedhashset.New[string]()
 	addServerAuthorities := func(server model.Server) {
-		authorities.Add(server.Public)
-		authorities.Add(server.Internal)
+		authorities.Add(oxiadcommonrpc.StripAuthorityScheme(server.Public))
+		authorities.Add(oxiadcommonrpc.StripAuthorityScheme(server.Internal))
 	}
 	for _, server := range servers {
 		addServerAuthorities(server)
@@ -454,7 +455,7 @@ func mergedAuthorities(status *model.ClusterStatus, servers []model.Server, extr
 		}
 	}
 	for _, authority := range extraAuthorities {
-		authorities.Add(authority)
+		authorities.Add(oxiadcommonrpc.StripAuthorityScheme(authority))
 	}
 	return authorities.Values()
 }

--- a/oxiad/coordinator/coordinator_authority_test.go
+++ b/oxiad/coordinator/coordinator_authority_test.go
@@ -29,8 +29,8 @@ import (
 
 func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 	leader := model.Server{
-		Public:   "leader-public:6648",
-		Internal: "leader-internal:6649",
+		Public:   "tls://leader-public:6648",
+		Internal: "tls://leader-internal:6649",
 	}
 
 	statusResource := resource.NewStatusResource(metadata.NewMetadataProviderMemory())
@@ -61,7 +61,7 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 		}},
 		Servers: []model.Server{leader},
 		AllowExtraAuthorities: []string{
-			"bootstrap:6648",
+			"tls://bootstrap:6648",
 			leader.Public,
 		},
 	}
@@ -81,6 +81,7 @@ func TestComputeNewAssignmentsIncludesExtraAuthorities(t *testing.T) {
 	nsAssignments, ok := c.assignments.Namespaces["default"]
 	require.True(t, ok)
 	require.Len(t, nsAssignments.Assignments, 1)
+	assert.Equal(t, "tls://leader-public:6648", nsAssignments.Assignments[0].Leader)
 	assert.Equal(t,
 		[]string{"leader-public:6648", "leader-internal:6649", "bootstrap:6648"},
 		c.assignments.AllowedAuthorities,
@@ -93,8 +94,8 @@ func TestComputeNewAssignmentsKeepsRemovedShardNodeAuthorities(t *testing.T) {
 		Internal: "active-internal:6649",
 	}
 	removed := model.Server{
-		Public:   "removed-public:6648",
-		Internal: "removed-internal:6649",
+		Public:   "tls://removed-public:6648",
+		Internal: "tls://removed-internal:6649",
 	}
 
 	statusResource := resource.NewStatusResource(metadata.NewMetadataProviderMemory())

--- a/oxiad/dataserver/assignment/authority_test.go
+++ b/oxiad/dataserver/assignment/authority_test.go
@@ -100,3 +100,8 @@ func TestValidateAuthorityAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestStripAuthorityScheme(t *testing.T) {
+	assert.Equal(t, "example.com:6648", rpc2.StripAuthorityScheme("tls://example.com:6648"))
+	assert.Equal(t, "example.com:6648", rpc2.StripAuthorityScheme("example.com:6648"))
+}


### PR DESCRIPTION
## Motivation
- Backport #1124 to `release-0.16` because it is labeled `release/0.16`.
- Dataserver authority validation expects plain `host:port`; scheme-prefixed allowed authorities can reject valid client authorities.

## Modifications
- Cherry-pick `6774eb7233e63eeea9af6bd399fcf73173bb7e15` onto `release-0.16`.
- Add `StripAuthorityScheme` and strip schemes from generated allowed authorities.
- Adapt the coordinator-side change to the `release-0.16` layout, where assignment logic lives in `oxiad/coordinator/coordinator.go`.

## Testing
- `go test ./oxiad/dataserver/assignment ./oxiad/coordinator`