### PR TITLE
docs: add release notes template

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -186,6 +186,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout release notes
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
       - name: Download all artifacts
         uses: actions/download-artifact@v7
         with:
@@ -207,10 +212,34 @@ jobs:
             cd ..
           done
 
-      - name: Create Release
+      - name: Prepare release notes
+        id: release-notes
+        run: |
+          NOTES_FILE="release-notes/${GITHUB_REF_NAME}.md"
+          if [[ -f "$NOTES_FILE" ]]; then
+            echo "notes_file=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
+          else
+            echo "notes_file=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Release with notes
+        if: steps.release-notes.outputs.notes_file != ''
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body_path: ${{ steps.release-notes.outputs.notes_file }}
+          prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') }}
+          files: |
+            release-assets/*
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release without notes
+        if: steps.release-notes.outputs.notes_file == ''
+        uses: softprops/action-gh-release@v2
+        with:
           prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') }}
           files: |
             release-assets/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,3 +75,21 @@ Requires: `protoc-gen-go`, `protoc-gen-go-grpc`, `protoc-gen-go-vtproto`
 - **gRPC + vtprotobuf**: Optimized RPC communication
 - **Cobra/Viper**: CLI framework and configuration
 - **OpenTelemetry**: Metrics and tracing
+
+## Release Notes
+
+Release notes are manually written. Do not rely on GitHub-generated release notes.
+
+When preparing release notes ahead of time, copy `release-notes/TEMPLATE.md` to
+`release-notes/<tag>.md` and fill it before creating the tag. The release workflow
+uses this file as the GitHub release body when it exists. If the file is missing,
+the workflow still creates the release so maintainers can add notes afterward.
+
+Formatting rules:
+- Do not include a redundant release-title line; GitHub already shows the tag.
+- Use bold section labels like `**Compatibility**`, not Markdown headings.
+- Do not include author names or generated `by @user in <url>` entries.
+- Always consider compatibility, requirements, public API changes, metrics changes,
+  and operational changes.
+- Keep change bullets concise and include PR numbers, for example
+  `dataserver: make authority validation configurable (#1136)`.

--- a/release-notes/TEMPLATE.md
+++ b/release-notes/TEMPLATE.md
@@ -1,0 +1,30 @@
+Short summary of why this release exists and what kind of release it is.
+Keep this to one or two sentences.
+
+**Compatibility**
+
+- No compatibility changes are expected.
+
+**Requirements**
+
+- No data migration is required.
+- No config change is required.
+
+**Public API Changes**
+
+- None.
+
+**Metrics Changes**
+
+- None.
+
+**Operational Changes**
+
+- None.
+
+**Changes Since vX.Y.Z**
+
+- subsystem: concise user-facing or operator-facing change (#PR)
+- subsystem: another notable change (#PR)
+
+**Full Changelog**: https://github.com/oxia-db/oxia/compare/vX.Y.Z...vA.B.C


### PR DESCRIPTION
## Motivation
- Make release notes consistently operator-focused instead of relying on generated PR lists.
- Ensure future releases explicitly mention compatibility, requirements, public API changes, metrics changes, and operational changes.

## Modifications
- Added `release-notes/TEMPLATE.md` for manually written GitHub release bodies.
- Updated `CLAUDE.md` with release-note formatting guidance.
- Updated the release workflow to require `release-notes/<tag>.md` and removed automatic GitHub release-note generation.

## Testing
- Ran `git diff --cached --check`.
- Verified edited 0.16 release bodies on GitHub after the remote release-note cleanup.
