### PR TITLE
fix: persist enabled features in database

### DIFF
--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -52,11 +52,12 @@ var (
 )
 
 const (
-	commitOffsetKey        = constant.InternalKeyPrefix + "commit-offset"
-	commitLastVersionIdKey = constant.InternalKeyPrefix + "last-version-id"
-	commitChecksumKey      = constant.InternalKeyPrefix + "checksum"
-	termKey                = constant.InternalKeyPrefix + "term"
-	termOptionsKey         = termKey + "-options"
+	commitOffsetKey         = constant.InternalKeyPrefix + "commit-offset"
+	commitLastVersionIdKey  = constant.InternalKeyPrefix + "last-version-id"
+	commitChecksumKey       = constant.InternalKeyPrefix + "checksum"
+	enabledFeatureKeyPrefix = constant.InternalKeyPrefix + "features"
+	termKey                 = constant.InternalKeyPrefix + "term"
+	termOptionsKey          = termKey + "-options"
 )
 
 type UpdateOperationCallback interface {
@@ -185,6 +186,10 @@ func NewDB(namespace string, shardId int64, factory kvstore.Factory,
 	}
 	db.committedChecksum.Store(&lastChecksum)
 
+	if err := db.readEnabledFeatures(); err != nil {
+		return nil, err
+	}
+
 	db.notificationsTracker = newNotificationsTracker(namespace, shardId, commitOffset, kv, notificationRetentionTime, clock)
 	return db, nil
 }
