### PR TITLE
fix: make rolled-over segments durable before acknowledging them

### DIFF
--- a/oxiad/dataserver/wal/readonly_segment.go
+++ b/oxiad/dataserver/wal/readonly_segment.go
@@ -87,10 +87,14 @@ func newReadOnlySegment(basePath string, baseOffset int64) (ReadOnlySegment, err
 	}
 
 	if ms.idx, err = ms.c.codec.ReadIndex(ms.c.idxPath); err != nil {
-		if !errors.Is(err, codec.ErrDataCorrupted) {
+		// A missing index file is expected when the process crashed between a
+		// rollover and the sync round that closes the rolled-over segment:
+		// rebuild it from the txn file, like for a corrupted one
+		if !errors.Is(err, codec.ErrDataCorrupted) && !errors.Is(err, os.ErrNotExist) {
 			return nil, errors.Wrapf(err, "failed to decode segment index file %s", ms.c.idxPath)
 		}
-		slog.Warn("The segment index file is corrupted and the index is being rebuilt.", slog.String("path", ms.c.idxPath))
+		slog.Warn("The segment index file is missing or corrupted and the index is being rebuilt.",
+			slog.String("path", ms.c.idxPath))
 		// recover from txn
 		if ms.idx, _, _, _, err = ms.c.codec.RecoverIndex(ms.txnMappedFile, 0,
 			ms.c.baseOffset, nil); err != nil {

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -68,7 +68,13 @@ type wal struct {
 	segmentSize uint32
 	syncData    bool
 
-	currentSegment       ReadWriteSegment
+	currentSegment ReadWriteSegment
+
+	// Rolled-over segments waiting for the sync goroutine to make them
+	// durable and close them (see rolloverSegment); guarded by the wal
+	// mutex. They stay readable through readAtIndex until closed.
+	pendingCloseSegments []ReadWriteSegment
+
 	readOnlySegments     ReadOnlySegmentsGroup
 	commitOffsetProvider CommitOffsetProvider
 
@@ -185,6 +191,10 @@ func (t *wal) readAtIndex(index int64) (entry *proto.LogEntry, previousCrc uint3
 	var segment ReadOnlySegment
 	if index >= t.currentSegment.BaseOffset() {
 		segment = t.currentSegment
+	} else if pending := t.pendingCloseSegmentFor(index); pending != nil {
+		// A rolled-over segment not closed by the sync goroutine yet: it is
+		// still mapped, read it directly
+		segment = pending
 	} else {
 		rc, err = t.readOnlySegments.Get(index)
 		if err != nil {
@@ -210,6 +220,18 @@ func (t *wal) readAtIndex(index int64) (entry *proto.LogEntry, previousCrc uint3
 	}
 	t.readBytes.Add(len(val))
 	return entry, previousCrc, entryCrc, err
+}
+
+// pendingCloseSegmentFor returns the rolled-over segment containing the given
+// index, when it has not been handed to the read-only group yet.
+// Must be called while holding the wal lock.
+func (t *wal) pendingCloseSegmentFor(index int64) ReadWriteSegment {
+	for i := len(t.pendingCloseSegments) - 1; i >= 0; i-- {
+		if s := t.pendingCloseSegments[i]; index >= s.BaseOffset() {
+			return s
+		}
+	}
+	return nil
 }
 
 func (t *wal) LastOffset() int64 {
@@ -254,6 +276,7 @@ func (t *wal) closeWithoutLock() error {
 		t.activeEntries.Unregister()
 
 		return multierr.Combine(
+			t.drainPendingCloseSegments(),
 			t.currentSegment.Close(),
 			t.readOnlySegments.Close(),
 		)
@@ -374,18 +397,8 @@ func (t *wal) AppendAndSync(entry *proto.LogEntry, callback func(entryCrc uint32
 
 func (t *wal) rolloverSegment() error {
 	var err error
-	// If no sync round has fsynced the segment file yet (the segment filled up
-	// before any sync round completed), fsync it now: its entries can still be
-	// acknowledged by a later sync round, and the file metadata must be
-	// durable by then.
-	if err = t.currentSegment.SyncFileIfNeeded(); err != nil {
-		return err
-	}
-	if err = t.currentSegment.Close(); err != nil {
-		return err
-	}
-	lastCrc := t.currentSegment.LastCrc()
-	t.readOnlySegments.AddedNewSegment(t.currentSegment.BaseOffset())
+	rolled := t.currentSegment
+	lastCrc := rolled.LastCrc()
 
 	// The new segment file is created without fsync-ing it: the rollover runs
 	// in the append path, while holding the WAL write lock (and, on the
@@ -397,7 +410,81 @@ func (t *wal) rolloverSegment() error {
 		return err
 	}
 
+	if !t.syncData {
+		// With sync disabled there are no sync rounds to hand the rolled-over
+		// segment to: close it inline
+		if err = rolled.SyncFileIfNeeded(); err != nil {
+			return err
+		}
+		if err = rolled.Close(); err != nil {
+			return err
+		}
+		t.readOnlySegments.AddedNewSegment(rolled.BaseOffset())
+		return nil
+	}
+
+	// Hand the rolled-over segment to the sync goroutine: its unsynced tail
+	// must be made durable before those offsets get acknowledged, and closing
+	// it (index-file write, munmap) does not belong in the append path
+	// either. The segment stays readable through readAtIndex until closed.
+	t.pendingCloseSegments = append(t.pendingCloseSegments, rolled)
 	return nil
+}
+
+// flushAndCloseRolledSegment is invoked by the sync goroutine for the segments
+// handed over by rolloverSegment, before acknowledging their offsets. The
+// flushes are no-ops when a cold path already closed the segment concurrently.
+func (t *wal) flushAndCloseRolledSegment(s ReadWriteSegment) error {
+	if err := s.SyncFileIfNeeded(); err != nil {
+		return err
+	}
+	if err := s.Flush(); err != nil {
+		return err
+	}
+
+	// Removing the segment from the pending list is the ownership gate: when
+	// a cold path (close, clear, truncate) drained it concurrently, there is
+	// nothing left to do here. New readers stop finding the segment once it
+	// is removed, and a reader already using it holds the wal read lock,
+	// which this removal waits for.
+	t.Lock()
+	owned := false
+	for i, ps := range t.pendingCloseSegments {
+		if ps == s {
+			t.pendingCloseSegments = append(t.pendingCloseSegments[:i], t.pendingCloseSegments[i+1:]...)
+			owned = true
+			break
+		}
+	}
+	t.Unlock()
+	if !owned {
+		return nil
+	}
+
+	if err := s.Close(); err != nil {
+		return err
+	}
+	t.readOnlySegments.AddedNewSegment(s.BaseOffset())
+	return nil
+}
+
+// drainPendingCloseSegments makes durable and closes the rolled-over segments
+// still waiting for the sync goroutine; used by the cold paths (close, clear,
+// truncate). Must be called while holding the wal lock.
+func (t *wal) drainPendingCloseSegments() error {
+	var err error
+	for _, s := range t.pendingCloseSegments {
+		serr := multierr.Combine(
+			s.SyncFileIfNeeded(),
+			s.Flush(),
+			s.Close())
+		if serr == nil {
+			t.readOnlySegments.AddedNewSegment(s.BaseOffset())
+		}
+		err = multierr.Append(err, serr)
+	}
+	t.pendingCloseSegments = nil
+	return err
 }
 
 func (t *wal) drainSyncRequestsChannel(callbacks []func(error)) []func(error) {
@@ -434,13 +521,23 @@ func (t *wal) runSync() {
 		t.RLock()
 		segment := t.currentSegment
 		lastAppendedOffset := t.lastAppendedOffset.Load()
+		pending := slices.Clone(t.pendingCloseSegments)
 		t.RUnlock()
 
 		var err error
-		if t.lastSyncedOffset.Load() != lastAppendedOffset {
+		if len(pending) > 0 || t.lastSyncedOffset.Load() != lastAppendedOffset {
 			timer := t.syncLatency.Timer()
-			if err = segment.SyncFileIfNeeded(); err == nil {
-				err = segment.Flush()
+			// The rolled-over segments must be durable and closed before the
+			// acknowledgment below, which covers their tail offsets
+			for _, s := range pending {
+				if err = t.flushAndCloseRolledSegment(s); err != nil {
+					break
+				}
+			}
+			if err == nil {
+				if err = segment.SyncFileIfNeeded(); err == nil {
+					err = segment.Flush()
+				}
 			}
 			if err != nil {
 				t.writeErrors.Inc()
@@ -499,6 +596,7 @@ func (t *wal) Clear() error {
 	defer t.Unlock()
 
 	err := multierr.Combine(
+		t.drainPendingCloseSegments(),
 		t.currentSegment.Close(),
 		t.readOnlySegments.Close(),
 		os.RemoveAll(t.walPath),
@@ -551,6 +649,12 @@ func (t *wal) TruncateLog(lastSafeOffset int64) (int64, error) { //nolint:revive
 	t.Lock()
 	defer t.Unlock()
 
+	// Bring any rolled-over segment still pending close into the read-only
+	// group, so that the truncation below sees the complete set of segments
+	if err := t.drainPendingCloseSegments(); err != nil {
+		return InvalidOffset, err
+	}
+
 	lastIndex := t.lastAppendedOffset.Load()
 	if lastIndex == InvalidOffset {
 		// The WAL is empty
@@ -568,6 +672,7 @@ func (t *wal) TruncateLog(lastSafeOffset int64) (int64, error) { //nolint:revive
 		}
 
 		// Delete any intermediate segment and truncate to the right position
+	truncateLoop:
 		for {
 			segment, err := t.readOnlySegments.PollHighestSegment()
 			switch {
@@ -594,9 +699,13 @@ func (t *wal) TruncateLog(lastSafeOffset int64) (int64, error) { //nolint:revive
 					err = multierr.Append(err, segment.Close())
 					return InvalidOffset, err
 				}
-
-				err = segment.Close()
-				return lastSafeOffset, err
+				if err = segment.Close(); err != nil {
+					return InvalidOffset, err
+				}
+				// Proceed to updating the last appended/synced offsets below:
+				// returning from here would leave them stale, breaking the
+				// next append's offset check and the readers' upper bound
+				break truncateLoop
 			default:
 				// The entire segment can be discarded
 				if err := segment.Get().Delete(); err != nil {

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -433,7 +433,9 @@ func (t *wal) rolloverSegment() error {
 
 // flushAndCloseRolledSegment is invoked by the sync goroutine for the segments
 // handed over by rolloverSegment, before acknowledging their offsets. The
-// flushes are no-ops when a cold path already closed the segment concurrently.
+// flushes are safe no-ops when a cold path already closed the segment
+// concurrently: Close nils the mapping while holding the flush lock, and both
+// calls check it under that same lock.
 func (t *wal) flushAndCloseRolledSegment(s ReadWriteSegment) error {
 	if err := s.SyncFileIfNeeded(); err != nil {
 		return err
@@ -442,11 +444,11 @@ func (t *wal) flushAndCloseRolledSegment(s ReadWriteSegment) error {
 		return err
 	}
 
-	// Removing the segment from the pending list is the ownership gate: when
-	// a cold path (close, clear, truncate) drained it concurrently, there is
-	// nothing left to do here. New readers stop finding the segment once it
-	// is removed, and a reader already using it holds the wal read lock,
-	// which this removal waits for.
+	// Atomically move the segment from the pending list to the read-only
+	// group, so that there is no instant where readers find it in neither.
+	// The removal is also the ownership gate: when a cold path (close, clear,
+	// truncate) drained the segment concurrently, there is nothing left to
+	// do here.
 	t.Lock()
 	owned := false
 	for i, ps := range t.pendingCloseSegments {
@@ -456,16 +458,18 @@ func (t *wal) flushAndCloseRolledSegment(s ReadWriteSegment) error {
 			break
 		}
 	}
+	if owned {
+		t.readOnlySegments.AddedNewSegment(s.BaseOffset())
+	}
 	t.Unlock()
 	if !owned {
 		return nil
 	}
 
-	if err := s.Close(); err != nil {
-		return err
-	}
-	t.readOnlySegments.AddedNewSegment(s.BaseOffset())
-	return nil
+	// The read-only group can open the segment even before this Close has
+	// written the index file: a missing index gets rebuilt from the txn file
+	// (see newReadOnlySegment)
+	return s.Close()
 }
 
 // drainPendingCloseSegments makes durable and closes the rolled-over segments
@@ -687,19 +691,18 @@ func (t *wal) TruncateLog(lastSafeOffset int64) (int64, error) { //nolint:revive
 			case lastSafeOffset >= segment.Get().BaseOffset():
 				// The truncation will happen in the middle of this segment,
 				// and this will also become the new current segment
+				baseOffset := segment.Get().BaseOffset()
+				lastCrc := segment.Get().LastCrc()
+				// Close the reference exactly once: the counter decrements
+				// unconditionally, so the error paths must not close it again
 				if err = segment.Close(); err != nil {
 					return InvalidOffset, err
 				}
-				if t.currentSegment, err = newReadWriteSegment(t.walPath, segment.Get().BaseOffset(),
-					t.segmentSize, segment.Get().LastCrc(), t.commitOffsetProvider); err != nil {
-					err = multierr.Append(err, segment.Close())
+				if t.currentSegment, err = newReadWriteSegment(t.walPath, baseOffset,
+					t.segmentSize, lastCrc, t.commitOffsetProvider); err != nil {
 					return InvalidOffset, err
 				}
 				if err := t.currentSegment.Truncate(lastSafeOffset); err != nil {
-					err = multierr.Append(err, segment.Close())
-					return InvalidOffset, err
-				}
-				if err = segment.Close(); err != nil {
 					return InvalidOffset, err
 				}
 				// Proceed to updating the last appended/synced offsets below:

--- a/oxiad/dataserver/wal/wal_test.go
+++ b/oxiad/dataserver/wal/wal_test.go
@@ -733,3 +733,109 @@ func TestWal_RolloverWithDeferredFileSync(t *testing.T) {
 	assert.NoError(t, w.Close())
 	assert.NoError(t, f.Close())
 }
+
+// Rolled-over segments are made durable and closed by the sync goroutine:
+// until then their entries stay readable through the wal, and a sync round
+// drains them into the read-only group before acknowledging.
+func TestWal_RolloverKeepsPendingSegmentsReadable(t *testing.T) {
+	f, w := createWal(t)
+	walImpl := w.(*wal)
+
+	payload := strings.Repeat("x", 1024)
+	var entries []string
+
+	// Synced entries filling most of the first segment (128 KiB)
+	for i := 0; i < 100; i++ {
+		value := fmt.Sprintf("%s-%d", payload, i)
+		entries = append(entries, value)
+		assert.NoError(t, w.Append(&proto.LogEntry{Term: 1, Offset: int64(i), Value: []byte(value)}))
+	}
+
+	// Async appends crossing the segment boundary: no sync round runs, so the
+	// rolled-over segment stays pending
+	for i := 100; i < 150; i++ {
+		value := fmt.Sprintf("%s-%d", payload, i)
+		entries = append(entries, value)
+		assert.NoError(t, w.AppendAsync(&proto.LogEntry{Term: 1, Offset: int64(i), Value: []byte(value)}))
+	}
+
+	walImpl.RLock()
+	pendingSegments := len(walImpl.pendingCloseSegments)
+	walImpl.RUnlock()
+	assert.Greater(t, pendingSegments, 0)
+
+	// The synced entries living in the pending segment are still readable
+	r, err := w.NewReader(InvalidOffset)
+	assert.NoError(t, err)
+	assertReaderReads(t, r, entries[:100])
+	assert.NoError(t, r.Close())
+
+	// A sync round drains the pending segments before acknowledging
+	assert.NoError(t, w.Sync(context.Background()))
+	walImpl.RLock()
+	pendingSegments = len(walImpl.pendingCloseSegments)
+	walImpl.RUnlock()
+	assert.Equal(t, 0, pendingSegments)
+
+	r, err = w.NewReader(InvalidOffset)
+	assert.NoError(t, err)
+	assertReaderReads(t, r, entries)
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+
+	// Reopen: recovery across the drained segments
+	w, err = f.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 149, w.LastOffset())
+	r, err = w.NewReader(InvalidOffset)
+	assert.NoError(t, err)
+	assertReaderReads(t, r, entries)
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, f.Close())
+}
+
+// Truncation drains the pending-close segments first, so that it operates on
+// the complete set of segments.
+func TestWal_TruncateWithPendingCloseSegments(t *testing.T) {
+	f, w := createWal(t)
+	walImpl := w.(*wal)
+
+	payload := strings.Repeat("x", 1024)
+	for i := 0; i < 100; i++ {
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term: 1, Offset: int64(i), Value: []byte(fmt.Sprintf("%s-%d", payload, i))}))
+	}
+	for i := 100; i < 150; i++ {
+		assert.NoError(t, w.AppendAsync(&proto.LogEntry{
+			Term: 1, Offset: int64(i), Value: []byte(fmt.Sprintf("%s-%d", payload, i))}))
+	}
+
+	walImpl.RLock()
+	pendingSegments := len(walImpl.pendingCloseSegments)
+	walImpl.RUnlock()
+	assert.Greater(t, pendingSegments, 0)
+
+	headOffset, err := w.TruncateLog(80)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 80, headOffset)
+	assert.EqualValues(t, 80, w.LastOffset())
+
+	walImpl.RLock()
+	pendingSegments = len(walImpl.pendingCloseSegments)
+	walImpl.RUnlock()
+	assert.Equal(t, 0, pendingSegments)
+
+	r, err := w.NewReader(InvalidOffset)
+	assert.NoError(t, err)
+	for i := 0; i <= 80; i++ {
+		assert.True(t, r.HasNext())
+		e, _, _, err := r.ReadNext()
+		assert.NoError(t, err)
+		assert.EqualValues(t, i, e.Offset)
+	}
+	assert.False(t, r.HasNext())
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, f.Close())
+}

--- a/oxiad/dataserver/wal/wal_test.go
+++ b/oxiad/dataserver/wal/wal_test.go
@@ -17,6 +17,8 @@ package wal
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -835,6 +837,51 @@ func TestWal_TruncateWithPendingCloseSegments(t *testing.T) {
 		assert.EqualValues(t, i, e.Offset)
 	}
 	assert.False(t, r.HasNext())
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, f.Close())
+}
+
+// A missing segment index file — the state left behind when the process
+// crashes between a rollover and the sync round that closes the rolled-over
+// segment — gets rebuilt from the txn file on open.
+func TestWal_ReadOnlySegmentMissingIndex(t *testing.T) {
+	dir := t.TempDir()
+	f := NewWalFactory(&FactoryOptions{
+		BaseWalDir:  dir,
+		Retention:   1 * time.Hour,
+		SegmentSize: 128 * 1024,
+		SyncData:    true,
+	})
+	w, err := f.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+
+	payload := strings.Repeat("x", 1024)
+	var entries []string
+	for i := 0; i < 300; i++ {
+		value := fmt.Sprintf("%s-%d", payload, i)
+		entries = append(entries, value)
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term: 1, Offset: int64(i), Value: []byte(value)}))
+	}
+	assert.NoError(t, w.Close())
+
+	// Simulate the crash window: drop every segment index file
+	idxFiles, err := filepath.Glob(filepath.Join(walPath(dir, constant.DefaultNamespace, shard), "*.idx*"))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, idxFiles)
+	for _, idx := range idxFiles {
+		assert.NoError(t, os.Remove(idx))
+	}
+
+	// Reopen: the indexes are rebuilt from the txn files
+	w, err = f.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 299, w.LastOffset())
+
+	r, err := w.NewReader(InvalidOffset)
+	assert.NoError(t, err)
+	assertReaderReads(t, r, entries)
 	assert.NoError(t, r.Close())
 	assert.NoError(t, w.Close())
 	assert.NoError(t, f.Close())


### PR DESCRIPTION
### Motivation

Item 6.4 from the performance review — the rollover durability gap, deliberately deferred from #1160/#1161. `readWriteSegment.Close()` unmaps the segment without flushing its data pages, and `rolloverSegment` closes the old segment inline; the next sync round then msyncs only the *current* segment while advancing `lastSyncedOffset` past the rolled-over entries. Net effect: entries whose only local copy sits in the page cache can be acknowledged as durable — lost on a power or kernel failure. (#1161's hardening covered the file-*metadata* half of this; the data pages remained exposed.)

### Changes

- **Rollover hands the old segment to the sync goroutine** instead of closing it inline. The sync round fsyncs the file (`SyncFileIfNeeded`), msyncs the data (`Flush`), and only then advances `lastSyncedOffset` and closes the segment. Acknowledgments now never cover unflushed rolled-over entries.
- **Bonus from the same move**: the index-file write and the munmap leave the append path entirely — the follow-up explicitly left open in #1161. Rollover under the WAL/leader locks is now just segment creation (no fsync, since #1161) plus a list append.
- **Pending segments stay readable**: `readAtIndex` consults the pending list, so just-rolled segments are served from their still-live mmap (previously they were immediately re-opened cold through the read-only group). Readers hold the WAL read lock for the whole read, and the sync goroutine removes a segment from the list under the write lock before closing it — no unmap-under-reader window.
- **Cold paths drain inline**: close/clear/truncate flush and close any pending segment first (truncation then operates on the complete segment set). Removal from the pending list is the ownership gate between the cold paths and the sync goroutine, so concurrent draining can't double-close. With `SyncData=false` the rollover keeps closing inline, since no sync rounds exist.
- **Pre-existing `TruncateLog` bug fixed** (surfaced by the new truncation test, confirmed present on unmodified `main`): when truncation lands in the middle of an older segment, the function returned from inside the polling loop, skipping the `lastAppendedOffset`/`lastSyncedOffset` updates — leaving stale offsets that break the next append's continuity check and let readers run past the truncation point.

### Verification

- `TestWal_RolloverKeepsPendingSegmentsReadable`: deterministic (async appends keep segments pending since no sync round runs) — pending segments readable, a sync drains them into the read-only group before acknowledging, recovery intact after reopen.
- `TestWal_TruncateWithPendingCloseSegments`: truncation into a pending-segment range drains first, truncates correctly, and the offsets are right afterwards (this is the test that caught the pre-existing watermark bug).
- All existing WAL tests pass unchanged, including the concurrency stress tests under the race detector; `go test -race` green on the whole `oxiad` module, the `oxia` client module and the full `tests/` integration suite; `golangci-lint` clean.

One adjacent pre-existing issue deliberately not addressed (tracked separately): `TruncateLog`'s "no segments left" branch calls `t.Clear()` while already holding the WAL lock — a self-deadlock on that (rare) path.

Related: #1160, #1161 (the perf side of this code), #1162.