### PR TITLE
fix: register the gRPC codec through the CodecV2 interface

### DIFF
--- a/common/proto/proto_grpc.go
+++ b/common/proto/proto_grpc.go
@@ -19,34 +19,74 @@ import (
 
 	"github.com/planetscale/vtprotobuf/codec/grpc"
 	"google.golang.org/grpc/encoding"
+
+	// Ensure the default proto codec registers first, so that this one
+	// deterministically overrides it in the CodecV2 registry.
 	_ "google.golang.org/grpc/encoding/proto"
+	"google.golang.org/grpc/mem"
 	pb "google.golang.org/protobuf/proto"
 )
 
+// vtprotoCodec is an encoding.CodecV2 serializing with the generated
+// vtprotobuf fast paths and the gRPC shared buffer pools. A legacy
+// encoding.Codec registration would instead get wrapped by gRPC in a bridge
+// that fully materializes (allocates and copies) every received message and
+// sends from unpooled marshal buffers: going through CodecV2 saves an
+// allocation and a full-payload copy per message, in each direction.
 type vtprotoCodec struct{}
 
 type vtprotoMessage interface {
-	MarshalVT() ([]byte, error)
+	SizeVT() int
+	MarshalToSizedBufferVT(dAtA []byte) (int, error)
 	UnmarshalVT([]byte) error
 }
 
