### PR TITLE
fix: [raft] retain coordinator metadata snapshots on persist

### DIFF
--- a/oxiad/coordinator/metadata/provider/raft/raft_fsm.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft_fsm.go
@@ -126,7 +126,10 @@ func (sc *stateContainer) Persist(sink raft.SnapshotSink) error {
 		// compacted, losing the state on the next restart
 		return multierr.Combine(err, sink.Cancel())
 	}
-	return sink.Close()
+	if err := sink.Close(); err != nil {
+		return multierr.Combine(err, sink.Cancel())
+	}
+	return nil
 }
 
 func (*stateContainer) Release() {}

--- a/oxiad/coordinator/metadata/provider/raft/raft_fsm.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft_fsm.go
@@ -93,12 +93,12 @@ func (sc *stateContainer) Snapshot() (raft.FSMSnapshot, error) {
 func (sc *stateContainer) Restore(rc io.ReadCloser) error {
 	dec := json.NewDecoder(rc)
 	persisted := &persistedStateContainer{}
-	sc.logger.Info("Restored metadata state from snapshot",
-		slog.Any("cluster-status", sc))
-
 	if err := dec.Decode(persisted); err != nil {
 		return multierr.Combine(err, rc.Close())
 	}
+
+	sc.logger.Info("Restored metadata state from snapshot",
+		slog.Int("documents", len(persisted.Documents)))
 
 	if len(persisted.Documents) > 0 {
 		sc.Documents = cloneDocuments(persisted.Documents)
@@ -120,8 +120,13 @@ func (sc *stateContainer) Persist(sink raft.SnapshotSink) error {
 		return multierr.Combine(err, sink.Cancel())
 	}
 
-	_, err = sink.Write(payload)
-	return multierr.Combine(err, sink.Cancel(), sink.Close())
+	if _, err = sink.Write(payload); err != nil {
+		// Cancel discards the snapshot: it must only be called on failure,
+		// or no snapshot is ever retained while the raft log still gets
+		// compacted, losing the state on the next restart
+		return multierr.Combine(err, sink.Cancel())
+	}
+	return sink.Close()
 }
 
 func (*stateContainer) Release() {}

--- a/oxiad/coordinator/metadata/provider/raft/raft_fsm_test.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft_fsm_test.go
@@ -58,3 +58,53 @@ func TestStateContainerApplySupportsV0163StatusLog(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, status.GetInstanceId(), decoded.GetInstanceId())
 }
+
+// Persist must retain the snapshot on success: a Cancel on the success path
+// discards it, while the raft log still gets compacted anyway, losing the
+// state on the next restart.
+func TestStateContainerPersistRetainsSnapshot(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	sc := newStateContainer(logger, nil)
+
+	status := &commonproto.ClusterStatus{InstanceId: "snapshot-test"}
+	statusBytes, err := metadatacodec.ClusterStatusCodec.MarshalJSON(status)
+	require.NoError(t, err)
+
+	cmd, err := json.Marshal(raftOpCmd{
+		Key:             metadatacodec.ClusterStatusCodec.GetKey(),
+		NewState:        statusBytes,
+		ExpectedVersion: -1,
+	})
+	require.NoError(t, err)
+	res := sc.Apply(&hashicorpraft.Log{Data: cmd})
+	require.True(t, res.(*applyResult).changeApplied)
+
+	snapshot, err := sc.Snapshot()
+	require.NoError(t, err)
+
+	store, err := hashicorpraft.NewFileSnapshotStoreWithLogger(t.TempDir(), 2, nil)
+	require.NoError(t, err)
+	_, trans := hashicorpraft.NewInmemTransport("")
+	sink, err := store.Create(hashicorpraft.SnapshotVersionMax, 1, 1, hashicorpraft.Configuration{}, 0, trans)
+	require.NoError(t, err)
+
+	require.NoError(t, snapshot.Persist(sink))
+
+	// The snapshot must be retained, not canceled
+	snapshots, err := store.List()
+	require.NoError(t, err)
+	require.Len(t, snapshots, 1)
+
+	// And a fresh container must restore the state from it
+	_, rc, err := store.Open(snapshots[0].ID)
+	require.NoError(t, err)
+
+	restored := newStateContainer(logger, nil)
+	require.NoError(t, restored.Restore(rc))
+
+	doc := restored.document(metadatacodec.ClusterStatusCodec.GetKey())
+	require.EqualValues(t, 0, doc.CurrentVersion)
+	restoredStatus, err := metadatacodec.ClusterStatusCodec.UnmarshalJSON(doc.State)
+	require.NoError(t, err)
+	require.Equal(t, "snapshot-test", restoredStatus.InstanceId)
+}


### PR DESCRIPTION
### Motivation

The raft FSM's `Persist` calls `sink.Cancel()` unconditionally — on the success path too. `FileSnapshotSink.Cancel` discards the snapshot, and since `Persist` still returns nil, raft believes the snapshot succeeded and compacts its log anyway. Consequence: **no snapshot is ever retained**, and after a restart following a log compaction the FSM starts empty, the truncated log's entries fail the expected-version check on replay, and the coordinator metadata is silently lost.

### Changes

- `Persist` cancels only on marshal/write failure and only closes on success.
- `Restore` logs after decoding the snapshot (it logged the not-yet-restored state before).

### Verification

`TestStateContainerPersistRetainsSnapshot` drives a snapshot through a real `FileSnapshotStore`: the store must list the snapshot after `Persist` (on the old code the list is empty — verified the test fails pre-fix), and a fresh state container restored from it must carry the document state and version.

Credit: this issue was independently identified in #1047 by @dao-jun, among a broader set of raft-provider fixes. Per the review feedback there, the still-valid fixes are being landed as focused patches — this is the first; resource-lifecycle and leadership-handling PRs follow.