### PR TITLE
feat: rename coordinator admin config to public

### DIFF
--- a/cmd/coordinator/cmd.go
+++ b/cmd/coordinator/cmd.go
@@ -50,7 +50,7 @@ func init() {
 	Cmd.Flags().StringVar(&sconfFile, "sconfig", "", "server config file path")
 
 	Cmd.Flags().StringVarP(&coordinatorOptions.Server.Internal.BindAddress, "internal-addr", "i", fmt.Sprintf("0.0.0.0:%d", constant.DefaultInternalPort), "Internal service bind address")
-	Cmd.Flags().StringVarP(&coordinatorOptions.Server.Admin.BindAddress, "admin-addr", "a", fmt.Sprintf("0.0.0.0:%d", constant.DefaultAdminPort), "Admin service bind address")
+	Cmd.Flags().StringVarP(&coordinatorOptions.Server.Public.BindAddress, "public-addr", "p", fmt.Sprintf("0.0.0.0:%d", constant.DefaultAdminPort), "Public service bind address")
 
 	observability := &coordinatorOptions.Observability
 	Cmd.Flags().StringVarP(&observability.Metric.BindAddress, "metrics-addr", "m", fmt.Sprintf("0.0.0.0:%d", oxiadcommonoption.DefaultMetricsPort), "Metrics service bind address")

--- a/cmd/coordinator/cmd_test.go
+++ b/cmd/coordinator/cmd_test.go
@@ -35,7 +35,7 @@ func TestCoordinator_ConfigurationLoading(t *testing.T) {
 cluster:
   configPath: "/path/to/cluster-config.json"
 server:
-  admin:
+  public:
     bindAddress: "0.0.0.0:6643"
   internal:
     bindAddress: "0.0.0.0:6645"
@@ -79,7 +79,7 @@ observability:
 	// Verify that config was loaded correctly
 	assert.Equal(t, "/path/to/cluster-config.json", opts.Cluster.ConfigPath)
 
-	assert.Equal(t, "0.0.0.0:6643", opts.Server.Admin.BindAddress)
+	assert.Equal(t, "0.0.0.0:6643", opts.Server.Public.BindAddress)
 	assert.Equal(t, "0.0.0.0:6645", opts.Server.Internal.BindAddress)
 	assert.Equal(t, "/path/to/internal-cert.pem", opts.Server.Internal.TLS.CertFile)
 	assert.Equal(t, "/path/to/internal-key.pem", opts.Server.Internal.TLS.KeyFile)
@@ -106,7 +106,7 @@ func TestCoordinator_ConfigurationWithDefaults(t *testing.T) {
 
 	configContent := `
 server:
-  admin:
+  public:
     bindAddress: "0.0.0.0:7000"
 metadata:
   providerName: "memory"
@@ -123,8 +123,8 @@ metadata:
 	require.NoError(t, err)
 
 	// Verify that partial config overrides defaults but other values use defaults
-	assert.Equal(t, "0.0.0.0:7000", opts.Server.Admin.BindAddress) // From config
-	assert.Equal(t, "memory", opts.Metadata.ProviderName)          // From config
+	assert.Equal(t, "0.0.0.0:7000", opts.Server.Public.BindAddress) // From config
+	assert.Equal(t, "memory", opts.Metadata.ProviderName)           // From config
 
 	// Verify defaults are applied to unset values
 	assert.NotEmpty(t, opts.Server.Internal.BindAddress)      // Default
@@ -277,7 +277,7 @@ func TestCoordinator_EmptyConfigFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify defaults are still applied
-	assert.NotEmpty(t, opts.Server.Admin.BindAddress)
+	assert.NotEmpty(t, opts.Server.Public.BindAddress)
 	assert.NotEmpty(t, opts.Server.Internal.BindAddress)
 	assert.Equal(t, "file", opts.Metadata.ProviderName)
 }
@@ -358,7 +358,7 @@ func TestCoordinator_CommandLineFlags(t *testing.T) {
 cluster:
   configPath: "/default/cluster.json"
 server:
-  admin:
+  public:
     bindAddress: "0.0.0.0:6643"
   internal:
     bindAddress: "0.0.0.0:6645"
@@ -379,20 +379,20 @@ metadata:
 
 	// Verify config file values were loaded
 	assert.Equal(t, "/default/cluster.json", coordinatorOptions.Cluster.ConfigPath)
-	assert.Equal(t, "0.0.0.0:6643", coordinatorOptions.Server.Admin.BindAddress)
+	assert.Equal(t, "0.0.0.0:6643", coordinatorOptions.Server.Public.BindAddress)
 	assert.Equal(t, "0.0.0.0:6645", coordinatorOptions.Server.Internal.BindAddress)
 	assert.Equal(t, "0.0.0.0:9090", coordinatorOptions.Observability.Metric.BindAddress)
 
 	// Now test that CLI flags can override these
 	// Note: In the actual cmd, flags are set during init(), but we can simulate this
 	// by directly setting the flag values on the options struct
-	coordinatorOptions.Server.Admin.BindAddress = "0.0.0.0:7000"
+	coordinatorOptions.Server.Public.BindAddress = "0.0.0.0:7000"
 	coordinatorOptions.Server.Internal.BindAddress = "0.0.0.0:7001"
 	coordinatorOptions.Observability.Metric.BindAddress = "0.0.0.0:8080"
 	coordinatorOptions.Metadata.ProviderName = "memory"
 
 	// Verify the options were updated
-	assert.Equal(t, "0.0.0.0:7000", coordinatorOptions.Server.Admin.BindAddress)
+	assert.Equal(t, "0.0.0.0:7000", coordinatorOptions.Server.Public.BindAddress)
 	assert.Equal(t, "0.0.0.0:7001", coordinatorOptions.Server.Internal.BindAddress)
 	assert.Equal(t, "0.0.0.0:8080", coordinatorOptions.Observability.Metric.BindAddress)
 	assert.Equal(t, "memory", coordinatorOptions.Metadata.ProviderName)

--- a/conf/coordinator.yaml
+++ b/conf/coordinator.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=./schema/coordinator.json
 
 server:
-  admin:
+  public:
     bindAddress: "0.0.0.0:6651"
   internal:
     bindAddress: "0.0.0.0:6649"

--- a/conf/schema/coordinator.json
+++ b/conf/schema/coordinator.json
@@ -3,27 +3,6 @@
   "$id": "https://github.com/oxia-db/oxia/oxiad/coordinator/option/options",
   "$ref": "#/$defs/Options",
   "$defs": {
-    "AdminServerOptions": {
-      "properties": {
-        "bindAddress": {
-          "type": "string",
-          "format": "hostname",
-          "description": "Bind address for the admin API server",
-          "examples": [
-            "0.0.0.0:6650"
-          ]
-        },
-        "tls": {
-          "$ref": "#/$defs/TLSOptions",
-          "description": "TLS configuration for securing admin API connections"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "bindAddress"
-      ]
-    },
     "ClusterOptions": {
       "properties": {
         "configPath": {
@@ -225,7 +204,7 @@
         },
         "server": {
           "$ref": "#/$defs/ServerOptions",
-          "description": "Server configuration for admin and internal endpoints"
+          "description": "Server configuration for public and internal endpoints"
         },
         "controller": {
           "$ref": "#/$defs/ControllerOptions",
@@ -246,6 +225,27 @@
         "server",
         "metadata",
         "observability"
+      ]
+    },
+    "PublicServerOptions": {
+      "properties": {
+        "bindAddress": {
+          "type": "string",
+          "format": "hostname",
+          "description": "Bind address for the public management API server",
+          "examples": [
+            "0.0.0.0:6651"
+          ]
+        },
+        "tls": {
+          "$ref": "#/$defs/TLSOptions",
+          "description": "TLS configuration for securing public management API connections"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "bindAddress"
       ]
     },
     "RaftMetadata": {
@@ -282,9 +282,9 @@
     },
     "ServerOptions": {
       "properties": {
-        "admin": {
-          "$ref": "#/$defs/AdminServerOptions",
-          "description": "Admin server configuration for management API endpoints"
+        "public": {
+          "$ref": "#/$defs/PublicServerOptions",
+          "description": "Public server configuration for management API endpoints"
         },
         "internal": {
           "$ref": "#/$defs/InternalServerOptions",
@@ -294,7 +294,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "admin",
+        "public",
         "internal"
       ]
     },

--- a/oxiad/coordinator/grpc_server.go
+++ b/oxiad/coordinator/grpc_server.go
@@ -118,7 +118,7 @@ func NewGrpcServer(parent context.Context, optionsWatch *commonwatch.Watch[*opti
 	}
 	reconciler = coordreconciler.New(parent, runtime)
 
-	managementSv := options.Server.Admin
+	managementSv := options.Server.Public
 	managementSvTLS, err := managementSv.TLS.TryIntoServerTLSConf()
 	if err != nil {
 		return nil, err
@@ -127,7 +127,7 @@ func NewGrpcServer(parent context.Context, optionsWatch *commonwatch.Watch[*opti
 		runtime.Metadata(),
 		runtime,
 	)
-	managementGrpcServer, err = commonrpc.Default.StartGrpcServer("admin", managementSv.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
+	managementGrpcServer, err = commonrpc.Default.StartGrpcServer("public", managementSv.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
 		proto.RegisterOxiaAdminServer(registrar, management)
 		grpc_health_v1.RegisterHealthServer(registrar, healthServer)
 	}, managementSvTLS, &managementSv.Auth, nil)

--- a/oxiad/coordinator/option/option.go
+++ b/oxiad/coordinator/option/option.go
@@ -34,7 +34,7 @@ import (
 
 type Options struct {
 	Cluster       ClusterOptions                    `yaml:"cluster,omitempty" json:"cluster,omitempty" jsonschema:"description=Deprecated cluster configuration settings"`
-	Server        ServerOptions                     `yaml:"server" json:"server" jsonschema:"description=Server configuration for admin and internal endpoints"`
+	Server        ServerOptions                     `yaml:"server" json:"server" jsonschema:"description=Server configuration for public and internal endpoints"`
 	Controller    ControllerOptions                 `yaml:"controller,omitempty" json:"controller,omitempty" jsonschema:"description=Controller configuration for cluster management"`
 	Metadata      MetadataOptions                   `yaml:"metadata" json:"metadata" jsonschema:"description=Metadata provider configuration"`
 	Observability commonoption.ObservabilityOptions `yaml:"observability" json:"observability" jsonschema:"description=Observability configuration for metrics and tracing"`
@@ -71,17 +71,17 @@ func (*ClusterOptions) Validate() error {
 }
 
 type ServerOptions struct {
-	Admin    AdminServerOptions    `yaml:"admin" json:"admin" jsonschema:"description=Admin server configuration for management API endpoints"`
+	Public   PublicServerOptions   `yaml:"public" json:"public" jsonschema:"description=Public server configuration for management API endpoints"`
 	Internal InternalServerOptions `yaml:"internal" json:"internal" jsonschema:"description=Internal server configuration for cluster communication"`
 }
 
 func (so *ServerOptions) WithDefault() {
-	so.Admin.WithDefault()
+	so.Public.WithDefault()
 	so.Internal.WithDefault()
 }
 
 func (so *ServerOptions) Validate() error {
-	return multierr.Combine(so.Admin.Validate(), so.Internal.Validate())
+	return multierr.Combine(so.Public.Validate(), so.Internal.Validate())
 }
 
 type InternalServerOptions struct {
@@ -105,24 +105,24 @@ func (iso *InternalServerOptions) Validate() error {
 	)
 }
 
-type AdminServerOptions struct {
-	BindAddress string              `yaml:"bindAddress" json:"bindAddress" jsonschema:"description=Bind address for the admin API server,example=0.0.0.0:6650,format=hostname"`
-	Auth        auth.Options        `yaml:"auth,omitempty" json:"auth,omitempty" jsonschema:"description=Authentication configuration for the admin API"`
-	TLS         security.TLSOptions `yaml:"tls,omitempty" json:"tls,omitempty" jsonschema:"description=TLS configuration for securing admin API connections"`
+type PublicServerOptions struct {
+	BindAddress string              `yaml:"bindAddress" json:"bindAddress" jsonschema:"description=Bind address for the public management API server,example=0.0.0.0:6651,format=hostname"`
+	Auth        auth.Options        `yaml:"auth,omitempty" json:"auth,omitempty" jsonschema:"description=Authentication configuration for the public management API"`
+	TLS         security.TLSOptions `yaml:"tls,omitempty" json:"tls,omitempty" jsonschema:"description=TLS configuration for securing public management API connections"`
 }
 
-func (aso *AdminServerOptions) WithDefault() {
-	if aso.BindAddress == "" {
-		aso.BindAddress = fmt.Sprintf("0.0.0.0:%d", constant.DefaultAdminPort)
+func (pso *PublicServerOptions) WithDefault() {
+	if pso.BindAddress == "" {
+		pso.BindAddress = fmt.Sprintf("0.0.0.0:%d", constant.DefaultAdminPort)
 	}
-	aso.Auth.WithDefault()
-	aso.TLS.WithDefault()
+	pso.Auth.WithDefault()
+	pso.TLS.WithDefault()
 }
 
-func (aso *AdminServerOptions) Validate() error {
+func (pso *PublicServerOptions) Validate() error {
 	return multierr.Combine(
-		aso.Auth.Validate(),
-		aso.TLS.Validate(),
+		pso.Auth.Validate(),
+		pso.TLS.Validate(),
 	)
 }
 

--- a/tests/coordinator/admin_dataserver_e2e_test.go
+++ b/tests/coordinator/admin_dataserver_e2e_test.go
@@ -36,7 +36,7 @@ func TestAdminDataServerCRUD(t *testing.T) {
 	adminAddr := freeAddress(t)
 	options := coordoption.NewDefaultOptions()
 	options.Server.Internal.BindAddress = "127.0.0.1:0"
-	options.Server.Admin.BindAddress = adminAddr
+	options.Server.Public.BindAddress = adminAddr
 	options.Observability.Metric.Enabled = &constant.FlagFalse
 	options.Metadata.ProviderName = metadatacommon.NameFile
 	options.Metadata.File.Dir = metadataDir

--- a/tests/coordinator/admin_namespace_e2e_test.go
+++ b/tests/coordinator/admin_namespace_e2e_test.go
@@ -35,7 +35,7 @@ func TestAdminNamespaceCreateAndGet(t *testing.T) {
 	adminAddr := freeAddress(t)
 	options := coordoption.NewDefaultOptions()
 	options.Server.Internal.BindAddress = "127.0.0.1:0"
-	options.Server.Admin.BindAddress = adminAddr
+	options.Server.Public.BindAddress = adminAddr
 	options.Observability.Metric.Enabled = &constant.FlagFalse
 	options.Metadata.ProviderName = metadatacommon.NameFile
 	options.Metadata.File.Dir = metadataDir


### PR DESCRIPTION
## Motivation
- Align coordinator management server configuration with the data server `server.public` naming.
- Prepare the coordinator management API for public leader metadata and redirect handling without continuing the `server.admin` config name.

## Modifications
- Rename coordinator `ServerOptions.Admin` to `ServerOptions.Public`.
- Update coordinator startup to bind the management API from `server.public`.
- Replace the coordinator CLI bind flag with `--public-addr` / `-p`, keeping the existing management port default.
- Update sample config, JSON schema, and coordinator management tests.

## Testing
- `go test ./cmd/coordinator ./oxiad/coordinator/... ./tests/coordinator`