### PR TITLE
fix: don't kill the process when Close() races ahead of grpc Serve()

### DIFF
--- a/oxiad/common/rpc/grpc_server.go
+++ b/oxiad/common/rpc/grpc_server.go
@@ -17,6 +17,7 @@ package rpc
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -142,7 +143,9 @@ func newDefaultGrpcProvider(name, bindAddress string, registerFunc func(grpc.Ser
 			"bind": listener.Addr().String(),
 		},
 		func() {
-			if err := c.server.Serve(listener); err != nil {
+			// Serve returns ErrServerStopped when Close() completed before this
+			// goroutine was scheduled: a benign race, not a startup failure.
+			if err := c.server.Serve(listener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 				c.log.Error(
 					"Failed to start serving",
 					slog.Any("error", err),

--- a/oxiad/common/rpc/grpc_server_test.go
+++ b/oxiad/common/rpc/grpc_server_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/oxia-db/oxia/oxiad/common/rpc/auth"
+)
+
+func TestGrpcServer_CloseBeforeServeStarts(t *testing.T) {
+	// Regression test: when Close() completes before the Serve() goroutine is
+	// scheduled, Serve() returns grpc.ErrServerStopped. That must be treated as
+	// a normal shutdown, not a startup failure that os.Exit(1)s the process.
+	// GOMAXPROCS(1) keeps the Serve goroutine queued until after Close().
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(1))
+
+	for i := 0; i < 100; i++ {
+		s, err := Default.StartGrpcServer("test", "localhost:0",
+			func(grpc.ServiceRegistrar) {}, nil, &auth.Options{}, nil)
+		require.NoError(t, err)
+		require.NoError(t, s.Close())
+	}
+}


### PR DESCRIPTION
### Motivation

`newDefaultGrpcProvider()` spawns the `Serve(listener)` goroutine and returns. If `Close()` → `GracefulStop()` completes before that goroutine is scheduled (fast create/close cycles, e.g. in tests on a loaded machine), `Serve()` returns `grpc.ErrServerStopped` and the error handler logs `Failed to start serving` and calls `os.Exit(1)`, killing the whole process.

Observed in CI ([run 27366486580](https://github.com/oxia-db/oxia/actions/runs/27366486580)): the `oxiad/dataserver` package FAILed in 0.386s with no individual test marked, with this in the log right after a normal "Stopped Grpc server" line:

```
{"error":"grpc: the server has been stopped","grpc-server":"public","message":"Failed to start serving"}
```

### Changes

Treat `grpc.ErrServerStopped` as a benign shutdown. grpc-go returns it from `Serve()` only when `Stop()`/`GracefulStop()` completed **before** `Serve()` was invoked; after a normal stop while serving, `Serve()` returns `nil`. Any other `Serve()` error (real bind/serve failures) still logs and exits the process.

Added a regression test: a create/`Close()` loop under `GOMAXPROCS(1)`, which keeps the `Serve` goroutine queued so `Close()` reliably wins the race. Against the unfixed code it kills the test binary after ~30 iterations with the exact CI signature; with the fix it passes under `-race -count=5`.

### Verification

- `go test -race ./oxiad/common/rpc/...` ✅
- `go test -race -count=10 ./oxiad/dataserver/` ✅
- Full `make test` green except the known pre-existing `TestBalancer` flake (#1163)