### PR TITLE
fix: defer the segment file fsync out of the rollover append path

### DIFF
--- a/oxiad/dataserver/wal/readwrite_segment.go
+++ b/oxiad/dataserver/wal/readwrite_segment.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/edsrzf/mmap-go"
@@ -67,7 +68,7 @@ type readWriteSegment struct {
 	writingIdx        []byte
 
 	segmentSize     uint32
-	pendingFileSync bool
+	pendingFileSync atomic.Bool
 }
 
 func newReadWriteSegment(basePath string, baseOffset int64, segmentSize uint32, lastCrc uint32,
@@ -96,13 +97,15 @@ func newReadWriteSegment(basePath string, baseOffset int64, segmentSize uint32, 
 
 	if !c.segmentExists {
 		if err = initFileWithZeroes(ms.txnFile, segmentSize); err != nil {
-			return nil, err
+			return nil, multierr.Append(err, ms.txnFile.Close())
 		}
-		ms.pendingFileSync = true
+		ms.pendingFileSync.Store(true)
 	}
 
 	if ms.txnMappedFile, err = mmap.MapRegion(ms.txnFile, int(segmentSize), mmap.RDWR, 0, 0); err != nil {
-		return nil, errors.Wrapf(err, "failed to map segment file %s", ms.c.txnPath)
+		return nil, multierr.Append(
+			errors.Wrapf(err, "failed to map segment file %s", ms.c.txnPath),
+			ms.txnFile.Close())
 	}
 
 	var commitOffset *int64
@@ -115,7 +118,10 @@ func newReadWriteSegment(basePath string, baseOffset int64, segmentSize uint32, 
 	initialLastCrc := ms.lastCrc
 	if ms.writingIdx, ms.lastCrc, ms.currentFileOffset, ms.lastOffset, err = ms.c.codec.RecoverIndex(ms.txnMappedFile,
 		ms.currentFileOffset, ms.c.baseOffset, commitOffset); err != nil {
-		return nil, errors.Wrapf(err, "failed to rebuild index for segment file %s", ms.c.txnPath)
+		return nil, multierr.Combine(
+			errors.Wrapf(err, "failed to rebuild index for segment file %s", ms.c.txnPath),
+			ms.txnMappedFile.Unmap(),
+			ms.txnFile.Close())
 	}
 	// If the segment is empty, preserve the caller's CRC seed so that it can
 	// be used as the previous CRC for the first entry appended to this segment.
@@ -199,9 +205,11 @@ func (ms *readWriteSegment) Flush() error {
 	return ms.txnMappedFile.Flush()
 }
 
-// SyncFileIfNeeded is only invoked by the WAL sync goroutine, before Flush.
+// SyncFileIfNeeded is invoked by the WAL sync goroutine before Flush and, as a
+// fallback for segments that fill up before any sync round has run, by the
+// rollover before closing the segment.
 func (ms *readWriteSegment) SyncFileIfNeeded() error {
-	if !ms.pendingFileSync {
+	if !ms.pendingFileSync.Load() {
 		return nil
 	}
 
@@ -213,7 +221,7 @@ func (ms *readWriteSegment) SyncFileIfNeeded() error {
 	if err := ms.txnFile.Sync(); err != nil {
 		return err
 	}
-	ms.pendingFileSync = false
+	ms.pendingFileSync.Store(false)
 	return nil
 }
 

--- a/oxiad/dataserver/wal/readwrite_segment.go
+++ b/oxiad/dataserver/wal/readwrite_segment.go
@@ -37,6 +37,14 @@ type ReadWriteSegment interface {
 	HasSpace(l int) bool
 
 	Flush() error
+
+	// SyncFileIfNeeded fsyncs the segment file after its creation: the fsync
+	// is deferred out of the creation path, since segments get created during
+	// rollovers, in the append path, while holding the WAL write lock. It
+	// must be called before the first entries of the segment are
+	// acknowledged, so that the file metadata (size, directory entry) is
+	// durable by then.
+	SyncFileIfNeeded() error
 }
 
 type readWriteSegment struct {
@@ -58,7 +66,8 @@ type readWriteSegment struct {
 	currentFileOffset uint32
 	writingIdx        []byte
 
-	segmentSize uint32
+	segmentSize     uint32
+	pendingFileSync bool
 }
 
 func newReadWriteSegment(basePath string, baseOffset int64, segmentSize uint32, lastCrc uint32,
@@ -89,6 +98,7 @@ func newReadWriteSegment(basePath string, baseOffset int64, segmentSize uint32, 
 		if err = initFileWithZeroes(ms.txnFile, segmentSize); err != nil {
 			return nil, err
 		}
+		ms.pendingFileSync = true
 	}
 
 	if ms.txnMappedFile, err = mmap.MapRegion(ms.txnFile, int(segmentSize), mmap.RDWR, 0, 0); err != nil {
@@ -189,6 +199,24 @@ func (ms *readWriteSegment) Flush() error {
 	return ms.txnMappedFile.Flush()
 }
 
+// SyncFileIfNeeded is only invoked by the WAL sync goroutine, before Flush.
+func (ms *readWriteSegment) SyncFileIfNeeded() error {
+	if !ms.pendingFileSync {
+		return nil
+	}
+
+	ms.flushLock.RLock()
+	defer ms.flushLock.RUnlock()
+	if ms.txnMappedFile == nil {
+		return nil
+	}
+	if err := ms.txnFile.Sync(); err != nil {
+		return err
+	}
+	ms.pendingFileSync = false
+	return nil
+}
+
 func (*readWriteSegment) OpenTimestamp() time.Time {
 	return time.Now()
 }
@@ -241,6 +269,9 @@ func (ms *readWriteSegment) Truncate(lastSafeOffset int64) error {
 	return ms.Flush()
 }
 
+// initFileWithZeroes extends the file to its full segment size, without
+// fsync-ing it: the file metadata is made durable by SyncFileIfNeeded before
+// the first entries of the segment get acknowledged.
 func initFileWithZeroes(f *os.File, size uint32) error {
 	if _, err := f.Seek(int64(size), 0); err != nil {
 		return err
@@ -250,5 +281,5 @@ func initFileWithZeroes(f *os.File, size uint32) error {
 		return err
 	}
 
-	return f.Sync()
+	return nil
 }

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -368,6 +368,13 @@ func (t *wal) AppendAndSync(entry *proto.LogEntry, callback func(entryCrc uint32
 
 func (t *wal) rolloverSegment() error {
 	var err error
+	// If no sync round has fsynced the segment file yet (the segment filled up
+	// before any sync round completed), fsync it now: its entries can still be
+	// acknowledged by a later sync round, and the file metadata must be
+	// durable by then.
+	if err = t.currentSegment.SyncFileIfNeeded(); err != nil {
+		return err
+	}
 	if err = t.currentSegment.Close(); err != nil {
 		return err
 	}

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -374,6 +374,11 @@ func (t *wal) rolloverSegment() error {
 	lastCrc := t.currentSegment.LastCrc()
 	t.readOnlySegments.AddedNewSegment(t.currentSegment.BaseOffset())
 
+	// The new segment file is created without fsync-ing it: the rollover runs
+	// in the append path, while holding the WAL write lock (and, on the
+	// leader, the controller lock), where the fsync would stall the whole
+	// shard. The sync goroutine fsyncs the file before the first entries of
+	// the segment are acknowledged (see runSync).
 	if t.currentSegment, err = newReadWriteSegment(t.walPath, t.lastAppendedOffset.Load()+1, t.segmentSize,
 		lastCrc, t.commitOffsetProvider); err != nil {
 		return err
@@ -421,7 +426,10 @@ func (t *wal) runSync() {
 		var err error
 		if t.lastSyncedOffset.Load() != lastAppendedOffset {
 			timer := t.syncLatency.Timer()
-			if err = segment.Flush(); err != nil {
+			if err = segment.SyncFileIfNeeded(); err == nil {
+				err = segment.Flush()
+			}
+			if err != nil {
 				t.writeErrors.Inc()
 			} else {
 				timer.Done()

--- a/oxiad/dataserver/wal/wal_test.go
+++ b/oxiad/dataserver/wal/wal_test.go
@@ -17,6 +17,7 @@ package wal
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -649,4 +650,43 @@ func TestAppendAsyncWithPreviousCrc(t *testing.T) {
 	assert.NoError(t, f1.Close())
 	assert.NoError(t, w2.Close())
 	assert.NoError(t, f2.Close())
+}
+
+// Segments created by rollovers defer the file fsync to the sync goroutine:
+// entries must stay intact across multiple rollovers, synced acknowledgments
+// and a wal reopen.
+func TestWal_RolloverWithDeferredFileSync(t *testing.T) {
+	f, w := createWal(t)
+
+	// Write enough to roll over several times (128KiB segments)
+	var entries []string
+	payload := strings.Repeat("x", 1024)
+	for i := 0; i < 1_000; i++ {
+		value := fmt.Sprintf("%s-%d", payload, i)
+		entries = append(entries, value)
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term:   1,
+			Offset: int64(i),
+			Value:  []byte(value),
+		}))
+	}
+	assert.EqualValues(t, 999, w.LastOffset())
+
+	r, err := w.NewReader(InvalidOffset)
+	assert.NoError(t, err)
+	assertReaderReads(t, r, entries)
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+
+	// Reopen: the rolled-over segment files must recover correctly
+	w, err = f.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 999, w.LastOffset())
+
+	r, err = w.NewReader(InvalidOffset)
+	assert.NoError(t, err)
+	assertReaderReads(t, r, entries)
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, f.Close())
 }

--- a/oxiad/dataserver/wal/wal_test.go
+++ b/oxiad/dataserver/wal/wal_test.go
@@ -652,6 +652,49 @@ func TestAppendAsyncWithPreviousCrc(t *testing.T) {
 	assert.NoError(t, f2.Close())
 }
 
+// With sync disabled there are no sync rounds: every rollover exercises the
+// fallback fsync of a still-pending segment file, and the data must stay
+// intact across rollovers and a reopen.
+func TestWal_RolloverWithoutSyncRounds(t *testing.T) {
+	f := NewWalFactory(&FactoryOptions{
+		BaseWalDir:  t.TempDir(),
+		Retention:   1 * time.Hour,
+		SegmentSize: 128 * 1024,
+		SyncData:    false,
+	})
+	w, err := f.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+
+	var entries []string
+	payload := strings.Repeat("x", 1024)
+	for i := 0; i < 1_000; i++ {
+		value := fmt.Sprintf("%s-%d", payload, i)
+		entries = append(entries, value)
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term:   1,
+			Offset: int64(i),
+			Value:  []byte(value),
+		}))
+	}
+
+	r, err := w.NewReader(InvalidOffset)
+	assert.NoError(t, err)
+	assertReaderReads(t, r, entries)
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+
+	w, err = f.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 999, w.LastOffset())
+
+	r, err = w.NewReader(InvalidOffset)
+	assert.NoError(t, err)
+	assertReaderReads(t, r, entries)
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, f.Close())
+}
+
 // Segments created by rollovers defer the file fsync to the sync goroutine:
 // entries must stay intact across multiple rollovers, synced acknowledgments
 // and a wal reopen.


### PR DESCRIPTION
### Motivation

Creating a new WAL segment fsyncs the freshly created file inline (`initFileWithZeroes` → `f.Sync()`). Segment rollovers run in the append path, while holding the WAL write lock and, on the leader, the controller lock — so every segment-size worth of appends, the whole shard (appends, follower tailing reads, read admission) stalls for the duration of an fsync. On cloud disks that's a recurring multi-ms p99/p999 spike.

### Changes

- Segment files are now created and extended **without** the inline fsync; the new `SyncFileIfNeeded` fsyncs the file on the segment's first sync round, on the WAL sync goroutine, **before any of its entries are acknowledged**.
- The durability ordering is unchanged: file metadata (size; directory entry via the file-system journal, same reliance as the previous fsync-on-create) is durable before the first acknowledgment. The fsync simply runs where the disk sync was already happening, without holding any lock.
- This applies uniformly to all segment creation paths (rollover, first segment, post-clear), which keeps a single constructor and identical semantics everywhere.

### Alternative considered and discarded

Pre-creating the next segment file in the background and renaming it into place at rollover was implemented and benchmarked first. It was discarded for two reasons: (a) the background fsync contends with the foreground msyncs on the file-system journal — a rollover-heavy benchmark showed a ~10x p99 regression (180µs → ~2ms) from the stall being smeared across neighboring appends; and (b) crash-safety of the rename before the first acknowledgment would additionally require a directory fsync, which the deferred-sync approach avoids entirely.

### Verification

- New `TestWal_RolloverWithDeferredFileSync`: multiple rollovers, full read-back, and recovery after reopen.
- `go test -race` green on the whole `oxiad` module, the `oxia` client module and the `tests/` integration suite. (`tests/balancer/TestBalancer` is flaky on a slow machine independent of this change — verified it fails identically on unmodified `main` and on pre-#1158 commits under the same conditions.)
- Rollover-heavy latency probe (128KiB segments, 10k synced appends ≈ 80 rollovers, macOS): parity with `main` on p50/p99/p999 — expected locally since macOS `fsync` without `F_FULLFSYNC` is cheap; the win targets Linux + cloud disks where the create-time fsync is a real journal commit + device flush. The probe did catch and veto the background-prepare design above.
- `golangci-lint` clean.

Remaining rollover costs left for follow-up, deliberately: the old segment's index write + munmap still happen inline (~100-300µs, page-cache only, no fsync), and the pre-existing rollover durability gap (old segment closed without a final flush) is a separate issue.

Related: #1160 (fsync vs appends locking), #1159 (commit callbacks off the tracker lock).