### PR TITLE
docs: add star history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Please 🌟 star the project if you like it.
 
 Feel free to open an [issue](https://github.com/oxia-db/oxia/issues/new) or start a [discussion](https://github.com/oxia-db/oxia/discussions/new/choose). You can also follow the development [guide]() to contribute and build on it.
 
+<p align="center">
+  <a href="https://star-history.com/#oxia-db/oxia&Date">
+    <img src="https://api.star-history.com/svg?repos=oxia-db/oxia&type=Date" alt="Star History Chart" width="600"/>
+  </a>
+</p>
+
 ### License
 
 Copyright 2023-2026 The Oxia Authors


### PR DESCRIPTION
## Motivation
- Make the star history visible from the Contributing section for readers considering starring the project.

## Modifications
- Embed the Star History SVG chart for `oxia-db/oxia` in the README.

## Testing
- Ran `git diff --cached --check`.
- Verified the Star History SVG endpoint returns `200 image/svg+xml`.
