### PR TITLE
fix: fence split children at the parent's term so observer cursors can attach

### DIFF
--- a/oxiad/coordinator/runtime/controller/split_controller.go
+++ b/oxiad/coordinator/runtime/controller/split_controller.go
@@ -244,24 +244,20 @@ func (sc *SplitController) runBootstrap() error {
 	if parentMeta.GetStatusOrDefault() != proto.ShardStatusSteadyState {
 		return errors.New("parent shard is not in steady state")
 	}
+	parentLeader := parentMeta.Leader
+	parentTerm := parentMeta.Term
 
 	// Step 1: Fence and elect each child leader (if not already done).
 	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		if err := sc.fenceAndElectChild(childId); err != nil {
+		if err := sc.fenceAndElectChild(childId, parentTerm); err != nil {
 			return err
 		}
 	}
 
-	// Step 2: Add each child leader as an observer on the parent leader.
-	// Re-read parent metadata in case the parent leader changed while
-	// fencing children.
-	parentMeta = sc.loadParentMeta()
-	if parentMeta == nil || parentMeta.Leader == nil {
-		return errors.New("parent shard has no leader")
-	}
-	parentLeader := parentMeta.Leader
-	parentTerm := parentMeta.Term
-
+	// Step 2: Add each child leader as an observer on the parent leader,
+	// using the same parent term the children were fenced with. If the
+	// parent had a new election in the meantime, AddFollower fails with
+	// an invalid-term error and Bootstrap is retried from scratch.
 	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
 		if err := sc.addChildObserver(childId, parentLeader, parentTerm); err != nil {
 			return err
@@ -288,14 +284,19 @@ func (sc *SplitController) runBootstrap() error {
 }
 
 // fenceAndElectChild fences a child shard's ensemble and elects a leader.
-// Skipped if the child already has a leader (from a previous Bootstrap run).
-func (sc *SplitController) fenceAndElectChild(childId int64) error {
+// The child is fenced at the parent's current term: the observer cursor that
+// streams parent data to the child runs at the parent's term, and the data
+// server converts the child leader into an observer-follower only when the
+// cursor's term matches the child's term (see shardsDirector.GetOrCreateFollower).
+// Skipped if the child already has a leader at that term (from a previous
+// Bootstrap run).
+func (sc *SplitController) fenceAndElectChild(childId int64, parentTerm int64) error {
 	childMeta := sc.loadShardMeta(childId)
 	if childMeta == nil {
 		return errors.Errorf("child shard %d not found", childId)
 	}
 
-	if childMeta.Leader != nil {
+	if childMeta.Leader != nil && childMeta.Term == parentTerm {
 		sc.logger.Info("Child already has leader, skipping fence/elect",
 			slog.Int64("child-shard", childId),
 			slog.Any("leader", childMeta.Leader),
@@ -303,7 +304,7 @@ func (sc *SplitController) fenceAndElectChild(childId int64) error {
 		return nil
 	}
 
-	childTerm := childMeta.Term + 1
+	childTerm := parentTerm
 	headEntries, err := sc.fenceEnsemble(childId, childTerm, childMeta.Ensemble)
 	if err != nil {
 		return errors.Wrapf(err, "failed to fence child shard %d", childId)

--- a/oxiad/coordinator/runtime/controller/split_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/split_controller_test.go
@@ -298,6 +298,64 @@ func TestSplitController_FullLifecycle(t *testing.T) {
 	assert.Nil(t, rightMeta.Split, "right child split metadata should be cleared")
 }
 
+// TestSplitController_ChildrenFencedAtParentTerm verifies that child shards
+// are fenced and elected at the parent's current term during Bootstrap. The
+// observer cursor that streams parent data to a child runs at the parent's
+// term, and the data server converts the child leader into an observer
+// follower only when the cursor's term matches the child's term: any other
+// term leaves the observer cursor retrying forever and the split stuck in
+// CatchUp.
+func TestSplitController_ChildrenFencedAtParentTerm(t *testing.T) {
+	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseBootstrap)
+
+	queueBootstrapResponses(rpcMock)
+	queueCatchUpResponses(rpcMock)
+	queueCutoverResponses(rpcMock)
+
+	sc := NewSplitController(SplitControllerConfig{
+		Namespace:     constant.DefaultNamespace,
+		ParentShardId: 0,
+		Metadata:      statusRes,
+		RpcProvider:   rpcMock,
+		EventListener: listener,
+	})
+	defer sc.Close()
+
+	// The parent shard is at term 5 in setupSplitTest.
+	const parentTerm = int64(5)
+
+	expectNewTermAt := func(node *proto.DataServerIdentity, shard int64) {
+		t.Helper()
+		select {
+		case r := <-rpcMock.GetNode(node).newTermRequests:
+			assert.Equal(t, shard, r.Shard)
+			assert.Equal(t, parentTerm, r.Term)
+		case <-time.After(defaultTimeout):
+			t.Fatalf("did not receive NewTerm request for shard %d", shard)
+		}
+	}
+
+	for _, node := range []*proto.DataServerIdentity{ls1, ls2, ls3} {
+		expectNewTermAt(node, 1)
+	}
+	rpcMock.GetNode(ls1).expectBecomeLeaderRequest(t, 1, parentTerm, 3)
+
+	for _, node := range []*proto.DataServerIdentity{rs1, rs2, rs3} {
+		expectNewTermAt(node, 2)
+	}
+	rpcMock.GetNode(rs1).expectBecomeLeaderRequest(t, 2, parentTerm, 3)
+
+	// Observers are added on the parent leader at the same term.
+	rpcMock.GetNode(ps1).expectAddFollowerRequest(t, 0, parentTerm)
+	rpcMock.GetNode(ps1).expectAddFollowerRequest(t, 0, parentTerm)
+
+	select {
+	case <-listener.completions:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Split did not complete in time")
+	}
+}
+
 func TestSplitController_ResumeFromBootstrap(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseBootstrap)
 
@@ -882,8 +940,20 @@ func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 	// It RemoveObserver(old leader) on parent, then falls back to Bootstrap.
 	rpcMock.GetNode(ps1).RemoveObserverResponse(nil) // RemoveObserver for stale observer
 
-	// Bootstrap re-run: children already have leaders (skipped).
-	// Step 2: re-read parent (still has leader), AddFollower for new child leaders.
+	// Bootstrap re-run: children are re-fenced at the parent's term, since
+	// their terms diverged from the parent's after the leader change. The
+	// nodes holding the data report the highest offset and stay leaders.
+	rpcMock.GetNode(ls1).NewTermResponse(2, 105, nil)
+	rpcMock.GetNode(ls2).NewTermResponse(2, 106, nil) // ls2 has the data -> stays leader
+	rpcMock.GetNode(ls3).NewTermResponse(2, 105, nil)
+	rpcMock.GetNode(ls2).BecomeLeaderResponse(nil)
+
+	rpcMock.GetNode(rs1).NewTermResponse(1, 106, nil) // rs1 has the data -> stays leader
+	rpcMock.GetNode(rs2).NewTermResponse(1, 105, nil)
+	rpcMock.GetNode(rs3).NewTermResponse(1, 105, nil)
+	rpcMock.GetNode(rs1).BecomeLeaderResponse(nil)
+
+	// Step 2: AddFollower for the child leaders.
 	rpcMock.GetNode(ps1).AddFollowerResponse(nil) // AddFollower for new left child leader (ls2)
 	rpcMock.GetNode(ps1).AddFollowerResponse(nil) // AddFollower for right child leader (rs1, unchanged)
 


### PR DESCRIPTION
### Problem

`TestCoordinator_ShardSplit_ConcurrentSplitRejected` is flaky on CI ([example failure](https://github.com/oxia-db/oxia/actions/runs/27367996769/job/80872485036?pr=1164)): it times out after 120s with `Condition never satisfied` while the data server logs show the parent's observer cursor endlessly retrying `SendSnapshot` against the children with `oxia: invalid term`, with the retry backoff grown to ~50s.

The split observer mechanism requires the child shards to be fenced **at the parent's current term**: the parent→child observer cursor runs at the parent's term (`leaderController.addObserver`), and the data server converts the child leader into an observer-follower only when the cursor's term matches the child's term (`shardsDirector.GetOrCreateFollower`). The comment in `addObserver` documents this invariant — but nothing enforced it.

`SplitController.fenceAndElectChild` fenced children at `childMeta.Term + 1`, which is always **1** for a fresh split (children are created with `Term: 0`), while the parent's term depends on startup timing:

- If the coordinator's first election attempt fails (data servers not yet handshaken — `oxia: server not initialized yet`), the retry lands the parent at term **1** → terms match by accident → split works.
- If the data servers come up fast enough (typical on CI runners), the first election succeeds at term **0** → terms never match → the observer snapshot is rejected forever → the split never completes.

So the test only passed thanks to a startup hiccup. Any parent term ≠ 1 (including parents that went through later re-elections) would hang a split the same way.

### Fix

Fence children at the parent's term, captured once in `runBootstrap` and used for both the child fencing and `AddFollower`:

- If the parent gets a new election mid-bootstrap, `AddFollower` now fails its term check (`leaderController.AddFollower`) and Bootstrap is retried from scratch with fresh state, instead of silently re-reading a newer parent term that wouldn't match the just-fenced children.
- On Bootstrap re-runs (e.g. after `checkObserverCursorsStale` resets the phase), children whose term diverged from the parent's are re-fenced at the current parent term rather than skipped, restoring the invariant after parent or child elections.

### Validation

- New regression test `TestSplitController_ChildrenFencedAtParentTerm` asserts children are fenced/elected and observers added at the parent's term (5 in the fixture). It fails on the old code (which sent term 1) and passes with the fix.
- `TestSplitController_ChildLeaderChangeDuringCatchUp` updated: the re-bootstrap recovery path now re-fences children at the parent's term, so the fixture queues those RPCs.
- Full `tests/coordinator` e2e package passes locally (incl. all `TestCoordinator_ShardSplit_*`); the previously flaky `TestCoordinator_ShardSplit_ConcurrentSplitRejected` passes 8/8 consecutive runs.

Side note (not addressed here): `checkObserverCursorsStale` guards the parent-term staleness check with `ParentTermAtBootstrap > 0`, which silently disables detection when the parent is legitimately at term 0. With this fix term-0 parents complete splits normally, but a parent re-election mid-catch-up at term 0 would stall until the split timeout aborts it. Can be tightened separately.