### PR TITLE
feat: add dataserver authority validation flag

### DIFF
--- a/cmd/server/cmd_test.go
+++ b/cmd/server/cmd_test.go
@@ -61,6 +61,8 @@ storage:
     readCacheSizeMB: 512
   notification:
     retention: "30m"
+featureFlags:
+  authorityValidation: true
 observability:
   metric:
     bindAddress: "0.0.0.0:9090"
@@ -101,6 +103,8 @@ observability:
 
 	assert.Equal(t, 30*time.Minute, opts.Storage.Notification.Retention.ToDuration())
 
+	assert.True(t, opts.FeatureFlags.IsAuthorityValidationEnabled())
+
 	assert.Equal(t, "0.0.0.0:9090", opts.Observability.Metric.BindAddress)
 	assert.Equal(t, "debug", opts.Observability.Log.Level)
 }
@@ -138,6 +142,7 @@ storage:
 	assert.NotEmpty(t, opts.Observability.Metric.BindAddress)             // Default
 	assert.Equal(t, 1*time.Hour, opts.Storage.WAL.Retention.ToDuration()) // Default
 	assert.True(t, *opts.Storage.WAL.Sync)                                // Default
+	assert.True(t, opts.FeatureFlags.IsAuthorityValidationEnabled())      // Default
 }
 
 func TestServer_ConfigurationValidation(t *testing.T) {
@@ -202,6 +207,7 @@ func TestServer_EmptyConfigFile(t *testing.T) {
 	// Verify defaults are still applied
 	assert.NotEmpty(t, opts.Server.Public.BindAddress)
 	assert.NotEmpty(t, opts.Server.Internal.BindAddress)
+	assert.True(t, opts.FeatureFlags.IsAuthorityValidationEnabled())
 }
 
 func TestServer_CommandLineFlags(t *testing.T) {

--- a/conf/dataserver.yaml
+++ b/conf/dataserver.yaml
@@ -18,6 +18,8 @@ storage:
 scheduler:
   checksum:
     interval: "5m"
+featureFlags:
+  authorityValidation: true
 observability:
   metric:
     enabled: true

--- a/conf/schema/dataserver.json
+++ b/conf/schema/dataserver.json
@@ -46,6 +46,17 @@
         "5s"
       ]
     },
