### PR TITLE
fix: stop notification dispatcher after dummy failure

### DIFF
--- a/oxiad/dataserver/controller/lead/leader_controller.go
+++ b/oxiad/dataserver/controller/lead/leader_controller.go
@@ -1092,6 +1092,7 @@ func (lc *leaderController) GetNotifications(ctx context.Context, req *proto.Not
 			Notifications: nil,
 		}); err != nil {
 			cb.OnComplete(err)
+			return
 		}
 		offsetExclusive = commitOffset
 	}


### PR DESCRIPTION
## Motivation
- The notification stream should stop if the initial dummy notification cannot be sent.
- Addresses review feedback from https://github.com/oxia-db/oxia/pull/1143#discussion_r3339361629.

## Modifications
- Return immediately after completing the callback when the dummy notification send fails.

## Testing
- `go test ./oxiad/dataserver/controller/lead`
- `git diff --check`