### PR TITLE
fix: backport stale grpc connection refresh

### DIFF
--- a/cmd/health/cmd.go
+++ b/cmd/health/cmd.go
@@ -65,14 +65,14 @@ func init() {
 
 func exec(*cobra.Command, []string) error {
 	clientPool := rpc.NewClientPool(nil, nil)
+	defer clientPool.Close()
 
 	serverAddress := fmt.Sprintf("%s:%d", config.Host, config.Port)
 
-	client, closer, err := clientPool.GetHealthRpc(serverAddress)
+	client, err := clientPool.GetHealthRpc(serverAddress)
 	if err != nil {
 		return err
 	}
-	defer closer.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 	defer cancel()

--- a/common/rpc/client_pool.go
+++ b/common/rpc/client_pool.go
@@ -19,17 +19,11 @@ import (
 	"crypto/tls"
 	"io"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
-	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
 
 	"github.com/oxia-db/oxia/common/auth"
@@ -38,27 +32,19 @@ import (
 
 const DefaultRpcTimeout = 30 * time.Second
 const AddressSchemaTLS = "tls://"
-const (
-	defaultGrpcClientKeepAliveTime       = time.Second * 10
-	defaultGrpcClientKeepAliveTimeout    = time.Second * 5
-	defaultGrpcClientPermitWithoutStream = true
-)
 
 type ClientPool interface {
 	io.Closer
 	GetClientRpc(target string) (proto.OxiaClientClient, error)
-	GetHealthRpc(target string) (grpc_health_v1.HealthClient, io.Closer, error)
+	GetHealthRpc(target string) (grpc_health_v1.HealthClient, error)
 	GetCoordinationRpc(target string) (proto.OxiaCoordinationClient, error)
 	GetReplicationRpc(target string) (proto.OxiaLogReplicationClient, error)
 	GetAminRpc(target string) (proto.OxiaAdminClient, error)
-
-	// Clear all the pooled client instances for the given target
-	Clear(target string)
 }
 
 type clientPool struct {
 	sync.RWMutex
-	connections map[string]*grpc.ClientConn
+	connections map[string]*connection
 
 	tls            *tls.Config
 	authentication auth.Authentication
@@ -76,7 +62,7 @@ func (cp *clientPool) GetAminRpc(target string) (proto.OxiaAdminClient, error) {
 
 func NewClientPool(tlsConf *tls.Config, authentication auth.Authentication, dialOptions ...grpc.DialOption) ClientPool {
 	return &clientPool{
-		connections:    make(map[string]*grpc.ClientConn),
+		connections:    make(map[string]*connection),
 		tls:            tlsConf,
 		authentication: authentication,
 		dialOptions:    dialOptions,
@@ -103,14 +89,13 @@ func (cp *clientPool) Close() error {
 	return nil
 }
 
-func (cp *clientPool) GetHealthRpc(target string) (grpc_health_v1.HealthClient, io.Closer, error) {
-	// Skip the pooling for health-checks
-	cnx, err := cp.newConnection(target)
+func (cp *clientPool) GetHealthRpc(target string) (grpc_health_v1.HealthClient, error) {
+	cnx, err := cp.getConnectionFromPool(target)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return grpc_health_v1.NewHealthClient(cnx), cnx, nil
+	return grpc_health_v1.NewHealthClient(cnx), nil
 }
 
 func (cp *clientPool) GetClientRpc(target string) (proto.OxiaClientClient, error) {
@@ -140,23 +125,6 @@ func (cp *clientPool) GetReplicationRpc(target string) (proto.OxiaLogReplication
 	return proto.NewOxiaLogReplicationClient(cnx), nil
 }
 
-func (cp *clientPool) Clear(target string) {
-	cp.Lock()
-	defer cp.Unlock()
-
-	if cnx, ok := cp.connections[target]; ok {
-		if err := cnx.Close(); err != nil {
-			cp.log.Warn(
-				"Failed to close GRPC connection",
-				slog.String("server_address", target),
-				slog.Any("error", err),
-			)
-		}
-
-		delete(cp.connections, target)
-	}
-}
-
 func (cp *clientPool) getConnectionFromPool(target string) (grpc.ClientConnInterface, error) {
 	cp.RLock()
 	cnx, ok := cp.connections[target]
@@ -173,7 +141,13 @@ func (cp *clientPool) getConnectionFromPool(target string) (grpc.ClientConnInter
 		return cnx, nil
 	}
 
-	cnx, err := cp.newConnection(target)
+	cnx, err := newConnection(
+		target,
+		cp.tls,
+		cp.authentication,
+		cp.dialOptions,
+		cp.removeConnection,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -181,54 +155,25 @@ func (cp *clientPool) getConnectionFromPool(target string) (grpc.ClientConnInter
 	return cnx, nil
 }
 
-func (cp *clientPool) newConnection(target string) (*grpc.ClientConn, error) {
-	cp.log.Debug(
-		"Creating new GRPC connection",
-		slog.String("server_address", target),
-	)
-
-	tcs := cp.getTransportCredential(target)
-
-	options := []grpc.DialOption{
-		grpc.WithTransportCredentials(tcs),
-		grpc.WithStreamInterceptor(grpcprometheus.StreamClientInterceptor),
-		grpc.WithUnaryInterceptor(grpcprometheus.UnaryClientInterceptor),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			PermitWithoutStream: defaultGrpcClientPermitWithoutStream,
-			Time:                defaultGrpcClientKeepAliveTime,
-			Timeout:             defaultGrpcClientKeepAliveTimeout,
-		}),
+func (cp *clientPool) removeConnection(target string) {
+	cp.Lock()
+	cnx, ok := cp.connections[target]
+	if ok {
+		delete(cp.connections, target)
 	}
-	if cp.authentication != nil {
-		options = append(options, grpc.WithPerRPCCredentials(cp.authentication))
-	}
-	options = append(options, cp.dialOptions...)
+	cp.Unlock()
 
-	cnx, err := grpc.NewClient(cp.getActualAddress(target), options...)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error connecting to %s", target)
+	if !ok {
+		return
 	}
 
-	return cnx, nil
-}
-
-func (*clientPool) getActualAddress(target string) string {
-	if strings.HasPrefix(target, AddressSchemaTLS) {
-		after, _ := strings.CutPrefix(target, AddressSchemaTLS)
-		return after
+	if err := cnx.Close(); err != nil {
+		cp.log.Warn(
+			"Failed to close GRPC connection",
+			slog.String("server_address", target),
+			slog.Any("error", err),
+		)
 	}
-	return target
-}
-
-func (cp *clientPool) getTransportCredential(target string) credentials.TransportCredentials {
-	tcs := insecure.NewCredentials()
-	if strings.HasPrefix(target, AddressSchemaTLS) {
-		tcs = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
-	}
-	if cp.tls != nil {
-		tcs = credentials.NewTLS(cp.tls)
-	}
-	return tcs
 }
 
 func GetPeer(ctx context.Context) string {

--- a/common/rpc/client_pool_test.go
+++ b/common/rpc/client_pool_test.go
@@ -15,29 +15,207 @@
 package rpc
 
 import (
+	"context"
+	"net"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-func TestClientPool_GetActualAddress(t *testing.T) {
-	pool := NewClientPool(nil, nil)
-	poolInstance := pool.(*clientPool)
+func TestClientPool_RemovesConnectionAfterHealthTimeout(t *testing.T) {
+	_, _, target := newTestHealthServer(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 
-	address := poolInstance.getActualAddress("tls://xxxxaa:6648")
-	assert.Equal(t, "xxxxaa:6648", address)
+	pool := NewClientPool(nil, nil).(*clientPool)
+	defer pool.Close()
 
-	actualAddress := poolInstance.getActualAddress("xxxxaaa:6649")
-	assert.Equal(t, "xxxxaaa:6649", actualAddress)
+	conn, err := newTestConnectionWithHealthConfig(pool, target,
+		10*time.Millisecond, 10*time.Millisecond, 50*time.Millisecond)
+	require.NoError(t, err)
+
+	pool.Lock()
+	pool.connections[target] = conn
+	pool.Unlock()
+
+	require.Eventually(t, func() bool {
+		pool.RLock()
+		defer pool.RUnlock()
+		_, ok := pool.connections[target]
+		return !ok
+	}, time.Second, 10*time.Millisecond)
 }
 
-func TestClientPool_GetTransportCredential(t *testing.T) {
-	pool := NewClientPool(nil, nil)
-	poolInstance := pool.(*clientPool)
+func TestClientPool_RemovesConnectionWhenHealthPingHangs(t *testing.T) {
+	_, target := newTestBlockingHealthServer(t)
 
-	credential := poolInstance.getTransportCredential("tls://xxxxaa:6648")
-	assert.Equal(t, "tls", credential.Info().SecurityProtocol)
+	pool := NewClientPool(nil, nil).(*clientPool)
+	defer pool.Close()
 
-	credential = poolInstance.getTransportCredential("xxxxaaa:6649")
-	assert.Equal(t, "insecure", credential.Info().SecurityProtocol)
+	conn, err := newTestConnectionWithHealthConfig(pool, target,
+		10*time.Millisecond, 10*time.Millisecond, 50*time.Millisecond)
+	require.NoError(t, err)
+
+	pool.Lock()
+	pool.connections[target] = conn
+	pool.Unlock()
+
+	require.Eventually(t, func() bool {
+		pool.RLock()
+		defer pool.RUnlock()
+		_, ok := pool.connections[target]
+		return !ok
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestClientPool_KeepsConnectionWhenHealthRecoversBeforeTimeout(t *testing.T) {
+	_, healthServer, target := newTestHealthServer(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	pool := NewClientPool(nil, nil).(*clientPool)
+	defer pool.Close()
+
+	conn, err := newTestConnectionWithHealthConfig(pool, target,
+		10*time.Millisecond, 10*time.Millisecond, 200*time.Millisecond)
+	require.NoError(t, err)
+
+	pool.Lock()
+	pool.connections[target] = conn
+	pool.Unlock()
+
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	require.Never(t, func() bool {
+		pool.RLock()
+		defer pool.RUnlock()
+		return pool.connections[target] != conn
+	}, 250*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestClientPool_KeepsConnectionWhenHealthCheckIsUnsupported(t *testing.T) {
+	_, target := newTestGrpcServerWithoutHealth(t)
+
+	pool := NewClientPool(nil, nil).(*clientPool)
+	defer pool.Close()
+
+	conn, err := newTestConnectionWithHealthConfig(pool, target,
+		10*time.Millisecond, 10*time.Millisecond, 50*time.Millisecond)
+	require.NoError(t, err)
+
+	pool.Lock()
+	pool.connections[target] = conn
+	pool.Unlock()
+
+	require.Never(t, func() bool {
+		pool.RLock()
+		defer pool.RUnlock()
+		return pool.connections[target] != conn
+	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func newTestConnectionWithHealthConfig(
+	pool *clientPool,
+	target string,
+	healthInterval time.Duration,
+	healthPingTimeout time.Duration,
+	healthTimeout time.Duration,
+) (*connection, error) {
+	return newConnectionWithHealthConfig(
+		target,
+		pool.tls,
+		pool.authentication,
+		pool.dialOptions,
+		pool.removeConnection,
+		healthInterval,
+		healthPingTimeout,
+		healthTimeout,
+	)
+}
+
+func newTestHealthServer(
+	t *testing.T,
+	status grpc_health_v1.HealthCheckResponse_ServingStatus,
+) (*grpc.Server, *health.Server, string) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", status)
+
+	server := grpc.NewServer()
+	grpc_health_v1.RegisterHealthServer(server, healthServer)
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		server.Stop()
+	})
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	healthClient := grpc_health_v1.NewHealthClient(conn)
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		_, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
+	require.NoError(t, conn.Close())
+
+	return server, healthServer, listener.Addr().String()
+}
+
+type blockingHealthServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+}
+
+func (*blockingHealthServer) Check(
+	ctx context.Context,
+	_ *grpc_health_v1.HealthCheckRequest,
+) (*grpc_health_v1.HealthCheckResponse, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func newTestBlockingHealthServer(t *testing.T) (*grpc.Server, string) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	grpc_health_v1.RegisterHealthServer(server, &blockingHealthServer{})
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		server.Stop()
+	})
+
+	return server, listener.Addr().String()
+}
+
+func newTestGrpcServerWithoutHealth(t *testing.T) (*grpc.Server, string) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		server.Stop()
+	})
+
+	return server, listener.Addr().String()
 }

--- a/common/rpc/client_pool_test.go
+++ b/common/rpc/client_pool_test.go
@@ -27,14 +27,14 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-func TestClientPool_RemovesConnectionAfterHealthTimeout(t *testing.T) {
+func TestClientPool_RemovesConnectionAfterHealthFailure(t *testing.T) {
 	_, _, target := newTestHealthServer(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 
 	pool := NewClientPool(nil, nil).(*clientPool)
 	defer pool.Close()
 
 	conn, err := newTestConnectionWithHealthConfig(pool, target,
-		10*time.Millisecond, 10*time.Millisecond, 50*time.Millisecond)
+		10*time.Millisecond, 10*time.Millisecond)
 	require.NoError(t, err)
 
 	pool.Lock()
@@ -56,7 +56,7 @@ func TestClientPool_RemovesConnectionWhenHealthPingHangs(t *testing.T) {
 	defer pool.Close()
 
 	conn, err := newTestConnectionWithHealthConfig(pool, target,
-		10*time.Millisecond, 10*time.Millisecond, 50*time.Millisecond)
+		10*time.Millisecond, 10*time.Millisecond)
 	require.NoError(t, err)
 
 	pool.Lock()
@@ -71,21 +71,20 @@ func TestClientPool_RemovesConnectionWhenHealthPingHangs(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
-func TestClientPool_KeepsConnectionWhenHealthRecoversBeforeTimeout(t *testing.T) {
-	_, healthServer, target := newTestHealthServer(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+func TestClientPool_KeepsConnectionWhenHealthIsServing(t *testing.T) {
+	_, _, target := newTestHealthServer(t, grpc_health_v1.HealthCheckResponse_SERVING)
 
 	pool := NewClientPool(nil, nil).(*clientPool)
 	defer pool.Close()
 
 	conn, err := newTestConnectionWithHealthConfig(pool, target,
-		10*time.Millisecond, 10*time.Millisecond, 200*time.Millisecond)
+		10*time.Millisecond, 10*time.Millisecond)
 	require.NoError(t, err)
 
 	pool.Lock()
 	pool.connections[target] = conn
 	pool.Unlock()
 
-	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 	require.Never(t, func() bool {
 		pool.RLock()
 		defer pool.RUnlock()
@@ -100,7 +99,7 @@ func TestClientPool_KeepsConnectionWhenHealthCheckIsUnsupported(t *testing.T) {
 	defer pool.Close()
 
 	conn, err := newTestConnectionWithHealthConfig(pool, target,
-		10*time.Millisecond, 10*time.Millisecond, 50*time.Millisecond)
+		10*time.Millisecond, 10*time.Millisecond)
 	require.NoError(t, err)
 
 	pool.Lock()
@@ -119,7 +118,6 @@ func newTestConnectionWithHealthConfig(
 	target string,
 	healthInterval time.Duration,
 	healthPingTimeout time.Duration,
-	healthTimeout time.Duration,
 ) (*connection, error) {
 	return newConnectionWithHealthConfig(
 		target,
@@ -129,7 +127,6 @@ func newTestConnectionWithHealthConfig(
 		pool.removeConnection,
 		healthInterval,
 		healthPingTimeout,
-		healthTimeout,
 	)
 }
 

--- a/common/rpc/connection.go
+++ b/common/rpc/connection.go
@@ -39,12 +39,9 @@ import (
 )
 
 const (
-	defaultGrpcClientKeepAliveTime            = 10 * time.Second
-	defaultGrpcClientKeepAliveTimeout         = 3 * time.Second
-	defaultGrpcConnectionHealthPingInterval   = defaultGrpcClientKeepAliveTime
-	defaultGrpcConnectionHealthPingTimeout    = defaultGrpcClientKeepAliveTimeout
-	defaultGrpcConnectionHealthFailureTimeout = 30 * time.Second
-	defaultGrpcClientPermitWithoutStream      = true
+	defaultGrpcClientKeepAliveTime       = 10 * time.Second
+	defaultGrpcClientKeepAliveTimeout    = 3 * time.Second
+	defaultGrpcClientPermitWithoutStream = true
 )
 
 type connectionFailureCallback func(target string)
@@ -60,7 +57,6 @@ type connection struct {
 	healthClient      grpc_health_v1.HealthClient
 	onFailure         connectionFailureCallback
 	healthPingTimeout time.Duration
-	healthTimeout     time.Duration
 	healthInterval    time.Duration
 	closeOnce         sync.Once
 	disconnected      atomic.Bool
@@ -83,9 +79,8 @@ func newConnection(
 		authentication,
 		dialOptions,
 		onFailure,
-		defaultGrpcConnectionHealthPingInterval,
-		defaultGrpcConnectionHealthPingTimeout,
-		defaultGrpcConnectionHealthFailureTimeout,
+		defaultGrpcClientKeepAliveTime,
+		defaultGrpcClientKeepAliveTimeout,
 	)
 }
 
@@ -97,7 +92,6 @@ func newConnectionWithHealthConfig(
 	onFailure connectionFailureCallback,
 	healthInterval time.Duration,
 	healthPingTimeout time.Duration,
-	healthTimeout time.Duration,
 ) (*connection, error) {
 	log := slog.With(slog.String("component", "rpc-connection"), slog.String("target", target))
 	log.Debug("Creating new GRPC connection")
@@ -139,7 +133,6 @@ func newConnectionWithHealthConfig(
 		healthClient:      grpc_health_v1.NewHealthClient(clientConn),
 		onFailure:         onFailure,
 		healthPingTimeout: healthPingTimeout,
-		healthTimeout:     healthTimeout,
 		healthInterval:    healthInterval,
 		ctx:               ctx,
 		cancel:            cancel,
@@ -159,7 +152,6 @@ func newConnectionWithHealthConfig(
 }
 
 func (c *connection) healthCheckLoop() {
-	var firstFailure time.Time
 	ticker := time.NewTicker(c.healthInterval)
 	defer ticker.Stop()
 
@@ -173,18 +165,13 @@ func (c *connection) healthCheckLoop() {
 			return
 		}
 
-		if err == nil && response.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING {
-			firstFailure = time.Time{}
-		} else {
+		if err != nil || response.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
 			if err != nil {
-				c.log.Debug("Connection health ping failed", slog.Any("error", err))
+				c.log.Warn("Connection health ping failed", slog.Any("error", err))
 			} else {
-				c.log.Debug("Connection health ping returned unhealthy status", slog.Any("status", response.GetStatus()))
+				c.log.Warn("Connection health ping returned unhealthy status", slog.Any("status", response.GetStatus()))
 			}
-			if firstFailure.IsZero() {
-				firstFailure = time.Now()
-			}
-			if time.Since(firstFailure) >= c.healthTimeout && c.disconnected.CompareAndSwap(false, true) {
+			if c.disconnected.CompareAndSwap(false, true) {
 				c.notifyDisconnect()
 				return
 			}
@@ -199,7 +186,6 @@ func (c *connection) healthCheckLoop() {
 }
 
 func (c *connection) notifyDisconnect() {
-	c.log.Warn("Connection health check timed out", slog.Duration("timeout", c.healthTimeout))
 	go process.DoWithLabels(
 		context.Background(),
 		map[string]string{

--- a/common/rpc/connection.go
+++ b/common/rpc/connection.go
@@ -1,0 +1,223 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/status"
+
+	"github.com/oxia-db/oxia/common/auth"
+	"github.com/oxia-db/oxia/common/process"
+)
+
+const (
+	defaultGrpcClientKeepAliveTime            = 10 * time.Second
+	defaultGrpcClientKeepAliveTimeout         = 3 * time.Second
+	defaultGrpcConnectionHealthPingInterval   = defaultGrpcClientKeepAliveTime
+	defaultGrpcConnectionHealthPingTimeout    = defaultGrpcClientKeepAliveTimeout
+	defaultGrpcConnectionHealthFailureTimeout = 30 * time.Second
+	defaultGrpcClientPermitWithoutStream      = true
+)
+
+type connectionFailureCallback func(target string)
+
+type connection struct {
+	*grpc.ClientConn
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	target            string
+	healthClient      grpc_health_v1.HealthClient
+	onFailure         connectionFailureCallback
+	healthPingTimeout time.Duration
+	healthTimeout     time.Duration
+	healthInterval    time.Duration
+	closeOnce         sync.Once
+	disconnected      atomic.Bool
+	log               *slog.Logger
+}
+
+var _ io.Closer = (*connection)(nil)
+var _ grpc.ClientConnInterface = (*connection)(nil)
+
+func newConnection(
+	target string,
+	tlsConf *tls.Config,
+	authentication auth.Authentication,
+	dialOptions []grpc.DialOption,
+	onFailure connectionFailureCallback,
+) (*connection, error) {
+	return newConnectionWithHealthConfig(
+		target,
+		tlsConf,
+		authentication,
+		dialOptions,
+		onFailure,
+		defaultGrpcConnectionHealthPingInterval,
+		defaultGrpcConnectionHealthPingTimeout,
+		defaultGrpcConnectionHealthFailureTimeout,
+	)
+}
+
+func newConnectionWithHealthConfig(
+	target string,
+	tlsConf *tls.Config,
+	authentication auth.Authentication,
+	dialOptions []grpc.DialOption,
+	onFailure connectionFailureCallback,
+	healthInterval time.Duration,
+	healthPingTimeout time.Duration,
+	healthTimeout time.Duration,
+) (*connection, error) {
+	log := slog.With(slog.String("component", "rpc-connection"), slog.String("target", target))
+	log.Debug("Creating new GRPC connection")
+
+	actualAddress := target
+	transportCredential := insecure.NewCredentials()
+	if strings.HasPrefix(target, AddressSchemaTLS) {
+		actualAddress, _ = strings.CutPrefix(target, AddressSchemaTLS)
+		transportCredential = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
+	}
+	if tlsConf != nil {
+		transportCredential = credentials.NewTLS(tlsConf)
+	}
+
+	options := []grpc.DialOption{
+		grpc.WithTransportCredentials(transportCredential),
+		grpc.WithChainStreamInterceptor(grpcprometheus.StreamClientInterceptor),
+		grpc.WithChainUnaryInterceptor(grpcprometheus.UnaryClientInterceptor),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			PermitWithoutStream: defaultGrpcClientPermitWithoutStream,
+			Time:                defaultGrpcClientKeepAliveTime,
+			Timeout:             defaultGrpcClientKeepAliveTimeout,
+		}),
+	}
+	if authentication != nil {
+		options = append(options, grpc.WithPerRPCCredentials(authentication))
+	}
+	options = append(options, dialOptions...)
+
+	clientConn, err := grpc.NewClient(actualAddress, options...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error connecting to %s", target)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &connection{
+		ClientConn:        clientConn,
+		target:            target,
+		healthClient:      grpc_health_v1.NewHealthClient(clientConn),
+		onFailure:         onFailure,
+		healthPingTimeout: healthPingTimeout,
+		healthTimeout:     healthTimeout,
+		healthInterval:    healthInterval,
+		ctx:               ctx,
+		cancel:            cancel,
+		log:               log,
+	}
+	c.wg.Go(func() {
+		process.DoWithLabels(
+			c.ctx,
+			map[string]string{
+				"component": "rpc-connection-health-ping",
+				"target":    c.target,
+			},
+			c.healthCheckLoop,
+		)
+	})
+	return c, nil
+}
+
+func (c *connection) healthCheckLoop() {
+	var firstFailure time.Time
+	ticker := time.NewTicker(c.healthInterval)
+	defer ticker.Stop()
+
+	for {
+		ctx, cancel := context.WithTimeout(c.ctx, c.healthPingTimeout)
+		response, err := c.healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: ""})
+		cancel()
+
+		if status.Code(err) == codes.Unimplemented {
+			c.log.Debug("Connection health ping is unsupported")
+			return
+		}
+
+		if err == nil && response.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING {
+			firstFailure = time.Time{}
+		} else {
+			if err != nil {
+				c.log.Debug("Connection health ping failed", slog.Any("error", err))
+			} else {
+				c.log.Debug("Connection health ping returned unhealthy status", slog.Any("status", response.GetStatus()))
+			}
+			if firstFailure.IsZero() {
+				firstFailure = time.Now()
+			}
+			if time.Since(firstFailure) >= c.healthTimeout && c.disconnected.CompareAndSwap(false, true) {
+				c.notifyDisconnect()
+				return
+			}
+		}
+
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (c *connection) notifyDisconnect() {
+	c.log.Warn("Connection health check timed out", slog.Duration("timeout", c.healthTimeout))
+	go process.DoWithLabels(
+		context.Background(),
+		map[string]string{
+			"component": "rpc-connection-failure-callback",
+			"target":    c.target,
+		},
+		func() {
+			c.onFailure(c.target)
+		},
+	)
+}
+
+func (c *connection) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		c.cancel()
+		c.wg.Wait()
+		err = c.ClientConn.Close()
+	})
+	return err
+}

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -17,7 +17,6 @@ package oxia
 import (
 	"context"
 	"errors"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,8 +70,8 @@ func (m *mockAdminClientPool) GetClientRpc(string) (proto.OxiaClientClient, erro
 	return nil, errors.New("unexpected GetClientRpc call")
 }
 
-func (m *mockAdminClientPool) GetHealthRpc(string) (grpc_health_v1.HealthClient, io.Closer, error) {
-	return nil, nil, errors.New("unexpected GetHealthRpc call")
+func (m *mockAdminClientPool) GetHealthRpc(string) (grpc_health_v1.HealthClient, error) {
+	return nil, errors.New("unexpected GetHealthRpc call")
 }
 
 func (m *mockAdminClientPool) GetCoordinationRpc(string) (proto.OxiaCoordinationClient, error) {

--- a/oxiad/coordinator/controller/dataserver_controller.go
+++ b/oxiad/coordinator/controller/dataserver_controller.go
@@ -31,8 +31,6 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 
-	commonio "github.com/oxia-db/oxia/common/io"
-
 	"github.com/oxia-db/oxia/common/metric"
 	"github.com/oxia-db/oxia/common/process"
 	"github.com/oxia-db/oxia/common/proto"
@@ -86,10 +84,6 @@ type dataServerController struct {
 	status            DataServerStatus
 	supportedFeatures atomic.Value
 
-	healthClientOnce   sync.Once
-	healthClient       grpc_health_v1.HealthClient
-	healthClientCloser io.Closer
-
 	healthCheckBackoff         *commontime.ConcurrentBackOff
 	dispatchAssignmentsBackoff backoff.BackOff
 
@@ -115,26 +109,6 @@ func (n *dataServerController) SetStatus(status DataServerStatus) {
 	n.Info("Changed status", slog.Any("from", previous), slog.Any("to", status))
 }
 
-func (n *dataServerController) maybeInitHealthClient() {
-	n.healthClientOnce.Do(func() {
-		_ = backoff.RetryNotify(func() error {
-			health, closer, err := n.rpc.GetHealthClient(n.dataServer)
-			if err != nil {
-				return err
-			}
-			n.healthClient = health
-			n.healthClientCloser = closer
-			return nil
-		}, backoff.NewExponentialBackOff(), func(err error, duration time.Duration) {
-			n.Warn(
-				"Failed to create health client to storage data server",
-				slog.Duration("retry-after", duration),
-				slog.Any("error", err),
-			)
-		})
-	})
-}
-
 func (n *dataServerController) Close() error {
 	if !n.closed.CompareAndSwap(false, true) {
 		return nil
@@ -143,12 +117,8 @@ func (n *dataServerController) Close() error {
 	n.cancel()
 	n.Wait()
 
-	var err error
-	if err = n.healthClientCloser.Close(); err != nil {
-		n.Warn("close data server controller health client failed", slog.Any("error", err))
-	}
 	n.Info("Closed data server controller")
-	return err
+	return nil
 }
 
 func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
@@ -202,9 +172,9 @@ func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
 	})
 }
 
-func (n *dataServerController) doHealthPing() error {
+func (n *dataServerController) doHealthPing(healthClient grpc_health_v1.HealthClient) error {
 	pingCtx, pingCancel := context.WithTimeout(n.ctx, healthCheckProbeTimeout)
-	response, err := n.healthClient.Check(pingCtx, &grpc_health_v1.HealthCheckRequest{Service: ""})
+	response, err := healthClient.Check(pingCtx, &grpc_health_v1.HealthCheckRequest{Service: ""})
 	pingCancel()
 	return n.healthCheckHandler(response, err)
 }
@@ -212,9 +182,13 @@ func (n *dataServerController) doHealthPing() error {
 func (n *dataServerController) healthPingWithRetries() {
 	defer n.Done()
 	_ = backoff.RetryNotify(func() error {
-		n.maybeInitHealthClient()
+		healthClient, err := n.rpc.GetHealthClient(n.dataServer)
+		if err != nil {
+			return err
+		}
+
 		// Immediate check on startup instead of waiting for first tick
-		if err := n.doHealthPing(); err != nil {
+		if err := n.doHealthPing(healthClient); err != nil {
 			return err
 		}
 		ticker := time.NewTicker(healthCheckProbeInterval)
@@ -224,7 +198,7 @@ func (n *dataServerController) healthPingWithRetries() {
 			case <-n.ctx.Done():
 				return nil
 			case <-ticker.C:
-				if err := n.doHealthPing(); err != nil {
+				if err := n.doHealthPing(healthClient); err != nil {
 					n.Warn("Data server stopped responding to ping")
 					return err
 				}
@@ -244,9 +218,12 @@ func (n *dataServerController) healthWatchWithRetries() {
 	defer n.Done()
 	_ = backoff.RetryNotify(func() error {
 		n.Debug("Start new health watch cycle")
-		n.maybeInitHealthClient()
+		healthClient, err := n.rpc.GetHealthClient(n.dataServer)
+		if err != nil {
+			return err
+		}
 
-		watchStream, err := n.healthClient.Watch(n.ctx, &grpc_health_v1.HealthCheckRequest{Service: ""})
+		watchStream, err := healthClient.Watch(n.ctx, &grpc_health_v1.HealthCheckRequest{Service: ""})
 		if err != nil {
 			return err
 		}
@@ -298,9 +275,6 @@ func (n *dataServerController) becomeAvailable() {
 
 	n.Info("Storage data server is back online")
 
-	// To avoid the send assignments stream to miss the notification about the current
-	// dataServer went down, we interrupt the current stream when the ping on the dataServer fails
-	n.rpc.ClearPooledConnections(n.dataServer)
 	n.healthCheckBackoff.Reset()
 	n.status = Running
 	n.statusLock.Unlock()
@@ -364,7 +338,6 @@ func newDataServerController(ctx context.Context, dataServer model.Server,
 	dataServerCtx, cancel := context.WithCancel(ctx)
 	dataServerID := dataServer.GetIdentifier()
 	labels := map[string]any{"data-server": dataServerID}
-
 	supportedFeatures := atomic.Value{}
 	supportedFeatures.Store(make([]proto.Feature, 0))
 
@@ -382,9 +355,6 @@ func newDataServerController(ctx context.Context, dataServer model.Server,
 			slog.String("component", "data-server-controller"),
 			slog.Any("data-server", dataServerID),
 		),
-		healthClientOnce:           sync.Once{},
-		healthClient:               nil,
-		healthClientCloser:         &commonio.NopCloser{},
 		healthCheckBackoff:         commontime.NewConcurrentBackOff(commontime.NewBackOffWithInitialInterval(dataServerCtx, initialRetryBackoff)),
 		dispatchAssignmentsBackoff: commontime.NewBackOffWithInitialInterval(dataServerCtx, initialRetryBackoff),
 		failedHealthChecks: metric.NewCounter("oxia_coordinator_node_health_checks_failed",

--- a/oxiad/coordinator/controller/mock_test.go
+++ b/oxiad/coordinator/controller/mock_test.go
@@ -17,7 +17,6 @@ package controller
 import (
 	"context"
 	"errors"
-	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -367,9 +366,6 @@ type mockRpcProvider struct {
 	channels map[string]*mockPerNodeChannels
 }
 
-func (r *mockRpcProvider) ClearPooledConnections(node model.Server) {
-}
-
 func newMockRpcProvider() *mockRpcProvider {
 	return &mockRpcProvider{
 		channels: make(map[string]*mockPerNodeChannels),
@@ -573,9 +569,9 @@ func (r *mockRpcProvider) RemoveObserver(ctx context.Context, node model.Server,
 	}
 }
 
-func (r *mockRpcProvider) GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (r *mockRpcProvider) GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, error) {
 	c := r.GetNode(node).healthClient
-	return c, c, nil
+	return c, nil
 }
 
 type mockShardAssignmentClient struct {

--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -523,6 +523,7 @@ func (c *coordinator) InitiateSplit(namespace string, parentShardId int64, split
 	// Update cloned status with left child placement before selecting right child
 	cloned.Namespaces[namespace].Shards[leftChildId] = model.ShardMetadata{
 		Status:   model.ShardStatusSteadyState,
+		Term:     -1,
 		Ensemble: leftEnsemble,
 		Int32HashRange: model.Int32HashRange{
 			Min: parentMeta.Int32HashRange.Min,
@@ -550,7 +551,7 @@ func (c *coordinator) InitiateSplit(namespace string, parentShardId int64, split
 	// Create left child shard
 	nsCloned.Shards[leftChildId] = model.ShardMetadata{
 		Status:   model.ShardStatusSteadyState,
-		Term:     0,
+		Term:     -1,
 		Ensemble: leftEnsemble,
 		Int32HashRange: model.Int32HashRange{
 			Min: parentMeta.Int32HashRange.Min,
@@ -566,7 +567,7 @@ func (c *coordinator) InitiateSplit(namespace string, parentShardId int64, split
 	// Create right child shard
 	nsCloned.Shards[rightChildId] = model.ShardMetadata{
 		Status:   model.ShardStatusSteadyState,
-		Term:     0,
+		Term:     -1,
 		Ensemble: rightEnsemble,
 		Int32HashRange: model.Int32HashRange{
 			Min: sp + 1,

--- a/oxiad/coordinator/rpc/rpc_provider.go
+++ b/oxiad/coordinator/rpc/rpc_provider.go
@@ -16,7 +16,6 @@ package rpc
 
 import (
 	"context"
-	"io"
 	"time"
 
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -40,9 +39,7 @@ type Provider interface {
 	RemoveObserver(ctx context.Context, node model.Server, req *proto.RemoveObserverRequest) (*proto.RemoveObserverResponse, error)
 	GetInfo(ctx context.Context, node model.Server, req *proto.GetInfoRequest) (*proto.GetInfoResponse, error)
 
-	GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, io.Closer, error)
-
-	ClearPooledConnections(node model.Server)
+	GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, error)
 }
 
 type rpcProvider struct {
@@ -146,10 +143,6 @@ func (r *rpcProvider) RemoveObserver(ctx context.Context, node model.Server, req
 	return client.RemoveObserver(ctx, req)
 }
 
-func (r *rpcProvider) GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (r *rpcProvider) GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, error) {
 	return r.pool.GetHealthRpc(node.Internal)
-}
-
-func (r *rpcProvider) ClearPooledConnections(node model.Server) {
-	r.pool.Clear(node.Internal)
 }

--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -205,6 +205,7 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 	)
 	adminGrpcServer, err := rpc2.Default.StartGrpcServer("admin", adminSv.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
 		proto.RegisterOxiaAdminServer(registrar, admin)
+		grpc_health_v1.RegisterHealthServer(registrar, healthServer)
 	}, adminSvTLS, &adminSv.Auth)
 	if err != nil {
 		return nil, err

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -63,15 +64,17 @@ type publicRpcServer struct {
 	assignmentDispatcher       assignment.ShardAssignmentsDispatcher
 	disableAuthorityValidation bool
 	grpcServer                 oxiadcommonrpc.GrpcServer
+	healthServer               oxiadcommonrpc.HealthServer
 	log                        *slog.Logger
 }
 
 func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector, assignmentDispatcher assignment.ShardAssignmentsDispatcher,
-	disableAuthorityValidation bool, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
+	disableAuthorityValidation bool, healthServer oxiadcommonrpc.HealthServer, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
 	server := &publicRpcServer{
 		shardsDirector:             shardsDirector,
 		assignmentDispatcher:       assignmentDispatcher,
 		disableAuthorityValidation: disableAuthorityValidation,
+		healthServer:               healthServer,
 		log: slog.With(
 			slog.String("component", "public-rpc-server"),
 		),
@@ -81,6 +84,7 @@ func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string
 	server.grpcServer, err = provider.StartGrpcServer("public", bindAddress, func(registrar grpc.ServiceRegistrar) {
 		proto.RegisterOxiaClientServer(registrar, server)
 		compat.RegisterOxiaClientServer(registrar, &compatPublicRpcServer{impl: server})
+		grpc_health_v1.RegisterHealthServer(registrar, server.healthServer)
 	}, tlsConf, options)
 	if err != nil {
 		return nil, err

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/protoadapt"
@@ -33,6 +34,7 @@ import (
 	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/common/logging"
+	oxiadcommonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
 	"github.com/oxia-db/oxia/oxiad/dataserver/assignment"
 	"github.com/oxia-db/oxia/oxiad/dataserver/controller"
 	"github.com/oxia-db/oxia/oxiad/dataserver/controller/follow"
@@ -135,6 +137,23 @@ func TestWriteClientClose(t *testing.T) {
 	t.Logf("resp %v err %v", resp, err)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestPublicHealthCheck(t *testing.T) {
+	standaloneServer, err := NewStandalone(NewTestConfig(t.TempDir()))
+	require.NoError(t, err)
+	defer standaloneServer.Close()
+
+	conn, err := grpc.NewClient(standaloneServer.ServiceAddr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := grpc_health_v1.NewHealthClient(conn)
+	resp, err := client.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+		Service: oxiadcommonrpc.ReadinessProbeService,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
 }
 
 func TestValidateAuthorityRejectsWrongAuthority(t *testing.T) {

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -134,7 +134,7 @@ func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.W
 		return nil, err
 	}
 	s.publicRpcServer, err = newPublicRpcServer(provider, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, disableAuthorityValidation, publicServerTLS, &publicServer.Auth)
+		s.shardAssignmentDispatcher, disableAuthorityValidation, s.healthServer, publicServerTLS, &publicServer.Auth)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/server_test.go
+++ b/oxiad/dataserver/server_test.go
@@ -69,10 +69,10 @@ func TestNewServerClosableWithHealthWatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	clientPool := rpc.NewClientPool(nil, nil)
+	defer clientPool.Close()
 
-	client, closer, err := clientPool.GetHealthRpc(fmt.Sprintf("127.0.0.1:%v", server.InternalPort()))
+	client, err := clientPool.GetHealthRpc(fmt.Sprintf("127.0.0.1:%v", server.InternalPort()))
 	assert.NoError(t, err)
-	defer closer.Close()
 	watchStream, err := client.Watch(t.Context(), &grpc_health_v1.HealthCheckRequest{Service: ""})
 	assert.NoError(t, err)
 

--- a/oxiad/dataserver/standalone.go
+++ b/oxiad/dataserver/standalone.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"go.uber.org/multierr"
+	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 	dataserveroption "github.com/oxia-db/oxia/oxiad/dataserver/option"
@@ -58,6 +59,7 @@ type Standalone struct {
 	walFactory                wal.Factory
 	shardsDirector            controller.ShardsDirector
 	shardAssignmentDispatcher assignment.ShardAssignmentsDispatcher
+	healthServer              rpc2.HealthServer
 
 	metrics *metric.PrometheusMetrics
 }
@@ -109,6 +111,8 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 	}
 
 	s.shardAssignmentDispatcher = assignment.NewStandaloneShardAssignmentDispatcher(config.NumShards)
+	s.healthServer = rpc2.NewClosableHealthServer(context.Background())
+	s.healthServer.SetServingStatus(rpc2.ReadinessProbeService, grpc_health_v1.HealthCheckResponse_SERVING)
 
 	publicServer := config.DataServerOptions.Server.Public
 	serverTLS, err := publicServer.TLS.TryIntoServerTLSConf()
@@ -116,7 +120,7 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 		return nil, err
 	}
 	s.rpc, err = newPublicRpcServer(rpc2.Default, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, false, serverTLS, &auth.Disabled)
+		s.shardAssignmentDispatcher, false, s.healthServer, serverTLS, &auth.Disabled)
 	if err != nil {
 		return nil, err
 	}
@@ -185,6 +189,7 @@ func (s *Standalone) Close() error {
 
 	return multierr.Combine(
 		err,
+		s.healthServer.Close(),
 		s.shardsDirector.Close(),
 		s.shardAssignmentDispatcher.Close(),
 		s.rpc.Close(),

--- a/oxiad/maelstrom/coordinator_rpc_client.go
+++ b/oxiad/maelstrom/coordinator_rpc_client.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"sync"
 
@@ -44,9 +43,6 @@ type maelstromCoordinatorRpcProvider struct {
 
 	dispatcher        *dispatcher
 	assignmentStreams map[int64]*maelstromShardAssignmentClient
-}
-
-func (m *maelstromCoordinatorRpcProvider) ClearPooledConnections(node model.Server) {
 }
 
 func newRpcProvider(dispatcher *dispatcher) rpc.Provider {
@@ -114,13 +110,13 @@ func (m *maelstromCoordinatorRpcProvider) GetInfo(ctx context.Context, node mode
 	}, nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (m *maelstromCoordinatorRpcProvider) GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, error) {
 	c := &maelstromHealthCheckClient{
 		provider: m,
 		node:     node.Internal,
 	}
 
-	return c, c, nil
+	return c, nil
 }
 
 type maelstromShardAssignmentClient struct {

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	commonoption "github.com/oxia-db/oxia/oxiad/common/option"
 
@@ -607,7 +608,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	clusterConfig := model.ClusterConfig{
 		Namespaces: []model.NamespaceConfig{{
 			Name:              "my-ns-1",
-			ReplicationFactor: 1,
+			ReplicationFactor: 3,
 			InitialShardCount: 1,
 		}},
 		Servers: []model.Server{sa1, sa2, sa3, sa4},
@@ -657,14 +658,14 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		for _, ns := range statusResource.Load().Namespaces {
 			for _, shard := range ns.Shards {
-				return shard.Term >= 0 && shard.Status == model.ShardStatusSteadyState
+				return shard.Term > 0 && shard.Status == model.ShardStatusSteadyState
 			}
 		}
 		return true
 	}, 10*time.Second, 10*time.Millisecond)
 
-	client, err := oxia.NewSyncClient(sa1.Public, oxia.WithNamespace("my-ns-1"))
-	assert.NoError(t, err)
+	client, err := oxia.NewSyncClient(clusterConfig.Servers[0].Public, oxia.WithNamespace("my-ns-1"))
+	require.NoError(t, err)
 
 	_, _, err = client.Put(context.Background(), "test", []byte("value"))
 	assert.NoError(t, err)

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -657,7 +657,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		for _, ns := range statusResource.Load().Namespaces {
 			for _, shard := range ns.Shards {
-				return shard.Term > 0 && shard.Status == model.ShardStatusSteadyState
+				return shard.Term >= 0 && shard.Status == model.ShardStatusSteadyState
 			}
 		}
 		return true


### PR DESCRIPTION
## Motivation
- Backport #1115 and #1116 to release-0.16 so proxied gRPC clients stop reusing stale connections.
- Keep release-0.16 behavior aligned with the main-branch connection health eviction fix.

## Modifications
- Added pooled connection health checks and immediate eviction on failed health probes.
- Registered gRPC health services on data server public RPC and coordinator admin RPC for the release-0.16 server layout.
- Adapted coordinator controller health-client ownership to the release-0.16 package structure.

## Testing
- `go test ./common/rpc`
- `go test ./oxiad/coordinator/...`
- `go test ./oxiad/dataserver/...`
- `go test ./oxiad/maelstrom`
- `go test ./cmd/health ./oxia`