### PR TITLE
ci: run PR build for release branches

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -18,6 +18,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Motivation
- The Build workflow on `main` only listens for PRs targeting `main`.
- Future release branches should inherit PR CI support for `release-*` targets from `main`.

## Modifications
- Add `release-*` to the `pull_request` branch filter in `.github/workflows/pr_build_and_test.yaml`.

## Testing
- `git diff --check`