### PR TITLE
fix: stop notification dispatcher after dummy failure

### DIFF
--- a/oxiad/dataserver/controller/lead/leader_controller.go
+++ b/oxiad/dataserver/controller/lead/leader_controller.go
@@ -1092,6 +1092,7 @@ func (lc *leaderController) GetNotifications(ctx context.Context, req *proto.Not
 			Notifications: nil,
 		}); err != nil {
 			cb.OnComplete(err)
+			return
 		}
 		offsetExclusive = commitOffset
 	}


### PR DESCRIPTION
## Motivation
- Backport #1144 to release-0.16.
- The notification stream should stop if the initial dummy notification cannot be sent.

## Modifications
- Cherry-pick `636f3e6a` from #1144 with `-x`.
- Return immediately after completing the callback when the dummy notification send fails.

## Testing
- `go test ./oxiad/dataserver/controller/lead -run 'TestLeaderController_Notifications' -timeout 60s`