### PR TITLE
fix: do not block WAL appends and reads during fsync

### DIFF
--- a/oxiad/dataserver/wal/readwrite_segment.go
+++ b/oxiad/dataserver/wal/readwrite_segment.go
@@ -42,6 +42,12 @@ type ReadWriteSegment interface {
 type readWriteSegment struct {
 	sync.RWMutex
 
+	// flushLock guards the mapping lifecycle: Flush runs the msync under its
+	// read side, without holding the main mutex, so that appends and reads can
+	// proceed while the disk sync is in flight. Only Close (unmap) needs to
+	// exclude an in-flight msync, through the write side.
+	flushLock sync.RWMutex
+
 	c *segmentConfig
 
 	lastOffset    int64
@@ -127,8 +133,8 @@ func (ms *readWriteSegment) LastOffset() int64 {
 }
 
 func (ms *readWriteSegment) Read(offset int64) (payload []byte, previousCrc uint32, payloadCrc uint32, err error) {
-	ms.Lock()
-	defer ms.Unlock()
+	ms.RLock()
+	defer ms.RUnlock()
 	if offset < ms.c.baseOffset || offset > ms.lastOffset {
 		return nil, 0, 0, codec.ErrOffsetOutOfBounds
 	}
@@ -170,9 +176,13 @@ func (ms *readWriteSegment) Append(offset int64, data []byte) error {
 	return nil
 }
 
+// Flush msyncs the mapped file without holding the segment mutex: appends and
+// reads are not blocked for the duration of the disk sync. Records written
+// concurrently with the msync may reach the disk torn, but they have not been
+// acknowledged yet and are discarded by the CRC validation in RecoverIndex.
 func (ms *readWriteSegment) Flush() error {
-	ms.RLock()
-	defer ms.RUnlock()
+	ms.flushLock.RLock()
+	defer ms.flushLock.RUnlock()
 	if ms.txnMappedFile == nil {
 		return nil
 	}
@@ -186,6 +196,8 @@ func (*readWriteSegment) OpenTimestamp() time.Time {
 func (ms *readWriteSegment) Close() error {
 	ms.Lock()
 	defer ms.Unlock()
+	ms.flushLock.Lock()
+	defer ms.flushLock.Unlock()
 
 	err := multierr.Combine(
 		ms.txnMappedFile.Unmap(),

--- a/oxiad/dataserver/wal/readwrite_segment_test.go
+++ b/oxiad/dataserver/wal/readwrite_segment_test.go
@@ -310,3 +310,87 @@ func TestSegmentAppendShouldNotPanic(t *testing.T) {
 	err = rw.Append(51, fmt.Appendf(nil, "entry-%d", 51))
 	assert.ErrorIs(t, err, ErrSegmentFull)
 }
+
+// Appends, reads and flushes run concurrently by design: the flusher (WAL sync
+// goroutine) must not block appends or tailing reads for the duration of the
+// msync, and the data must stay consistent throughout.
+func TestReadWriteSegment_ConcurrentAppendReadFlush(t *testing.T) {
+	path := t.TempDir()
+
+	rw, err := newReadWriteSegment(path, 0, 10*1024*1024, 0, nil)
+	assert.NoError(t, err)
+
+	const entries = 5_000
+	done := make(chan struct{})
+	flusherDone := make(chan struct{})
+	readerDone := make(chan struct{})
+
+	go func() {
+		defer close(flusherDone)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				assert.NoError(t, rw.Flush())
+			}
+		}
+	}()
+
+	go func() {
+		defer close(readerDone)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				last := rw.LastOffset()
+				if last < 0 {
+					continue
+				}
+				payload, _, _, err := rw.Read(last)
+				assert.NoError(t, err)
+				assert.Equal(t, fmt.Sprintf("entry-%d", last), string(payload))
+			}
+		}
+	}()
+
+	for i := 0; i < entries; i++ {
+		assert.NoError(t, rw.Append(int64(i), []byte(fmt.Sprintf("entry-%d", i))))
+	}
+
+	close(done)
+	<-flusherDone
+	<-readerDone
+
+	for i := 0; i < entries; i++ {
+		payload, _, _, err := rw.Read(int64(i))
+		assert.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("entry-%d", i), string(payload))
+	}
+
+	assert.NoError(t, rw.Close())
+}
+
+// Closing the segment must wait for an in-flight msync: the mapping cannot be
+// unmapped under it.
+func TestReadWriteSegment_CloseWithConcurrentFlush(t *testing.T) {
+	path := t.TempDir()
+
+	rw, err := newReadWriteSegment(path, 0, 128*1024, 0, nil)
+	assert.NoError(t, err)
+	assert.NoError(t, rw.Append(0, []byte("entry-0")))
+
+	flusherDone := make(chan struct{})
+	go func() {
+		defer close(flusherDone)
+		for i := 0; i < 1_000; i++ {
+			// After Close, Flush must keep returning nil instead of msyncing
+			// an unmapped region
+			assert.NoError(t, rw.Flush())
+		}
+	}()
+
+	assert.NoError(t, rw.Close())
+	<-flusherDone
+}

--- a/oxiad/dataserver/wal/readwrite_segment_test.go
+++ b/oxiad/dataserver/wal/readwrite_segment_test.go
@@ -17,6 +17,7 @@ package wal
 import (
 	"encoding/binary"
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -333,6 +334,9 @@ func TestReadWriteSegment_ConcurrentAppendReadFlush(t *testing.T) {
 				return
 			default:
 				assert.NoError(t, rw.Flush())
+				// Yield between iterations: keeps the loop from pegging a core
+				// while still maximizing the append/read/flush interleaving
+				runtime.Gosched()
 			}
 		}
 	}()
@@ -345,12 +349,12 @@ func TestReadWriteSegment_ConcurrentAppendReadFlush(t *testing.T) {
 				return
 			default:
 				last := rw.LastOffset()
-				if last < 0 {
-					continue
+				if last >= 0 {
+					payload, _, _, err := rw.Read(last)
+					assert.NoError(t, err)
+					assert.Equal(t, fmt.Sprintf("entry-%d", last), string(payload))
 				}
-				payload, _, _, err := rw.Read(last)
-				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("entry-%d", last), string(payload))
+				runtime.Gosched()
 			}
 		}
 	}()

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -350,12 +350,17 @@ func (t *wal) appendAsync0(entry *proto.LogEntry, previousCrc *uint32) error {
 
 func (t *wal) AppendAndSync(entry *proto.LogEntry, callback func(entryCrc uint32, err error)) {
 	t.Lock()
-	defer t.Unlock()
 	if err := t.appendAsync0(entry, nil); err != nil {
+		t.Unlock()
 		callback(0, err)
 		return
 	}
 	entryCrc := t.currentSegment.LastCrc()
+	t.Unlock()
+
+	// Enqueue outside the lock: when the sync queue is full, the backpressure
+	// must only block this writer, not the WAL readers (the follower cursors
+	// tailing the log).
 	t.doSync(func(err error) {
 		callback(entryCrc, err)
 	})
@@ -408,10 +413,10 @@ func (t *wal) runSync() {
 		// Clear all the other requests in the channel
 		callbacks = t.drainSyncRequestsChannel(callbacks)
 
-		t.Lock()
+		t.RLock()
 		segment := t.currentSegment
 		lastAppendedOffset := t.lastAppendedOffset.Load()
-		t.Unlock()
+		t.RUnlock()
 
 		var err error
 		if t.lastSyncedOffset.Load() != lastAppendedOffset {


### PR DESCRIPTION
### Motivation

`readWriteSegment.Flush()` runs the msync while holding the read side of the segment RWMutex; `Append()` needs the write side, so every disk sync blocks all appends for its entire duration (0.5–2ms+ per round on typical cloud disks). The blocking compounds: the appender is already holding the WAL-wide write lock (`AppendAndSync`) and, on the leader, the controller lock — so during every fsync the follower cursors tailing the log (`readAtIndex` takes the WAL read lock) and the leader's read admission stall too. `Read()` on the current segment also takes the *exclusive* lock for a read-only operation, serializing tailing reads against each other and queueing them behind any writer parked on the in-flight msync. Net effect: the group commit amortizes callbacks but not appends — under concurrent writers, roughly one write batch is admitted per fsync.

### Changes

- **msync no longer excludes appends or reads.** `Flush()` runs under a dedicated mapping-lifecycle lock (`flushLock`, read side); only `Close()` (unmap) takes its write side. This is safe: a sync round only acknowledges offsets captured *before* the flush, and records written concurrently with an in-flight msync that reach the disk torn are unacknowledged and discarded by the CRC validation in `RecoverIndex`. Unmapping under an in-flight msync remains impossible.
- **`Read()` takes the read lock** instead of the exclusive lock: tailing reads of the current segment run concurrently with each other and with the msync, conflicting only with `Append`'s short in-memory critical section.
- **`AppendAndSync` enqueues the sync request after releasing the WAL lock**: if the sync queue (cap 1000) fills because fsync falls behind, the backpressure blocks only the writer instead of freezing WAL readers.
- `runSync` captures the current segment under the WAL read lock instead of the write lock.

Lock ordering stays acyclic (`Close` is the only dual acquirer: state lock → flushLock), so no deadlock is possible.

### Verification

- New `TestReadWriteSegment_ConcurrentAppendReadFlush`: appends, tailing reads and flushes running concurrently under the race detector, with full data validation afterwards.
- New `TestReadWriteSegment_CloseWithConcurrentFlush`: close must wait for an in-flight msync; flushes after close are no-ops.
- `go test -race` green on the whole `oxiad` module, the `oxia` client module and the entire `tests/` integration suite; `golangci-lint` clean.
- Concurrent-writer throughput A/B (16 clients, standalone, macOS): parity with `main` — expected locally, since macOS `msync(MS_SYNC)` is a fast page-writeback without a disk barrier, so the convoy window being removed is tiny there. The win this targets is Linux + cloud disks where each sync round is ms-scale; on macOS the measurement confirms no regression. Single-writer sequential latency also unchanged (~122µs p50).

Note: the pre-existing rollover durability gap (the old segment is closed without a final flush while `lastSyncedOffset` can advance past its entries) is intentionally **not** addressed here — it predates this change and deserves its own fix. Same for msync'ing only the dirty page range, which interacts with `Truncate` in subtle ways and was deliberately left out to keep this change minimal.

Related: #1158, #1159 (other write-path serialization fixes; independent files).