@@ -231,7 +236,6 @@ func (d *db) ReadChecksum() crc.Checksum {
 func (d *db) ResetChecksum() {
 	var zero crc.Checksum
 	d.committedChecksum.Store(&zero)
-	d.enabledFeatures.Delete(proto.Feature_FEATURE_DB_CHECKSUM)
 }
 
 func (d *db) Close() error {
@@ -304,6 +308,10 @@ func (d *db) EnableFeature(feature proto.Feature) {
 	d.enabledFeatures.Store(feature, true)
 }
 
+func enabledFeatureKey(feature proto.Feature) string {
+	return fmt.Sprintf("%s/%d", enabledFeatureKeyPrefix, feature)
+}
+
 func (d *db) ProcessControlRequest(cmd *proto.ControlRequest, commitOffset int64, timestamp uint64, _ UpdateOperationCallback) (*Meta, error) {
 	meta := &Meta{
 		Checksum: new(d.ReadChecksum()),
@@ -325,6 +333,11 @@ func (d *db) ProcessControlRequest(cmd *proto.ControlRequest, commitOffset int64
 
 	if err := d.addASCIILong(commitOffsetKey, commitOffset, batch, timestamp); err != nil {
 		return nil, err
+	}
+	for _, feature := range featuresToEnable {
+		if err := d.addASCIILong(enabledFeatureKey(feature), int64(feature), batch, timestamp); err != nil {
+			return nil, err
+		}
 	}
 	if err := batch.Commit(); err != nil {
 		return nil, err
@@ -545,6 +558,30 @@ func (d *db) readLastChecksum() (crc.Checksum, error) {
 		return 0, err
 	}
 	return crc.Checksum(uint32(cs)), nil
+}
+
+func (d *db) readEnabledFeatures() error {
+	it, err := d.kv.KeyRangeScan(enabledFeatureKeyPrefix+"/", "", kvstore.ShowInternalKeys)
+	if err != nil {
+		return err
+	}
+	defer it.Close()
+
+	for it.Valid() {
+		key := it.Key()
+		if !strings.HasPrefix(key, enabledFeatureKeyPrefix+"/") {
+			break
+		}
+
+		var feature int32
+		if _, err := fmt.Sscanf(strings.TrimPrefix(key, enabledFeatureKeyPrefix+"/"), "%d", &feature); err != nil {
+			return err
+		}
+		d.enabledFeatures.Store(proto.Feature(feature), true)
+
+		it.Next()
+	}
+	return nil
 }
 
 func (d *db) readASCIILongOrDefault(key string, defaultValue int64) (int64, error) {

--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log/slog"
 	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -309,7 +310,7 @@ func (d *db) EnableFeature(feature proto.Feature) {
 }
 
 func featureFlagKey(feature proto.Feature) string {
-	return fmt.Sprintf("%s/%d", featureFlagKeyPrefix, feature)
+	return fmt.Sprintf("%s/%010d", featureFlagKeyPrefix, feature)
 }
 
 func (d *db) ProcessControlRequest(cmd *proto.ControlRequest, commitOffset int64, timestamp uint64, _ UpdateOperationCallback) (*Meta, error) {
@@ -574,11 +575,19 @@ func (d *db) recoverFeatureFlags() error {
 			break
 		}
 
-		var feature int32
-		if _, err := fmt.Sscanf(strings.TrimPrefix(key, featureFlagKeyPrefix+"/"), "%d", &feature); err != nil {
-			return err
+		featureValue, err := strconv.ParseInt(strings.TrimPrefix(key, featureFlagKeyPrefix+"/"), 10, 32)
+		if err != nil {
+			return errors.Wrapf(err, "invalid feature flag key %q", key)
 		}
-		d.enabledFeatures.Store(proto.Feature(feature), true)
+		if featureValue < 0 {
+			return errors.Errorf("invalid feature flag key %q", key)
+		}
+
+		feature := proto.Feature(featureValue)
+		if key != featureFlagKey(feature) {
+			return errors.Errorf("invalid feature flag key %q", key)
+		}
+		d.enabledFeatures.Store(feature, true)
 
 		it.Next()
 	}

--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -52,12 +52,12 @@ var (
 )
 
 const (
-	commitOffsetKey         = constant.InternalKeyPrefix + "commit-offset"
-	commitLastVersionIdKey  = constant.InternalKeyPrefix + "last-version-id"
-	commitChecksumKey       = constant.InternalKeyPrefix + "checksum"
-	enabledFeatureKeyPrefix = constant.InternalKeyPrefix + "features"
-	termKey                 = constant.InternalKeyPrefix + "term"
-	termOptionsKey          = termKey + "-options"
+	commitOffsetKey        = constant.InternalKeyPrefix + "commit-offset"
+	commitLastVersionIdKey = constant.InternalKeyPrefix + "last-version-id"
+	commitChecksumKey      = constant.InternalKeyPrefix + "checksum"
+	featureFlagKeyPrefix   = constant.InternalKeyPrefix + "features"
+	termKey                = constant.InternalKeyPrefix + "term"
+	termOptionsKey         = termKey + "-options"
 )
 
 type UpdateOperationCallback interface {
@@ -186,7 +186,7 @@ func NewDB(namespace string, shardId int64, factory kvstore.Factory,
 	}
 	db.committedChecksum.Store(&lastChecksum)
 
-	if err := db.readEnabledFeatures(); err != nil {
+	if err := db.recoverFeatureFlags(); err != nil {
 		return nil, err
 	}
 
@@ -308,8 +308,8 @@ func (d *db) EnableFeature(feature proto.Feature) {
 	d.enabledFeatures.Store(feature, true)
 }
 
-func enabledFeatureKey(feature proto.Feature) string {
-	return fmt.Sprintf("%s/%d", enabledFeatureKeyPrefix, feature)
+func featureFlagKey(feature proto.Feature) string {
+	return fmt.Sprintf("%s/%d", featureFlagKeyPrefix, feature)
 }
 
 func (d *db) ProcessControlRequest(cmd *proto.ControlRequest, commitOffset int64, timestamp uint64, _ UpdateOperationCallback) (*Meta, error) {
@@ -335,7 +335,7 @@ func (d *db) ProcessControlRequest(cmd *proto.ControlRequest, commitOffset int64
 		return nil, err
 	}
 	for _, feature := range featuresToEnable {
-		if err := d.addASCIILong(enabledFeatureKey(feature), int64(feature), batch, timestamp); err != nil {
+		if err := d.addASCIILong(featureFlagKey(feature), int64(feature), batch, timestamp); err != nil {
 			return nil, err
 		}
 	}
@@ -560,21 +560,22 @@ func (d *db) readLastChecksum() (crc.Checksum, error) {
 	return crc.Checksum(uint32(cs)), nil
 }
 
-func (d *db) readEnabledFeatures() error {
-	it, err := d.kv.KeyRangeScan(enabledFeatureKeyPrefix+"/", "", kvstore.ShowInternalKeys)
+func (d *db) recoverFeatureFlags() error {
+	// Use a prefix break instead of an upper bound because key ordering can be
+	// natural or hierarchical, and the safe upper bound differs between them.
+	it, err := d.kv.KeyRangeScan(featureFlagKeyPrefix+"/", "", kvstore.ShowInternalKeys)
 	if err != nil {
 		return err
 	}
 	defer it.Close()
-
 	for it.Valid() {
 		key := it.Key()
-		if !strings.HasPrefix(key, enabledFeatureKeyPrefix+"/") {
+		if !strings.HasPrefix(key, featureFlagKeyPrefix+"/") {
 			break
 		}
 
 		var feature int32
-		if _, err := fmt.Sscanf(strings.TrimPrefix(key, enabledFeatureKeyPrefix+"/"), "%d", &feature); err != nil {
+		if _, err := fmt.Sscanf(strings.TrimPrefix(key, featureFlagKeyPrefix+"/"), "%d", &feature); err != nil {
 			return err
 		}
 		d.enabledFeatures.Store(proto.Feature(feature), true)

--- a/oxiad/dataserver/database/db_test.go
+++ b/oxiad/dataserver/database/db_test.go
@@ -452,6 +452,39 @@ func TestDB_ReadCommitOffset(t *testing.T) {
 	assert.NoError(t, factory.Close())
 }
 
+func TestDB_EnabledFeaturePersistence(t *testing.T) {
+	const commitOffset = int64(7)
+
+	factory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	db, err := NewDB(constant.DefaultNamespace, 1, factory, proto.KeySortingType_NATURAL, 0, time.SystemClock)
+	assert.NoError(t, err)
+
+	assert.False(t, db.IsFeatureEnabled(proto.Feature_FEATURE_DB_CHECKSUM))
+
+	_, err = db.ProcessControlRequest(&proto.ControlRequest{
+		Value: &proto.ControlRequest_FeatureEnable{
+			FeatureEnable: &proto.FeatureEnableRequest{
+				Features: []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM},
+			},
+		},
+	}, commitOffset, 0, NoOpCallback)
+	assert.NoError(t, err)
+	assert.True(t, db.IsFeatureEnabled(proto.Feature_FEATURE_DB_CHECKSUM))
+	assert.NoError(t, db.Close())
+
+	db, err = NewDB(constant.DefaultNamespace, 1, factory, proto.KeySortingType_NATURAL, 0, time.SystemClock)
+	assert.NoError(t, err)
+	assert.True(t, db.IsFeatureEnabled(proto.Feature_FEATURE_DB_CHECKSUM))
+
+	restoredCommitOffset, err := db.ReadCommitOffset()
+	assert.NoError(t, err)
+	assert.Equal(t, commitOffset, restoredCommitOffset)
+
+	assert.NoError(t, db.Close())
+	assert.NoError(t, factory.Close())
+}
+
 func TestDb_UpdateTerm(t *testing.T) {
 	factory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
 	assert.NoError(t, err)
@@ -1191,6 +1224,22 @@ func TestDB_ChecksumPersistence(t *testing.T) {
 	restoredChecksum := testDB.(*db).committedChecksum.Load().Value()
 	assert.NotNil(t, restoredChecksum)
 	assert.Equal(t, checksum1, restoredChecksum)
+
+	assert.NoError(t, testDB.Close())
+	assert.NoError(t, factory.Close())
+}
+
+func TestDB_ResetChecksumKeepsFeatureEnabled(t *testing.T) {
+	factory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	testDB, err := NewDB(constant.DefaultNamespace, 1, factory, proto.KeySortingType_NATURAL, 0, time.SystemClock)
+	assert.NoError(t, err)
+	testDB.EnableFeature(proto.Feature_FEATURE_DB_CHECKSUM)
+
+	testDB.ResetChecksum()
+
+	assert.Equal(t, crc.Checksum(0), testDB.ReadChecksum())
+	assert.True(t, testDB.IsFeatureEnabled(proto.Feature_FEATURE_DB_CHECKSUM))
 
 	assert.NoError(t, testDB.Close())
 	assert.NoError(t, factory.Close())

--- a/oxiad/dataserver/database/db_test.go
+++ b/oxiad/dataserver/database/db_test.go
@@ -485,6 +485,26 @@ func TestDB_EnabledFeaturePersistence(t *testing.T) {
 	assert.NoError(t, factory.Close())
 }
 
+func TestDB_RecoverFeatureFlagsRejectsMalformedKeys(t *testing.T) {
+	factory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	testDB, err := NewDB(constant.DefaultNamespace, 1, factory, proto.KeySortingType_NATURAL, 0, time.SystemClock)
+	assert.NoError(t, err)
+
+	batch := testDB.(*db).kv.NewWriteBatch()
+	err = testDB.(*db).addASCIILong(featureFlagKeyPrefix+"/1/extra", 1, batch, 0)
+	assert.NoError(t, err)
+	assert.NoError(t, batch.Commit())
+	assert.NoError(t, batch.Close())
+	assert.NoError(t, testDB.Close())
+
+	testDB, err = NewDB(constant.DefaultNamespace, 1, factory, proto.KeySortingType_NATURAL, 0, time.SystemClock)
+	assert.Nil(t, testDB)
+	assert.ErrorContains(t, err, "invalid feature flag key")
+
+	assert.NoError(t, factory.Close())
+}
+
 func TestDb_UpdateTerm(t *testing.T) {
 	factory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
 	assert.NoError(t, err)

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -46,7 +46,7 @@ var secondaryIdxRegex = regexp.MustCompile(
 //
 // Key classification:
 //   - User data keys: filter by hash of partition_key (or key if no partition_key)
-//   - __oxia/last-version-id, commit-offset, term, term-options: keep
+//   - __oxia/last-version-id, commit-offset, features, term, term-options: keep
 //   - __oxia/checksum: delete (invalid after filtering)
 //   - __oxia/notifications/{offset}: filter notification map by key hash; delete if empty
 //   - __oxia/session/{id}: keep (session metadata duplicated to both children)
@@ -142,7 +142,8 @@ func classifyInternalKey(
 	case key == commitOffsetKey,
 		key == commitLastVersionIdKey,
 		key == termKey,
-		key == termOptionsKey:
+		key == termOptionsKey,
+		strings.HasPrefix(key, enabledFeatureKeyPrefix+"/"):
 		// Metadata keys: keep in both children
 		return splitActionKeep, nil
 

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -143,7 +143,7 @@ func classifyInternalKey(
 		key == commitLastVersionIdKey,
 		key == termKey,
 		key == termOptionsKey,
-		strings.HasPrefix(key, enabledFeatureKeyPrefix+"/"):
+		strings.HasPrefix(key, featureFlagKeyPrefix+"/"):
 		// Metadata keys: keep in both children
 		return splitActionKeep, nil
 

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -169,7 +169,7 @@ func TestFilterDBForSplit_MetadataKeys(t *testing.T) {
 	putRawKey(t, kv, commitOffsetKey, []byte("42"))
 	putRawKey(t, kv, commitLastVersionIdKey, []byte("100"))
 	putRawKey(t, kv, commitChecksumKey, []byte("999"))
-	putRawKey(t, kv, enabledFeatureKey(proto.Feature_FEATURE_DB_CHECKSUM), []byte("1"))
+	putRawKey(t, kv, featureFlagKey(proto.Feature_FEATURE_DB_CHECKSUM), []byte("1"))
 	putRawKey(t, kv, termKey, []byte("5"))
 	putRawKey(t, kv, termOptionsKey, []byte(`{"notificationsEnabled":true}`))
 
@@ -178,7 +178,7 @@ func TestFilterDBForSplit_MetadataKeys(t *testing.T) {
 	// Kept
 	assert.True(t, keyExists(t, kv, commitOffsetKey))
 	assert.True(t, keyExists(t, kv, commitLastVersionIdKey))
-	assert.True(t, keyExists(t, kv, enabledFeatureKey(proto.Feature_FEATURE_DB_CHECKSUM)))
+	assert.True(t, keyExists(t, kv, featureFlagKey(proto.Feature_FEATURE_DB_CHECKSUM)))
 	assert.True(t, keyExists(t, kv, termKey))
 	assert.True(t, keyExists(t, kv, termOptionsKey))
 

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -169,6 +169,7 @@ func TestFilterDBForSplit_MetadataKeys(t *testing.T) {
 	putRawKey(t, kv, commitOffsetKey, []byte("42"))
 	putRawKey(t, kv, commitLastVersionIdKey, []byte("100"))
 	putRawKey(t, kv, commitChecksumKey, []byte("999"))
+	putRawKey(t, kv, enabledFeatureKey(proto.Feature_FEATURE_DB_CHECKSUM), []byte("1"))
 	putRawKey(t, kv, termKey, []byte("5"))
 	putRawKey(t, kv, termOptionsKey, []byte(`{"notificationsEnabled":true}`))
 
@@ -177,6 +178,7 @@ func TestFilterDBForSplit_MetadataKeys(t *testing.T) {
 	// Kept
 	assert.True(t, keyExists(t, kv, commitOffsetKey))
 	assert.True(t, keyExists(t, kv, commitLastVersionIdKey))
+	assert.True(t, keyExists(t, kv, enabledFeatureKey(proto.Feature_FEATURE_DB_CHECKSUM)))
 	assert.True(t, keyExists(t, kv, termKey))
 	assert.True(t, keyExists(t, kv, termOptionsKey))
 


### PR DESCRIPTION
## Motivation
- Feature enable control records persisted the commit offset but only kept enabled features in memory.
- After restart, a node could skip WAL replay past the feature enable record and lose the enabled feature state.

## Modifications
- Persist enabled features as internal database keys under `__oxia/features/` in the same batch as the control request commit offset.
- Restore enabled features when opening the database.
- Keep enabled feature metadata across split filtering and keep checksum reset scoped to the checksum value.

## Testing
- `go test ./oxiad/dataserver/database ./oxiad/dataserver/controller/statemachine`
- `go test ./oxiad/dataserver/controller/lead ./oxiad/dataserver/controller/follow ./tests/control`
