### PR TITLE
feat: add coordinator metadata identity for leader election

### DIFF
--- a/cmd/coordinator/cmd_test.go
+++ b/cmd/coordinator/cmd_test.go
@@ -128,6 +128,7 @@ metadata:
 
 	// Verify defaults are applied to unset values
 	assert.NotEmpty(t, opts.Server.Internal.BindAddress)      // Default
+	assert.NotEmpty(t, opts.Metadata.Identity)                // Default
 	assert.NotEmpty(t, opts.Observability.Metric.BindAddress) // Default
 }
 
@@ -207,7 +208,7 @@ func TestCoordinator_ConfigurationValidation(t *testing.T) {
 	// Test that validation works correctly
 	opts := option.NewDefaultOptions()
 
-	// Need to set a valid provider since WithDefault() is empty for MetadataOptions
+	// Need to set a valid provider since MetadataOptions does not default the provider type.
 	opts.Metadata.ProviderName = "file"
 
 	// Should pass validation with defaults
@@ -268,7 +269,7 @@ func TestCoordinator_EmptyConfigFile(t *testing.T) {
 
 	opts := option.NewDefaultOptions()
 
-	// Since MetadataOptions.WithDefault() is empty, we need to set a valid provider
+	// Need to set a valid provider since MetadataOptions does not default the provider type.
 	// This simulates what would happen in the actual CLI where flags set defaults
 	opts.Metadata.ProviderName = "file"
 
@@ -279,6 +280,7 @@ func TestCoordinator_EmptyConfigFile(t *testing.T) {
 	// Verify defaults are still applied
 	assert.NotEmpty(t, opts.Server.Public.BindAddress)
 	assert.NotEmpty(t, opts.Server.Internal.BindAddress)
+	assert.NotEmpty(t, opts.Metadata.Identity)
 	assert.Equal(t, "file", opts.Metadata.ProviderName)
 }
 

--- a/conf/schema/coordinator.json
+++ b/conf/schema/coordinator.json
@@ -134,6 +134,13 @@
     },
     "MetadataOptions": {
       "properties": {
+        "identity": {
+          "type": "string",
+          "description": "Stable coordinator identity used by metadata leader election",
+          "examples": [
+            "coordinator-0"
+          ]
+        },
         "providerName": {
           "type": "string",
           "description": "Metadata provider type. Valid values: memory/configmap/file/raft",

--- a/oxiad/coordinator/metadata/factory.go
+++ b/oxiad/coordinator/metadata/factory.go
@@ -78,10 +78,10 @@ func New(ctx context.Context, options *option.Options) (*Factory, error) {
 		if err != nil {
 			return nil, err
 		}
-		if factory.statusProvider, err = kubernetes.NewProvider(ctx, client, meta.Kubernetes.Namespace, meta.Kubernetes.StatusNameOrDefault(), metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled); err != nil {
+		if factory.statusProvider, err = kubernetes.NewProvider(ctx, client, meta.Kubernetes.Namespace, meta.Kubernetes.StatusNameOrDefault(), metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled, meta.Identity); err != nil {
 			return nil, err
 		}
-		if factory.configProvider, err = kubernetes.NewProvider(ctx, client, meta.Kubernetes.Namespace, meta.Kubernetes.ConfigNameOrDefault(), metadatacodec.ClusterConfigCodec, metadatacommon.WatchEnabled); err != nil {
+		if factory.configProvider, err = kubernetes.NewProvider(ctx, client, meta.Kubernetes.Namespace, meta.Kubernetes.ConfigNameOrDefault(), metadatacodec.ClusterConfigCodec, metadatacommon.WatchEnabled, meta.Identity); err != nil {
 			return nil, err
 		}
 	case metadatacommon.NameRaft:

--- a/oxiad/coordinator/metadata/provider/kubernetes/provider.go
+++ b/oxiad/coordinator/metadata/provider/kubernetes/provider.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -67,6 +66,7 @@ type Provider[T gproto.Message] struct {
 	namespace, name string
 	codec           metadatacodec.Codec[T]
 	watchEnabled    metadatacommon.WatchMode
+	identity        string
 
 	metadataSize      atomic.Int64
 	getLatencyHisto   metric.LatencyHistogram
@@ -88,6 +88,7 @@ func NewProvider[T gproto.Message](
 	namespace, name string,
 	codec metadatacodec.Codec[T],
 	watchEnabled metadatacommon.WatchMode,
+	identity string,
 ) (provider.Provider[T], error) {
 	m := &Provider[T]{
 		kubernetes:   kc,
@@ -95,6 +96,7 @@ func NewProvider[T gproto.Message](
 		name:         name,
 		codec:        codec,
 		watchEnabled: watchEnabled,
+		identity:     identity,
 		logger:       slog.With("component", "metadata-config-map"),
 
 		getLatencyHisto: metric.NewLatencyHistogram("oxia_coordinator_metadata_get_latency",
@@ -244,7 +246,7 @@ func (m *Provider[T]) Store(snapshot provider.Versioned[T]) (metadatacommon.Vers
 }
 
 func (m *Provider[T]) WaitToBecomeLeader() error {
-	myIdentity, _ := os.Hostname()
+	myIdentity := m.identity
 
 	// Create a lease lock
 	lock := &resourcelock.LeaseLock{

--- a/oxiad/coordinator/metadata/provider/kubernetes/provider_test.go
+++ b/oxiad/coordinator/metadata/provider/kubernetes/provider_test.go
@@ -1,0 +1,44 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+
+	commonproto "github.com/oxia-db/oxia/common/proto"
+	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	metadatacodec "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common/codec"
+)
+
+func TestProviderElectionIdentityUsesConfiguredIdentity(t *testing.T) {
+	p, err := NewProvider(
+		t.Context(),
+		fake.NewSimpleClientset(),
+		"ns",
+		"status",
+		metadatacodec.ClusterStatusCodec,
+		metadatacommon.WatchDisabled,
+		"coordinator-0",
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, p.Close())
+	})
+
+	require.Equal(t, "coordinator-0", p.(*Provider[*commonproto.ClusterStatus]).identity)
+}

--- a/oxiad/coordinator/metadata/provider/provider_test.go
+++ b/oxiad/coordinator/metadata/provider/provider_test.go
@@ -63,7 +63,7 @@ var (
 		"configmap": func(t *testing.T) provider.Provider[*proto.ClusterStatus] {
 			t.Helper()
 
-			p, err := kubernetes.NewProvider(t.Context(), newFake(), "ns", "n", metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled)
+			p, err := kubernetes.NewProvider(t.Context(), newFake(), "ns", "n", metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled, "coordinator-test")
 			assert.NoError(t, err)
 			return p
 		},
@@ -136,7 +136,7 @@ func TestProviderConfigResource(t *testing.T) {
 		"configmap": func(t *testing.T) provider.Provider[*proto.ClusterConfiguration] {
 			t.Helper()
 
-			p, err := kubernetes.NewProvider(t.Context(), newFake(), "ns", "config", metadatacodec.ClusterConfigCodec, metadatacommon.WatchDisabled)
+			p, err := kubernetes.NewProvider(t.Context(), newFake(), "ns", "config", metadatacodec.ClusterConfigCodec, metadatacommon.WatchDisabled, "coordinator-test")
 			assert.NoError(t, err)
 			return p
 		},

--- a/oxiad/coordinator/option/option.go
+++ b/oxiad/coordinator/option/option.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -146,10 +147,16 @@ type ProviderOptions struct {
 }
 
 type MetadataOptions struct {
+	Identity        string `yaml:"identity,omitempty" json:"identity,omitempty" jsonschema:"description=Stable coordinator identity used by metadata leader election,example=coordinator-0"`
 	ProviderOptions `yaml:",inline"`
 }
 
-func (*MetadataOptions) WithDefault() {
+func (mo *MetadataOptions) WithDefault() {
+	if mo.Identity == "" {
+		if hostname, err := os.Hostname(); err == nil {
+			mo.Identity = hostname
+		}
+	}
 }
 
 func (mo *MetadataOptions) Validate() error {

--- a/oxiad/coordinator/option/option_test.go
+++ b/oxiad/coordinator/option/option_test.go
@@ -34,6 +34,27 @@ metadata:
 	require.Equal(t, "metadata/cluster.yaml", opts.Metadata.File.ConfigPath())
 }
 
+func TestMetadataOptionsIdentity(t *testing.T) {
+	opts := readOptions(t, `
+metadata:
+  identity: coordinator-0
+  providerName: memory
+`)
+
+	require.NoError(t, opts.Validate())
+	require.Equal(t, "coordinator-0", opts.Metadata.Identity)
+}
+
+func TestMetadataOptionsDefaultIdentity(t *testing.T) {
+	opts := readOptions(t, `
+metadata:
+  providerName: memory
+`)
+
+	require.NoError(t, opts.Validate())
+	require.NotEmpty(t, opts.Metadata.Identity)
+}
+
 func TestMetadataOptionsFileDefaultsStatusPathWithoutDir(t *testing.T) {
 	opts := readOptions(t, `
 metadata:


### PR DESCRIPTION
## Motivation
- Kubernetes metadata leader election needs a stable coordinator identity.
- Future coordinator management API leader redirection needs a reliable leader identity without adding hostname fallback inside the provider.

## Modifications
- Add optional `metadata.identity` to coordinator options and config schema.
- Default an empty metadata identity from the host name in `MetadataOptions.WithDefault()`.
- Pass the defaulted identity into Kubernetes metadata providers and use it directly as the lease identity.
- Make the Kubernetes provider constructor accept one explicit identity value.
- Add coverage for configured/default identity handling and Kubernetes provider identity selection.

## Testing
- `jq empty conf/schema/coordinator.json`
- `go test ./cmd/coordinator ./oxiad/coordinator/... ./tests/coordinator`