### PR TITLE
fix: add dataserver authority validation config to 0.16

### DIFF
--- a/cmd/server/cmd_test.go
+++ b/cmd/server/cmd_test.go
@@ -61,6 +61,8 @@ storage:
     readCacheSizeMB: 512
   notification:
     retention: "30m"
+featureFlags:
+  authorityValidation: true
 observability:
   metric:
     bindAddress: "0.0.0.0:9090"
@@ -101,6 +103,8 @@ observability:
 
 	assert.Equal(t, 30*time.Minute, opts.Storage.Notification.Retention.ToDuration())
 
+	assert.True(t, opts.FeatureFlags.IsAuthorityValidationEnabled())
+
 	assert.Equal(t, "0.0.0.0:9090", opts.Observability.Metric.BindAddress)
 	assert.Equal(t, "debug", opts.Observability.Log.Level)
 }
@@ -138,6 +142,7 @@ storage:
 	assert.NotEmpty(t, opts.Observability.Metric.BindAddress)             // Default
 	assert.Equal(t, 1*time.Hour, opts.Storage.WAL.Retention.ToDuration()) // Default
 	assert.True(t, *opts.Storage.WAL.Sync)                                // Default
+	assert.False(t, opts.FeatureFlags.IsAuthorityValidationEnabled())     // Default
 }
 
 func TestServer_ConfigurationValidation(t *testing.T) {
@@ -202,6 +207,7 @@ func TestServer_EmptyConfigFile(t *testing.T) {
 	// Verify defaults are still applied
 	assert.NotEmpty(t, opts.Server.Public.BindAddress)
 	assert.NotEmpty(t, opts.Server.Internal.BindAddress)
+	assert.False(t, opts.FeatureFlags.IsAuthorityValidationEnabled())
 }
 
 func TestServer_CommandLineFlags(t *testing.T) {

--- a/conf/dataserver.yaml
+++ b/conf/dataserver.yaml
@@ -18,6 +18,8 @@ storage:
 scheduler:
   checksum:
     interval: "5m"
+featureFlags:
+  authorityValidation: false
 observability:
   metric:
     enabled: true

--- a/conf/schema/dataserver.json
+++ b/conf/schema/dataserver.json
@@ -46,6 +46,17 @@
         "5s"
       ]
     },
