### PR TITLE
fix: drain leader operations before closing Pebble DB

### DIFF
--- a/oxiad/dataserver/controller/lead/leader_controller.go
+++ b/oxiad/dataserver/controller/lead/leader_controller.go
@@ -762,9 +762,9 @@ func getHighestEntryOfTerm(w wal.Wal, term int64) (*proto.EntryId, error) {
 
 func (lc *leaderController) Read(ctx context.Context, request *proto.ReadRequest, cb concurrent.StreamCallback[*proto.GetResponse]) {
 	lc.RLock()
-	defer lc.RUnlock()
 	err := checkStatusIsLeader(lc.status)
 	if err != nil {
+		lc.RUnlock()
 		cb.OnComplete(err)
 		return
 	}
@@ -801,6 +801,7 @@ func (lc *leaderController) Read(ctx context.Context, request *proto.ReadRequest
 			},
 		)
 	})
+	lc.RUnlock()
 }
 
 func (lc *leaderController) GetSequenceUpdates(_ context.Context, request *proto.GetSequenceUpdatesRequest) (database.SequenceWaiter, error) {
@@ -817,13 +818,16 @@ func (lc *leaderController) GetSequenceUpdates(_ context.Context, request *proto
 
 func (lc *leaderController) List(ctx context.Context, request *proto.ListRequest, cb concurrent.StreamCallback[string]) {
 	lc.RLock()
-	defer lc.RUnlock()
 	err := checkStatusIsLeader(lc.status)
 	if err != nil {
+		lc.RUnlock()
 		cb.OnComplete(err)
 		return
 	}
-	lc.waitGroup.Go(func() { lc.list(ctx, request, cb) })
+	lc.waitGroup.Go(func() {
+		lc.list(ctx, request, cb)
+	})
+	lc.RUnlock()
 }
 
 func (lc *leaderController) list(ctx context.Context, request *proto.ListRequest, cb concurrent.StreamCallback[string]) {
@@ -879,9 +883,9 @@ func (lc *leaderController) ListBlock(ctx context.Context, request *proto.ListRe
 
 func (lc *leaderController) RangeScan(ctx context.Context, request *proto.RangeScanRequest, cb concurrent.StreamCallback[*proto.GetResponse]) {
 	lc.RLock()
-	defer lc.RUnlock()
 	err := checkStatusIsLeader(lc.status)
 	if err != nil {
+		lc.RUnlock()
 		cb.OnComplete(err)
 		return
 	}
@@ -929,6 +933,7 @@ func (lc *leaderController) RangeScan(ctx context.Context, request *proto.RangeS
 			},
 		)
 	})
+	lc.RUnlock()
 }
 
 func (lc *leaderController) WriteBlock(ctx context.Context, request *proto.WriteRequest) (*proto.WriteResponse, error) {
@@ -1065,12 +1070,13 @@ func (lc *leaderController) propose(ctx context.Context, proposalSupplier func(o
 //nolint:revive
 func (lc *leaderController) GetNotifications(ctx context.Context, req *proto.NotificationsRequest, cb concurrent.StreamCallback[*proto.NotificationBatch]) {
 	lc.Lock()
-	defer lc.Unlock()
 	if err := checkStatusIsLeader(lc.status); err != nil {
+		lc.Unlock()
 		cb.OnComplete(err)
 		return
 	}
 	if !lc.termOptions.NotificationsEnabled {
+		lc.Unlock()
 		cb.OnComplete(constant.ErrNotificationsNotEnabled)
 		return
 	}
@@ -1081,6 +1087,7 @@ func (lc *leaderController) GetNotifications(ctx context.Context, req *proto.Not
 		offsetExclusive = *req.StartOffsetExclusive
 	} else {
 		if qat == nil {
+			lc.Unlock()
 			cb.OnComplete(constant.ErrInvalidStatus)
 			return
 		}
@@ -1100,6 +1107,7 @@ func (lc *leaderController) GetNotifications(ctx context.Context, req *proto.Not
 			Timestamp:     0,
 			Notifications: nil,
 		}); err != nil {
+			lc.Unlock()
 			cb.OnComplete(err)
 			return
 		}
@@ -1151,6 +1159,7 @@ func (lc *leaderController) GetNotifications(ctx context.Context, req *proto.Not
 			},
 		)
 	})
+	lc.Unlock()
 }
 
 func (lc *leaderController) Close() error {

--- a/oxiad/dataserver/controller/lead/leader_controller.go
+++ b/oxiad/dataserver/controller/lead/leader_controller.go
@@ -113,6 +113,8 @@ type leaderController struct {
 
 	ctx            context.Context
 	cancel         context.CancelFunc
+	waitGroup      sync.WaitGroup
+	closed         bool
 	wal            wal.Wal
 	db             database.DB
 	termOptions    database.TermOptions
@@ -262,7 +264,7 @@ func (lc *leaderController) NewTerm(req *proto.NewTermRequest) (*proto.NewTermRe
 	lc.Lock()
 	defer lc.Unlock()
 
-	if lc.isClosed() {
+	if lc.closed {
 		return nil, constant.ErrResourceUnavailable
 	}
 
@@ -344,7 +346,7 @@ func (lc *leaderController) becomeLeader(ctx context.Context, req *proto.BecomeL
 	lc.Lock()
 	defer lc.Unlock()
 
-	if lc.isClosed() {
+	if lc.closed {
 		return nil, constant.ErrResourceUnavailable
 	}
 
@@ -760,49 +762,51 @@ func getHighestEntryOfTerm(w wal.Wal, term int64) (*proto.EntryId, error) {
 
 func (lc *leaderController) Read(ctx context.Context, request *proto.ReadRequest, cb concurrent.StreamCallback[*proto.GetResponse]) {
 	lc.RLock()
+	defer lc.RUnlock()
 	err := checkStatusIsLeader(lc.status)
-	lc.RUnlock()
 	if err != nil {
 		cb.OnComplete(err)
 		return
 	}
-	go process.DoWithLabels(
-		ctx,
-		map[string]string{
-			"oxia":  "read",
-			"shard": fmt.Sprintf("%d", lc.shardId),
-			"peer":  commonrpc.GetPeer(ctx),
-		},
-		func() {
-			lc.log.Debug("Received read request", slog.Int64("term", lc.term.Load()))
-			var response *proto.GetResponse
-			var err error
+	lc.waitGroup.Go(func() {
+		process.DoWithLabels(
+			ctx,
+			map[string]string{
+				"oxia":  "read",
+				"shard": fmt.Sprintf("%d", lc.shardId),
+				"peer":  commonrpc.GetPeer(ctx),
+			},
+			func() {
+				lc.log.Debug("Received read request", slog.Int64("term", lc.term.Load()))
+				var response *proto.GetResponse
+				var err error
 
-			for _, get := range request.Gets {
-				if get.SecondaryIndexName != nil {
-					response, err = secondaryIndexGet(get, lc.db)
-				} else {
-					response, err = lc.db.Get(get)
+				for _, get := range request.Gets {
+					if get.SecondaryIndexName != nil {
+						response, err = secondaryIndexGet(get, lc.db)
+					} else {
+						response, err = lc.db.Get(get)
+					}
+					if err != nil {
+						break
+					}
+					if err = cb.OnNext(response); err != nil {
+						break
+					}
+					if err = ctx.Err(); err != nil {
+						break
+					}
 				}
-				if err != nil {
-					break
-				}
-				if err = cb.OnNext(response); err != nil {
-					break
-				}
-				if err = ctx.Err(); err != nil {
-					break
-				}
-			}
-			cb.OnComplete(err)
-		},
-	)
+				cb.OnComplete(err)
+			},
+		)
+	})
 }
 
 func (lc *leaderController) GetSequenceUpdates(_ context.Context, request *proto.GetSequenceUpdatesRequest) (database.SequenceWaiter, error) {
 	lc.RLock()
+	defer lc.RUnlock()
 	err := checkStatusIsLeader(lc.status)
-	lc.RUnlock()
 	if err != nil {
 		return nil, err
 	}
@@ -813,17 +817,17 @@ func (lc *leaderController) GetSequenceUpdates(_ context.Context, request *proto
 
 func (lc *leaderController) List(ctx context.Context, request *proto.ListRequest, cb concurrent.StreamCallback[string]) {
 	lc.RLock()
+	defer lc.RUnlock()
 	err := checkStatusIsLeader(lc.status)
-	lc.RUnlock()
 	if err != nil {
 		cb.OnComplete(err)
 		return
 	}
-	lc.list(ctx, request, cb)
+	lc.waitGroup.Go(func() { lc.list(ctx, request, cb) })
 }
 
 func (lc *leaderController) list(ctx context.Context, request *proto.ListRequest, cb concurrent.StreamCallback[string]) {
-	go process.DoWithLabels(
+	process.DoWithLabels(
 		ctx,
 		map[string]string{
 			"oxia":  "list",
@@ -869,60 +873,62 @@ func (lc *leaderController) list(ctx context.Context, request *proto.ListRequest
 func (lc *leaderController) ListBlock(ctx context.Context, request *proto.ListRequest) ([]string, error) {
 	// todo: support leader status check without lock
 	ch := make(chan *entity.TWithError[string])
-	go lc.list(ctx, request, concurrent.ReadFromStreamCallback(ch))
+	lc.waitGroup.Go(func() { lc.list(ctx, request, concurrent.ReadFromStreamCallback(ch)) })
 	return channel.ReadAll(ctx, ch)
 }
 
 func (lc *leaderController) RangeScan(ctx context.Context, request *proto.RangeScanRequest, cb concurrent.StreamCallback[*proto.GetResponse]) {
 	lc.RLock()
+	defer lc.RUnlock()
 	err := checkStatusIsLeader(lc.status)
-	lc.RUnlock()
 	if err != nil {
 		cb.OnComplete(err)
 		return
 	}
 
-	go process.DoWithLabels(ctx,
-		map[string]string{
-			"oxia":  "range-scan",
-			"shard": fmt.Sprintf("%d", lc.shardId),
-			"peer":  commonrpc.GetPeer(ctx),
-		},
-		func() {
-			lc.log.Debug("Received range-scan request", slog.Int64("term", lc.term.Load()), slog.Any("request", request))
+	lc.waitGroup.Go(func() {
+		process.DoWithLabels(ctx,
+			map[string]string{
+				"oxia":  "range-scan",
+				"shard": fmt.Sprintf("%d", lc.shardId),
+				"peer":  commonrpc.GetPeer(ctx),
+			},
+			func() {
+				lc.log.Debug("Received range-scan request", slog.Int64("term", lc.term.Load()), slog.Any("request", request))
 
-			var it database.RangeScanIterator
-			var err error
+				var it database.RangeScanIterator
+				var err error
 
-			if request.SecondaryIndexName != nil {
-				it, err = newSecondaryIndexRangeScanIterator(request, lc.db)
-			} else {
-				it, err = lc.db.RangeScan(request)
-			}
+				if request.SecondaryIndexName != nil {
+					it, err = newSecondaryIndexRangeScanIterator(request, lc.db)
+				} else {
+					it, err = lc.db.RangeScan(request)
+				}
 
-			if err != nil {
-				lc.log.Warn("Failed to process range-scan request", slog.Any("error", err), slog.Int64("term", lc.term.Load()))
+				if err != nil {
+					lc.log.Warn("Failed to process range-scan request", slog.Any("error", err), slog.Int64("term", lc.term.Load()))
+					cb.OnComplete(err)
+					return
+				}
+
+				var gr *proto.GetResponse
+				for ; it.Valid(); it.Next() {
+					if gr, err = it.Value(); err != nil {
+						break
+					}
+					if err = cb.OnNext(gr); err != nil {
+						break
+					}
+					if err = ctx.Err(); err != nil {
+						break
+					}
+				}
+
+				err = multierr.Combine(err, it.Close())
 				cb.OnComplete(err)
-				return
-			}
-
-			var gr *proto.GetResponse
-			for ; it.Valid(); it.Next() {
-				if gr, err = it.Value(); err != nil {
-					break
-				}
-				if err = cb.OnNext(gr); err != nil {
-					break
-				}
-				if err = ctx.Err(); err != nil {
-					break
-				}
-			}
-
-			err = multierr.Combine(err, it.Close())
-			cb.OnComplete(err)
-		},
-	)
+			},
+		)
+	})
 }
 
 func (lc *leaderController) WriteBlock(ctx context.Context, request *proto.WriteRequest) (*proto.WriteResponse, error) {
@@ -1022,9 +1028,11 @@ func (lc *leaderController) propose(ctx context.Context, proposalSupplier func(o
 		return
 	}
 
+	lc.waitGroup.Add(1) // inflight proposal
 	deferDbWrite := func(entryCrc uint32, err error) {
 		if err != nil {
 			timer.DoneCtx(ctx)
+			lc.waitGroup.Done()
 			cb.OnCompleteError(errors.Wrap(err, "oxia: failed to append to wal"))
 			return
 		}
@@ -1034,6 +1042,7 @@ func (lc *leaderController) propose(ctx context.Context, proposalSupplier func(o
 				defer timer.DoneCtx(ctx)
 				response, err := proposal.Apply(lc.db, WrapperUpdateOperationCallback)
 				if err != nil {
+					lc.waitGroup.Done()
 					cb.OnCompleteError(err)
 					return
 				}
@@ -1041,9 +1050,11 @@ func (lc *leaderController) propose(ctx context.Context, proposalSupplier func(o
 					lc.checksumGauge.Record(int64(*response.Checksum))
 					lc.walChecksumGauge.Record(int64(entryCrc))
 				}
+				lc.waitGroup.Done()
 				cb.OnComplete(response)
 			}, func(err error) {
 				timer.DoneCtx(ctx)
+				lc.waitGroup.Done()
 				cb.OnCompleteError(errors.Wrap(err, "oxia: failed to append to wal"))
 			}))
 	}
@@ -1054,18 +1065,16 @@ func (lc *leaderController) propose(ctx context.Context, proposalSupplier func(o
 //nolint:revive
 func (lc *leaderController) GetNotifications(ctx context.Context, req *proto.NotificationsRequest, cb concurrent.StreamCallback[*proto.NotificationBatch]) {
 	lc.Lock()
+	defer lc.Unlock()
 	if err := checkStatusIsLeader(lc.status); err != nil {
-		lc.Unlock()
 		cb.OnComplete(err)
 		return
 	}
 	if !lc.termOptions.NotificationsEnabled {
-		lc.Unlock()
 		cb.OnComplete(constant.ErrNotificationsNotEnabled)
 		return
 	}
 	qat := lc.quorumAckTracker
-	lc.Unlock()
 
 	var offsetExclusive int64
 	if req.StartOffsetExclusive != nil {
@@ -1097,53 +1106,51 @@ func (lc *leaderController) GetNotifications(ctx context.Context, req *proto.Not
 		offsetExclusive = commitOffset
 	}
 
-	go process.DoWithLabels(
-		ctx,
-		map[string]string{
-			"oxia":  "dispatch-notifications",
-			"shard": fmt.Sprintf("%d", lc.shardId),
-			"peer":  commonrpc.GetPeer(ctx),
-		},
-		func() {
-			lc.log.Debug("Dispatch notifications", slog.Int64("term", lc.term.Load()), slog.Any("start-offset-include", offsetExclusive))
-			offset := offsetExclusive
-			for {
-				select {
-				case <-lc.ctx.Done():
-					cb.OnComplete(constant.ErrResourceUnavailable)
-					return
-				case <-ctx.Done():
-					cb.OnComplete(nil)
-					return
-				default:
-					notifications, err := lc.db.ReadNextNotifications(ctx, offset+1)
-					if err != nil {
-						cb.OnComplete(err)
+	lc.waitGroup.Go(func() {
+		process.DoWithLabels(
+			ctx,
+			map[string]string{
+				"oxia":  "dispatch-notifications",
+				"shard": fmt.Sprintf("%d", lc.shardId),
+				"peer":  commonrpc.GetPeer(ctx),
+			},
+			func() {
+				lc.log.Debug("Dispatch notifications", slog.Int64("term", lc.term.Load()), slog.Any("start-offset-include", offsetExclusive))
+				offset := offsetExclusive
+				for {
+					select {
+					case <-lc.ctx.Done():
+						cb.OnComplete(constant.ErrResourceUnavailable)
 						return
-					}
-					lc.log.Debug(
-						"Got a new list of notification batches",
-						slog.Int64("term", lc.term.Load()),
-						slog.Int("list-size", len(notifications)),
-					)
-					if len(notifications) > 0 {
-						for idx := range notifications {
-							notification := notifications[idx]
-							if err := cb.OnNext(notification); err != nil {
-								cb.OnComplete(err)
-								return
+					case <-ctx.Done():
+						cb.OnComplete(nil)
+						return
+					default:
+						notifications, err := lc.db.ReadNextNotifications(ctx, offset+1)
+						if err != nil {
+							cb.OnComplete(err)
+							return
+						}
+						lc.log.Debug(
+							"Got a new list of notification batches",
+							slog.Int64("term", lc.term.Load()),
+							slog.Int("list-size", len(notifications)),
+						)
+						if len(notifications) > 0 {
+							for idx := range notifications {
+								notification := notifications[idx]
+								if err := cb.OnNext(notification); err != nil {
+									cb.OnComplete(err)
+									return
+								}
+								offset = notification.Offset
 							}
-							offset = notification.Offset
 						}
 					}
 				}
-			}
-		},
-	)
-}
-
-func (lc *leaderController) isClosed() bool {
-	return lc.ctx.Err() != nil
+			},
+		)
+	})
 }
 
 func (lc *leaderController) Close() error {
@@ -1156,9 +1163,15 @@ func (lc *leaderController) close() error {
 	lc.log.Info("Closing leader controller", slog.Int64("term", lc.term.Load()))
 
 	lc.status = proto.ServingStatus_NOT_MEMBER
+	lc.closed = true
 	lc.cancel()
 
 	var err error
+	if lc.quorumAckTracker != nil {
+		err = multierr.Append(err, lc.quorumAckTracker.Close())
+	}
+
+	lc.waitGroup.Wait()
 	for _, follower := range lc.followers {
 		err = multierr.Append(err, follower.Close())
 	}
@@ -1180,15 +1193,11 @@ func (lc *leaderController) close() error {
 		err = multierr.Append(err, lc.wal.Close())
 		lc.wal = nil
 	}
+	lc.quorumAckTracker = nil
 
 	if lc.db != nil {
 		err = multierr.Append(err, lc.db.Close())
 		lc.db = nil
-	}
-
-	if lc.quorumAckTracker != nil {
-		err = multierr.Append(err, lc.quorumAckTracker.Close())
-		lc.quorumAckTracker = nil
 	}
 
 	return err
@@ -1212,6 +1221,8 @@ func getLastEntryIdInWal(walObject wal.Wal) (*proto.EntryId, error) {
 }
 
 func (lc *leaderController) CommitOffset() int64 {
+	// WAL trimming can call back into this provider while leader close holds the
+	// leader lock and waits for WAL close. Do not take the leader lock here.
 	qat := lc.quorumAckTracker
 	if qat != nil {
 		return qat.CommitOffset()
@@ -1243,6 +1254,9 @@ func (lc *leaderController) GetStatus(_ *proto.GetStatusRequest) (*proto.GetStat
 func (lc *leaderController) DeleteShard(request *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
 	lc.Lock()
 	defer lc.Unlock()
+	if lc.closed {
+		return nil, constant.ErrResourceUnavailable
+	}
 
 	currentTerm := lc.term.Load()
 	if request.Term < currentTerm {

--- a/oxiad/dataserver/controller/lead/leader_controller.go
+++ b/oxiad/dataserver/controller/lead/leader_controller.go
@@ -1170,6 +1170,7 @@ func (lc *leaderController) close() error {
 	if lc.quorumAckTracker != nil {
 		err = multierr.Append(err, lc.quorumAckTracker.Close())
 	}
+	lc.quorumAckTracker = nil
 
 	lc.waitGroup.Wait()
 	for _, follower := range lc.followers {
@@ -1193,7 +1194,6 @@ func (lc *leaderController) close() error {
 		err = multierr.Append(err, lc.wal.Close())
 		lc.wal = nil
 	}
-	lc.quorumAckTracker = nil
 
 	if lc.db != nil {
 		err = multierr.Append(err, lc.db.Close())

--- a/oxiad/dataserver/controller/lead/leader_controller_test.go
+++ b/oxiad/dataserver/controller/lead/leader_controller_test.go
@@ -1133,14 +1133,15 @@ func TestLeaderController_NotificationsCloseLeader(t *testing.T) {
 
 	assert.False(t, adaptor.IsCompleted())
 
-	// Closing the leader should close the `GetNotification()` handler
+	cancel()
+
+	// Closing the leader should wait for the `GetNotification()` handler
 	assert.NoError(t, lc.Close())
 
 	time.Sleep(1 * time.Second)
 
 	assert.True(t, adaptor.IsCompleted())
 
-	cancel()
 	assert.NoError(t, kvFactory.Close())
 	assert.NoError(t, walFactory.Close())
 }

--- a/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
+++ b/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
@@ -247,9 +247,11 @@ func (q *quorumAckTracker) Close() error {
 	q.Lock()
 	q.closed = true
 	q.waitForHeadOffset.Broadcast()
+	waitingRequests := q.waitingRequests
+	q.waitingRequests = make([]waitingRequest, 0)
 	q.Unlock()
 	// unblock waiting request
-	for _, r := range q.waitingRequests {
+	for _, r := range waitingRequests {
 		r.callback.OnCompleteError(constant.ErrResourceUnavailable)
 	}
 	return nil
@@ -298,6 +300,9 @@ func (c *cursorAcker) Ack(offset int64) {
 	c.quorumTracker.Lock()
 	defer c.quorumTracker.Unlock()
 
+	if c.quorumTracker.closed {
+		return
+	}
 	c.ack(offset)
 }
 

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -388,6 +388,7 @@ func (s *publicRpcServer) GetNotifications(req *proto.NotificationsRequest, stre
 		channel.PushNoBlock(finish, err)
 	}))
 
+	leaderCtx := lc.Context()
 	for {
 		select {
 		case err := <-finish:
@@ -401,6 +402,8 @@ func (s *publicRpcServer) GetNotifications(req *proto.NotificationsRequest, stre
 			return nil
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-leaderCtx.Done():
+			return constant.IntoGrpcStatusError(constant.ErrResourceUnavailable)
 		}
 	}
 }


### PR DESCRIPTION
## Motivation
- A leader can be closed while leader-owned work is still using DB, WAL, or quorum tracker state.
- During a leader-to-follower transition triggered by replication, this can close Pebble while file/cache references are still outstanding, causing `panic: element has outstanding references`.
- The shutdown path needs to stop accepting new leader work, unblock pending commit waiters, and wait for in-flight leader operations before closing storage.

## Modifications
- Add explicit leader closed state and prevent new term/leader/delete operations after close starts.
- Track leader async work with a wait group and drain it after leader cancellation but before closing followers, observers, WAL, and DB.
- Include read, list, range scan, notification dispatch, sequence-update initialization, and proposal WAL/commit/apply callbacks in the protected lifecycle.
- Close the quorum ack tracker before draining so pending commit wait callbacks are released, and ignore late cursor acks after the tracker is closed.
- Keep WAL commit-offset observation non-blocking during leader close to avoid deadlocking the WAL trimmer while closing the WAL.
- Return a retryable unavailable error when public notification streams terminate because the leader context closed.

## Testing
- `go test ./oxiad/dataserver/controller/lead ./oxiad/dataserver -count=1`
- `go test -cover -race ./oxiad/dataserver/controller/lead -count=1`
- `go test -cover -race ./oxiad/dataserver -count=1`
