### PR TITLE
fix: resource lifecycle issues in the raft metadata provider

### DIFF
--- a/oxiad/coordinator/metadata/provider/raft/raft.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft.go
@@ -34,6 +34,7 @@ type Raft struct {
 	sc          *stateContainer
 	node        *hashicorpraft.Raft
 	store       *kvRaftStore
+	transport   *hashicorpraft.NetworkTransport
 	logger      *slog.Logger
 	interceptor Interceptor
 
@@ -48,7 +49,7 @@ func New(
 	raftBootstrapNodes []string,
 	raftDataDir string,
 	interceptor Interceptor,
-) (*Raft, error) {
+) (_ *Raft, err error) {
 	metadataRaft := &Raft{
 		logger:      slog.With(slog.String("component", "metadata-provider-raft")),
 		interceptor: interceptor,
@@ -77,10 +78,18 @@ func New(
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to resolve raft address")
 	}
-	transport, err := hashicorpraft.NewTCPTransport(raftAddress, addr, 3, 10*time.Second, os.Stderr)
+	metadataRaft.transport, err = hashicorpraft.NewTCPTransport(raftAddress, addr, 3, 10*time.Second, os.Stderr)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create raft transport")
 	}
+
+	// Release whatever has been created so far when a later step fails:
+	// the transport holds a TCP listener and the store an open database
+	defer func() {
+		if err != nil {
+			_ = metadataRaft.release()
+		}
+	}()
 
 	metadataRaft.store, err = newKVRaftStore(filepath.Join(dataDir, "store"))
 	if err != nil {
@@ -92,7 +101,7 @@ func New(
 		return nil, errors.Wrap(err, "failed to create snapshot store")
 	}
 
-	metadataRaft.node, err = hashicorpraft.NewRaft(config, metadataRaft.sc, metadataRaft.store, metadataRaft.store, snapshotStore, transport)
+	metadataRaft.node, err = hashicorpraft.NewRaft(config, metadataRaft.sc, metadataRaft.store, metadataRaft.store, snapshotStore, metadataRaft.transport)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create raft node")
 	}
@@ -125,12 +134,25 @@ func getRaftServers(bootstrapNodes []string) []hashicorpraft.Server {
 
 func (r *Raft) Close() error {
 	r.closeOnce.Do(func() {
-		r.closeErr = multierr.Combine(
-			r.node.Shutdown().Error(),
-			r.store.Close(),
-		)
+		r.closeErr = r.release()
 	})
 	return r.closeErr
+}
+
+// release shuts down whichever components have been created, in dependency
+// order: the node first, then the store and the transport it was using.
+func (r *Raft) release() error {
+	var err error
+	if r.node != nil {
+		err = multierr.Append(err, r.node.Shutdown().Error())
+	}
+	if r.store != nil {
+		err = multierr.Append(err, r.store.Close())
+	}
+	if r.transport != nil {
+		err = multierr.Append(err, r.transport.Close())
+	}
+	return err
 }
 
 var _ io.Closer = (*Raft)(nil)

--- a/oxiad/coordinator/metadata/provider/raft/raft_storage.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft_storage.go
@@ -46,7 +46,7 @@ func newKVRaftStore(path string) (store *kvRaftStore, err error) {
 	}
 
 	if store.kv, err = store.factory.NewKV("raft", 0, proto.KeySortingType_NATURAL); err != nil {
-		return nil, err
+		return nil, multierr.Combine(err, store.factory.Close())
 	}
 
 	return store, nil
@@ -125,11 +125,11 @@ func (s *kvRaftStore) StoreLogs(logs []*raft.Log) error {
 
 		value, err := json.Marshal(log)
 		if err != nil {
-			return err
+			return multierr.Combine(err, wb.Close())
 		}
 
 		if err := wb.Put(key, value); err != nil {
-			return err
+			return multierr.Combine(err, wb.Close())
 		}
 	}
 
@@ -141,7 +141,13 @@ func (s *kvRaftStore) StoreLogs(logs []*raft.Log) error {
 
 func (s *kvRaftStore) DeleteRange(minInclusive, maxInclusive uint64) error {
 	minKeyInclusive := fmt.Sprintf(logKeyFormat, minInclusive)
-	maxKeyExclusive := fmt.Sprintf(logKeyFormat, maxInclusive+1)
+	var maxKeyExclusive string
+	if maxInclusive == math.MaxUint64 {
+		// maxInclusive+1 would overflow to 0, inverting the range into a no-op
+		maxKeyExclusive = logKeyMax + "\x00"
+	} else {
+		maxKeyExclusive = fmt.Sprintf(logKeyFormat, maxInclusive+1)
+	}
 	wb := s.kv.NewWriteBatch()
 
 	return multierr.Combine(

--- a/oxiad/coordinator/metadata/provider/raft/raft_storage_test.go
+++ b/oxiad/coordinator/metadata/provider/raft/raft_storage_test.go
@@ -1,0 +1,105 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"math"
+	"testing"
+
+	hashicorpraft "github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStore(t *testing.T) *kvRaftStore {
+	t.Helper()
+	store, err := newKVRaftStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, store.Close()) })
+	return store
+}
+
+func storeLogs(t *testing.T, store *kvRaftStore, indexes ...uint64) {
+	t.Helper()
+	logs := make([]*hashicorpraft.Log, len(indexes))
+	for i, index := range indexes {
+		logs[i] = &hashicorpraft.Log{Index: index, Term: 1, Data: []byte("entry")}
+	}
+	require.NoError(t, store.StoreLogs(logs))
+}
+
+func TestKVRaftStoreLogRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+
+	first, err := store.FirstIndex()
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, first)
+
+	storeLogs(t, store, 1, 2, 3, 4, 5)
+
+	first, err = store.FirstIndex()
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, first)
+
+	last, err := store.LastIndex()
+	require.NoError(t, err)
+	assert.EqualValues(t, 5, last)
+
+	log := &hashicorpraft.Log{}
+	require.NoError(t, store.GetLog(3, log))
+	assert.EqualValues(t, 3, log.Index)
+	assert.Equal(t, []byte("entry"), log.Data)
+}
+
+func TestKVRaftStoreDeleteRange(t *testing.T) {
+	store := newTestStore(t)
+	storeLogs(t, store, 1, 2, 3, 4, 5)
+
+	require.NoError(t, store.DeleteRange(1, 3))
+
+	first, err := store.FirstIndex()
+	require.NoError(t, err)
+	assert.EqualValues(t, 4, first)
+}
+
+// maxInclusive+1 overflows when maxInclusive is MaxUint64, inverting the
+// range into a no-op that silently deletes nothing.
+func TestKVRaftStoreDeleteRangeMaxUint64(t *testing.T) {
+	store := newTestStore(t)
+	storeLogs(t, store, 1, 2, 3)
+
+	require.NoError(t, store.DeleteRange(0, math.MaxUint64))
+
+	first, err := store.FirstIndex()
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, first)
+	last, err := store.LastIndex()
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, last)
+}
+
+func TestKVRaftStoreStableStore(t *testing.T) {
+	store := newTestStore(t)
+
+	require.NoError(t, store.Set([]byte("key"), []byte("value")))
+	value, err := store.Get([]byte("key"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value"), value)
+
+	require.NoError(t, store.SetUint64([]byte("counter"), 42))
+	n, err := store.GetUint64([]byte("counter"))
+	require.NoError(t, err)
+	assert.EqualValues(t, 42, n)
+}


### PR DESCRIPTION
### Motivation

The raft metadata provider leaks resources on several paths, and its log compaction has a silent-no-op edge:

- `New()` creates the TCP transport, then the store, then the raft node — and returns on any later failure without releasing what was already created (the transport holds a live TCP listener, the store an open Pebble instance).
- `Close()` shuts down the node and the store but never closes the network transport.
- `StoreLogs` returns on marshal/put errors without closing the write batch.
- `newKVRaftStore` leaks the Pebble factory when opening the KV fails.
- `DeleteRange(min, MaxUint64)`: `maxInclusive+1` overflows to zero, inverting the range into a no-op that silently deletes nothing.

### Changes

One `release()` helper shuts down whichever components exist, in dependency order (node → store → transport); `New()` invokes it via a deferred cleanup on failure, and `Close()` uses it (still under `sync.Once`). The write-batch error paths close the batch; the KV-store constructor closes the factory on failure; `DeleteRange` clamps the overflow to a key just past the maximum log key.

### Verification

New `raft_storage_test.go`: log round-trip (`StoreLogs`/`GetLog`/`FirstIndex`/`LastIndex`), partial `DeleteRange`, the stable-store accessors, and `TestKVRaftStoreDeleteRangeMaxUint64` — verified to fail against the previous implementation (the inverted range leaves all logs in place). Full `oxiad/coordinator/...` packages and the `tests/coordinator` e2e suite pass with `-race`; lint reports no new findings (the one gosec hit pre-exists in `provider.go` and is a false positive — the cancel func is stored on the struct and called in `Close`).

Credit: these issues were independently identified in #1047 by @dao-jun. Part of splitting that work into focused patches, together with #1170; a leadership-handling PR follows.