### PR TITLE
fix: initialize notifications from notification offset

### DIFF
--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -166,11 +166,6 @@ func NewDB(namespace string, shardId int64, factory kvstore.Factory,
 			"The total number of range-scan operations", "count", labels),
 	}
 
-	commitOffset, err := db.ReadCommitOffset()
-	if err != nil {
-		return nil, err
-	}
-
 	lastVersionId, err := db.readLastVersionId()
 	if err != nil {
 		return nil, err
@@ -191,7 +186,12 @@ func NewDB(namespace string, shardId int64, factory kvstore.Factory,
 		return nil, err
 	}
 
-	db.notificationsTracker = newNotificationsTracker(namespace, shardId, commitOffset, kv, notificationRetentionTime, clock)
+	lastNotificationOffset, err := db.readLastNotificationOffset()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read last notification offset")
+	}
+
+	db.notificationsTracker = newNotificationsTracker(namespace, shardId, lastNotificationOffset, kv, notificationRetentionTime, clock)
 	return db, nil
 }
 
@@ -592,6 +592,25 @@ func (d *db) recoverFeatureFlags() error {
 		it.Next()
 	}
 	return nil
+}
+
+func (d *db) readLastNotificationOffset() (int64, error) {
+	key, _, closer, err := d.kv.Get(lastNotificationKey, kvstore.ComparisonFloor, kvstore.ShowInternalKeys)
+	if errors.Is(err, kvstore.ErrKeyNotFound) {
+		d.log.Debug("No notification offset found")
+		return constant.I64NegativeOne, nil
+	}
+	if err != nil {
+		return constant.I64NegativeOne, err
+	}
+	defer closer.Close()
+
+	if !strings.HasPrefix(key, notificationsPrefix+"/") {
+		d.log.Debug("No notification offset found", slog.String("floor-key", key))
+		return constant.I64NegativeOne, nil
+	}
+
+	return parseNotificationKey(key)
 }
 
 func (d *db) readASCIILongOrDefault(key string, defaultValue int64) (int64, error) {

--- a/oxiad/dataserver/database/db_notifications_test.go
+++ b/oxiad/dataserver/database/db_notifications_test.go
@@ -210,6 +210,78 @@ func TestDB_NotificationsCancelWait(t *testing.T) {
 	assert.NoError(t, factory.Close())
 }
 
+func TestDB_NotificationsWaitAfterControlOnlyTailReopen(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *proto.ControlRequest
+	}{
+		{
+			name: "record checksum",
+			request: &proto.ControlRequest{
+				Value: &proto.ControlRequest_RecordChecksum{
+					RecordChecksum: &proto.RecordChecksumRequest{},
+				},
+			},
+		},
+		{
+			name: "feature enable",
+			request: &proto.ControlRequest{
+				Value: &proto.ControlRequest_FeatureEnable{
+					FeatureEnable: &proto.FeatureEnableRequest{
+						Features: []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+			assert.NoError(t, err)
+			db, err := NewDB(constant.DefaultNamespace, 1, factory, proto.KeySortingType_NATURAL, 1*time.Hour, time2.SystemClock)
+			assert.NoError(t, err)
+
+			_, err = db.ProcessWrite(&proto.WriteRequest{
+				Puts: []*proto.PutRequest{{
+					Key:   "a",
+					Value: []byte("0"),
+				}},
+			}, 0, now(), NoOpCallback)
+			assert.NoError(t, err)
+
+			_, err = db.ProcessControlRequest(tt.request, 1, now(), NoOpCallback)
+			assert.NoError(t, err)
+			assert.NoError(t, db.Close())
+
+			db, err = NewDB(constant.DefaultNamespace, 1, factory, proto.KeySortingType_NATURAL, 1*time.Hour, time2.SystemClock)
+			assert.NoError(t, err)
+			defer db.Close()
+			defer factory.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			notifications, err := db.ReadNextNotifications(ctx, 1)
+			cancel()
+			assert.ErrorIs(t, err, context.DeadlineExceeded)
+			assert.Nil(t, notifications)
+
+			_, err = db.ProcessWrite(&proto.WriteRequest{
+				Puts: []*proto.PutRequest{{
+					Key:   "b",
+					Value: []byte("1"),
+				}},
+			}, 2, now(), NoOpCallback)
+			assert.NoError(t, err)
+
+			notifications, err = db.ReadNextNotifications(context.Background(), 1)
+			assert.NoError(t, err)
+			if assert.Len(t, notifications, 1) {
+				assert.EqualValues(t, 2, notifications[0].Offset)
+			}
+		})
+	}
+}
+
 func TestDB_NotificationsDisabled(t *testing.T) {
 	factory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
 	assert.NoError(t, err)

--- a/oxiad/dataserver/database/notifications_tracker.go
+++ b/oxiad/dataserver/database/notifications_tracker.go
@@ -163,7 +163,7 @@ func (nt *notificationsTracker) waitForNotifications(ctx context.Context, startO
 		nt.log.Debug(
 			"Waiting for notification to be available",
 			slog.Int64("start-offset", startOffset),
-			slog.Int64("last-committed-offset", nt.lastOffset.Load()),
+			slog.Int64("last-notification-offset", nt.lastOffset.Load()),
 		)
 
 		if err := nt.cond.Wait(ctx); err != nil {


### PR DESCRIPTION
## Motivation
- Backport #1147 to release-0.16.
- Control commands advance the applied commit offset without creating notification rows.
- After restart, initializing the notification tracker from the commit offset can make notification reads return empty batches at a control-only tail and spin.

## Modifications
- Initialize the notification tracker from the highest actual notification key instead of the DB commit offset.
- Add regression coverage for control-only tail reopen behavior.
- Rename the wait log field to `last-notification-offset`.

## Testing
- `go test ./oxiad/dataserver/database`
- `go test ./oxiad/dataserver/controller/statemachine -run 'TestApplyLogEntry_ControlRequest|TestApplyLogEntry_ControlRequestPersistsCommitOffsetForWalReplay|TestNotificationsTrimmer_GapFromControlRequests'`
- `go test ./oxiad/dataserver/controller/lead -run 'TestLeaderController_Notifications'`
- `go test ./oxia ./tests/client -run 'Notifications'`
- `git diff --check origin/release-0.16..HEAD`
