### PR TITLE
fix: do not decode natural internal keys in place

### DIFF
--- a/common/compare/encode.go
+++ b/common/compare/encode.go
@@ -143,12 +143,10 @@ func (encoderNatural) Decode(encoded []byte) string {
 	// only an implementation detail of the current version copies before
 	// they reach the caller.
 	if bytes.HasPrefix(encoded, encodedInternalKeyPrefixBytes) {
-		// Decode the internal key into a new string
-		var sb strings.Builder
-		sb.Grow(len(encoded))
-		sb.WriteString("__")
-		sb.Write(encoded[2:])
-		return sb.String()
+		// Decode the internal key into a new string. The concatenation makes
+		// a single allocation: the compiler does not allocate for a
+		// []byte-to-string conversion used directly as a concat operand.
+		return "__" + string(encoded[2:])
 	}
 
 	// Copy is necessary because the []byte memory is managed by Pebble

--- a/common/compare/encode.go
+++ b/common/compare/encode.go
@@ -135,10 +135,20 @@ func (encoderNatural) Encode(key string) []byte {
 }
 
 func (encoderNatural) Decode(encoded []byte) string {
+	// The buffer must not be modified: it is Pebble's memory, handed out
+	// under an explicit read-only contract ("the caller should not modify
+	// the contents of the returned slice", Iterator.Key). Today it is the
+	// iterator's own position buffer — which Pebble keeps using internally —
+	// and Pebble's lower layers hand out direct block-cache references that
+	// only an implementation detail of the current version copies before
+	// they reach the caller.
 	if bytes.HasPrefix(encoded, encodedInternalKeyPrefixBytes) {
-		// Decode the internal key
-		encoded[0] = '_'
-		encoded[1] = '_'
+		// Decode the internal key into a new string
+		var sb strings.Builder
+		sb.Grow(len(encoded))
+		sb.WriteString("__")
+		sb.Write(encoded[2:])
+		return sb.String()
 	}
 
 	// Copy is necessary because the []byte memory is managed by Pebble

--- a/common/compare/encode_test.go
+++ b/common/compare/encode_test.go
@@ -110,3 +110,40 @@ func TestEncodeInternalKeys(t *testing.T) {
 		})
 	}
 }
+
+// The buffer passed to Decode can alias Pebble's shared block cache: it must
+// never be modified, or the cached block gets corrupted for every other
+// reader (the old in-place rewrite changed the internal-key prefix bytes,
+// breaking the sort order within the block).
+func TestEncoderNaturalDecodeDoesNotMutateInput(t *testing.T) {
+	encoded := []byte("\xff\xffoxia/session/123")
+	original := bytes.Clone(encoded)
+
+	decoded := encoderNatural{}.Decode(encoded)
+	assert.Equal(t, "__oxia/session/123", decoded)
+	assert.Equal(t, original, encoded)
+
+	// Non-internal keys are returned as-is, also untouched
+	plain := []byte("a/b/c")
+	originalPlain := bytes.Clone(plain)
+	assert.Equal(t, "a/b/c", encoderNatural{}.Decode(plain))
+	assert.Equal(t, originalPlain, plain)
+}
+
+func BenchmarkEncoderNaturalDecode(b *testing.B) {
+	internal := []byte("\xff\xffoxia/session/0000000000123456")
+	plain := []byte("/some/regular/application/key-123456")
+
+	b.Run("internal", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = encoderNatural{}.Decode(internal)
+		}
+	})
+	b.Run("plain", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = encoderNatural{}.Decode(plain)
+		}
+	})
+}

--- a/common/compare/encode_test.go
+++ b/common/compare/encode_test.go
@@ -111,10 +111,11 @@ func TestEncodeInternalKeys(t *testing.T) {
 	}
 }
 
-// The buffer passed to Decode can alias Pebble's shared block cache: it must
-// never be modified, or the cached block gets corrupted for every other
-// reader (the old in-place rewrite changed the internal-key prefix bytes,
-// breaking the sort order within the block).
+// The buffer passed to Decode is Pebble memory, handed out under an explicit
+// read-only contract (Iterator.Key): it must not be modified. In the current
+// pebble version it is the iterator's own position buffer, which pebble keeps
+// using internally — the layers below alias the shared block cache, with the
+// top-level iterator copying every key before it reaches the caller.
 func TestEncoderNaturalDecodeDoesNotMutateInput(t *testing.T) {
 	encoded := []byte("\xff\xffoxia/session/123")
 	original := bytes.Clone(encoded)


### PR DESCRIPTION
### Motivation

Item 6.6 (first part) from the performance review. The natural encoder decodes internal keys by rewriting the two prefix bytes (`0xffff` → `__`) **in place** on the buffer returned by `Iterator.Key()`, before copying it into a string.

Honest framing of the severity, after investigating it properly: Pebble hands that slice out under an explicit read-only contract (*"the caller should not modify the contents of the returned slice"* — `Iterator.Key` docs), and the buffer is the iterator's own position state, which Pebble keeps consulting internally. The layers below hand out direct block-cache references for keys at block restart points (`sstable/rowblk/rowblk_iter.go`, the `shared == 0` branch) — but in pebble v2.1.0 the top-level iterator copies every key into its private `keyBuf` before it reaches the caller, so the shared-cache corruption scenario is **not reachable today**: an end-to-end repro (internal keys flushed to an sstable, decoded through the scan path, then re-read) passes against the old code. This is contract hygiene against an implementation detail Pebble actively tries to avoid in its lower layers (and that a future upgrade could change), not a fix for an observed corruption.

### Changes

`Decode` builds the decoded internal key into a new string (`"__" + string(encoded[2:])`) and leaves the input untouched; the regular-key path is unchanged. (`Encode` was already safe — it copies before mutating.)

### Cost

One allocation either way (`string(encoded)` already allocated and copied). Benchmarked with the final concatenation version: regular keys byte-identical (~17 ns/op); internal keys ~17 → ~13.7 ns/op — the `[]byte`→`string` conversion used directly as a concat operand doesn't allocate, so the whole decode is the one concat allocation (the microbenchmark even reports 0 B/op on that path because the non-escaping result stays on the stack). Internal keys only occur on internal bookkeeping scans. Amusing artifact: the old code benchmarks its internal path at 4.4 ns/op with zero allocations — because the in-place mutation disables its own prefix branch after the first iteration.

### Verification

- `TestEncoderNaturalDecodeDoesNotMutateInput`: pins input immutability for both key kinds; fails against the old code by catching the mutated buffer.
- `BenchmarkEncoderNaturalDecode` added for both paths.
- `go test -race` green on `common/compare` and the `database`/`kvstore` packages; `golangci-lint` clean both locally and with the CI-pinned v2.6.2 (whose revive rejects the earlier `strings.Builder` version).
