### PR TITLE
fix: persist control request commit offset

### DIFF
--- a/oxiad/dataserver/controller/statemachine/proposal.go
+++ b/oxiad/dataserver/controller/statemachine/proposal.go
@@ -15,7 +15,6 @@
 package statemachine
 
 import (
-	"errors"
 	"time"
 
 	"github.com/oxia-db/oxia/common/proto"
@@ -91,19 +90,14 @@ func (c *ControlProposal) ToLogEntry(vtEntry *proto.LogEntryValue) {
 	vtEntry.Value = &proto.LogEntryValue_ControlRequest{ControlRequest: c.request}
 }
 
-func (c *ControlProposal) Apply(db database.DB, _ database.UpdateOperationCallback) (ApplyResponse, error) {
-	switch v := c.request.Value.(type) {
-	case *proto.ControlRequest_FeatureEnable:
-		for _, feature := range v.FeatureEnable.GetFeatures() {
-			db.EnableFeature(feature)
-		}
-	case *proto.ControlRequest_RecordChecksum:
-		checksum := db.ReadChecksum()
-		return ApplyResponse{Checksum: &checksum}, nil
-	default:
-		return ApplyResponse{}, errors.New("unknown control request type")
+func (c *ControlProposal) Apply(db database.DB, cb database.UpdateOperationCallback) (ApplyResponse, error) {
+	meta, err := db.ProcessControlRequest(c.request, c.offset, c.timestamp, cb)
+	if err != nil {
+		return ApplyResponse{}, err
 	}
-	return ApplyResponse{}, nil
+	return ApplyResponse{
+		Checksum: meta.Checksum,
+	}, nil
 }
 
 func NewControlProposal(offset int64, request *proto.ControlRequest) Proposal {

--- a/oxiad/dataserver/controller/statemachine/state_machine.go
+++ b/oxiad/dataserver/controller/statemachine/state_machine.go
@@ -31,17 +31,13 @@ func ApplyLogEntry(db database.DB, entry *proto.LogEntry, updateOperationCallbac
 
 	switch logEntryValue.Value.(type) {
 	case *proto.LogEntryValue_ControlRequest:
-		switch v := logEntryValue.GetControlRequest().Value.(type) {
-		case *proto.ControlRequest_FeatureEnable:
-			for _, feature := range v.FeatureEnable.GetFeatures() {
-				db.EnableFeature(feature)
-			}
-		case *proto.ControlRequest_RecordChecksum:
-			checksum := db.ReadChecksum()
-			return ApplyResponse{Checksum: &checksum}, nil
-		default:
-			return ApplyResponse{}, errors.New("unknown control request type")
+		meta, err := db.ProcessControlRequest(logEntryValue.GetControlRequest(), entry.Offset, entry.Timestamp, updateOperationCallback)
+		if err != nil {
+			return ApplyResponse{}, err
 		}
+		return ApplyResponse{
+			Checksum: meta.Checksum,
+		}, nil
 	case *proto.LogEntryValue_Requests:
 		for _, writeRequest := range logEntryValue.GetRequests().Writes {
 			if _, err := db.ProcessWrite(writeRequest, entry.Offset, entry.Timestamp, updateOperationCallback); err != nil {
@@ -74,17 +70,13 @@ func ApplyLogEntryWithSplitFilter(
 
 	switch logEntryValue.Value.(type) {
 	case *proto.LogEntryValue_ControlRequest:
-		switch v := logEntryValue.GetControlRequest().Value.(type) {
-		case *proto.ControlRequest_FeatureEnable:
-			for _, feature := range v.FeatureEnable.GetFeatures() {
-				db.EnableFeature(feature)
-			}
-		case *proto.ControlRequest_RecordChecksum:
-			checksum := db.ReadChecksum()
-			return ApplyResponse{Checksum: &checksum}, nil
-		default:
-			// Unknown control request type — ignore
+		meta, err := db.ProcessControlRequest(logEntryValue.GetControlRequest(), entry.Offset, entry.Timestamp, updateOperationCallback)
+		if err != nil {
+			return ApplyResponse{}, err
 		}
+		return ApplyResponse{
+			Checksum: meta.Checksum,
+		}, nil
 	case *proto.LogEntryValue_Requests:
 		for _, writeRequest := range logEntryValue.GetRequests().Writes {
 			filtered := database.FilterWriteRequestForSplit(writeRequest, hashRange)

--- a/oxiad/dataserver/controller/statemachine/state_machine_test.go
+++ b/oxiad/dataserver/controller/statemachine/state_machine_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/oxia-db/oxia/common/time"
 	"github.com/oxia-db/oxia/oxiad/dataserver/database"
 	"github.com/oxia-db/oxia/oxiad/dataserver/database/kvstore"
+	"github.com/oxia-db/oxia/oxiad/dataserver/wal"
 )
 
 func newTestDB(t *testing.T) database.DB {
@@ -280,4 +281,82 @@ func TestApplyLogEntry_MultipleEntries(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, proto.Status_OK, getY.Status)
 	assert.Equal(t, []byte("2"), getY.Value)
+}
+
+func TestApplyLogEntry_ControlRequestPersistsCommitOffsetForWalReplay(t *testing.T) {
+	const shard = int64(19)
+
+	kvFactory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, kvFactory.Close()) })
+
+	db, err := database.NewDB(constant.DefaultNamespace, shard, kvFactory,
+		proto.KeySortingType_NATURAL, 0, time.SystemClock)
+	assert.NoError(t, err)
+
+	walFactory := wal.NewWalFactory(&wal.FactoryOptions{BaseWalDir: t.TempDir()})
+	t.Cleanup(func() { assert.NoError(t, walFactory.Close()) })
+
+	w, err := walFactory.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, w.Close()) })
+
+	writeProposal := NewWriteProposal(0, &proto.WriteRequest{
+		Puts: []*proto.PutRequest{{Key: "a", Value: []byte("0")}},
+	})
+	controlProposal := NewControlProposal(1, &proto.ControlRequest{
+		Value: &proto.ControlRequest_RecordChecksum{
+			RecordChecksum: &proto.RecordChecksumRequest{},
+		},
+	})
+
+	for _, proposal := range []Proposal{writeProposal, controlProposal} {
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term:      1,
+			Offset:    proposal.GetOffset(),
+			Value:     marshalProposal(t, proposal),
+			Timestamp: proposal.GetTimestamp(),
+		}))
+	}
+
+	reader, err := w.NewReader(wal.InvalidOffset)
+	assert.NoError(t, err)
+	for reader.HasNext() {
+		entry, _, _, err := reader.ReadNext()
+		assert.NoError(t, err)
+		_, err = ApplyLogEntry(db, entry, database.NoOpCallback)
+		assert.NoError(t, err)
+	}
+	assert.NoError(t, reader.Close())
+	assert.NoError(t, db.Close())
+
+	db, err = database.NewDB(constant.DefaultNamespace, shard, kvFactory,
+		proto.KeySortingType_NATURAL, 0, time.SystemClock)
+	assert.NoError(t, err)
+	defer db.Close()
+
+	commitOffset, err := db.ReadCommitOffset()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, commitOffset)
+
+	assert.NoError(t, w.Clear())
+	nextWriteProposal := NewWriteProposal(2, &proto.WriteRequest{
+		Puts: []*proto.PutRequest{{Key: "b", Value: []byte("1")}},
+	})
+	assert.NoError(t, w.Append(&proto.LogEntry{
+		Term:      1,
+		Offset:    nextWriteProposal.GetOffset(),
+		Value:     marshalProposal(t, nextWriteProposal),
+		Timestamp: nextWriteProposal.GetTimestamp(),
+	}))
+
+	reader, err = w.NewReader(commitOffset)
+	if assert.NoError(t, err) {
+		if assert.True(t, reader.HasNext()) {
+			entry, _, _, err := reader.ReadNext()
+			assert.NoError(t, err)
+			assert.EqualValues(t, 2, entry.Offset)
+		}
+		assert.NoError(t, reader.Close())
+	}
 }

--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -79,6 +79,10 @@ type TermOptions struct {
 	KeySorting           proto.KeySortingType
 }
 
+type Meta struct {
+	Checksum *crc.Checksum
+}
+
 type DB interface {
 	io.Closer
 
@@ -90,6 +94,8 @@ type DB interface {
 	ResetChecksum()
 
 	ProcessWrite(b *proto.WriteRequest, commitOffset int64, timestamp uint64, updateOperationCallback UpdateOperationCallback) (*proto.WriteResponse, error)
+	ProcessControlRequest(controlRequest *proto.ControlRequest, commitOffset int64, timestamp uint64, updateOperationCallback UpdateOperationCallback) (*Meta, error)
+
 	Get(request *proto.GetRequest) (*proto.GetResponse, error)
 	List(request *proto.ListRequest) (kvstore.KeyIterator, error)
 	RangeScan(request *proto.RangeScanRequest) (RangeScanIterator, error)
@@ -296,6 +302,34 @@ func (d *db) IsFeatureEnabled(feature proto.Feature) bool {
 
 func (d *db) EnableFeature(feature proto.Feature) {
 	d.enabledFeatures.Store(feature, true)
+}
+
+func (d *db) ProcessControlRequest(cmd *proto.ControlRequest, commitOffset int64, timestamp uint64, _ UpdateOperationCallback) (*Meta, error) {
+	meta := &Meta{
+		Checksum: new(d.ReadChecksum()),
+	}
+	switch v := cmd.Value.(type) {
+	case *proto.ControlRequest_FeatureEnable:
+		for _, feature := range v.FeatureEnable.GetFeatures() {
+			d.enabledFeatures.Store(feature, true)
+		}
+	case *proto.ControlRequest_RecordChecksum:
+		// skip directly
+	default:
+		return nil, errors.New("unknown control request feature")
+	}
+
+	batch := d.kv.NewWriteBatch()
+	if err := d.addASCIILong(commitOffsetKey, commitOffset, batch, timestamp); err != nil {
+		return nil, err
+	}
+	if err := batch.Commit(); err != nil {
+		return nil, err
+	}
+	if err := batch.Close(); err != nil {
+		return nil, err
+	}
+	return meta, nil
 }
 
 func (d *db) ProcessWrite(b *proto.WriteRequest, commitOffset int64, timestamp uint64, updateOperationCallback UpdateOperationCallback) (*proto.WriteResponse, error) {

--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -310,13 +310,14 @@ func (d *db) ProcessControlRequest(cmd *proto.ControlRequest, commitOffset int64
 	}
 
 	var featuresToEnable []proto.Feature
-	switch v := cmd.Value.(type) {
+	controlValue := cmd.GetValue()
+	switch v := controlValue.(type) {
 	case *proto.ControlRequest_FeatureEnable:
 		featuresToEnable = v.FeatureEnable.GetFeatures()
 	case *proto.ControlRequest_RecordChecksum:
 		// Recognized no-op. Checksum is already in meta.
 	default:
-		return nil, errors.New("unknown control request feature")
+		return nil, errors.Errorf("unknown control request type %T", controlValue)
 	}
 
 	batch := d.kv.NewWriteBatch()

--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -308,27 +308,31 @@ func (d *db) ProcessControlRequest(cmd *proto.ControlRequest, commitOffset int64
 	meta := &Meta{
 		Checksum: new(d.ReadChecksum()),
 	}
+
+	var featuresToEnable []proto.Feature
 	switch v := cmd.Value.(type) {
 	case *proto.ControlRequest_FeatureEnable:
-		for _, feature := range v.FeatureEnable.GetFeatures() {
-			d.enabledFeatures.Store(feature, true)
-		}
+		featuresToEnable = v.FeatureEnable.GetFeatures()
 	case *proto.ControlRequest_RecordChecksum:
-		// skip directly
+		// Recognized no-op. Checksum is already in meta.
 	default:
 		return nil, errors.New("unknown control request feature")
 	}
 
 	batch := d.kv.NewWriteBatch()
+	defer batch.Close()
+
 	if err := d.addASCIILong(commitOffsetKey, commitOffset, batch, timestamp); err != nil {
 		return nil, err
 	}
 	if err := batch.Commit(); err != nil {
 		return nil, err
 	}
-	if err := batch.Close(); err != nil {
-		return nil, err
+
+	for _, feature := range featuresToEnable {
+		d.enabledFeatures.Store(feature, true)
 	}
+
 	return meta, nil
 }
 

--- a/oxiad/dataserver/wal/wal_test.go
+++ b/oxiad/dataserver/wal/wal_test.go
@@ -492,41 +492,6 @@ func TestTrim(t *testing.T) {
 	assert.NoError(t, f.Close())
 }
 
-func TestTrimNoSegmentDeletedDoesNotReturnEntryNotFound(t *testing.T) {
-	f, w := createWal(t)
-
-	const (
-		commitOffset = int64(15098)
-		trimOffset   = int64(15156)
-		headOffset   = int64(15168)
-	)
-
-	for offset := commitOffset; offset <= headOffset; offset++ {
-		assert.NoError(t, w.Append(&proto.LogEntry{
-			Term:   1,
-			Offset: offset,
-			Value:  []byte(fmt.Sprintf("entry-%d", offset)),
-		}))
-	}
-
-	assert.EqualValues(t, commitOffset, w.FirstOffset())
-	assert.EqualValues(t, headOffset, w.LastOffset())
-	assert.NoError(t, w.(*wal).trim(trimOffset))
-
-	r, err := w.NewReader(commitOffset)
-	if assert.NoError(t, err) {
-		assert.True(t, r.HasNext())
-		le, _, _, err := r.ReadNext()
-		assert.NoError(t, err)
-		assert.EqualValues(t, commitOffset+1, le.Offset)
-		assert.Equal(t, fmt.Sprintf("entry-%d", commitOffset+1), string(le.Value))
-		assert.NoError(t, r.Close())
-	}
-
-	assert.NoError(t, w.Close())
-	assert.NoError(t, f.Close())
-}
-
 func TestDelete(t *testing.T) {
 	f, w := createWal(t)
 

--- a/oxiad/dataserver/wal/wal_test.go
+++ b/oxiad/dataserver/wal/wal_test.go
@@ -492,6 +492,41 @@ func TestTrim(t *testing.T) {
 	assert.NoError(t, f.Close())
 }
 
+func TestTrimNoSegmentDeletedDoesNotReturnEntryNotFound(t *testing.T) {
+	f, w := createWal(t)
+
+	const (
+		commitOffset = int64(15098)
+		trimOffset   = int64(15156)
+		headOffset   = int64(15168)
+	)
+
+	for offset := commitOffset; offset <= headOffset; offset++ {
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term:   1,
+			Offset: offset,
+			Value:  []byte(fmt.Sprintf("entry-%d", offset)),
+		}))
+	}
+
+	assert.EqualValues(t, commitOffset, w.FirstOffset())
+	assert.EqualValues(t, headOffset, w.LastOffset())
+	assert.NoError(t, w.(*wal).trim(trimOffset))
+
+	r, err := w.NewReader(commitOffset)
+	if assert.NoError(t, err) {
+		assert.True(t, r.HasNext())
+		le, _, _, err := r.ReadNext()
+		assert.NoError(t, err)
+		assert.EqualValues(t, commitOffset+1, le.Offset)
+		assert.Equal(t, fmt.Sprintf("entry-%d", commitOffset+1), string(le.Value))
+		assert.NoError(t, r.Close())
+	}
+
+	assert.NoError(t, w.Close())
+	assert.NoError(t, f.Close())
+}
+
 func TestDelete(t *testing.T) {
 	f, w := createWal(t)
 


### PR DESCRIPTION
## Motivation
- Control requests are persisted in the WAL but previously did not advance the database commit offset when replayed.
- After WAL retention or restart, a follower could resume from a stale DB commit offset that is earlier than the WAL first offset and fail with `oxia: entry not found`.

## Modifications
- Route control proposal and replay handling through `database.ProcessControlRequest`.
- Persist the DB commit offset for recognized control requests while keeping feature-enable and checksum control handling centralized.
- Replace the WAL-only trim regression with a real Pebble DB + real WAL replay test that verifies control entries advance the persisted commit offset before replay resumes.

## Testing
- Verified the new regression test fails against old production logic with commit offset `0` instead of `1`, followed by `wal.NewReader(commitOffset)` returning `oxia: entry not found`.
- `go test ./oxiad/dataserver/controller/statemachine -run TestApplyLogEntry_ControlRequestPersistsCommitOffsetForWalReplay -count=1`
- `go test ./oxiad/dataserver/controller/statemachine ./oxiad/dataserver/wal ./oxiad/dataserver/database`