+    "FeatureFlagsOptions": {
+      "properties": {
+        "authorityValidation": {
+          "type": "boolean",
+          "description": "Enable public RPC authority validation against shard assignments",
+          "default": true
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "InternalServerOptions": {
       "properties": {
         "bindAddress": {
@@ -147,6 +158,10 @@
         "scheduler": {
           "$ref": "#/$defs/SchedulerOptions",
           "description": "Scheduler configuration for periodic tasks"
+        },
+        "featureFlags": {
+          "$ref": "#/$defs/FeatureFlagsOptions",
+          "description": "Feature flags for rollout-sensitive dataserver behavior"
         },
         "observability": {
           "$ref": "#/$defs/ObservabilityOptions",

--- a/deploy/chaos-mesh/oxia-cluster.yaml
+++ b/deploy/chaos-mesh/oxia-cluster.yaml
@@ -2,3 +2,6 @@ image:
   repository: oxia
   tag: latest
   pullPolicy: Never
+
+allowExtraAuthorities:
+  - oxia:6648

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -249,8 +249,7 @@ func TestManagementServerListNamespaces(t *testing.T) {
 	res, err := management.ListNamespaces(context.Background(), &proto.ListNamespacesRequest{})
 	require.NoError(t, err)
 	require.Len(t, res.Namespaces, 2)
-	assert.Equal(t, "ns-1", res.Namespaces[0].GetName())
-	assert.Equal(t, "ns-2", res.Namespaces[1].GetName())
+	assert.ElementsMatch(t, []string{"ns-1", "ns-2"}, []string{res.Namespaces[0].GetName(), res.Namespaces[1].GetName()})
 }
 
 func TestManagementServerCreateNamespace(t *testing.T) {

--- a/oxiad/dataserver/option/option.go
+++ b/oxiad/dataserver/option/option.go
@@ -26,10 +26,6 @@ import (
 	"github.com/oxia-db/oxia/oxiad/common/rpc/auth"
 )
 
-func boolRef(value bool) *bool {
-	return &value
-}
-
 type PublicServerOptions struct {
 	BindAddress string              `yaml:"bindAddress" json:"bindAddress" jsonschema:"description=Bind address for the public API server,example=0.0.0.0:6648,format=hostname"`
 	Auth        auth.Options        `yaml:"auth,omitempty" json:"auth,omitempty" jsonschema:"description=Authentication configuration for the public API"`
@@ -220,7 +216,8 @@ func (fo *FeatureFlagsOptions) IsAuthorityValidationEnabled() bool {
 
 func (fo *FeatureFlagsOptions) WithDefault() {
 	if fo.AuthorityValidation == nil {
-		fo.AuthorityValidation = boolRef(true)
+		fo.AuthorityValidation = new(bool)
+		*fo.AuthorityValidation = true
 	}
 }
 

--- a/oxiad/dataserver/option/option.go
+++ b/oxiad/dataserver/option/option.go
@@ -26,6 +26,10 @@ import (
 	"github.com/oxia-db/oxia/oxiad/common/rpc/auth"
 )
 
+func boolRef(value bool) *bool {
+	return &value
+}
+
 type PublicServerOptions struct {
 	BindAddress string              `yaml:"bindAddress" json:"bindAddress" jsonschema:"description=Bind address for the public API server,example=0.0.0.0:6648,format=hostname"`
 	Auth        auth.Options        `yaml:"auth,omitempty" json:"auth,omitempty" jsonschema:"description=Authentication configuration for the public API"`
@@ -203,11 +207,33 @@ func (so *SchedulerOptions) Validate() error {
 	return so.Checksum.Validate()
 }
 
+type FeatureFlagsOptions struct {
+	AuthorityValidation *bool `yaml:"authorityValidation,omitempty" json:"authorityValidation,omitempty" jsonschema:"description=Enable public RPC authority validation against shard assignments,default=true"`
+}
+
+func (fo *FeatureFlagsOptions) IsAuthorityValidationEnabled() bool {
+	if fo.AuthorityValidation == nil {
+		return true
+	}
+	return *fo.AuthorityValidation
+}
+
+func (fo *FeatureFlagsOptions) WithDefault() {
+	if fo.AuthorityValidation == nil {
+		fo.AuthorityValidation = boolRef(true)
+	}
+}
+
+func (*FeatureFlagsOptions) Validate() error {
+	return nil
+}
+
 type Options struct {
 	Server        ServerOptions               `yaml:"server" json:"server" jsonschema:"description=Server configuration for public and internal endpoints"`
 	Replication   ReplicationOptions          `yaml:"replication,omitempty" json:"replication,omitempty" jsonschema:"description=Replication configuration for data consistency"`
 	Storage       StorageOptions              `yaml:"storage" json:"storage" jsonschema:"description=Storage configuration for WAL, database, and notifications"`
 	Scheduler     SchedulerOptions            `yaml:"scheduler" json:"scheduler" jsonschema:"description=Scheduler configuration for periodic tasks"`
+	FeatureFlags  FeatureFlagsOptions         `yaml:"featureFlags,omitempty" json:"featureFlags,omitempty" jsonschema:"description=Feature flags for rollout-sensitive dataserver behavior"`
 	Observability option.ObservabilityOptions `yaml:"observability" json:"observability" jsonschema:"description=Observability configuration for metrics and tracing"`
 }
 
@@ -216,6 +242,7 @@ func (op *Options) WithDefault() {
 	op.Replication.WithDefault()
 	op.Storage.WithDefault()
 	op.Scheduler.WithDefault()
+	op.FeatureFlags.WithDefault()
 	op.Observability.WithDefault()
 }
 
@@ -225,6 +252,7 @@ func (op *Options) Validate() error {
 		op.Replication.Validate(),
 		op.Storage.Validate(),
 		op.Scheduler.Validate(),
+		op.FeatureFlags.Validate(),
 		op.Observability.Validate(),
 	)
 }

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -62,18 +62,18 @@ type publicRpcServer struct {
 
 	shardsDirector             controller.ShardsDirector
 	assignmentDispatcher       assignment.ShardAssignmentsDispatcher
-	disableAuthorityValidation bool
+	authorityValidationEnabled bool
 	grpcServer                 oxiadcommonrpc.GrpcServer
 	healthServer               oxiadcommonrpc.HealthServer
 	log                        *slog.Logger
 }
 
 func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector, assignmentDispatcher assignment.ShardAssignmentsDispatcher,
-	disableAuthorityValidation bool, healthServer oxiadcommonrpc.HealthServer, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
+	authorityValidationEnabled bool, healthServer oxiadcommonrpc.HealthServer, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
 	server := &publicRpcServer{
 		shardsDirector:             shardsDirector,
 		assignmentDispatcher:       assignmentDispatcher,
-		disableAuthorityValidation: disableAuthorityValidation,
+		authorityValidationEnabled: authorityValidationEnabled,
 		healthServer:               healthServer,
 		log: slog.With(
 			slog.String("component", "public-rpc-server"),
@@ -94,7 +94,7 @@ func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string
 }
 
 func (s *publicRpcServer) validateAuthority(ctx context.Context) error {
-	if s.disableAuthorityValidation {
+	if !s.authorityValidationEnabled {
 		return nil
 	}
 

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -159,7 +159,8 @@ func TestPublicHealthCheck(t *testing.T) {
 
 func TestValidateAuthorityRejectsWrongAuthority(t *testing.T) {
 	server := &publicRpcServer{
-		log: slog.Default(),
+		log:                        slog.Default(),
+		authorityValidationEnabled: true,
 		assignmentDispatcher: &testAssignmentDispatcher{initialized: true, validAuthorities: map[string]bool{
 			"expected-host:6648": true,
 		}},
@@ -176,7 +177,8 @@ func TestValidateAuthorityRejectsWrongAuthority(t *testing.T) {
 
 func TestValidateAuthorityReturnsNotInitializedBeforeAssignmentsReady(t *testing.T) {
 	server := &publicRpcServer{
-		assignmentDispatcher: &testAssignmentDispatcher{},
+		authorityValidationEnabled: true,
+		assignmentDispatcher:       &testAssignmentDispatcher{},
 	}
 
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
@@ -188,10 +190,9 @@ func TestValidateAuthorityReturnsNotInitializedBeforeAssignmentsReady(t *testing
 	assert.Equal(t, codes.Unavailable, grpcstatus.Code(err))
 }
 
-func TestValidateAuthorityCanBeDisabled(t *testing.T) {
+func TestValidateAuthoritySkippedWhenDisabled(t *testing.T) {
 	server := &publicRpcServer{
-		disableAuthorityValidation: true,
-		assignmentDispatcher:       &testAssignmentDispatcher{},
+		assignmentDispatcher: &testAssignmentDispatcher{},
 	}
 
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
@@ -224,7 +225,8 @@ func (t *testShardAssignmentsServer) SendMsgV2(protoadapt.MessageV2) error {
 
 func TestGetShardAssignmentsValidatesAuthority(t *testing.T) {
 	server := &publicRpcServer{
-		log: slog.Default(),
+		log:                        slog.Default(),
+		authorityValidationEnabled: true,
 		assignmentDispatcher: &testAssignmentDispatcher{initialized: true, validAuthorities: map[string]bool{
 			"expected-host:6648": true,
 		}},
@@ -240,9 +242,25 @@ func TestGetShardAssignmentsValidatesAuthority(t *testing.T) {
 	assert.Equal(t, codes.PermissionDenied, grpcstatus.Code(err))
 }
 
+func TestGetShardAssignmentsSkipsAuthorityValidationWhenDisabled(t *testing.T) {
+	server := &publicRpcServer{
+		log:                  slog.Default(),
+		assignmentDispatcher: &testAssignmentDispatcher{},
+	}
+
+	err := server.GetShardAssignments(&proto.ShardAssignmentsRequest{}, &testShardAssignmentsServer{
+		ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+			":authority": "wrong-host:6648",
+		})),
+	})
+
+	require.NoError(t, err)
+}
+
 func TestGetShardAssignmentsConvertsRegisterError(t *testing.T) {
 	server := &publicRpcServer{
-		log: slog.Default(),
+		log:                        slog.Default(),
+		authorityValidationEnabled: true,
 		assignmentDispatcher: &testAssignmentDispatcher{
 			initialized: true,
 			validAuthorities: map[string]bool{
@@ -266,7 +284,8 @@ func TestGetShardAssignmentsConvertsRegisterError(t *testing.T) {
 
 func TestResolveLeaderValidatesAuthorityBeforeLeaderLookup(t *testing.T) {
 	server := &publicRpcServer{
-		log: slog.Default(),
+		log:                        slog.Default(),
+		authorityValidationEnabled: true,
 		shardsDirector: &testShardsDirector{
 			getLeader: func(int64) (lead.LeaderController, error) {
 				return nil, constant.IntoGrpcStatusError(constant.ErrNodeIsNotLeader, constant.WithLeaderHint(1, "leader:6648"))

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -70,12 +70,12 @@ func New(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options
 	if err != nil {
 		return nil, err
 	}
-	grpcProvider, err := NewWithGrpcProvider(parent, optionsWatch, commonrpc.Default, provider, manifest, false)
+	grpcProvider, err := NewWithGrpcProvider(parent, optionsWatch, commonrpc.Default, provider, manifest)
 	return grpcProvider, err
 }
 
 func NewWithGrpcProvider(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options], provider commonrpc.GrpcProvider,
-	replicationRpcProvider dataserverrpc.ReplicationRpcProvider, manifest *manifestpkg.Manifest, disableAuthorityValidation bool) (*Server, error) {
+	replicationRpcProvider dataserverrpc.ReplicationRpcProvider, manifest *manifestpkg.Manifest) (*Server, error) {
 	options := optionsWatch.Load()
 	slog.Info("Starting Oxia dataServer", slog.Any("options", options))
 
@@ -138,7 +138,7 @@ func NewWithGrpcProvider(parent context.Context, optionsWatch *commonwatch.Watch
 		return nil, err
 	}
 	s.publicRpcServer, err = newPublicRpcServer(provider, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, disableAuthorityValidation, s.healthServer, publicServerTLS, &publicServer.Auth)
+		s.shardAssignmentDispatcher, options.FeatureFlags.IsAuthorityValidationEnabled(), s.healthServer, publicServerTLS, &publicServer.Auth)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/server_test.go
+++ b/oxiad/dataserver/server_test.go
@@ -109,7 +109,7 @@ func TestNewServerAuthorityValidationFeatureFlag(t *testing.T) {
 			}
 			defer server.Close()
 
-			assert.Equal(t, tt.enabled, server.publicRpcServer.authorityValidationEnabled)
+			assert.Equal(t, tt.enabled, server.authorityValidationEnabled)
 		})
 	}
 }

--- a/oxiad/dataserver/server_test.go
+++ b/oxiad/dataserver/server_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/oxia-db/oxia/common/constant"
 	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/option"
@@ -80,4 +81,35 @@ func TestNewServerClosableWithHealthWatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, watchStream.CloseSend())
+}
+
+func TestNewServerAuthorityValidationFeatureFlag(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "enabled by default", enabled: true},
+		{name: "disabled by config"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			options := option.NewDefaultOptions()
+			options.Server.Public.BindAddress = "localhost:0"
+			options.Server.Internal.BindAddress = "localhost:0"
+			options.Observability.Metric.Enabled = &constant.FlagFalse
+			options.Storage.Database.Dir = t.TempDir()
+			options.Storage.WAL.Dir = t.TempDir()
+			if !tt.enabled {
+				authorityValidation := false
+				options.FeatureFlags.AuthorityValidation = &authorityValidation
+			}
+
+			server, err := New(t.Context(), commonwatch.New(options))
+			if !assert.NoError(t, err) {
+				return
+			}
+			defer server.Close()
+
+			assert.Equal(t, tt.enabled, server.publicRpcServer.authorityValidationEnabled)
+		})
+	}
 }

--- a/oxiad/dataserver/standalone.go
+++ b/oxiad/dataserver/standalone.go
@@ -118,7 +118,7 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 		return nil, err
 	}
 	s.rpc, err = newPublicRpcServer(rpc2.Default, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, false, s.healthServer, serverTLS, &auth.Disabled)
+		s.shardAssignmentDispatcher, config.DataServerOptions.FeatureFlags.IsAuthorityValidationEnabled(), s.healthServer, serverTLS, &auth.Disabled)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/maelstrom/main.go
+++ b/oxiad/maelstrom/main.go
@@ -186,6 +186,7 @@ func main() {
 		}
 
 		dataServerOption := option.NewDefaultOptions()
+		dataServerOption.FeatureFlags.AuthorityValidation = new(bool)
 		dataServerOption.Observability.Metric.Enabled = &constant.FlagFalse
 		dataServerOption.Storage.Database.Dir = filepath.Join(dataDir, thisNode, "db")
 		dataServerOption.Storage.WAL.Dir = filepath.Join(dataDir, thisNode, "wal")

--- a/oxiad/maelstrom/main.go
+++ b/oxiad/maelstrom/main.go
@@ -203,7 +203,6 @@ func main() {
 			grpcProvider,
 			replicationGrpcProvider,
 			manifest,
-			true,
 		)
 		if err != nil {
 			return


### PR DESCRIPTION
## Motivation
- Authority validation is currently active for normal dataserver startup and can reject clients during rollout or address-transition scenarios.
- Keep the validation enabled by default on `main`, while allowing deployments to opt out through dataserver configuration.

## Modifications
- Added `featureFlags.authorityValidation`, defaulting to `true`, to dataserver options.
- Wired dataserver and standalone public RPC startup to run authority validation only when the config flag is enabled.
- Updated the sample dataserver config and schema with the new flag.
- Adjusted tests to cover the enabled-by-default behavior and the disabled validation path.

## Testing
- `go test ./cmd/server`
- `go test ./oxiad/dataserver`
- `go test ./oxiad/maelstrom`
