### PR TITLE
fix: use default pebble memtable size (release-0.16)

### DIFF
--- a/oxiad/dataserver/database/kvstore/kv_pebble.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble.go
@@ -239,12 +239,11 @@ func newKVPebble(factory *PebbleFactory, namespace string, shardId int64, keySor
 		slog.Int64("shard", shardId),
 	)
 	pbOptions := &pebble.Options{
-		Cache:        factory.cache,
-		MemTableSize: 32 * 1024 * 1024,
-		Levels:       levelOptions,
-		FS:           vfs.Default,
-		DisableWAL:   !factory.options.UseWAL,
-		Logger:       &pebbleLogger{log},
+		Cache:      factory.cache,
+		Levels:     levelOptions,
+		FS:         vfs.Default,
+		DisableWAL: !factory.options.UseWAL,
+		Logger:     &pebbleLogger{log},
 
 		FormatMajorVersion: pebble.FormatVirtualSSTables,
 	}


### PR DESCRIPTION
## Motivation
- Backport #1123 to `release-0.16` because it is labeled `release/0.16`.
- Avoid wasting memory in multi-shard deployments where each shard owns a Pebble DB.

## Modifications
- Cherry-pick `fbe85f4fcd9a9559fc78f4201c5849d850e5ce72` onto `release-0.16`.
- Remove the explicit 32 MiB Pebble `MemTableSize` override so Pebble uses its default.

## Testing
- `go test ./oxiad/dataserver/database/kvstore`