-func (vtprotoCodec) Marshal(v any) ([]byte, error) {
+func (vtprotoCodec) Marshal(v any) (mem.BufferSlice, error) {
 	switch v := v.(type) {
 	case vtprotoMessage:
-		return v.MarshalVT()
+		size := v.SizeVT()
+		if mem.IsBelowBufferPoolingThreshold(size) {
+			buf := make([]byte, size)
+			if _, err := v.MarshalToSizedBufferVT(buf); err != nil {
+				return nil, err
+			}
+			return mem.BufferSlice{mem.SliceBuffer(buf)}, nil
+		}
+
+		pool := mem.DefaultBufferPool()
+		buf := pool.Get(size)
+		*buf = (*buf)[:size]
+		if _, err := v.MarshalToSizedBufferVT(*buf); err != nil {
+			pool.Put(buf)
+			return nil, err
+		}
+		return mem.BufferSlice{mem.NewBuffer(buf, pool)}, nil
+
 	case pb.Message:
-		return pb.Marshal(v)
+		buf, err := pb.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		return mem.BufferSlice{mem.SliceBuffer(buf)}, nil
+
 	default:
 		return nil, fmt.Errorf("failed to marshal, message is %T, must satisfy the vtprotoMessage interface or want proto.Message", v)
 	}
 }
 
-func (vtprotoCodec) Unmarshal(data []byte, v any) error {
+func (vtprotoCodec) Unmarshal(data mem.BufferSlice, v any) error {
+	// In the common single-buffer case, MaterializeToBuffer just references
+	// the received buffer, without copying it. The buffer can be freed right
+	// after unmarshaling: UnmarshalVT (and pb.Unmarshal) copy the bytes
+	// fields out of it.
+	buf := data.MaterializeToBuffer(mem.DefaultBufferPool())
+	defer buf.Free()
+
 	switch v := v.(type) {
 	case vtprotoMessage:
-		return v.UnmarshalVT(data)
+		return v.UnmarshalVT(buf.ReadOnlyData())
 	case pb.Message:
-		return pb.Unmarshal(data, v)
+		return pb.Unmarshal(buf.ReadOnlyData(), v)
 	default:
 		return fmt.Errorf("failed to unmarshal, message is %T, must satisfy the vtprotoMessage interface or want proto.Message", v)
 	}
@@ -57,5 +97,5 @@ func (vtprotoCodec) Name() string {
 }
 
 func init() {
-	encoding.RegisterCodec(vtprotoCodec{})
+	encoding.RegisterCodecV2(vtprotoCodec{})
 }

--- a/common/proto/proto_grpc_test.go
+++ b/common/proto/proto_grpc_test.go
@@ -1,0 +1,158 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proto
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/planetscale/vtprotobuf/codec/grpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/encoding"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/mem"
+)
+
+func TestVtprotoCodec_Registration(t *testing.T) {
+	// The codec must live in the CodecV2 registry: a legacy (V1) registration
+	// would shadow it through the gRPC bridge, reintroducing a full copy of
+	// every received message
+	assert.Nil(t, encoding.GetCodec(grpc.Name))
+
+	codec := encoding.GetCodecV2(grpc.Name)
+	require.NotNil(t, codec)
+	assert.IsType(t, vtprotoCodec{}, codec)
+}
+
+func TestVtprotoCodec_RoundTrip(t *testing.T) {
+	codec := vtprotoCodec{}
+
+	// Below and above the buffer-pooling threshold
+	for _, size := range []int{16, 64 * 1024} {
+		entry := &LogEntry{Term: 1, Offset: 42, Timestamp: 123, Value: bytes.Repeat([]byte("x"), size)}
+
+		data, err := codec.Marshal(entry)
+		require.NoError(t, err)
+
+		decoded := &LogEntry{}
+		require.NoError(t, codec.Unmarshal(data, decoded))
+		data.Free()
+
+		assert.EqualValues(t, 1, decoded.Term)
+		assert.EqualValues(t, 42, decoded.Offset)
+		assert.EqualValues(t, 123, decoded.Timestamp)
+		assert.Equal(t, entry.Value, decoded.Value)
+	}
+}
+
+func TestVtprotoCodec_UnmarshalMultiBuffer(t *testing.T) {
+	codec := vtprotoCodec{}
+
+	entry := &LogEntry{Term: 7, Offset: 1, Value: bytes.Repeat([]byte("y"), 4096)}
+	raw, err := entry.MarshalVT()
+	require.NoError(t, err)
+
+	// A message split across multiple receive buffers gets reassembled
+	mid := len(raw) / 2
+	data := mem.BufferSlice{mem.SliceBuffer(raw[:mid]), mem.SliceBuffer(raw[mid:])}
+
+	decoded := &LogEntry{}
+	require.NoError(t, codec.Unmarshal(data, decoded))
+	assert.Equal(t, entry.Value, decoded.Value)
+}
+
+func TestVtprotoCodec_StandardProtoFallback(t *testing.T) {
+	codec := vtprotoCodec{}
+
+	// Messages without the generated vtproto methods (e.g. the gRPC health
+	// service) go through the standard proto marshaling
+	req := &grpc_health_v1.HealthCheckRequest{Service: "oxia"}
+	data, err := codec.Marshal(req)
+	require.NoError(t, err)
+
+	decoded := &grpc_health_v1.HealthCheckRequest{}
+	require.NoError(t, codec.Unmarshal(data, decoded))
+	data.Free()
+	assert.Equal(t, "oxia", decoded.Service)
+}
+
+func TestVtprotoCodec_InvalidMessage(t *testing.T) {
+	codec := vtprotoCodec{}
+
+	_, err := codec.Marshal(struct{}{})
+	assert.Error(t, err)
+	assert.Error(t, codec.Unmarshal(mem.BufferSlice{}, struct{}{}))
+}
+
+func BenchmarkCodecUnmarshal(b *testing.B) {
+	entry := &LogEntry{Term: 1, Offset: 1, Value: make([]byte, 4096)}
+	raw, err := entry.MarshalVT()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// The receive path of the legacy V1 registration: gRPC's bridge fully
+	// materializes the buffer slice before invoking the codec
+	b.Run("v1-bridge", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			data := mem.BufferSlice{mem.SliceBuffer(raw)}
+			decoded := &LogEntry{}
+			if err := decoded.UnmarshalVT(data.Materialize()); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("v2", func(b *testing.B) {
+		codec := vtprotoCodec{}
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			data := mem.BufferSlice{mem.SliceBuffer(raw)}
+			decoded := &LogEntry{}
+			if err := codec.Unmarshal(data, decoded); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkCodecMarshal(b *testing.B) {
+	entry := &LogEntry{Term: 1, Offset: 1, Value: make([]byte, 4096)}
+
+	// The send path of the legacy V1 registration: a fresh full-size buffer
+	// per message
+	b.Run("v1-bridge", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := entry.MarshalVT(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("v2", func(b *testing.B) {
+		codec := vtprotoCodec{}
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			data, err := codec.Marshal(entry)
+			if err != nil {
+				b.Fatal(err)
+			}
+			data.Free()
+		}
+	})
+}


### PR DESCRIPTION
### Motivation

The vtproto codec is registered as a legacy `encoding.Codec` (V1). Since grpc-go 1.66, V1 codecs get wrapped in a bridge whose `Unmarshal` calls `BufferSlice.Materialize()` — an unconditional allocate-and-copy of every received message — while the codec's `MarshalVT` allocates a fresh, unpooled buffer for every outgoing message. Every message of every RPC in the system (client writes/reads, replication appends/acks, assignments) pays one avoidable allocation and one full-payload copy in each direction. At replication rates this is hundreds of MB/s of garbage cluster-wide.

### Changes

- **`encoding.CodecV2` registration**:
  - Outgoing messages marshal via the generated `SizeVT` + `MarshalToSizedBufferVT` directly into gRPC's shared buffer pools (plain buffer below the pooling threshold, mirroring the stock codec's structure).
  - Incoming messages unmarshal straight from the transport buffer: in the common single-buffer case `MaterializeToBuffer` only takes a reference — no copy — and the buffer returns to the pool immediately after, which is safe because `UnmarshalVT` copies bytes fields out (the `unsafe` aliasing variant is deliberately not used).
  - Messages without vtproto codegen (e.g. the gRPC health service) keep the standard proto fallback.
- The V1 registration is removed — required, since gRPC's codec lookup checks the V1 registry *first*, so any V1 codec named `proto` would shadow the V2 one through the bridge. `TestVtprotoCodec_Registration` pins exactly that (asserts the V1 registry stays empty), so a future re-registration can't silently reintroduce the copy.

### Verification

- Codec tests: round-trip below/above the pooling threshold, multi-buffer reassembly, standard-proto fallback, invalid-message errors, plus the registration pin above.
- Codec benchmark (4KiB message, on the current grpc v1.79.3):

  | | ns/op | B/op |
  |---|---|---|
  | Unmarshal v1-bridge | 1305 | 8984 |
  | Unmarshal v2 | **699** | **4216** |
  | Marshal v1-bridge | 640 | 4864 |
  | Marshal v2 | **270** | **16** |

  ~1.9x faster receive (the bridge copy is gone), ~2.4x faster send with ~300x less allocation (pooled buffers).
- `go test -race` green on the whole `oxiad` module, the `oxia` client module and `tests/client`; the full suite also ran green against this codec in the original combined PR (#1166). `golangci-lint` clean.

Independent of #1168 (grpc-go upgrade): the codec uses only APIs that are identical between grpc v1.79.3 and v1.81.1, so the two merge in any order. Split out of #1166.

Related: #1158–#1164 (performance review series). This compounds with #1162: the same write payload previously paid the WAL marshal allocation and the codec allocation back to back.
