### PR TITLE
fix: drain follower cursor on close

### DIFF
--- a/common/rpc/mock.go
+++ b/common/rpc/mock.go
@@ -17,6 +17,7 @@ package rpc
 import (
 	"context"
 	"io"
+	"sync"
 
 	"google.golang.org/grpc/metadata"
 
@@ -89,34 +90,35 @@ type TruncateResps struct {
 	Error    error
 }
 type MockRpcClient struct {
-	MockBase
 	SendSnapshotStream *MockSendSnapshotClientStream
 	AppendReqs         chan *proto.Append
 	AckResps           chan *proto.Ack
 	TruncateReqs       chan *proto.TruncateRequest
 	TruncateResps      chan TruncateResps
+	streamsMutex       sync.Mutex
+	streams            []*MockReplicateStream
 }
 
-func (*MockRpcClient) Close() error {
+func (m *MockRpcClient) Close() error {
+	m.streamsMutex.Lock()
+	defer m.streamsMutex.Unlock()
+
+	for _, stream := range m.streams {
+		if err := stream.CloseSend(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
-func (m *MockRpcClient) Send(request *proto.Append) error {
-	m.AppendReqs <- request
-	return nil
-}
+func (m *MockRpcClient) GetReplicateStream(ctx context.Context, _ string, _ string, _ int64, _ int64) (proto.OxiaLogReplication_ReplicateClient, error) {
+	stream := NewMockReplicateStream(ctx, m.AppendReqs, m.AckResps)
 
-func (m *MockRpcClient) Recv() (*proto.Ack, error) {
-	res := <-m.AckResps
-	return res, nil
-}
+	m.streamsMutex.Lock()
+	m.streams = append(m.streams, stream)
+	m.streamsMutex.Unlock()
 
-func (*MockRpcClient) CloseSend() error {
-	return nil
-}
-
-func (m *MockRpcClient) GetReplicateStream(context.Context, string, string, int64, int64) (proto.OxiaLogReplication_ReplicateClient, error) {
-	return m, nil
+	return stream, nil
 }
 
 func (m *MockRpcClient) SendSnapshot(context.Context, string, string, int64, int64) (proto.OxiaLogReplication_SendSnapshotClient, error) {
@@ -130,6 +132,50 @@ func (m *MockRpcClient) Truncate(_ string, req *proto.TruncateRequest) (*proto.T
 
 	x := <-m.TruncateResps
 	return x.Response, x.Error
+}
+
+type MockReplicateStream struct {
+	MockBase
+	send   chan *proto.Append
+	recv   chan *proto.Ack
+	cancel context.CancelFunc
+}
+
+func NewMockReplicateStream(ctx context.Context, send chan *proto.Append, recv chan *proto.Ack) *MockReplicateStream {
+	stream := &MockReplicateStream{
+		send: send,
+		recv: recv,
+	}
+	stream.ctx, stream.cancel = context.WithCancel(ctx)
+	return stream
+}
+
+func (m *MockReplicateStream) Send(request *proto.Append) error {
+	select {
+	case <-m.ctx.Done():
+		return m.ctx.Err()
+	case m.send <- request:
+		return nil
+	}
+}
+
+func (m *MockReplicateStream) Recv() (*proto.Ack, error) {
+	select {
+	case <-m.ctx.Done():
+		return nil, m.ctx.Err()
+	case res, ok := <-m.recv:
+		if !ok {
+			return nil, io.EOF
+		}
+		return res, nil
+	}
+}
+
+func (m *MockReplicateStream) CloseSend() error {
+	if m.cancel != nil {
+		m.cancel()
+	}
+	return nil
 }
 
 func NewMockShardAssignmentClientStream() *MockShardAssignmentClientStream {

--- a/oxiad/dataserver/controller/lead/follower_cursor.go
+++ b/oxiad/dataserver/controller/lead/follower_cursor.go
@@ -81,6 +81,7 @@ type followerCursor struct {
 	closed         atomic.Bool
 	ctx            context.Context
 	cancel         context.CancelFunc
+	latch          sync.WaitGroup
 	log            *slog.Logger
 	splitHashRange *proto.Int32HashRange // non-nil for split observer cursors
 
@@ -148,17 +149,19 @@ func NewFollowerCursor( //nolint:revive
 		return nil, err
 	}
 
-	go process.DoWithLabels(
-		context.Background(),
-		map[string]string{
-			"oxia":      "follower-cursor-send",
-			"namespace": namespace,
-			"shard":     fmt.Sprintf("%d", fc.shardId),
-		},
-		func() {
-			fc.run()
-		},
-	)
+	fc.latch.Go(func() {
+		process.DoWithLabels(
+			context.Background(),
+			map[string]string{
+				"oxia":      "follower-cursor-send",
+				"namespace": namespace,
+				"shard":     fmt.Sprintf("%d", fc.shardId),
+			},
+			func() {
+				fc.run()
+			},
+		)
+	})
 
 	return fc, nil
 }
@@ -224,17 +227,19 @@ func NewObserverFollowerCursor( //nolint:revive
 	// Observer uses a no-op cursor acker — its acks don't affect quorum
 	fc.cursorAcker = NewNoOpCursorAcker()
 
-	go process.DoWithLabels(
-		context.Background(),
-		map[string]string{
-			"oxia":      "observer-cursor-send",
-			"namespace": namespace,
-			"shard":     fmt.Sprintf("%d", fc.shardId),
-		},
-		func() {
-			fc.run()
-		},
-	)
+	fc.latch.Go(func() {
+		process.DoWithLabels(
+			context.Background(),
+			map[string]string{
+				"oxia":      "observer-cursor-send",
+				"namespace": namespace,
+				"shard":     fmt.Sprintf("%d", fc.shardId),
+			},
+			func() {
+				fc.run()
+			},
+		)
+	})
 
 	return fc, nil
 }
@@ -270,6 +275,7 @@ func (fc *followerCursor) shouldSendSnapshot() bool {
 func (fc *followerCursor) Close() error {
 	fc.closed.Store(true)
 	fc.cancel()
+	fc.latch.Wait()
 	return nil
 }
 

--- a/oxiad/dataserver/controller/lead/follower_cursor_test.go
+++ b/oxiad/dataserver/controller/lead/follower_cursor_test.go
@@ -15,12 +15,17 @@
 package lead
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
 	pb "google.golang.org/protobuf/proto"
 
 	"github.com/oxia-db/oxia/common/rpc"
@@ -203,6 +208,93 @@ func TestFollowerCursor_SendSnapshot(t *testing.T) {
 	assert.NoError(t, fc.Close())
 }
 
+func TestFollowerCursor_CloseWaitsForInFlightSnapshot(t *testing.T) {
+	var term int64 = 1
+	var shard int64 = 2
+
+	kvf, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	db, err := database.NewDB(constant.DefaultNamespace, shard, kvf, proto.KeySortingType_HIERARCHICAL, 1*time.Hour, time2.SystemClock)
+	assert.NoError(t, err)
+	wf := wal.NewWalFactory(&wal.FactoryOptions{BaseWalDir: t.TempDir()})
+	w, err := wf.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+
+	wr := &proto.WriteRequest{
+		Shard: &shard,
+		Puts: []*proto.PutRequest{{
+			Key:   "key",
+			Value: []byte("value"),
+		}},
+	}
+	e, _ := pb.Marshal(wrapInLogEntryValue(wr))
+	assert.NoError(t, w.Append(&proto.LogEntry{
+		Term:      1,
+		Offset:    0,
+		Value:     e,
+		Timestamp: 0,
+	}))
+	_, err = db.ProcessWrite(wr, 0, 0, database.NoOpCallback)
+	assert.NoError(t, err)
+
+	stream := newBlockingSnapshotStream()
+	provider := &blockingSnapshotProvider{stream: stream}
+	ackTracker := NewQuorumAckTracker(3, 0, 0)
+
+	var fc FollowerCursor
+	t.Cleanup(func() {
+		stream.unblock()
+		if fc != nil {
+			assert.NoError(t, fc.Close())
+		}
+		assert.NoError(t, w.Close())
+		assert.NoError(t, wf.Close())
+		assert.NoError(t, db.Close())
+		assert.NoError(t, kvf.Close())
+	})
+
+	fc, err = NewFollowerCursor("f1", term, constant.DefaultNamespace, shard, provider, ackTracker, w, db, wal.InvalidOffset)
+	assert.NoError(t, err)
+
+	// The blocked Send call is after db.Snapshot() succeeds, so the cursor still
+	// owns Pebble snapshot references. Close must not return before that sender
+	// exits, otherwise the leader can close the DB with outstanding references.
+	select {
+	case <-stream.sendStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for snapshot send to start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- fc.Close()
+	}()
+
+	select {
+	case <-stream.Context().Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for cursor close to cancel snapshot context")
+	}
+
+	select {
+	case err := <-closeDone:
+		assert.NoError(t, err)
+		t.Fatal("Close returned before the snapshot sender exited")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	stream.unblock()
+
+	select {
+	case err := <-closeDone:
+		assert.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for cursor close")
+	}
+
+	fc = nil
+}
+
 func wrapInLogEntryValue(wr *proto.WriteRequest) *proto.LogEntryValue {
 	return &proto.LogEntryValue{
 		Value: &proto.LogEntryValue_Requests{
@@ -213,4 +305,80 @@ func wrapInLogEntryValue(wr *proto.WriteRequest) *proto.LogEntryValue {
 			},
 		},
 	}
+}
+
+type blockingSnapshotProvider struct {
+	stream *blockingSnapshotStream
+}
+
+func (*blockingSnapshotProvider) GetReplicateStream(context.Context, string, string, int64, int64) (proto.OxiaLogReplication_ReplicateClient, error) {
+	return nil, errors.New("unexpected replicate stream")
+}
+
+func (p *blockingSnapshotProvider) SendSnapshot(ctx context.Context, _ string, _ string, _ int64, _ int64) (proto.OxiaLogReplication_SendSnapshotClient, error) {
+	p.stream.ctx = ctx
+	return p.stream, nil
+}
+
+type blockingSnapshotStream struct {
+	ctx         context.Context
+	sendStarted chan struct{}
+	release     chan struct{}
+	startOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func newBlockingSnapshotStream() *blockingSnapshotStream {
+	return &blockingSnapshotStream{
+		sendStarted: make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+}
+
+func (s *blockingSnapshotStream) unblock() {
+	s.releaseOnce.Do(func() {
+		close(s.release)
+	})
+}
+
+func (s *blockingSnapshotStream) Send(*proto.SnapshotChunk) error {
+	s.startOnce.Do(func() {
+		close(s.sendStarted)
+	})
+	<-s.release
+	if s.ctx != nil && s.ctx.Err() != nil {
+		return s.ctx.Err()
+	}
+	return context.Canceled
+}
+
+func (*blockingSnapshotStream) CloseAndRecv() (*proto.SnapshotResponse, error) {
+	return nil, context.Canceled
+}
+
+func (*blockingSnapshotStream) Header() (metadata.MD, error) {
+	return metadata.MD{}, nil
+}
+
+func (*blockingSnapshotStream) Trailer() metadata.MD {
+	return nil
+}
+
+func (*blockingSnapshotStream) CloseSend() error {
+	return nil
+}
+
+func (s *blockingSnapshotStream) Context() context.Context {
+	if s.ctx != nil {
+		return s.ctx
+	}
+	return context.Background()
+}
+
+func (*blockingSnapshotStream) SendMsg(any) error {
+	return nil
+}
+
+func (*blockingSnapshotStream) RecvMsg(any) error {
+	return io.EOF
 }


### PR DESCRIPTION
## Motivation
- Closing a leader during a role transition can close Pebble while follower or observer cursor goroutines are still sending snapshots or streaming replication.
- Pebble can panic with `element has outstanding references` if DB close races with outstanding snapshot/file references.

## Modifications
- Track follower and observer cursor sender goroutines with a `latch`.
- Cancel and wait for cursor sender goroutines during `FollowerCursor.Close()`.
- Split the test mock replication provider from per-stream state so mock replicate streams observe context cancellation.
- Add a regression test that verifies cursor close waits for an in-flight snapshot before leader-owned DB resources can be closed.

## Testing
- `go test ./oxiad/dataserver/controller/lead -run TestFollowerCursor -count=1 -timeout=30s`
- `go test ./oxiad/dataserver/controller/lead -count=1 -timeout=120s`
- `go test ./common/rpc -count=1 -timeout=60s`
- `go test ./oxiad/dataserver/controller/... -count=1 -timeout=180s`