### PR TITLE
fix: discard multi-shard get responses after the first error

### DIFF
--- a/oxia/async_client_impl.go
+++ b/oxia/async_client_impl.go
@@ -361,10 +361,8 @@ func (c *clientImpl) doMultiShardGet(key string, options *getOptions, ch chan Ge
 		return
 	}
 
-	m := sync.Mutex{}
 	shards := c.shardManager.GetAll()
-	counter := len(shards)
-	selected := keyNotFound
+	callback := multiShardGetCallback(key, options.comparisonType, len(shards), ch)
 
 	for _, shardId := range shards {
 		c.readBatchManager.Get(shardId).Add(model.GetCall{
@@ -372,30 +370,44 @@ func (c *clientImpl) doMultiShardGet(key string, options *getOptions, ch chan Ge
 			ComparisonType:     options.comparisonType,
 			IncludeValue:       options.includeValue,
 			SecondaryIndexName: options.secondaryIndexName,
-			Callback: func(response *proto.GetResponse, err error) {
-				m.Lock()
-				defer m.Unlock()
-
-				if counter == 0 {
-					// Response already sent, nothing to do
-					return
-				}
-
-				if err != nil {
-					ch <- toGetResult(nil, key, err)
-					close(ch)
-					counter = 0
-				}
-
-				selected = selectResponse(options.comparisonType, selected, response)
-
-				counter--
-				if counter == 0 {
-					ch <- toGetResult(selected, key, nil)
-					close(ch)
-				}
-			},
+			Callback:           callback,
 		})
+	}
+}
+
+// multiShardGetCallback aggregates the per-shard responses of a multi-shard
+// get: the first error wins and terminates the result channel, discarding the
+// remaining responses; otherwise the best response for the comparison type is
+// selected once every shard has responded.
+func multiShardGetCallback(key string, comparisonType proto.KeyComparisonType, numShards int,
+	ch chan GetResult) func(*proto.GetResponse, error) {
+	m := sync.Mutex{}
+	counter := numShards
+	selected := keyNotFound
+
+	return func(response *proto.GetResponse, err error) {
+		m.Lock()
+		defer m.Unlock()
+
+		if counter == 0 {
+			// Response already sent, nothing to do
+			return
+		}
+
+		if err != nil {
+			ch <- toGetResult(nil, key, err)
+			close(ch)
+			counter = 0
+			return
+		}
+
+		selected = selectResponse(comparisonType, selected, response)
+
+		counter--
+		if counter == 0 {
+			ch <- toGetResult(selected, key, nil)
+			close(ch)
+		}
 	}
 }
 

--- a/oxia/async_client_impl_test.go
+++ b/oxia/async_client_impl_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oxia
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+// The first shard error terminates the result channel; the responses of the
+// remaining shards — errors included — must be discarded, not panic with a
+// send on the closed channel (the error path used to fall through and leave
+// the counter sentinel negative, defeating the response-already-sent guard).
+func TestMultiShardGetCallback_ErrorsAfterFirstAreDiscarded(t *testing.T) {
+	ch := make(chan GetResult, 1)
+	callback := multiShardGetCallback("key-a", proto.KeyComparisonType_FLOOR, 3, ch)
+
+	callback(nil, errors.New("shard-0 failed"))
+	result := <-ch
+	require.Error(t, result.Err)
+
+	assert.NotPanics(t, func() {
+		callback(nil, errors.New("shard-1 failed"))
+		callback(&proto.GetResponse{Status: proto.Status_KEY_NOT_FOUND}, nil)
+	})
+
+	// The channel was closed exactly once, after the single error result
+	_, open := <-ch
+	assert.False(t, open)
+}
+
+func TestMultiShardGetCallback_AllShardsRespond(t *testing.T) {
+	ch := make(chan GetResult, 1)
+	callback := multiShardGetCallback("key-a", proto.KeyComparisonType_FLOOR, 3, ch)
+
+	for i := 0; i < 3; i++ {
+		callback(&proto.GetResponse{Status: proto.Status_KEY_NOT_FOUND}, nil)
+	}
+
+	result := <-ch
+	assert.ErrorIs(t, result.Err, ErrKeyNotFound)
+	_, open := <-ch
+	assert.False(t, open)
+}


### PR DESCRIPTION
### Motivation

Item 6.5 (second half) from the performance review. The error path of the multi-shard get aggregation sets the response-already-sent sentinel (`counter = 0`) but falls through to the `counter--` below, leaving the sentinel at **-1**: the guard at the top then never fires again for the remaining shards. A second shard error sends on the already-closed result channel — panicking the read-batcher goroutine and taking the whole client down — and the error responses also flow into `selectResponse`. Realistic trigger: a multi-shard FLOOR/CEILING/secondary-index `Get` during an outage spanning more than one shard.

### Changes

- The missing `return` in the error branch: the first error wins and terminates the result channel, and every subsequent shard response — errors included — is discarded by the sentinel guard.
- The aggregation callback is extracted into `multiShardGetCallback(...)` — behavior-preserving (same mutex/counter/selection state) — so the sentinel semantics are pinned by unit tests without standing up a client. Side benefit: one shared callback instead of a closure literal per shard.

### Verification

- `TestMultiShardGetCallback_ErrorsAfterFirstAreDiscarded`: verified to discriminate — with the `return` temporarily removed (recreating the old fall-through), it panics with the exact send-on-closed-channel signature; with the fix it passes every run, and it asserts the channel closes exactly once with the single error result.
- `TestMultiShardGetCallback_AllShardsRespond`: the all-shards-respond path still selects and terminates correctly.
- `go test -race` green on the whole `oxia` client module; `golangci-lint` reports only the pre-existing gosec finding in untouched `notifications.go`.

Related: #1179 (the other half of review item 6.5).