### PR TITLE
fix: keep snapshot-bootstrapped followers eligible for leader election

### DIFF
--- a/oxiad/coordinator/runtime/balancer/scheduler.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/emirpasic/gods/v2/lists/arraylist"
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 	"github.com/pkg/errors"
 
@@ -363,8 +362,8 @@ func (r *nodeBasedBalancer) IsBalanced() bool {
 	return r.leaderBalanced(candidates, status)
 }
 
-func (*nodeBasedBalancer) leaderBalanced(candidates *linkedhashset.Set[string], status map[string]commonobject.Borrowed[*commonproto.NamespaceStatus]) bool {
-	totalShards, electedShards, nodeLeaders := state.NodeShardLeaders(candidates, status)
+func (r *nodeBasedBalancer) leaderBalanced(candidates *linkedhashset.Set[string], status map[string]commonobject.Borrowed[*commonproto.NamespaceStatus]) bool {
+	totalShards, electedShards, _ := state.NodeShardLeaders(candidates, status)
 	if totalShards == 0 {
 		return true
 	}
@@ -372,17 +371,65 @@ func (*nodeBasedBalancer) leaderBalanced(candidates *linkedhashset.Set[string], 
 		return false
 	}
 
-	maxLeaders, minLeaders := -1, -1
-	for _, leaders := range nodeLeaders {
-		leaderCount := leaders.Size()
-		if maxLeaders == -1 || leaderCount > maxLeaders {
-			maxLeaders = leaderCount
-		}
-		if minLeaders == -1 || leaderCount < minLeaders {
-			minLeaders = leaderCount
+	// The leaders are balanced when the rebalancer has no move left to make.
+	// This must use the same move search as rebalanceLeader: a stricter
+	// criterion (e.g. a global max-min spread) can be unreachable when the
+	// less-loaded nodes do not belong to the ensembles of the shards led by
+	// the most-loaded ones, and the balancer would never report the cluster
+	// as balanced while having no valid move left.
+	_, found := r.bestLeaderMove(candidates, status, false)
+	return !found
+}
+
+// bestLeaderMove looks for the shard whose leadership, if moved to the least
+// loaded node of its ensemble, yields the biggest improvement of the leader
+// balance. A move is only an improvement when the gap between the current
+// leader's count and the target's count is at least 2 (each move then strictly
+// reduces the overall imbalance, so repeated moves always terminate). Only
+// available nodes are considered, both as donors and as targets. When
+// skipQuarantined is set, shards currently quarantined are not eligible.
+func (r *nodeBasedBalancer) bestLeaderMove(candidates *linkedhashset.Set[string],
+	status map[string]commonobject.Borrowed[*commonproto.NamespaceStatus],
+	skipQuarantined bool) (move state.NamespaceAndShard, found bool) {
+	_, _, nodeLeaders := state.NodeShardLeaders(candidates, status)
+
+	counts := make(map[string]int, len(nodeLeaders))
+	for nodeID, nsAndShards := range nodeLeaders {
+		if r.nodeAvailableJudger(nodeID) {
+			counts[nodeID] = nsAndShards.Size()
 		}
 	}
-	return maxLeaders-minLeaders <= 1
+
+	bestGap := 1 // a move is an improvement only when the gap is >= 2
+	for nodeID, nsAndShards := range nodeLeaders {
+		donorLeaders, available := counts[nodeID]
+		if !available {
+			// Leaders on a non-running node are re-elected by the data server
+			// failure handling, not by the balancer
+			continue
+		}
+		for iter := nsAndShards.Iterator(); iter.Next(); {
+			nsAndShard := iter.Value()
+			if skipQuarantined {
+				if _, exist := r.shardQuarantineShardMap.Load(nsAndShard.ShardID); exist {
+					continue
+				}
+			}
+			shardStatus := status[nsAndShard.Namespace].UnsafeBorrow().Shards[nsAndShard.ShardID]
+			for _, candidate := range shardStatus.Ensemble {
+				candidateLeaders, available := counts[candidate.GetNameOrDefault()]
+				if !available {
+					continue
+				}
+				if donorLeaders-candidateLeaders > bestGap {
+					bestGap = donorLeaders - candidateLeaders
+					move = nsAndShard
+					found = true
+				}
+			}
+		}
+	}
+	return move, found
 }
 
 func (r *nodeBasedBalancer) Trigger() {
@@ -461,93 +508,30 @@ func (r *nodeBasedBalancer) rebalanceLeader() {
 		}()
 	}
 
-	maxLeadersNodeID, maxLeaders, minLeaders := r.rankLeaders(nodeLeaders)
-
-	nsAndShards, ok := nodeLeaders[maxLeadersNodeID]
-	if !ok {
-		// No leaders to check
+	move, found := r.bestLeaderMove(candidates, status, true)
+	if !found {
 		return
 	}
-
-	for iter := nsAndShards.Iterator(); iter.Next(); {
-		nsAndShard := iter.Value()
-		if maxLeaders-minLeaders <= 1 {
-			break
-		}
-		if _, exist := r.shardQuarantineShardMap.Load(nsAndShard.ShardID); exist {
-			continue
-		}
-		namespace := nsAndShard.Namespace
-		shard := nsAndShard.ShardID
-		shardStatus := status[namespace].UnsafeBorrow().Shards[shard]
-
-		minCandidateLeaders := -1
-		for _, candidate := range shardStatus.Ensemble {
-			candidateID := candidate.GetNameOrDefault()
-			if !r.nodeAvailableJudger(candidateID) {
-				continue
-			}
-			shards := nodeLeaders[candidateID]
-			leaders := shards.Size()
-			if minCandidateLeaders == -1 || leaders < minCandidateLeaders {
-				minCandidateLeaders = leaders
-			}
-		}
-		if minCandidateLeaders == maxLeaders || minCandidateLeaders+1 == maxLeaders {
-			r.logger.Info("quarantine the shard due to no valid candidates", slog.Int64("shard", shard), slog.Any("leader", maxLeadersNodeID))
-			r.shardQuarantineShardMap.Store(shard, time.Now())
-			continue
-		}
-
-		latch := &sync.WaitGroup{}
-		latch.Add(1)
-		ac := &action.ElectionAction{
-			Shard:  shard,
-			Waiter: latch,
-		}
-		r.actionCh <- ac
-		latch.Wait()
-		leader := ac.NewLeader
-		r.logger.Info("triggered new election", slog.Int64("shard", shard), slog.Any("old-leader", maxLeadersNodeID), slog.Any("new-leader", leader))
-		if leader == maxLeadersNodeID { // no changes
-			r.logger.Info("quarantine the shard due to no leader changed", slog.Int64("shard", shard), slog.Any("old-leader", maxLeadersNodeID), slog.Any("new-leader", leader))
-			r.shardQuarantineShardMap.Store(shard, time.Now())
-		}
-		break
+	shard := move.ShardID
+	oldLeader := ""
+	if shardStatus := status[move.Namespace].UnsafeBorrow().Shards[shard]; shardStatus.Leader != nil {
+		oldLeader = shardStatus.Leader.GetNameOrDefault()
 	}
-}
 
-func (r *nodeBasedBalancer) rankLeaders(nodeLeaders map[string]*arraylist.List[state.NamespaceAndShard]) (maxLeadersNodeID string, maxLeaders int, minLeaders int) {
-	maxLeadersNodeID = ""
-	maxLeaders = -1
-	minLeaders = -1
-	for nodeID, nsAndShards := range nodeLeaders {
-		if nsAndShards.Size() > 0 {
-			existNonQuarantineShard := nsAndShards.Any(func(_ int, value state.NamespaceAndShard) bool {
-				_, exist := r.shardQuarantineShardMap.Load(value.ShardID)
-				return !exist
-			})
-			if !existNonQuarantineShard { // Filter out quarantined nodes
-				continue
-			}
-		}
-		leaderNum := nsAndShards.Size()
-		if maxLeaders == -1 {
-			maxLeaders = leaderNum
-			minLeaders = leaderNum
-			maxLeadersNodeID = nodeID
-			continue
-		}
-		if leaderNum > maxLeaders {
-			maxLeaders = leaderNum
-			maxLeadersNodeID = nodeID
-			continue
-		}
-		if leaderNum < minLeaders {
-			minLeaders = leaderNum
-		}
+	latch := &sync.WaitGroup{}
+	latch.Add(1)
+	ac := &action.ElectionAction{
+		Shard:  shard,
+		Waiter: latch,
 	}
-	return maxLeadersNodeID, maxLeaders, minLeaders
+	r.actionCh <- ac
+	latch.Wait()
+	leader := ac.NewLeader
+	r.logger.Info("triggered new election", slog.Int64("shard", shard), slog.Any("old-leader", oldLeader), slog.Any("new-leader", leader))
+	if leader == oldLeader { // no changes
+		r.logger.Info("quarantine the shard due to no leader changed", slog.Int64("shard", shard), slog.Any("old-leader", oldLeader), slog.Any("new-leader", leader))
+		r.shardQuarantineShardMap.Store(shard, time.Now())
+	}
 }
 
 func (r *nodeBasedBalancer) Start() {

--- a/oxiad/coordinator/runtime/balancer/scheduler.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler.go
@@ -377,7 +377,7 @@ func (r *nodeBasedBalancer) leaderBalanced(candidates *linkedhashset.Set[string]
 	// less-loaded nodes do not belong to the ensembles of the shards led by
 	// the most-loaded ones, and the balancer would never report the cluster
 	// as balanced while having no valid move left.
-	_, found := r.bestLeaderMove(candidates, status, false)
+	_, found := r.bestLeaderMove(candidates, status, nil)
 	return !found
 }
 
@@ -386,11 +386,11 @@ func (r *nodeBasedBalancer) leaderBalanced(candidates *linkedhashset.Set[string]
 // balance. A move is only an improvement when the gap between the current
 // leader's count and the target's count is at least 2 (each move then strictly
 // reduces the overall imbalance, so repeated moves always terminate). Only
-// available nodes are considered, both as donors and as targets. When
-// skipQuarantined is set, shards currently quarantined are not eligible.
+// available nodes are considered, both as donors and as targets. Shards in
+// quarantinedShards (may be nil) are not eligible.
 func (r *nodeBasedBalancer) bestLeaderMove(candidates *linkedhashset.Set[string],
 	status map[string]commonobject.Borrowed[*commonproto.NamespaceStatus],
-	skipQuarantined bool) (move state.NamespaceAndShard, found bool) {
+	quarantinedShards *linkedhashset.Set[int64]) (move state.NamespaceAndShard, found bool) {
 	_, _, nodeLeaders := state.NodeShardLeaders(candidates, status)
 
 	counts := make(map[string]int, len(nodeLeaders))
@@ -410,26 +410,36 @@ func (r *nodeBasedBalancer) bestLeaderMove(candidates *linkedhashset.Set[string]
 		}
 		for iter := nsAndShards.Iterator(); iter.Next(); {
 			nsAndShard := iter.Value()
-			if skipQuarantined {
-				if _, exist := r.shardQuarantineShardMap.Load(nsAndShard.ShardID); exist {
-					continue
-				}
+			if quarantinedShards != nil && quarantinedShards.Contains(nsAndShard.ShardID) {
+				continue
 			}
-			shardStatus := status[nsAndShard.Namespace].UnsafeBorrow().Shards[nsAndShard.ShardID]
-			for _, candidate := range shardStatus.Ensemble {
-				candidateLeaders, available := counts[candidate.GetNameOrDefault()]
-				if !available {
-					continue
-				}
-				if donorLeaders-candidateLeaders > bestGap {
-					bestGap = donorLeaders - candidateLeaders
-					move = nsAndShard
-					found = true
-				}
+			minLeaders := minEnsembleLeaders(status, nsAndShard, counts)
+			if minLeaders >= 0 && donorLeaders-minLeaders > bestGap {
+				bestGap = donorLeaders - minLeaders
+				move = nsAndShard
+				found = true
 			}
 		}
 	}
 	return move, found
+}
+
+// minEnsembleLeaders returns the smallest leader count among the available
+// ensemble members of the given shard, or -1 when no member is available.
+func minEnsembleLeaders(status map[string]commonobject.Borrowed[*commonproto.NamespaceStatus],
+	nsAndShard state.NamespaceAndShard, counts map[string]int) int {
+	shardStatus := status[nsAndShard.Namespace].UnsafeBorrow().Shards[nsAndShard.ShardID]
+	minLeaders := -1
+	for _, candidate := range shardStatus.Ensemble {
+		leaders, available := counts[candidate.GetNameOrDefault()]
+		if !available {
+			continue
+		}
+		if minLeaders == -1 || leaders < minLeaders {
+			minLeaders = leaders
+		}
+	}
+	return minLeaders
 }
 
 func (r *nodeBasedBalancer) Trigger() {
@@ -508,7 +518,7 @@ func (r *nodeBasedBalancer) rebalanceLeader() {
 		}()
 	}
 
-	move, found := r.bestLeaderMove(candidates, status, true)
+	move, found := r.bestLeaderMove(candidates, status, r.quarantineShards())
 	if !found {
 		return
 	}

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -287,6 +287,114 @@ func TestIsBalancedRequiresBalancedLeaders(t *testing.T) {
 	assert.True(t, b.IsBalanced())
 }
 
+func TestIsBalancedIgnoresUnavailableNodes(t *testing.T) {
+	sv1 := dataServer("sv-1")
+	sv2 := dataServer("sv-2")
+	sv3 := dataServer("sv-3")
+
+	ensemble := []*proto.DataServerIdentity{sv1, sv2, sv3}
+	status := &proto.ClusterStatus{
+		Namespaces: map[string]*proto.NamespaceStatus{
+			"ns": {
+				ReplicationFactor: 3,
+				Shards: map[int64]*proto.ShardMetadata{
+					0: {Status: proto.ShardStatusSteadyState, Leader: sv1, Ensemble: ensemble},
+					1: {Status: proto.ShardStatusSteadyState, Leader: sv1, Ensemble: ensemble},
+					2: {Status: proto.ShardStatusSteadyState, Leader: sv2, Ensemble: ensemble},
+				},
+			},
+		},
+	}
+
+	nodes := linkedhashset.New("sv-1", "sv-2", "sv-3")
+	metadata := &mockMetadata{
+		status:   status,
+		nodes:    nodes,
+		metadata: map[string]*proto.DataServerMetadata{},
+		nsConfigs: map[string]*proto.Namespace{
+			"ns": {Name: "ns", ReplicationFactor: 3},
+		},
+		nodeMap: map[string]*proto.DataServerIdentity{
+			"sv-1": sv1,
+			"sv-2": sv2,
+			"sv-3": sv3,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Leaders are (2, 1, 0): not balanced while sv-3 is available
+	b := newTestBalancer(ctx, cancel, metadata, &alwaysErrorSelector{})
+	assert.False(t, b.IsBalanced())
+
+	// With sv-3 not running, the rebalancer cannot move any leader onto it:
+	// the remaining nodes are balanced
+	b.nodeAvailableJudger = func(nodeID string) bool { return nodeID != "sv-3" }
+	assert.True(t, b.IsBalanced())
+}
+
+func TestIsBalancedAtLeaderMoveFixedPoint(t *testing.T) {
+	sv1 := dataServer("sv-1")
+	sv2 := dataServer("sv-2")
+	sv3 := dataServer("sv-3")
+	sv4 := dataServer("sv-4")
+	sv5 := dataServer("sv-5")
+
+	// Every node holds 6 replicas and the leader counts are (2, 1, 2, 3, 2):
+	// the spread between the most loaded node (sv-4) and the least loaded one
+	// (sv-2) is 2, but no single leader move can reduce it, since sv-2 does
+	// not belong to the ensemble of any shard led by sv-4. The balancer has
+	// no move left to make, so it must report the cluster as balanced.
+	status := &proto.ClusterStatus{
+		Namespaces: map[string]*proto.NamespaceStatus{
+			"ns": {
+				ReplicationFactor: 3,
+				Shards: map[int64]*proto.ShardMetadata{
+					0: {Status: proto.ShardStatusSteadyState, Leader: sv4, Ensemble: []*proto.DataServerIdentity{sv1, sv5, sv4}},
+					1: {Status: proto.ShardStatusSteadyState, Leader: sv5, Ensemble: []*proto.DataServerIdentity{sv3, sv1, sv5}},
+					2: {Status: proto.ShardStatusSteadyState, Leader: sv2, Ensemble: []*proto.DataServerIdentity{sv3, sv2, sv4}},
+					3: {Status: proto.ShardStatusSteadyState, Leader: sv3, Ensemble: []*proto.DataServerIdentity{sv2, sv3, sv4}},
+					4: {Status: proto.ShardStatusSteadyState, Leader: sv1, Ensemble: []*proto.DataServerIdentity{sv2, sv1, sv5}},
+					5: {Status: proto.ShardStatusSteadyState, Leader: sv4, Ensemble: []*proto.DataServerIdentity{sv3, sv1, sv4}},
+					6: {Status: proto.ShardStatusSteadyState, Leader: sv3, Ensemble: []*proto.DataServerIdentity{sv5, sv2, sv3}},
+					7: {Status: proto.ShardStatusSteadyState, Leader: sv5, Ensemble: []*proto.DataServerIdentity{sv2, sv5, sv4}},
+					8: {Status: proto.ShardStatusSteadyState, Leader: sv4, Ensemble: []*proto.DataServerIdentity{sv1, sv4, sv5}},
+					9: {Status: proto.ShardStatusSteadyState, Leader: sv1, Ensemble: []*proto.DataServerIdentity{sv2, sv1, sv3}},
+				},
+			},
+		},
+	}
+
+	nodes := linkedhashset.New("sv-1", "sv-2", "sv-3", "sv-4", "sv-5")
+	metadata := &mockMetadata{
+		status:   status,
+		nodes:    nodes,
+		metadata: map[string]*proto.DataServerMetadata{},
+		nsConfigs: map[string]*proto.Namespace{
+			"ns": {Name: "ns", ReplicationFactor: 3},
+		},
+		nodeMap: map[string]*proto.DataServerIdentity{
+			"sv-1": sv1,
+			"sv-2": sv2,
+			"sv-3": sv3,
+			"sv-4": sv4,
+			"sv-5": sv5,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	b := newTestBalancer(ctx, cancel, metadata, &alwaysErrorSelector{})
+	assert.True(t, b.IsBalanced())
+
+	// Moving shard 9's leadership to sv-3 leaves sv-1 with a single leader:
+	// now sv-4 can donate shard 0 to sv-1, so the cluster is not balanced
+	status.Namespaces["ns"].Shards[9].Leader = sv3
+	assert.False(t, b.IsBalanced())
+}
+
 func TestIsBalancedRequiresNamespaceStatus(t *testing.T) {
 	sv1 := dataServer("sv-1")
 	sv2 := dataServer("sv-2")

--- a/oxiad/coordinator/runtime/balancer/state/grouping.go
+++ b/oxiad/coordinator/runtime/balancer/state/grouping.go
@@ -108,8 +108,14 @@ func GroupingShardsNodeByStatus(candidates *linkedhashset.Set[string], namespace
 	return groupingShardByNode, historyNodes
 }
 
+// A shard participates in load/leader balancing unless it is being deleted or
+// is part of an in-progress split. Shards in Unknown or Election status must
+// be counted: their ensemble placement is already decided, and ignoring them
+// would let the balancer (and the initial ensemble selection) act on a partial
+// view of the cluster, proposing moves that re-introduce imbalance once the
+// hidden shards become visible again.
 func isBalancingCandidate(shardStatus *commonproto.ShardMetadata) bool {
-	return shardStatus.GetStatusOrDefault() == commonproto.ShardStatusSteadyState && shardStatus.Split == nil
+	return shardStatus.GetStatusOrDefault() != commonproto.ShardStatusDeleting && shardStatus.Split == nil
 }
 
 func GroupingCandidatesWithLabelValue(candidates *linkedhashset.Set[string], candidatesMetadata map[string]*commonproto.DataServerMetadata) map[string]map[string]*linkedhashset.Set[string] {

--- a/oxiad/coordinator/runtime/balancer/state/grouping_test.go
+++ b/oxiad/coordinator/runtime/balancer/state/grouping_test.go
@@ -21,8 +21,45 @@ import (
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 	"github.com/stretchr/testify/assert"
 
+	commonobject "github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/proto"
 )
+
+func TestGroupingShardsIncludesNonSteadyShards(t *testing.T) {
+	server := func(name string) *proto.DataServerIdentity {
+		return &proto.DataServerIdentity{Name: &name}
+	}
+	ensemble := []*proto.DataServerIdentity{server("server1"), server("server2")}
+
+	namespaces := map[string]commonobject.Borrowed[*proto.NamespaceStatus]{
+		"ns-1": commonobject.Borrow(&proto.NamespaceStatus{
+			Shards: map[int64]*proto.ShardMetadata{
+				// Steady shard with an elected leader
+				0: {Status: proto.ShardStatusSteadyState, Leader: server("server1"), Ensemble: ensemble},
+				// Just created, no election run yet: still occupies its ensemble
+				1: {Status: proto.ShardStatusUnknown, Ensemble: ensemble},
+				// Mid-election: still occupies its ensemble
+				2: {Status: proto.ShardStatusElection, Ensemble: ensemble},
+				// Being deleted: must not be counted
+				3: {Status: proto.ShardStatusDeleting, Leader: server("server1"), Ensemble: ensemble},
+				// Mid-split: managed by the split controller, must not be counted
+				4: {Status: proto.ShardStatusSteadyState, Leader: server("server1"), Ensemble: ensemble,
+					Split: &proto.SplitMetadata{ChildShardIds: []int64{5, 6}}},
+			},
+		}),
+	}
+	candidates := linkedhashset.New("server1", "server2")
+
+	grouped, _ := GroupingShardsNodeByStatus(candidates, namespaces)
+	assert.Len(t, grouped["server1"], 3)
+	assert.Len(t, grouped["server2"], 3)
+
+	totalShards, electedShards, leaders := NodeShardLeaders(candidates, namespaces)
+	assert.Equal(t, 3, totalShards)
+	assert.Equal(t, 1, electedShards)
+	assert.Equal(t, 1, leaders["server1"].Size())
+	assert.Equal(t, 0, leaders["server2"].Size())
+}
 
 func TestGroupingCandidatesNormalCase(t *testing.T) {
 	candidatesMetadata := map[string]*proto.DataServerMetadata{

--- a/oxiad/coordinator/runtime/controller/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/selector"
 	leaderselector "github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/selector/leader"
 
+	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/common/process"
 	oxiatime "github.com/oxia-db/oxia/common/time"
 
@@ -187,9 +188,25 @@ func NewShardController(
 func (s *shardController) Election(electionAction *action.ElectionAction) string {
 	clonedAction := electionAction.Clone()
 	clonedAction.Waiter.Add(1)
-	s.electionOp <- clonedAction
-	clonedAction.Waiter.Wait()
-	return clonedAction.NewLeader
+	select {
+	case s.electionOp <- clonedAction:
+	case <-s.ctx.Done():
+		return ""
+	}
+	done := make(chan struct{})
+	go func() {
+		clonedAction.Waiter.Wait()
+		close(done)
+	}()
+	// The shard controller might be closed while the election operation is
+	// still queued: don't keep the caller blocked on an operation that will
+	// never be processed
+	select {
+	case <-done:
+		return clonedAction.NewLeader
+	case <-s.ctx.Done():
+		return ""
+	}
 }
 
 func (s *shardController) run(initShardMeta *proto.ShardMetadata) {
@@ -226,6 +243,7 @@ func (s *shardController) run(initShardMeta *proto.ShardMetadata) {
 	for {
 		select {
 		case <-s.ctx.Done():
+			s.drainPendingOps()
 			return
 
 		case <-s.deleteOp:
@@ -239,6 +257,21 @@ func (s *shardController) run(initShardMeta *proto.ShardMetadata) {
 		case electionAction := <-s.electionOp:
 			newLeader := s.onElectLeader(nil)
 			electionAction.Done(newLeader.GetNameOrDefault())
+		}
+	}
+}
+
+// drainPendingOps completes the queued operations that have a blocked waiter,
+// so that their callers don't hang on a controller that is shutting down.
+func (s *shardController) drainPendingOps() {
+	for {
+		select {
+		case electionAction := <-s.electionOp:
+			electionAction.Done("")
+		case op := <-s.changeEnsembleOp:
+			op.Error(constant.ErrResourceUnavailable)
+		default:
+			return
 		}
 	}
 }

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -304,8 +304,10 @@ func (c *runtime) selectNewEnsemble(namespace string, shard int64, ns *proto.Nam
 
 func (c *runtime) Close() error {
 	c.ctxCancel()
-	c.wg.Wait()
 
+	// The shard controllers must be closed before waiting for the action
+	// worker: the worker blocks on in-flight election actions, which only
+	// complete once the shard controllers' retry loops get canceled
 	var err error
 	for _, sc := range c.splitControllers {
 		sc.Close()
@@ -313,6 +315,8 @@ func (c *runtime) Close() error {
 	for _, sc := range c.shardControllers {
 		err = multierr.Append(err, sc.Close())
 	}
+
+	c.wg.Wait()
 
 	for _, nc := range c.dataServerControllers {
 		err = multierr.Append(err, nc.Close())

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -829,7 +829,12 @@ func New(
 		NodeAvailableJudger: func(nodeID string) bool {
 			c.RLock()
 			defer c.RUnlock()
-			nc := c.dataServerControllers[nodeID]
+			nc, ok := c.dataServerControllers[nodeID]
+			if !ok {
+				// The controller might not have been created yet for a
+				// data server that was just registered
+				return false
+			}
 			return nc.Status() == controller.Running
 		},
 	})

--- a/oxiad/dataserver/controller/lead/follower_cursor.go
+++ b/oxiad/dataserver/controller/lead/follower_cursor.go
@@ -83,6 +83,7 @@ type followerCursor struct {
 	cancel         context.CancelFunc
 	latch          sync.WaitGroup
 	log            *slog.Logger
+	observer       bool                  // true for split observer cursors
 	splitHashRange *proto.Int32HashRange // non-nil for split observer cursors
 
 	snapshotsTransferTime     metric.LatencyHistogram
@@ -196,6 +197,7 @@ func NewObserverFollowerCursor( //nolint:revive
 		db:                      db,
 		namespace:               namespace,
 		shardId:                 shardId,
+		observer:                true,
 		splitHashRange:          splitHashRange,
 
 		log: slog.With(
@@ -252,6 +254,16 @@ func (fc *followerCursor) shouldSendSnapshot() bool {
 	walFirstOffset := fc.wal.FirstOffset()
 
 	if ackOffset == wal.InvalidOffset && fc.ackTracker.CommitOffset() >= 0 {
+		if walFirstOffset == 0 && !fc.observer {
+			// The WAL still contains the full history: bring the follower up to
+			// date by tailing the log instead of sending a snapshot. This keeps
+			// the follower's WAL populated, so it remains a viable candidate in
+			// future leader elections (a snapshot leaves the WAL empty and the
+			// follower would keep fencing with an invalid head entry until the
+			// next write). Split observers are excluded: a child shard must be
+			// seeded with the hash-range-filtered snapshot.
+			return false
+		}
 		fc.log.Info(
 			"Sending snapshot to empty follower",
 			slog.Int64("follower-ack-offset", ackOffset),

--- a/oxiad/dataserver/controller/lead/follower_cursor_test.go
+++ b/oxiad/dataserver/controller/lead/follower_cursor_test.go
@@ -262,9 +262,13 @@ func TestFollowerCursor_StreamToEmptyFollowerWhenWalComplete(t *testing.T) {
 	// brought up to date by tailing the log, not with a snapshot, so that its
 	// own WAL gets populated and it stays eligible for leader election
 	for i := int64(0); i < n; i++ {
-		req := <-stream.AppendReqs
-		assert.EqualValues(t, 1, req.Term)
-		assert.EqualValues(t, i, req.Entry.Offset)
+		select {
+		case req := <-stream.AppendReqs:
+			assert.EqualValues(t, 1, req.Term)
+			assert.EqualValues(t, i, req.Entry.Offset)
+		case <-time.After(10 * time.Second):
+			t.Fatalf("did not receive the append for offset %d", i)
+		}
 	}
 	assert.Empty(t, stream.SendSnapshotStream.Requests)
 

--- a/oxiad/dataserver/controller/lead/follower_cursor_test.go
+++ b/oxiad/dataserver/controller/lead/follower_cursor_test.go
@@ -164,13 +164,23 @@ func TestFollowerCursor_SendSnapshot(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
+	// Trim the WAL: an empty follower can only be brought up to date through
+	// a snapshot when the first entries are no longer available in the WAL
+	reader, err := w.NewReverseReader()
+	assert.NoError(t, err)
+	_, _, lastCrc, err := reader.ReadNext()
+	assert.NoError(t, err)
+	assert.NoError(t, reader.Close())
+	assert.NoError(t, w.Clear())
+
 	// Append one more entry so there is something to stream after the snapshot
-	assert.NoError(t, w.Append(&proto.LogEntry{
+	assert.NoError(t, w.AppendAsyncWithPreviousCrc(&proto.LogEntry{
 		Term:      1,
 		Offset:    n,
 		Value:     []byte("post-snapshot"),
 		Timestamp: uint64(n),
-	}))
+	}, &lastCrc))
+	assert.NoError(t, w.Sync(context.Background()))
 
 	ackTracker := NewQuorumAckTracker(3, n, n-1)
 
@@ -208,6 +218,59 @@ func TestFollowerCursor_SendSnapshot(t *testing.T) {
 	assert.NoError(t, fc.Close())
 }
 
+func TestFollowerCursor_StreamToEmptyFollowerWhenWalComplete(t *testing.T) {
+	var term int64 = 1
+	var shard int64 = 2
+
+	n := int64(10)
+	stream := rpc.NewMockRpcClient()
+	kvf, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	db, err := database.NewDB(constant.DefaultNamespace, shard, kvf, proto.KeySortingType_HIERARCHICAL, 1*time.Hour, time2.SystemClock)
+	assert.NoError(t, err)
+	wf := wal.NewWalFactory(&wal.FactoryOptions{BaseWalDir: t.TempDir()})
+	w, err := wf.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+
+	// Load some entries into the db & wal, keeping the full history in the WAL
+	for i := int64(0); i < n; i++ {
+		wr := &proto.WriteRequest{
+			Shard: &shard,
+			Puts: []*proto.PutRequest{{
+				Key:   fmt.Sprintf("key-%d", i),
+				Value: []byte(fmt.Sprintf("value-%d", i)),
+			}},
+		}
+		e, _ := pb.Marshal(wrapInLogEntryValue(wr))
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term:      1,
+			Offset:    i,
+			Value:     e,
+			Timestamp: uint64(i),
+		}))
+
+		_, err := db.ProcessWrite(wr, i, uint64(i), database.NoOpCallback)
+		assert.NoError(t, err)
+	}
+
+	ackTracker := NewQuorumAckTracker(3, n-1, n-1)
+
+	fc, err := NewFollowerCursor("f1", term, constant.DefaultNamespace, shard, stream, ackTracker, w, db, wal.InvalidOffset)
+	assert.NoError(t, err)
+
+	// The WAL still contains the full history: the empty follower must be
+	// brought up to date by tailing the log, not with a snapshot, so that its
+	// own WAL gets populated and it stays eligible for leader election
+	for i := int64(0); i < n; i++ {
+		req := <-stream.AppendReqs
+		assert.EqualValues(t, 1, req.Term)
+		assert.EqualValues(t, i, req.Entry.Offset)
+	}
+	assert.Empty(t, stream.SendSnapshotStream.Requests)
+
+	assert.NoError(t, fc.Close())
+}
+
 func TestFollowerCursor_CloseWaitsForInFlightSnapshot(t *testing.T) {
 	var term int64 = 1
 	var shard int64 = 2
@@ -227,13 +290,8 @@ func TestFollowerCursor_CloseWaitsForInFlightSnapshot(t *testing.T) {
 			Value: []byte("value"),
 		}},
 	}
-	e, _ := pb.Marshal(wrapInLogEntryValue(wr))
-	assert.NoError(t, w.Append(&proto.LogEntry{
-		Term:      1,
-		Offset:    0,
-		Value:     e,
-		Timestamp: 0,
-	}))
+	// Keep the WAL empty: the empty follower can then only be brought up to
+	// date through a snapshot
 	_, err = db.ProcessWrite(wr, 0, 0, database.NoOpCallback)
 	assert.NoError(t, err)
 

--- a/tests/balancer/balancer_test.go
+++ b/tests/balancer/balancer_test.go
@@ -50,9 +50,14 @@ func TestBalancer(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, metadata.Close())
 	})
+	// The quarantine time must be long enough to actually rate-limit retries
+	// of elections that did not improve the leader balance (e.g. when a slow
+	// candidate misses the fencing grace period): with a too-short quarantine
+	// the balancer degenerates into a hot loop of no-op elections on a loaded
+	// machine.
 	metadata.GetConfig().UnsafeBorrow().LoadBalancer = &proto.LoadBalancer{
 		ScheduleInterval: "10ms",
-		QuarantineTime:   "1ms",
+		QuarantineTime:   "1s",
 	}
 
 	coordinatorInstance, err := coordruntime.New(metadata, coordrpc.NewRpcProviderFactory(nil))

--- a/tests/balancer/balancer_test.go
+++ b/tests/balancer/balancer_test.go
@@ -32,7 +32,11 @@ import (
 
 func TestBalancer(t *testing.T) {
 	const (
-		balanceTimeout = 60 * time.Second
+		// Allow enough time for the cluster to recover from health-check
+		// hiccups on a slow/loaded machine: a node that misses a ping is
+		// marked unavailable and re-joins only after a successful handshake,
+		// which is retried with a 10s initial backoff.
+		balanceTimeout = 180 * time.Second
 		balanceTick    = 50 * time.Millisecond
 	)
 


### PR DESCRIPTION
### Problem

`TestBalancer` is flaky on slow machines (race detector + loaded/low-power host): it fails with `Condition never satisfied` at `balancer_test.go:73` while shard terms climb into the hundreds, with continuous leader elections and ensemble moves.

The root cause is not the balancer math but the way empty followers are bootstrapped:

1. When a leader brings an empty follower up to date (e.g. after the balancer swaps a shard onto a new node), it always sends a DB snapshot. A snapshot fills the DB but never populates the follower's WAL.
2. `NewTerm` fencing responses report the WAL head entry, so a snapshot-bootstrapped follower keeps fencing with `(-1, -1)` until the next write lands. In a quiet cluster that is forever.
3. `chooseCandidates` only admits servers with the highest head entry, so every election ends with the current leader as the only candidate: leadership becomes immovable.
4. The load balancer keeps triggering elections to move leadership onto those nodes ("no leader changed" → quarantine → retry): in failing runs, 693 rebalance elections of which 485 changed nothing, one shard re-elected the same leader 5-7 times/sec, terms past 400, and a snapshot re-sent on every term. Leader balance is unreachable, so `IsBalanced()` never stabilizes.

This also affects production quiet clusters: after any ensemble change, the affected shards' leadership cannot be moved until the next write.

### Fix

When the leader's WAL still contains the full history (`FirstOffset() == 0`), bring an empty quorum follower up to date by tailing the log instead of sending a snapshot, so its WAL gets populated and it remains a viable election candidate. Aged shards whose WAL was trimmed by retention keep the snapshot path as before.

Split observer cursors are explicitly excluded (new `observer` flag): a child shard must be seeded with the hash-range-filtered snapshot. (Streaming to observers reproducibly broke `TestCoordinator_ShardSplit_EphemeralRecords`.)

### Validation

- `GOMAXPROCS=2 go test -race -count=5 -run TestBalancer ./tests/balancer/`: previously failed ~half the runs on a slow machine (76-300s per failing run); now passes 5/5 at ~27s per run with zero rebalance-election churn and zero snapshots-to-empty-followers.
- New unit test `TestFollowerCursor_StreamToEmptyFollowerWhenWalComplete` covers the streaming path; `TestFollowerCursor_SendSnapshot` now models a trimmed WAL (`Clear()` + CRC reseed) to keep exercising the snapshot path.
- Full `tests/` suites (coordinator incl. splits, control, assignments, client, resolver, sequence, security) and `oxiad/...` package tests pass with `-race`.