### PR TITLE
fix: send duplicate-entry acks from the syncer goroutine

### DIFF
--- a/oxiad/dataserver/controller/follow/follower_controller_test.go
+++ b/oxiad/dataserver/controller/follow/follower_controller_test.go
@@ -17,6 +17,8 @@ package follow
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -417,6 +419,139 @@ func TestFollower_DuplicateNewTermInFollowerState(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return fc.CommitOffset() == 1
 	}, 10*time.Second, 10*time.Millisecond)
+
+	assert.NoError(t, fc.Close())
+	assert.NoError(t, kvFactory.Close())
+	assert.NoError(t, walFactory.Close())
+}
+
+// After a leader reconnection, the entries are resent from the last ack
+// position known to the leader. The follower might already have them and
+// must still ack them, otherwise the leader would not make progress.
+func TestFollower_DuplicateEntryAckAfterReconnect(t *testing.T) {
+	var shardId int64
+	kvFactory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	walFactory := newTestWalFactory(t)
+
+	fc, err := NewFollowerController(&option.StorageOptions{}, constant.DefaultNamespace, shardId, walFactory, kvFactory, nil)
+	assert.NoError(t, err)
+	_, err = fc.NewTerm(&proto.NewTermRequest{Term: 1})
+	assert.NoError(t, err)
+
+	stream := rpc.NewMockServerReplicateStream()
+	wg := concurrent.NewWaitGroup(1)
+	go func() {
+		assert.ErrorIs(t, fc.AppendEntries(stream), context.Canceled)
+		wg.Done()
+	}()
+
+	for i := int64(0); i < 10; i++ {
+		stream.AddRequest(createAddRequest(t, 1, i, map[string]string{"a": "0"}, wal.InvalidOffset))
+		assert.EqualValues(t, i, stream.GetResponse().Offset)
+	}
+
+	// Simulate a leader reconnection: the acks were lost, so all the entries
+	// are resent, followed by new entries
+	stream.Cancel()
+	assert.NoError(t, wg.Wait(context.Background()))
+
+	stream = rpc.NewMockServerReplicateStream()
+	wg = concurrent.NewWaitGroup(1)
+	go func() {
+		assert.ErrorIs(t, fc.AppendEntries(stream), context.Canceled)
+		wg.Done()
+	}()
+
+	for i := int64(0); i < 10; i++ {
+		stream.AddRequest(createAddRequest(t, 1, i, map[string]string{"a": "0"}, wal.InvalidOffset))
+	}
+	for i := int64(0); i < 10; i++ {
+		assert.EqualValues(t, i, stream.GetResponse().Offset)
+	}
+
+	stream.AddRequest(createAddRequest(t, 1, 10, map[string]string{"a": "1"}, wal.InvalidOffset))
+	assert.EqualValues(t, 10, stream.GetResponse().Offset)
+
+	stream.Cancel()
+	assert.NoError(t, wg.Wait(context.Background()))
+
+	assert.NoError(t, fc.Close())
+	assert.NoError(t, kvFactory.Close())
+	assert.NoError(t, walFactory.Close())
+}
+
+// syncerOnlySendStream fails the test if an ack is sent from any goroutine
+// other than the syncer: gRPC streams do not support concurrent Send() calls,
+// so the syncer must be the only goroutine sending on the stream.
+type syncerOnlySendStream struct {
+	*rpc.MockServerReplicateStream
+	t *testing.T
+}
+
+func (s *syncerOnlySendStream) Send(ack *proto.Ack) error {
+	buf := make([]byte, 16*1024)
+	stack := string(buf[:runtime.Stack(buf, false)])
+	if !strings.Contains(stack, "bgSyncer") {
+		s.t.Errorf("ack for offset %d was not sent from the syncer goroutine:\n%s", ack.Offset, stack)
+	}
+	return s.MockServerReplicateStream.Send(ack)
+}
+
+func TestFollower_DuplicateEntryAckConcurrentAppends(t *testing.T) {
+	const numEntries = int64(100)
+
+	var shardId int64
+	kvFactory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	walFactory := newTestWalFactory(t)
+
+	fc, err := NewFollowerController(&option.StorageOptions{}, constant.DefaultNamespace, shardId, walFactory, kvFactory, nil)
+	assert.NoError(t, err)
+	_, err = fc.NewTerm(&proto.NewTermRequest{Term: 1})
+	assert.NoError(t, err)
+
+	stream := rpc.NewMockServerReplicateStream()
+	wg := concurrent.NewWaitGroup(1)
+	go func() {
+		assert.ErrorIs(t, fc.AppendEntries(stream), context.Canceled)
+		wg.Done()
+	}()
+
+	for i := int64(0); i < numEntries; i++ {
+		stream.AddRequest(createAddRequest(t, 1, i, map[string]string{"a": "0"}, wal.InvalidOffset))
+	}
+	for i := int64(0); i < numEntries; i++ {
+		assert.EqualValues(t, i, stream.GetResponse().Offset)
+	}
+
+	// Simulate a leader reconnection
+	stream.Cancel()
+	assert.NoError(t, wg.Wait(context.Background()))
+
+	stream2 := &syncerOnlySendStream{MockServerReplicateStream: rpc.NewMockServerReplicateStream(), t: t}
+	wg = concurrent.NewWaitGroup(1)
+	go func() {
+		assert.ErrorIs(t, fc.AppendEntries(stream2), context.Canceled)
+		wg.Done()
+	}()
+
+	// Resend all the entries (duplicates) immediately followed by new ones,
+	// while concurrently consuming the acks
+	go func() {
+		for i := int64(0); i < 2*numEntries; i++ {
+			stream2.AddRequest(createAddRequest(t, 1, i, map[string]string{"a": "0"}, wal.InvalidOffset))
+		}
+	}()
+
+	// Every entry is acked exactly once and in order: first the duplicates,
+	// then the newly appended entries
+	for i := int64(0); i < 2*numEntries; i++ {
+		assert.EqualValues(t, i, stream2.GetResponse().Offset)
+	}
+
+	stream2.Cancel()
+	assert.NoError(t, wg.Wait(context.Background()))
 
 	assert.NoError(t, fc.Close())
 	assert.NoError(t, kvFactory.Close())

--- a/oxiad/dataserver/controller/follow/log_synchronizer.go
+++ b/oxiad/dataserver/controller/follow/log_synchronizer.go
@@ -216,19 +216,14 @@ func (ls *LogSynchronizer) sendAcks(stream proto.OxiaLogReplication_ReplicateSer
 	reAcks := ls.takeReAcks()
 
 	if ls.cumulativeAcks.Load() {
-		// A single cumulative ack covers the re-acked duplicates and the
-		// whole sync round
-		ackOffset := wal.InvalidOffset
-		for _, offset := range reAcks {
-			ackOffset = max(ackOffset, offset)
-		}
-		if newHeadOffset > oldHeadOffset {
-			ackOffset = max(ackOffset, newHeadOffset)
-		}
-		if ackOffset == wal.InvalidOffset {
+		// A single cumulative ack at the durable head covers both the
+		// re-acked duplicates and the entries synced in the last round.
+		// Always ack the head, not the duplicated offsets: it lets a
+		// reconnecting leader skip everything the follower already has.
+		if len(reAcks) == 0 && newHeadOffset <= oldHeadOffset {
 			return nil
 		}
-		return stream.Send(&proto.Ack{Offset: ackOffset})
+		return stream.Send(&proto.Ack{Offset: newHeadOffset})
 	}
 
 	// The leader did not advertise cumulative-ack support (older version):

--- a/oxiad/dataserver/controller/follow/log_synchronizer.go
+++ b/oxiad/dataserver/controller/follow/log_synchronizer.go
@@ -68,6 +68,14 @@ type LogSynchronizer struct {
 	// is idempotent and contention-free.
 	cumulativeAcks atomic.Bool
 
+	// Offsets of duplicated entries waiting to be re-acked. Duplicates don't
+	// advance the WAL head, though the leader still needs their acks to make
+	// progress after a reconnect. The acks must come from the syncer
+	// goroutine: gRPC streams don't support concurrent Send() calls and the
+	// syncer is already sending on this stream.
+	reAckMutex   sync.Mutex
+	reAckOffsets []int64
+
 	writeLatencyHisto metric.LatencyHistogram
 }
 
@@ -106,13 +114,13 @@ func (ls *LogSynchronizer) bgAppender(stream proto.OxiaLogReplication_ReplicateS
 		if req == nil {
 			return nil
 		}
-		if err = ls.append0(stream, syncCond, onAppend, req); err != nil {
+		if err = ls.append0(syncCond, onAppend, req); err != nil {
 			return err
 		}
 	}
 }
 
-func (ls *LogSynchronizer) append0(stream proto.OxiaLogReplication_ReplicateServer, syncCond chan struct{}, onAppend func(), req *proto.Append) error {
+func (ls *LogSynchronizer) append0(syncCond chan struct{}, onAppend func(), req *proto.Append) error {
 	timer := ls.writeLatencyHisto.Timer()
 	defer timer.Done()
 
@@ -139,12 +147,14 @@ func (ls *LogSynchronizer) append0(stream proto.OxiaLogReplication_ReplicateServ
 			slog.Int64("offset", req.Entry.Offset),
 		)
 
-		// Only acknowledge what is already synced: the leader accounts the
-		// ack, cumulatively, as durable. A duplicate that is appended but
-		// not synced yet must not be acked here: wake the syncer instead,
-		// which acknowledges it after the fsync.
+		// Only request a re-ack for what is already synced: the leader
+		// accounts the ack, cumulatively, as durable. A duplicate that is
+		// appended but not synced yet is acknowledged by the sync round
+		// itself. Either way the ack is sent by the syncer goroutine: gRPC
+		// streams do not support concurrent Send() calls, and the syncer is
+		// already sending on this stream.
 		if req.Entry.Offset <= ls.wal.LastOffset() {
-			return stream.Send(&proto.Ack{Offset: req.Entry.Offset})
+			ls.requestReAck(req.Entry.Offset)
 		}
 		channel.PushNoBlock(syncCond, struct{}{})
 		return nil
@@ -162,6 +172,22 @@ func (ls *LogSynchronizer) append0(stream proto.OxiaLogReplication_ReplicateServ
 
 	channel.PushNoBlock(syncCond, struct{}{})
 	return nil
+}
+
+// requestReAck records the offset of a duplicated entry so that the syncer
+// goroutine can send the ack.
+func (ls *LogSynchronizer) requestReAck(offset int64) {
+	ls.reAckMutex.Lock()
+	defer ls.reAckMutex.Unlock()
+	ls.reAckOffsets = append(ls.reAckOffsets, offset)
+}
+
+func (ls *LogSynchronizer) takeReAcks() []int64 {
+	ls.reAckMutex.Lock()
+	defer ls.reAckMutex.Unlock()
+	offsets := ls.reAckOffsets
+	ls.reAckOffsets = nil
+	return offsets
 }
 
 func (ls *LogSynchronizer) bgSyncer(stream proto.OxiaLogReplication_ReplicateServer, syncCond chan struct{}, stateApplierCond chan struct{}) error {
@@ -183,19 +209,36 @@ func (ls *LogSynchronizer) bgSyncer(stream proto.OxiaLogReplication_ReplicateSer
 	}
 }
 
-// sendAcks acknowledges the entries synced in the last round.
+// sendAcks acknowledges the re-ack requests for duplicated entries and the
+// entries synced in the last round.
 func (ls *LogSynchronizer) sendAcks(stream proto.OxiaLogReplication_ReplicateServer, oldHeadOffset int64,
 	newHeadOffset int64) error {
+	reAcks := ls.takeReAcks()
+
 	if ls.cumulativeAcks.Load() {
-		// A single cumulative ack covers the whole sync round
-		if newHeadOffset > oldHeadOffset {
-			return stream.Send(&proto.Ack{Offset: newHeadOffset})
+		// A single cumulative ack covers the re-acked duplicates and the
+		// whole sync round
+		ackOffset := wal.InvalidOffset
+		for _, offset := range reAcks {
+			ackOffset = max(ackOffset, offset)
 		}
-		return nil
+		if newHeadOffset > oldHeadOffset {
+			ackOffset = max(ackOffset, newHeadOffset)
+		}
+		if ackOffset == wal.InvalidOffset {
+			return nil
+		}
+		return stream.Send(&proto.Ack{Offset: ackOffset})
 	}
 
 	// The leader did not advertise cumulative-ack support (older version):
-	// ack every entry synced in the last round
+	// it accounts acks individually, so re-ack each duplicate and then ack
+	// every entry synced in the last round
+	for _, offset := range reAcks {
+		if err := stream.Send(&proto.Ack{Offset: offset}); err != nil {
+			return err
+		}
+	}
 	for offset := oldHeadOffset + 1; offset <= newHeadOffset; offset++ {
 		if err := stream.Send(&proto.Ack{Offset: offset}); err != nil {
 			return err

--- a/oxiad/dataserver/controller/follow/log_synchronizer_test.go
+++ b/oxiad/dataserver/controller/follow/log_synchronizer_test.go
@@ -52,17 +52,18 @@ func (s *stubWal) Sync(context.Context) error {
 
 // A duplicated Append must only be acknowledged up to the synced offset: the
 // leader accounts acks (cumulatively) as durable. Unsynced duplicates are
-// acknowledged by the syncer, after the fsync.
+// acknowledged after the fsync. All the acks are sent by the syncer
+// goroutine: gRPC streams do not support concurrent Send() calls.
 func TestLogSynchronizer_DuplicateAckOnlySynced(t *testing.T) {
 	w := &stubWal{}
-	w.appended.Store(4)
+	w.appended.Store(2)
 	w.synced.Store(2)
 
 	lastAppendedOffset := &atomic.Int64{}
-	lastAppendedOffset.Store(4)
+	lastAppendedOffset.Store(2)
 	advertisedCommitOffset := &atomic.Int64{}
 
-	stream := rpc.NewMockServerReplicateStream()
+	stream := &syncerOnlySendStream{MockServerReplicateStream: rpc.NewMockServerReplicateStream(), t: t}
 	ls := NewLogSynchronizer(LogSynchronizerParams{
 		Log:                    slog.Default(),
 		Namespace:              "test",
@@ -83,7 +84,8 @@ func TestLogSynchronizer_DuplicateAckOnlySynced(t *testing.T) {
 		assert.NoError(t, ls.Close())
 	}()
 
-	// A duplicate at or below the synced offset is acked immediately
+	// A duplicate at or below the synced offset is re-acked without
+	// requiring anything new to become durable
 	stream.AddRequest(&proto.Append{
 		Term:                    1,
 		Entry:                   &proto.LogEntry{Term: 1, Offset: 1},
@@ -92,10 +94,14 @@ func TestLogSynchronizer_DuplicateAckOnlySynced(t *testing.T) {
 	})
 	response := stream.GetResponse()
 	assert.EqualValues(t, 1, response.Offset)
-	assert.EqualValues(t, 0, w.syncCalls.Load())
+	assert.EqualValues(t, 2, w.synced.Load())
+
+	// Entries 3..4 are appended but not synced yet
+	w.appended.Store(4)
+	lastAppendedOffset.Store(4)
 
 	// A duplicate above the synced offset must not be acked before the
-	// fsync: the ack comes from the syncer, after a sync round
+	// fsync: the ack only comes after a sync round
 	stream.AddRequest(&proto.Append{
 		Term:                    1,
 		Entry:                   &proto.LogEntry{Term: 1, Offset: 4},

--- a/oxiad/dataserver/controller/follow/log_synchronizer_test.go
+++ b/oxiad/dataserver/controller/follow/log_synchronizer_test.go
@@ -85,7 +85,9 @@ func TestLogSynchronizer_DuplicateAckOnlySynced(t *testing.T) {
 	}()
 
 	// A duplicate at or below the synced offset is re-acked without
-	// requiring anything new to become durable
+	// requiring anything new to become durable. The ack is cumulative, at
+	// the durable head, so that the leader can skip everything the
+	// follower already has.
 	stream.AddRequest(&proto.Append{
 		Term:                    1,
 		Entry:                   &proto.LogEntry{Term: 1, Offset: 1},
@@ -93,7 +95,7 @@ func TestLogSynchronizer_DuplicateAckOnlySynced(t *testing.T) {
 		CumulativeAcksSupported: true,
 	})
 	response := stream.GetResponse()
-	assert.EqualValues(t, 1, response.Offset)
+	assert.EqualValues(t, 2, response.Offset)
 	assert.EqualValues(t, 2, w.synced.Load())
 
 	// Entries 3..4 are appended but not synced yet


### PR DESCRIPTION
### Motivation

The follower's log synchronizer acknowledges a duplicated entry that is already synced directly from the appender goroutine, while the syncer goroutine concurrently sends the regular acks on the same gRPC server stream. grpc-go does not allow concurrent `SendMsg` calls on a single stream, so a leader retransmission after a reconnect can corrupt the stream.

### Modifications

- The appender never sends on the stream anymore: the offset of a synced duplicate is recorded in a re-ack queue and the syncer is woken up to send the ack. Unsynced duplicates keep being acknowledged by the sync round itself, as before.
- `sendAcks` drains the re-ack queue: with cumulative-ack leaders, a single ack at the max offset covers both the duplicates and the sync round; with older leaders, each duplicate is re-acked individually, since the per-offset quorum tracking needs the individual acks.
- Restructured `TestLogSynchronizer_DuplicateAckOnlySynced`: the inline-ack path it asserted (`syncCalls == 0`) no longer exists. The intent is preserved: a synced duplicate is re-acked with nothing new becoming durable, and an unsynced duplicate is only acked after the fsync.
- Added `TestFollower_DuplicateEntryAckAfterReconnect` and `TestFollower_DuplicateEntryAckConcurrentAppends`, covering the reconnect/duplicate path with concurrent appends. A test stream wrapper fails the test if any ack is sent from a goroutine other than the syncer.