### PR TITLE
fix: close sessions outside the session-manager lock

### DIFF
--- a/oxiad/dataserver/controller/lead/session_manager.go
+++ b/oxiad/dataserver/controller/lead/session_manager.go
@@ -300,10 +300,18 @@ func (sm *sessionManager) readSessions() (map[SessionId]*proto.SessionMetadata, 
 
 func (sm *sessionManager) Close() error {
 	sm.Lock()
-	defer sm.Unlock()
 	sm.cancel()
-	for _, s := range sm.sessions.Values() {
+	sessions := sm.sessions.Values()
+	for _, s := range sessions {
 		sm.sessions.Remove(s.id)
+	}
+	sm.Unlock()
+
+	// Close the sessions outside the manager lock: closing a session waits
+	// for its goroutine, and the expiry path of that goroutine acquires the
+	// manager lock — closing under the lock can deadlock with an in-flight
+	// expiry (same ordering as CloseSession above).
+	for _, s := range sessions {
 		s.Close()
 	}
 

--- a/oxiad/dataserver/controller/lead/session_manager_test.go
+++ b/oxiad/dataserver/controller/lead/session_manager_test.go
@@ -19,12 +19,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	pb "google.golang.org/protobuf/proto"
 
+	"github.com/oxia-db/oxia/common/metric"
+	"github.com/oxia-db/oxia/oxiad/common/collection"
 	"github.com/oxia-db/oxia/oxiad/common/crc"
 
 	commonoption "github.com/oxia-db/oxia/oxiad/common/option"
@@ -726,5 +729,51 @@ func TestIsSessionKey(t *testing.T) {
 				t.Errorf("IsSessionKey(%q) got = %v, want %v", tc.key, got, tc.want)
 			}
 		})
+	}
+}
+
+// Closing the manager must not hold the manager lock while waiting for the
+// session goroutines: the expiry path of a session goroutine acquires the
+// manager lock, and a session in the middle of expiring would deadlock the
+// close.
+func TestSessionManager_CloseWithInFlightExpiry(t *testing.T) {
+	sm := &sessionManager{
+		sessions: collection.NewVisibleMap[SessionId, *session](),
+		activeSessions: metric.NewGauge("oxia_test_close_expiry_sessions", "test", "count",
+			map[string]any{}, func() int64 { return 0 }),
+	}
+	sm.ctx, sm.cancel = context.WithCancel(context.Background())
+
+	s := &session{
+		id:  1,
+		sm:  sm,
+		log: slog.Default(),
+	}
+	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
+
+	// Mimics the tail of the session expiry path (waitForHeartbeats), which
+	// acquires the manager lock from the session goroutine. The session
+	// context is canceled by close(): with the close happening under the
+	// manager lock, this deterministically deadlocks.
+	s.latch.Add(1)
+	go func() {
+		defer s.latch.Done()
+		<-s.ctx.Done()
+		sm.Lock()
+		sm.sessions.Remove(s.id)
+		sm.Unlock()
+	}()
+	sm.sessions.Put(s.id, s)
+
+	closeDone := make(chan struct{})
+	go func() {
+		assert.NoError(t, sm.Close())
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("session manager close deadlocked with an in-flight session expiry")
 	}
 }


### PR DESCRIPTION
### Motivation

Follow-up on the session-deadlock finding from the performance review (item 6.2). The original heartbeat half — a blocking send on the cap-1 `heartbeatCh` while holding the session mutex, racing the expiry branch — turned out to be already fixed upstream by #1027 (the review ran on a checkout whose `main` predated that merge). Verifying the current code surfaced an adjacent deadlock in the same family, still live on `main`:

`sessionManager.Close()` holds the manager lock while closing every session, and closing a session waits (`latch.Wait`) for the session goroutine to exit. The expiry path of that goroutine acquires the manager lock right after deleting the session record. A session in the middle of expiring while the manager closes deadlocks the whole close path — wedging the leader-controller shutdown (and anything waiting on it, e.g. a term change or a graceful stop). The window includes the expiry's blocking `delete()` write, and mass session expiry is most likely exactly when a leader is going away.

### Changes

Snapshot and unregister the sessions under the lock, then close them outside of it — the same ordering `CloseSession` already uses.

### Verification

- New `TestSessionManager_CloseWithInFlightExpiry`: reproduces the deadlock deterministically (no sleeps/races) by keying a session goroutine on the context cancellation that the close itself performs — with the old code the cancellation happens while the manager lock is held, so the test deadlocks every time (verified: fails at the 10s guard on unmodified code); with the fix it passes every time.
- `go test -race` green on the `lead` and `dataserver` packages; `golangci-lint` clean.