### PR TITLE
fix: avoid wal self-deadlock when truncating below all retained segments

### DIFF
--- a/oxiad/dataserver/wal/readwrite_segment.go
+++ b/oxiad/dataserver/wal/readwrite_segment.go
@@ -235,6 +235,12 @@ func (ms *readWriteSegment) Close() error {
 	ms.flushLock.Lock()
 	defer ms.flushLock.Unlock()
 
+	if ms.txnMappedFile == nil {
+		// Already closed: TruncateLog clears the wal after having deleted
+		// (and thus closed) the current segment
+		return nil
+	}
+
 	err := multierr.Combine(
 		ms.txnMappedFile.Unmap(),
 		ms.txnFile.Close(),

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -599,6 +599,10 @@ func (t *wal) Clear() error {
 	t.Lock()
 	defer t.Unlock()
 
+	return t.clearWithoutLock()
+}
+
+func (t *wal) clearWithoutLock() error {
 	err := multierr.Combine(
 		t.drainPendingCloseSegments(),
 		t.currentSegment.Close(),
@@ -684,7 +688,7 @@ func (t *wal) TruncateLog(lastSafeOffset int64) (int64, error) { //nolint:revive
 				return InvalidOffset, err
 			case segment == nil:
 				// There are no segments left
-				if err := t.Clear(); err != nil {
+				if err := t.clearWithoutLock(); err != nil {
 					return InvalidOffset, err
 				}
 				return t.LastOffset(), nil

--- a/oxiad/dataserver/wal/wal_test.go
+++ b/oxiad/dataserver/wal/wal_test.go
@@ -886,3 +886,48 @@ func TestWal_ReadOnlySegmentMissingIndex(t *testing.T) {
 	assert.NoError(t, w.Close())
 	assert.NoError(t, f.Close())
 }
+
+// Truncating to an offset below all the retained segments clears the wal:
+// the clear used to re-acquire the wal lock already held by TruncateLog,
+// deadlocking the wal permanently (this test would time out).
+func TestWal_TruncateBelowAllSegments(t *testing.T) {
+	f, w := createWal(t)
+
+	// Leave the wal with segments whose base offsets are all above the
+	// truncation target: start from a non-initial offset, as a follower
+	// does after its wal got cleared, and roll over at least once
+	assert.NoError(t, w.Clear())
+	payload := strings.Repeat("x", 1024)
+	for i := 100; i < 300; i++ {
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term: 1, Offset: int64(i), Value: []byte(fmt.Sprintf("%s-%d", payload, i))}))
+	}
+
+	headOffset, err := w.TruncateLog(50)
+	assert.NoError(t, err)
+	assert.Equal(t, InvalidOffset, headOffset)
+	assert.Equal(t, InvalidOffset, w.FirstOffset())
+	assert.Equal(t, InvalidOffset, w.LastOffset())
+
+	// The cleared wal must be usable, appendable from right after the
+	// truncation point
+	for i := 51; i < 55; i++ {
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term: 2, Offset: int64(i), Value: []byte(fmt.Sprintf("entry-%d", i))}))
+	}
+	assert.EqualValues(t, 51, w.FirstOffset())
+	assert.EqualValues(t, 54, w.LastOffset())
+
+	r, err := w.NewReader(50)
+	assert.NoError(t, err)
+	for i := 51; i < 55; i++ {
+		assert.True(t, r.HasNext())
+		e, _, _, err := r.ReadNext()
+		assert.NoError(t, err)
+		assert.EqualValues(t, i, e.Offset)
+	}
+	assert.False(t, r.HasNext())
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, f.Close())
+}


### PR DESCRIPTION
### Motivation

The pre-existing issue explicitly deferred from #1176: `TruncateLog` holds the WAL write lock, and the "no segments left" branch of its segment-polling loop called `Clear()`, which re-acquires the same non-reentrant `sync.RWMutex` — permanently deadlocking the WAL (appends, reads, syncs and truncations all block forever). The branch is reachable when the truncation offset lies below every retained segment — e.g. aggressive trimming combined with a follower truncation during fencing — rare enough that it has never fired in practice. (The other `Clear()` call in `TruncateLog`, on the `lastSafeOffset == InvalidOffset` early path, runs before the lock is taken and was always fine.)

### Changes

- **Extract the body of `Clear()` into `clearWithoutLock()`**, mirroring the existing `Close`/`closeWithoutLock` pattern: `Clear()` keeps its public behavior (lock + delegate) and the polling loop calls the helper directly. The pending-close list is already empty by the time the branch runs (drained at the top of `TruncateLog`), so the helper's drain is a harmless no-op kept for safety.
- **Make `readWriteSegment.Close()` idempotent** (the same nil-guard `Flush`/`SyncFileIfNeeded` already use). Required for the un-deadlocked branch to actually work: `TruncateLog` deletes the current segment — which closes it — before entering the loop, so the clear closes it a second time. Without the guard, that second close returns `ErrClosed` plus `EINVAL` from the nil munmap, failing the truncation with "failed to clear wal" and leaving the WAL unusable (verified empirically with only the lock fix applied). The guard also keeps a second close from re-creating the index file `Delete` just removed, and from double-returning the index buffer to the pool.

### Verification

- New `TestWal_TruncateBelowAllSegments`: leaves the WAL with every segment base offset above the truncation target (append from a non-initial offset after a clear, with one rollover so the loop also discards a whole read-only segment before hitting the empty branch), truncates below them, and asserts completion plus an empty WAL that is appendable and readable from right after the truncation point. The test hangs on unfixed code — goroutine blocked in `Clear → RWMutex.Lock` while `TruncateLog` holds the write side — and fails with "failed to clear wal" with only the lock fix.
- Full `make test` green (race detector on); `golangci-lint` clean on the wal package.

Related: #1176 (called this out as "deliberately not addressed, tracked separately").