+    "FeatureFlagsOptions": {
+      "properties": {
+        "authorityValidation": {
+          "type": "boolean",
+          "description": "Enable public RPC authority validation against shard assignments",
+          "default": false
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "InternalServerOptions": {
       "properties": {
         "bindAddress": {
@@ -147,6 +158,10 @@
         "scheduler": {
           "$ref": "#/$defs/SchedulerOptions",
           "description": "Scheduler configuration for periodic tasks"
+        },
+        "featureFlags": {
+          "$ref": "#/$defs/FeatureFlagsOptions",
+          "description": "Feature flags for rollout-sensitive dataserver behavior"
         },
         "observability": {
           "$ref": "#/$defs/ObservabilityOptions",

--- a/oxiad/dataserver/option/option.go
+++ b/oxiad/dataserver/option/option.go
@@ -203,11 +203,33 @@ func (so *SchedulerOptions) Validate() error {
 	return so.Checksum.Validate()
 }
 
+type FeatureFlagsOptions struct {
+	AuthorityValidation *bool `yaml:"authorityValidation,omitempty" json:"authorityValidation,omitempty" jsonschema:"description=Enable public RPC authority validation against shard assignments,default=false"`
+}
+
+func (fo *FeatureFlagsOptions) IsAuthorityValidationEnabled() bool {
+	if fo.AuthorityValidation == nil {
+		return false
+	}
+	return *fo.AuthorityValidation
+}
+
+func (fo *FeatureFlagsOptions) WithDefault() {
+	if fo.AuthorityValidation == nil {
+		fo.AuthorityValidation = new(bool)
+	}
+}
+
+func (*FeatureFlagsOptions) Validate() error {
+	return nil
+}
+
 type Options struct {
 	Server        ServerOptions               `yaml:"server" json:"server" jsonschema:"description=Server configuration for public and internal endpoints"`
 	Replication   ReplicationOptions          `yaml:"replication,omitempty" json:"replication,omitempty" jsonschema:"description=Replication configuration for data consistency"`
 	Storage       StorageOptions              `yaml:"storage" json:"storage" jsonschema:"description=Storage configuration for WAL, database, and notifications"`
 	Scheduler     SchedulerOptions            `yaml:"scheduler" json:"scheduler" jsonschema:"description=Scheduler configuration for periodic tasks"`
+	FeatureFlags  FeatureFlagsOptions         `yaml:"featureFlags,omitempty" json:"featureFlags,omitempty" jsonschema:"description=Feature flags for rollout-sensitive dataserver behavior"`
 	Observability option.ObservabilityOptions `yaml:"observability" json:"observability" jsonschema:"description=Observability configuration for metrics and tracing"`
 }
 
@@ -216,6 +238,7 @@ func (op *Options) WithDefault() {
 	op.Replication.WithDefault()
 	op.Storage.WithDefault()
 	op.Scheduler.WithDefault()
+	op.FeatureFlags.WithDefault()
 	op.Observability.WithDefault()
 }
 
@@ -225,6 +248,7 @@ func (op *Options) Validate() error {
 		op.Replication.Validate(),
 		op.Storage.Validate(),
 		op.Scheduler.Validate(),
+		op.FeatureFlags.Validate(),
 		op.Observability.Validate(),
 	)
 }

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -62,18 +62,18 @@ type publicRpcServer struct {
 
 	shardsDirector             controller.ShardsDirector
 	assignmentDispatcher       assignment.ShardAssignmentsDispatcher
-	disableAuthorityValidation bool
+	authorityValidationEnabled bool
 	grpcServer                 oxiadcommonrpc.GrpcServer
 	healthServer               oxiadcommonrpc.HealthServer
 	log                        *slog.Logger
 }
 
 func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector, assignmentDispatcher assignment.ShardAssignmentsDispatcher,
-	disableAuthorityValidation bool, healthServer oxiadcommonrpc.HealthServer, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
+	authorityValidationEnabled bool, healthServer oxiadcommonrpc.HealthServer, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
 	server := &publicRpcServer{
 		shardsDirector:             shardsDirector,
 		assignmentDispatcher:       assignmentDispatcher,
-		disableAuthorityValidation: disableAuthorityValidation,
+		authorityValidationEnabled: authorityValidationEnabled,
 		healthServer:               healthServer,
 		log: slog.With(
 			slog.String("component", "public-rpc-server"),
@@ -94,7 +94,7 @@ func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string
 }
 
 func (s *publicRpcServer) validateAuthority(ctx context.Context) error {
-	if s.disableAuthorityValidation {
+	if !s.authorityValidationEnabled {
 		return nil
 	}
 

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -49,6 +49,7 @@ func init() {
 type testAssignmentDispatcher struct {
 	initialized      bool
 	validAuthorities map[string]bool
+	registerErr      error
 }
 
 func (*testAssignmentDispatcher) Close() error { return nil }
@@ -58,8 +59,8 @@ func (t *testAssignmentDispatcher) Initialized() bool {
 func (*testAssignmentDispatcher) PushShardAssignments(proto.OxiaCoordination_PushShardAssignmentsServer) error {
 	panic("unexpected call")
 }
-func (*testAssignmentDispatcher) RegisterForUpdates(*proto.ShardAssignmentsRequest, assignment.Client) error {
-	panic("unexpected call")
+func (t *testAssignmentDispatcher) RegisterForUpdates(*proto.ShardAssignmentsRequest, assignment.Client) error {
+	return t.registerErr
 }
 func (*testAssignmentDispatcher) GetLeader(int64) string { return "" }
 func (t *testAssignmentDispatcher) HasAuthority(authority string) bool {
@@ -158,7 +159,8 @@ func TestPublicHealthCheck(t *testing.T) {
 
 func TestValidateAuthorityRejectsWrongAuthority(t *testing.T) {
 	server := &publicRpcServer{
-		log: slog.Default(),
+		log:                        slog.Default(),
+		authorityValidationEnabled: true,
 		assignmentDispatcher: &testAssignmentDispatcher{initialized: true, validAuthorities: map[string]bool{
 			"expected-host:6648": true,
 		}},
@@ -175,7 +177,8 @@ func TestValidateAuthorityRejectsWrongAuthority(t *testing.T) {
 
 func TestValidateAuthorityReturnsNotInitializedBeforeAssignmentsReady(t *testing.T) {
 	server := &publicRpcServer{
-		assignmentDispatcher: &testAssignmentDispatcher{},
+		authorityValidationEnabled: true,
+		assignmentDispatcher:       &testAssignmentDispatcher{},
 	}
 
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
@@ -187,10 +190,9 @@ func TestValidateAuthorityReturnsNotInitializedBeforeAssignmentsReady(t *testing
 	assert.Equal(t, constant.CodeNotInitialized, grpcstatus.Code(err))
 }
 
-func TestValidateAuthorityCanBeDisabled(t *testing.T) {
+func TestValidateAuthoritySkippedWhenDisabled(t *testing.T) {
 	server := &publicRpcServer{
-		disableAuthorityValidation: true,
-		assignmentDispatcher:       &testAssignmentDispatcher{},
+		assignmentDispatcher: &testAssignmentDispatcher{},
 	}
 
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
@@ -223,7 +225,8 @@ func (t *testShardAssignmentsServer) SendMsgV2(protoadapt.MessageV2) error {
 
 func TestGetShardAssignmentsValidatesAuthority(t *testing.T) {
 	server := &publicRpcServer{
-		log: slog.Default(),
+		log:                        slog.Default(),
+		authorityValidationEnabled: true,
 		assignmentDispatcher: &testAssignmentDispatcher{initialized: true, validAuthorities: map[string]bool{
 			"expected-host:6648": true,
 		}},
@@ -239,9 +242,49 @@ func TestGetShardAssignmentsValidatesAuthority(t *testing.T) {
 	assert.Equal(t, codes.PermissionDenied, grpcstatus.Code(err))
 }
 
+func TestGetShardAssignmentsSkipsAuthorityValidationWhenDisabled(t *testing.T) {
+	server := &publicRpcServer{
+		log:                  slog.Default(),
+		assignmentDispatcher: &testAssignmentDispatcher{},
+	}
+
+	err := server.GetShardAssignments(&proto.ShardAssignmentsRequest{}, &testShardAssignmentsServer{
+		ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+			":authority": "wrong-host:6648",
+		})),
+	})
+
+	require.NoError(t, err)
+}
+
+func TestGetShardAssignmentsConvertsRegisterError(t *testing.T) {
+	server := &publicRpcServer{
+		log:                        slog.Default(),
+		authorityValidationEnabled: true,
+		assignmentDispatcher: &testAssignmentDispatcher{
+			initialized: true,
+			validAuthorities: map[string]bool{
+				"expected-host:6648": true,
+			},
+			registerErr: constant.ErrNamespaceNotFound,
+		},
+	}
+
+	err := server.GetShardAssignments(&proto.ShardAssignmentsRequest{}, &testShardAssignmentsServer{
+		ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+			":authority": "expected-host:6648",
+		})),
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, constant.CodeNamespaceNotFound, grpcstatus.Code(err))
+	assert.ErrorIs(t, err, constant.ErrNamespaceNotFound)
+}
+
 func TestResolveLeaderValidatesAuthorityBeforeLeaderLookup(t *testing.T) {
 	server := &publicRpcServer{
-		log: slog.Default(),
+		log:                        slog.Default(),
+		authorityValidationEnabled: true,
 		shardsDirector: &testShardsDirector{
 			getLeader: func(int64) (lead.LeaderController, error) {
 				return nil, constant.NewNodeIsNotLeaderWithHint(1, "leader:6648")

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -66,12 +66,12 @@ func New(parent context.Context, watchableOption *commonoption.Watch[*option.Opt
 	if err != nil {
 		return nil, err
 	}
-	grpcProvider, err := NewWithGrpcProvider(parent, watchableOption, rpc2.Default, provider, false)
+	grpcProvider, err := NewWithGrpcProvider(parent, watchableOption, rpc2.Default, provider)
 	return grpcProvider, err
 }
 
 func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.Watch[*option.Options], provider rpc2.GrpcProvider,
-	replicationRpcProvider rpc.ReplicationRpcProvider, disableAuthorityValidation bool) (*Server, error) {
+	replicationRpcProvider rpc.ReplicationRpcProvider) (*Server, error) {
 	options, _ := watchableOption.Load()
 	slog.Info("Starting Oxia dataServer", slog.Any("options", options))
 
@@ -134,7 +134,7 @@ func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.W
 		return nil, err
 	}
 	s.publicRpcServer, err = newPublicRpcServer(provider, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, disableAuthorityValidation, s.healthServer, publicServerTLS, &publicServer.Auth)
+		s.shardAssignmentDispatcher, options.FeatureFlags.IsAuthorityValidationEnabled(), s.healthServer, publicServerTLS, &publicServer.Auth)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/server_test.go
+++ b/oxiad/dataserver/server_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/oxia-db/oxia/common/constant"
 	commonoption "github.com/oxia-db/oxia/oxiad/common/option"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/option"
@@ -80,4 +81,35 @@ func TestNewServerClosableWithHealthWatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, watchStream.CloseSend())
+}
+
+func TestNewServerAuthorityValidationFeatureFlag(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "disabled by default"},
+		{name: "enabled by config", enabled: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			options := option.NewDefaultOptions()
+			options.Server.Public.BindAddress = "localhost:0"
+			options.Server.Internal.BindAddress = "localhost:0"
+			options.Observability.Metric.Enabled = &constant.FlagFalse
+			options.Storage.Database.Dir = t.TempDir()
+			options.Storage.WAL.Dir = t.TempDir()
+			if tt.enabled {
+				authorityValidation := true
+				options.FeatureFlags.AuthorityValidation = &authorityValidation
+			}
+
+			server, err := New(t.Context(), commonoption.NewWatch(options))
+			if !assert.NoError(t, err) {
+				return
+			}
+			defer server.Close()
+
+			assert.Equal(t, tt.enabled, server.authorityValidationEnabled)
+		})
+	}
 }

--- a/oxiad/dataserver/standalone.go
+++ b/oxiad/dataserver/standalone.go
@@ -120,7 +120,7 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 		return nil, err
 	}
 	s.rpc, err = newPublicRpcServer(rpc2.Default, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, false, s.healthServer, serverTLS, &auth.Disabled)
+		s.shardAssignmentDispatcher, config.DataServerOptions.FeatureFlags.IsAuthorityValidationEnabled(), s.healthServer, serverTLS, &auth.Disabled)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/maelstrom/main.go
+++ b/oxiad/maelstrom/main.go
@@ -201,7 +201,6 @@ func main() {
 			commonoption.NewWatch(dataServerOption),
 			grpcProvider,
 			replicationGrpcProvider,
-			true,
 		)
 		if err != nil {
 			return

--- a/tests/resolver/target_ip_flip_test.go
+++ b/tests/resolver/target_ip_flip_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 	coordinatorrpc "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	"github.com/oxia-db/oxia/oxiad/dataserver"
+	dataserveroption "github.com/oxia-db/oxia/oxiad/dataserver/option"
 	"github.com/oxia-db/oxia/tests/mock"
 )
 
@@ -59,7 +60,9 @@ func newCoordinatorCluster(t *testing.T, prefix string, serverCount int) *testCl
 
 	for i := 0; i < serverCount; i++ {
 		name := fmt.Sprintf("%s-s%d", prefix, i+1)
-		server, addr := mock.NewServer(t, name)
+		server, addr := mock.NewServerWithOptions(t, name, func(options *dataserveroption.Options) {
+			options.FeatureFlags.AuthorityValidation = &constant.FlagTrue
+		})
 		cluster.servers[addr.GetIdentifier()] = server
 		cluster.addresses = append(cluster.addresses, addr)
 	}


### PR DESCRIPTION
## Motivation
- Backport dataserver authority validation configuration to the 0.16 release line.
- Keep the release default disabled to avoid introducing a breaking validation change in a patch release.

## Modifications
- Added `featureFlags.authorityValidation` to dataserver options, defaulting to `false` on `release-0.16`.
- Wired dataserver and standalone public RPC startup to run authority validation only when the config flag is enabled.
- Updated the sample dataserver config and schema with the new flag.
- Adjusted tests to cover the disabled-by-default release behavior and enabled validation path.

## Testing
- `go test ./cmd/server`
- `go test ./oxiad/dataserver`
- `go test ./oxiad/maelstrom`
