### PR TITLE
ci: run PR build on release branches

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -18,9 +18,11 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-*'
   push:
     branches:
       - main
+      - 'release-*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Motivation
- Backport PRs targeting `release-0.16` currently do not run the Build workflow.
- The workflow only listens for pull requests and pushes on `main`, so release branch PRs only show non-workflow checks such as DCO.

## Modifications
- Add `release-*` to the `pull_request` branch filter.
- Add `release-*` to the `push` branch filter.

## Testing
- `git diff --check`
- Not run through GitHub Actions yet because this workflow change must first exist on the `release-0.16` base branch.`