### PR TITLE
fix: do not re-acquire the sessions lock on a failed session start

### DIFF
--- a/oxia/sessions.go
+++ b/oxia/sessions.go
@@ -68,14 +68,20 @@ func (s *sessions) executeWithSessionId(shardId int64, callback func(int64, erro
 		session = s.startSession(shardId)
 		s.sessionsByShard[shardId] = session
 	}
-	session.executeWithId(callback)
+	if !session.executeWithId(callback) {
+		// The session failed to start: forget it, so that the next operation
+		// attempts a fresh one
+		delete(s.sessionsByShard, shardId)
+	}
 }
 
 func (s *sessions) startSession(shardId int64) *clientSession {
 	cs := &clientSession{
 		shardId:  shardId,
 		sessions: s,
-		started:  make(chan error),
+		// Buffered: the failure notification must not block the creator
+		// goroutine until an operation happens to come by
+		started: make(chan error, 1),
 		log: slog.With(
 			slog.String("component", "session"),
 			slog.Int64("shard", shardId),
@@ -116,26 +122,26 @@ type clientSession struct {
 	cancel    context.CancelFunc
 }
 
-func (cs *clientSession) executeWithId(callback func(int64, error)) {
+// executeWithId invokes the callback with the session id, once the session
+// has been established. It returns false when the session failed to start:
+// the caller — which already holds the sessions lock — discards it, so that
+// re-acquiring that lock here (a self-deadlock) is never needed.
+func (cs *clientSession) executeWithId(callback func(int64, error)) bool {
 	select {
 	case err := <-cs.started:
 		if err != nil {
 			callback(-1, err)
-			cs.sessions.Lock()
-			defer cs.sessions.Unlock()
-			cs.Lock()
-			defer cs.Unlock()
-			delete(cs.sessions.sessionsByShard, cs.shardId)
-		} else {
-			cs.Lock()
-			callback(cs.sessionId, nil)
-			cs.Unlock()
+			return false
 		}
+		cs.Lock()
+		callback(cs.sessionId, nil)
+		cs.Unlock()
 	case <-cs.ctx.Done():
 		if cs.ctx.Err() != nil && !errors.Is(cs.ctx.Err(), context.Canceled) {
 			callback(-1, cs.ctx.Err())
 		}
 	}
+	return true
 }
 
 func (cs *clientSession) createSessionWithRetries() {

--- a/oxia/sessions_test.go
+++ b/oxia/sessions_test.go
@@ -1,0 +1,68 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oxia
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// An operation hitting a session that failed to start must fail its callback
+// and discard the session — without re-acquiring the sessions lock that the
+// caller already holds, which was a self-deadlock wedging every subsequent
+// ephemeral operation of the client.
+func TestSessions_FailedSessionStartDoesNotDeadlock(t *testing.T) {
+	s := &sessions{
+		sessionsByShard: map[int64]*clientSession{},
+		log:             slog.Default(),
+	}
+
+	cs := &clientSession{
+		shardId:  1,
+		sessions: s,
+		started:  make(chan error, 1),
+		log:      slog.Default(),
+	}
+	cs.ctx, cs.cancel = context.WithCancel(context.Background())
+	cs.started <- errors.New("session start failed")
+	s.sessionsByShard[1] = cs
+
+	done := make(chan struct{})
+	go func() {
+		s.executeWithSessionId(1, func(sessionId int64, err error) {
+			assert.Error(t, err)
+			assert.EqualValues(t, -1, sessionId)
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("executeWithSessionId deadlocked on a failed session start")
+	}
+
+	// The failed session has been discarded: the next operation will attempt
+	// a fresh one
+	s.Lock()
+	_, found := s.sessionsByShard[1]
+	s.Unlock()
+	assert.False(t, found)
+}


### PR DESCRIPTION
### Motivation

Item 6.5 from the performance review, client side. `executeWithSessionId` holds the client-wide `sessions` mutex while waiting for the shard session to be established; on a failed session start, `executeWithId`'s failure branch re-acquired that same, non-reentrant mutex to discard the session — a guaranteed self-deadlock that wedges the operation and every subsequent ephemeral operation of the client, on every shard. The failure surfaces when the session-creation retries give up (a non-canceled error delivered on the `started` channel), so the deadlock would fire exactly while recovering from an extended shard unavailability.

### Changes

- `executeWithId` reports the failure to its (only) caller instead of re-locking; the caller discards the session while still holding the lock. The cleanup thereby becomes **atomic** with the lookup/create — no window where a dead session lingers in the map — instead of a separate critical section. The `cs.Lock()` that wrapped the old delete is dropped too: the map is guarded by the sessions lock, so it protected nothing.
- The `started` channel becomes buffered(1), fixing the sibling leak where the creator goroutine blocked forever on delivering the failure when no operation ever came by. Safe because only one waiter can ever observe a failed session: waiters are serialized by the sessions lock, and the first one to see the error now atomically removes the session — the closed-channel-yields-nil case is unreachable.

### Verification

- New `TestSessions_FailedSessionStartDoesNotDeadlock`: deterministic in both directions, no RPC stubs (the map is pre-seeded with a session whose `started` channel already carries the failure). Verified to deadlock on every run against unmodified code (fails at the 10s guard) and pass on every run with the fix; also asserts the failed session is discarded.
- `go test -race` green on the whole `oxia` client module; `golangci-lint` reports only a pre-existing gosec finding in untouched `notifications.go`.
- Note for reviewers: `tests/client` currently fails on this machine independent of any change — a leftover `bin/oxia standalone` on the default port 6648 hijacks the fixed-port example tests (reproduced identically on three older commits including merged ones). CI should be unaffected.

Related: the head-of-line-blocking half of review item 3.4 (the sessions lock held across the session-creation wait) is a separate performance change, deliberately not part of this fix.