### PR TITLE
fix: run commit callbacks off the quorum-ack tracker lock

### DIFF
--- a/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
+++ b/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/oxia-db/oxia/common/channel"
 	"github.com/oxia-db/oxia/common/concurrent"
 	"github.com/oxia-db/oxia/common/constant"
 )
@@ -110,6 +111,14 @@ type quorumAckTracker struct {
 	tracker            map[int64]*BitSet
 	cursorIdxGenerator int
 	closed             bool
+
+	// The callbacks of the waiting requests perform the database apply and the
+	// client response on the write path: they must never run under the tracker
+	// mutex or on the cursor ack goroutines, where they would stall the whole
+	// shard pipeline. They are invoked, in offset order, by a dedicated
+	// goroutine that is woken up through commitSignal.
+	commitSignal  chan struct{}
+	callbacksDone chan struct{}
 }
 
 type CursorAcker interface {
@@ -146,7 +155,59 @@ func NewQuorumAckTracker(replicationFactor uint32, headOffset int64, commitOffse
 	}
 
 	q.waitForHeadOffset = concurrent.NewConditionContext(q)
+	q.commitSignal = make(chan struct{}, 1)
+	q.callbacksDone = make(chan struct{})
+	go q.runCallbacks()
 	return q
+}
+
+// runCallbacks is the only place where the waiting requests get completed,
+// keeping the callbacks out of the tracker mutex and in offset order.
+func (q *quorumAckTracker) runCallbacks() {
+	defer close(q.callbacksDone)
+
+	for {
+		<-q.commitSignal
+
+		for {
+			q.Lock()
+			if q.closed {
+				pending := q.waitingRequests
+				q.waitingRequests = nil
+				q.Unlock()
+
+				for _, r := range pending {
+					r.callback.OnCompleteError(constant.ErrResourceUnavailable)
+				}
+				return
+			}
+
+			ready := q.dequeueReadyWaiters()
+			q.Unlock()
+
+			if len(ready) == 0 {
+				break
+			}
+			for _, r := range ready {
+				r.callback.OnComplete(nil)
+			}
+		}
+	}
+}
+
+// dequeueReadyWaiters must be called while holding the tracker mutex.
+// The waiting requests are registered in offset order, so the committed
+// ones are always a prefix of the slice.
+func (q *quorumAckTracker) dequeueReadyWaiters() []waitingRequest {
+	commitOffset := q.commitOffset.Load()
+	n := 0
+	for n < len(q.waitingRequests) &&
+		(q.requiredAcks == 0 || q.waitingRequests[n].minOffset <= commitOffset) {
+		n++
+	}
+	ready := q.waitingRequests[:n]
+	q.waitingRequests = q.waitingRequests[n:]
+	return ready
 }
 
 func (q *quorumAckTracker) AdvanceHeadOffset(headOffset int64) {
@@ -220,40 +281,37 @@ func (q *quorumAckTracker) WaitForCommitOffsetAsync(_ context.Context, offset in
 		return
 	}
 
-	if q.requiredAcks == 0 || q.commitOffset.Load() >= offset {
-		q.Unlock()
-		cb.OnComplete(nil)
-		return
-	}
-
 	q.waitingRequests = append(q.waitingRequests, waitingRequest{offset, cb})
+	if q.requiredAcks == 0 || q.commitOffset.Load() >= offset {
+		// Already satisfied: the callback is still invoked from the callbacks
+		// goroutine, never inline, so that the caller (e.g. the WAL sync
+		// goroutine) does not block behind the database apply.
+		channel.PushNoBlock(q.commitSignal, struct{}{})
+	}
 	q.Unlock()
 }
 
 func (q *quorumAckTracker) notifyCommitOffsetAdvanced(commitOffset int64) {
 	q.commitOffset.Store(commitOffset)
 
-	for _, r := range q.waitingRequests {
-		if r.minOffset > commitOffset {
-			return
-		}
-
-		q.waitingRequests = q.waitingRequests[1:]
-		r.callback.OnComplete(nil)
+	if len(q.waitingRequests) > 0 {
+		channel.PushNoBlock(q.commitSignal, struct{}{})
 	}
 }
 
 func (q *quorumAckTracker) Close() error {
 	q.Lock()
+	alreadyClosed := q.closed
 	q.closed = true
 	q.waitForHeadOffset.Broadcast()
-	waitingRequests := q.waitingRequests
-	q.waitingRequests = make([]waitingRequest, 0)
 	q.Unlock()
-	// unblock waiting request
-	for _, r := range waitingRequests {
-		r.callback.OnCompleteError(constant.ErrResourceUnavailable)
+
+	if !alreadyClosed {
+		channel.PushNoBlock(q.commitSignal, struct{}{})
 	}
+	// Wait for the callbacks goroutine to fail the pending requests and drain:
+	// once Close returns, no callback is running or will ever run.
+	<-q.callbacksDone
 	return nil
 }
 

--- a/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
+++ b/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sort"
 	"sync"
 	"sync/atomic"
 
@@ -196,8 +197,8 @@ func (q *quorumAckTracker) runCallbacks() {
 }
 
 // dequeueReadyWaiters must be called while holding the tracker mutex.
-// The waiting requests are registered in offset order, so the committed
-// ones are always a prefix of the slice.
+// The waiting requests are kept sorted by minOffset (see insertWaitingRequest),
+// so the committed ones are always a prefix of the slice.
 func (q *quorumAckTracker) dequeueReadyWaiters() []waitingRequest {
 	commitOffset := q.commitOffset.Load()
 	n := 0
@@ -281,7 +282,7 @@ func (q *quorumAckTracker) WaitForCommitOffsetAsync(_ context.Context, offset in
 		return
 	}
 
-	q.waitingRequests = append(q.waitingRequests, waitingRequest{offset, cb})
+	q.insertWaitingRequest(waitingRequest{offset, cb})
 	if q.requiredAcks == 0 || q.commitOffset.Load() >= offset {
 		// Already satisfied: the callback is still invoked from the callbacks
 		// goroutine, never inline, so that the caller (e.g. the WAL sync
@@ -289,6 +290,20 @@ func (q *quorumAckTracker) WaitForCommitOffsetAsync(_ context.Context, offset in
 		channel.PushNoBlock(q.commitSignal, struct{}{})
 	}
 	q.Unlock()
+}
+
+// insertWaitingRequest keeps the waiting requests sorted by minOffset, so that
+// the committed ones always form a prefix of the slice. The requests are
+// normally registered in offset order, making this an append in practice; the
+// requests for the same offset preserve their registration order.
+// It must be called while holding the tracker mutex.
+func (q *quorumAckTracker) insertWaitingRequest(r waitingRequest) {
+	i := sort.Search(len(q.waitingRequests), func(i int) bool {
+		return q.waitingRequests[i].minOffset > r.minOffset
+	})
+	q.waitingRequests = append(q.waitingRequests, waitingRequest{})
+	copy(q.waitingRequests[i+1:], q.waitingRequests[i:])
+	q.waitingRequests[i] = r
 }
 
 func (q *quorumAckTracker) notifyCommitOffsetAdvanced(commitOffset int64) {

--- a/oxiad/dataserver/controller/lead/quorum_ack_tracker_test.go
+++ b/oxiad/dataserver/controller/lead/quorum_ack_tracker_test.go
@@ -390,6 +390,51 @@ func TestQuorumAckTracker_CallbacksOffTheAckPath(t *testing.T) {
 	}
 }
 
+// A wait registered out of offset order (for an offset that is already
+// committed, while an earlier-registered waiter is still pending on a later
+// offset) must complete promptly instead of queueing behind the pending one.
+func TestQuorumAckTracker_OutOfOrderWait(t *testing.T) {
+	at := NewQuorumAckTracker(3, 1, wal.InvalidOffset)
+	defer at.Close()
+
+	for offset := int64(2); offset <= 5; offset++ {
+		at.AdvanceHeadOffset(offset)
+	}
+
+	pending := make(chan error, 1)
+	at.WaitForCommitOffsetAsync(context.Background(), 5, concurrent.NewOnce(
+		func(any) { pending <- nil }, func(err error) { pending <- err }))
+
+	c1, err := at.NewCursorAcker(wal.InvalidOffset)
+	assert.NoError(t, err)
+	c1.Ack(2)
+	assert.EqualValues(t, 2, at.CommitOffset())
+
+	// Offset 2 is committed: waiting on it must complete even though the
+	// waiter for offset 5 was registered first and is still pending
+	satisfied := make(chan error, 1)
+	at.WaitForCommitOffsetAsync(context.Background(), 2, concurrent.NewOnce(
+		func(any) { satisfied <- nil }, func(err error) { satisfied <- err }))
+
+	select {
+	case err := <-satisfied:
+		assert.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("already-satisfied wait queued behind a pending one")
+	}
+	assert.Len(t, pending, 0)
+
+	for offset := int64(3); offset <= 5; offset++ {
+		c1.Ack(offset)
+	}
+	select {
+	case err := <-pending:
+		assert.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("pending wait did not complete")
+	}
+}
+
 // Close must not return while a waiting-request callback is still in flight,
 // so that the database is never closed under an in-progress apply.
 func TestQuorumAckTracker_CloseWaitsForInFlightCallback(t *testing.T) {

--- a/oxiad/dataserver/controller/lead/quorum_ack_tracker_test.go
+++ b/oxiad/dataserver/controller/lead/quorum_ack_tracker_test.go
@@ -16,6 +16,7 @@ package lead
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/wal"
 
+	"github.com/oxia-db/oxia/common/concurrent"
 	"github.com/oxia-db/oxia/common/constant"
 )
 
@@ -314,4 +316,128 @@ func TestQuorumAckTracker_ClearPending(t *testing.T) {
 	case <-time.After(2 * time.Second): // Adding a timeout for safety
 		t.Fatal("Timed out waiting for async result")
 	}
+}
+
+// The waiting-request callbacks perform the database apply and the client response
+// on the leader write path: the cursor acks must never block behind them, and they
+// must be invoked one at a time, in offset order.
+func TestQuorumAckTracker_CallbacksOffTheAckPath(t *testing.T) {
+	at := NewQuorumAckTracker(2, 1, wal.InvalidOffset)
+	defer at.Close()
+
+	gate := make(chan struct{})
+	closeGate := sync.OnceFunc(func() { close(gate) })
+	defer closeGate()
+
+	at.AdvanceHeadOffset(2)
+	at.AdvanceHeadOffset(3)
+
+	started := make(chan int64, 2)
+	completed := make(chan int64, 2)
+
+	at.WaitForCommitOffsetAsync(context.Background(), 2, concurrent.NewOnce(
+		func(any) {
+			started <- 2
+			<-gate
+			completed <- 2
+		}, func(error) {}))
+	at.WaitForCommitOffsetAsync(context.Background(), 3, concurrent.NewOnce(
+		func(any) {
+			started <- 3
+			completed <- 3
+		}, func(error) {}))
+
+	c1, err := at.NewCursorAcker(wal.InvalidOffset)
+	assert.NoError(t, err)
+
+	// The acks must complete promptly, even with the first callback blocked
+	ackDone := make(chan struct{})
+	go func() {
+		c1.Ack(2)
+		c1.Ack(3)
+		close(ackDone)
+	}()
+
+	select {
+	case <-ackDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Ack blocked behind a waiting-request callback")
+	}
+	assert.EqualValues(t, 3, at.CommitOffset())
+
+	// The first callback is in progress: the second must not start before it completes
+	select {
+	case offset := <-started:
+		assert.EqualValues(t, 2, offset)
+	case <-time.After(10 * time.Second):
+		t.Fatal("first callback did not start")
+	}
+	select {
+	case <-started:
+		t.Fatal("second callback started while the first was still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	closeGate()
+
+	for _, expected := range []int64{2, 3} {
+		select {
+		case offset := <-completed:
+			assert.EqualValues(t, expected, offset)
+		case <-time.After(10 * time.Second):
+			t.Fatal("callback did not complete")
+		}
+	}
+}
+
+// Close must not return while a waiting-request callback is still in flight,
+// so that the database is never closed under an in-progress apply.
+func TestQuorumAckTracker_CloseWaitsForInFlightCallback(t *testing.T) {
+	at := NewQuorumAckTracker(2, 1, wal.InvalidOffset)
+
+	gate := make(chan struct{})
+	closeGate := sync.OnceFunc(func() { close(gate) })
+	defer closeGate()
+
+	at.AdvanceHeadOffset(2)
+
+	started := make(chan struct{})
+	completed := make(chan struct{}, 1)
+	at.WaitForCommitOffsetAsync(context.Background(), 2, concurrent.NewOnce(
+		func(any) {
+			close(started)
+			<-gate
+			completed <- struct{}{}
+		}, func(error) {}))
+
+	c1, err := at.NewCursorAcker(wal.InvalidOffset)
+	assert.NoError(t, err)
+	c1.Ack(2)
+
+	select {
+	case <-started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("callback did not start")
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		assert.NoError(t, at.Close())
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+		t.Fatal("Close returned while a callback was still in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	closeGate()
+
+	select {
+	case <-closeDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close did not return after the callback completed")
+	}
+	assert.Len(t, completed, 1)
 }


### PR DESCRIPTION
### Motivation

For every committed write, the quorum-ack tracker invokes the waiting-request callbacks inline from `notifyCommitOffsetAdvanced`, while holding the tracker mutex, on whichever goroutine advanced the commit offset. On the leader write path that callback performs the full database apply (`proposal.Apply` → Pebble batch build + commit, including notifications and session-shadow writes) and the client response. The tracker mutex is therefore held for the duration of a Pebble commit, executed on the follower ack-receive goroutine: the other followers' acks, the WAL group-commit callbacks (`AdvanceHeadOffset` / `WaitForCommitOffsetAsync`) and the cursor wake-ups all serialize behind it. This single mutex is effectively the throughput ceiling of the shard.

### Changes

- The waiting requests are now completed by a dedicated per-tracker goroutine. The ack path only updates the bitset, advances the commit offset and wakes that goroutine through a non-blocking, coalescing signal — no callbacks run under the tracker mutex or on the ack-receive goroutines anymore.
- The callbacks goroutine dequeues the committed prefix of the (offset-ordered) waiting requests under the lock and invokes the callbacks outside of it, one at a time and in offset order — the database apply ordering is unchanged.
- The already-satisfied `WaitForCommitOffsetAsync` fast path goes through the same queue instead of completing inline, so in the RF=1 case the database apply also moves off the WAL fsync goroutine, no longer serializing applies with the fsync cadence.
- `Close()` waits for the callbacks goroutine to drain: the existing guarantee that no apply is in flight once the tracker is closed (before the Pebble DB is shut down) is preserved, and pending requests are still failed with `ErrResourceUnavailable`.

The change is fully contained in `quorum_ack_tracker.go`: the leader controller's callback (apply + response) is untouched and simply runs on the new goroutine.

### Verification

- New `TestQuorumAckTracker_CallbacksOffTheAckPath`: cursor acks must complete promptly while a callback is blocked, callbacks must run one at a time and in offset order.
- New `TestQuorumAckTracker_CloseWaitsForInFlightCallback`: `Close()` must not return while a callback is in flight.
- All existing tracker tests pass unchanged (the commit offset still advances synchronously on the ack path; only callback invocation is deferred).
- `go test -race` green on the whole `oxiad` module, the `oxia` client module and the entire `tests/` integration module; `golangci-lint` clean.
- Standalone sequential-write latency A/B vs `main`: p50 ≈ 122µs on both sides (within noise). The structural win — acks and WAL group commit no longer waiting behind Pebble commits — applies under concurrent replicated load.

Related: #1158 (moves the client `stream.Send` out of this same critical section; independent change, different files).