### PR TITLE
perf: skip the periodic shard-status persist when nothing changed

### DIFF
--- a/oxiad/coordinator/runtime/controller/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller.go
@@ -243,6 +243,7 @@ func (s *shardController) run(initShardMeta *proto.ShardMetadata) {
 	// the first periodic tick over the interval so the periodic tasks don't
 	// fire as a herd.
 	periodicTasksTimer := time.NewTimer(rand.N(s.periodicTasksInterval)) //nolint:gosec
+	defer periodicTasksTimer.Stop()
 
 	for {
 		select {
@@ -538,8 +539,14 @@ func (s *shardController) handlePeriodicTasks() {
 			s.logger.Warn("Failed to handle pending delete shard", "error", err)
 			return
 		}
-		// The local view changed: the pending-delete nodes are now cleared
-		s.metadata.Store(mutShardMeta)
+		// Clear the pending-delete nodes in the canonical view. Compute (not
+		// Store of the snapshot): the DeleteShard RPCs above leave a long
+		// window since Load(), and the split controller can store a term bump
+		// into this controller's metadata concurrently (SplitComplete) —
+		// writing the whole snapshot back would revert it.
+		mutShardMeta = s.metadata.Compute(func(m *proto.ShardMetadata) {
+			m.PendingDeleteShardNodes = nil
+		})
 	}
 
 	// Re-assert the shard status only when the status resource diverges from
@@ -570,6 +577,5 @@ func (s *shardController) handlePendingDeleteShard(mutShardMeta *proto.ShardMeta
 		s.logger.Info("Successfully deleted shard from data server", slog.Any("data-server", ds))
 	}
 
-	mutShardMeta.PendingDeleteShardNodes = nil
 	return nil
 }

--- a/oxiad/coordinator/runtime/controller/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -238,7 +239,10 @@ func (s *shardController) run(initShardMeta *proto.ShardMetadata) {
 
 	s.logger.Info("Shard is ready", slog.Any("leader", initShardMeta.Leader))
 
-	periodicTasksTimer := time.NewTicker(s.periodicTasksInterval)
+	// All the shard controllers start together at coordinator startup: spread
+	// the first periodic tick over the interval so the periodic tasks don't
+	// fire as a herd.
+	periodicTasksTimer := time.NewTimer(rand.N(s.periodicTasksInterval)) //nolint:gosec
 
 	for {
 		select {
@@ -254,6 +258,7 @@ func (s *shardController) run(initShardMeta *proto.ShardMetadata) {
 			s.onChangeEnsemble(op)
 		case <-periodicTasksTimer.C:
 			s.handlePeriodicTasks()
+			periodicTasksTimer.Reset(s.periodicTasksInterval)
 		case electionAction := <-s.electionOp:
 			newLeader := s.onElectLeader(nil)
 			electionAction.Done(newLeader.GetNameOrDefault())
@@ -533,11 +538,20 @@ func (s *shardController) handlePeriodicTasks() {
 			s.logger.Warn("Failed to handle pending delete shard", "error", err)
 			return
 		}
+		// The local view changed: the pending-delete nodes are now cleared
+		s.metadata.Store(mutShardMeta)
 	}
 
-	// Update the shard status
+	// Re-assert the shard status only when the status resource diverges from
+	// the local view: each UpdateShardStatus persists the full cluster status,
+	// so unconditionally writing it for every shard on every tick costs
+	// O(shards^2) bytes per interval on the metadata backend.
+	if borrowedMeta, exists := s.metadataStore.GetShardStatus(s.namespace, s.shard); exists &&
+		borrowedMeta.UnsafeBorrow().EqualVT(mutShardMeta) {
+		return
+	}
+
 	s.metadataStore.UpdateShardStatus(s.namespace, s.shard, mutShardMeta)
-	s.metadata.Store(mutShardMeta)
 }
 
 func (s *shardController) handlePendingDeleteShard(mutShardMeta *proto.ShardMetadata) error {

--- a/oxiad/coordinator/runtime/controller/shard_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller_test.go
@@ -909,3 +909,66 @@ func TestShardController_PeriodicTasksSkipUnchangedPersist(t *testing.T) {
 	borrowedFinal, _ := metadata.GetShardStatus(constant.DefaultNamespace, shard)
 	assert.Same(t, borrowedChanged.UnsafeBorrow(), borrowedFinal.UnsafeBorrow())
 }
+
+// While handlePeriodicTasks is blocked in the DeleteShard RPCs, the split
+// controller can store a term bump into this controller's metadata
+// (runtime.SplitComplete syncing the parent after Cutover). Clearing the
+// pending-delete nodes must merge with that update, not write the whole
+// pre-RPC snapshot back over it.
+func TestShardController_PendingDeleteDoesNotClobberConcurrentMetadataUpdate(t *testing.T) {
+	var shard int64 = 5
+	rpc := newMockRpcProvider()
+	metadata := newTestMetadata(t, memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled), &proto.ClusterConfiguration{})
+
+	leader := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	removed := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	shardMeta := &proto.ShardMetadata{
+		Status:                  proto.ShardStatusSteadyState,
+		Term:                    1,
+		Leader:                  leader,
+		PendingDeleteShardNodes: []*proto.DataServerIdentity{removed},
+	}
+	assert.True(t, metadata.CreateNamespaceStatus(constant.DefaultNamespace, &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{shard: shardMeta},
+	}))
+
+	// Built by hand so the run loop's own timer cannot race the direct call
+	s := &shardController{
+		namespace:     constant.DefaultNamespace,
+		shard:         shard,
+		metadata:      NewMetadata(shardMeta),
+		metadataStore: metadata,
+		rpc:           rpc,
+		logger:        slog.Default(),
+	}
+	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
+	defer s.ctxCancel()
+
+	done := make(chan struct{})
+	go func() {
+		s.handlePeriodicTasks()
+		close(done)
+	}()
+
+	// The periodic task is now blocked inside the DeleteShard RPC
+	rpc.GetNode(removed).expectDeleteShardRequest(t, shard, 1)
+
+	// A concurrent term bump lands while the RPC is in flight
+	s.metadata.Compute(func(m *proto.ShardMetadata) { m.Term = 7 })
+
+	rpc.GetNode(removed).DeleteShardResponse(nil)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("handlePeriodicTasks did not complete")
+	}
+
+	// The bump survives the pending-delete bookkeeping, and the merged view
+	// is what gets persisted to the status resource
+	assert.EqualValues(t, 7, s.metadata.Term())
+	assert.Empty(t, s.metadata.Load().PendingDeleteShardNodes)
+	borrowed, exists := metadata.GetShardStatus(constant.DefaultNamespace, shard)
+	assert.True(t, exists)
+	assert.EqualValues(t, 7, borrowed.UnsafeBorrow().Term)
+	assert.Empty(t, borrowed.UnsafeBorrow().PendingDeleteShardNodes)
+}

--- a/oxiad/coordinator/runtime/controller/shard_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller_test.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"log/slog"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -856,4 +857,55 @@ func TestShardController_FeatureNegotiation_MixedVersions(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond)
 
 	sc.Close()
+}
+
+// Each UpdateShardStatus persists the full cluster status, so re-writing it
+// for every shard on every periodic tick costs O(shards^2) bytes per interval
+// on the metadata backend. The periodic task must persist only when the
+// status resource diverges from the controller's local view. Every real
+// persist replaces the cached status object graph, so pointer identity
+// through GetShardStatus observes whether a write happened.
+func TestShardController_PeriodicTasksSkipUnchangedPersist(t *testing.T) {
+	var shard int64 = 5
+	metadata := newTestMetadata(t, memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled), &proto.ClusterConfiguration{})
+
+	shardMeta := &proto.ShardMetadata{
+		Status: proto.ShardStatusSteadyState,
+		Term:   1,
+		Leader: &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"},
+	}
+	assert.True(t, metadata.CreateNamespaceStatus(constant.DefaultNamespace, &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{shard: shardMeta},
+	}))
+
+	// Built by hand instead of through NewShardController so the run loop's
+	// own periodic timer cannot race the direct handlePeriodicTasks calls
+	s := &shardController{
+		namespace:     constant.DefaultNamespace,
+		shard:         shard,
+		metadata:      NewMetadata(shardMeta),
+		metadataStore: metadata,
+		logger:        slog.Default(),
+	}
+
+	borrowedBefore, exists := metadata.GetShardStatus(constant.DefaultNamespace, shard)
+	assert.True(t, exists)
+
+	// Steady state: the status resource matches the local view — no persist
+	s.handlePeriodicTasks()
+	borrowedAfter, _ := metadata.GetShardStatus(constant.DefaultNamespace, shard)
+	assert.Same(t, borrowedBefore.UnsafeBorrow(), borrowedAfter.UnsafeBorrow())
+
+	// Local divergence (what an election leaves behind): must persist
+	shardMeta.Term = 2
+	s.metadata.Store(shardMeta)
+	s.handlePeriodicTasks()
+	borrowedChanged, _ := metadata.GetShardStatus(constant.DefaultNamespace, shard)
+	assert.NotSame(t, borrowedAfter.UnsafeBorrow(), borrowedChanged.UnsafeBorrow())
+	assert.EqualValues(t, 2, borrowedChanged.UnsafeBorrow().Term)
+
+	// Converged again: back to skipping
+	s.handlePeriodicTasks()
+	borrowedFinal, _ := metadata.GetShardStatus(constant.DefaultNamespace, shard)
+	assert.Same(t, borrowedChanged.UnsafeBorrow(), borrowedFinal.UnsafeBorrow())
 }


### PR DESCRIPTION
### Motivation

Item 5.2 from the performance review. Every shard controller re-writes its status on every periodic tick, and each `UpdateShardStatus` persists the **full cluster status**: with S shards that is O(S²) bytes per interval to the metadata backend even when the cluster is completely idle — apiserver-throttling territory for the ConfigMap provider at a few thousand shards, and a continuous fsync load for the file and raft providers. The controllers are also all created in a loop at coordinator startup, so their tickers fire as a herd.

### Changes

- **Persist only on divergence.** The periodic task compares the computed shard status against the status resource and skips the persist when they match. Comparing against the resource — rather than tracking what this controller last wrote — keeps the periodic task's self-healing property: any divergence, whatever its origin, is re-asserted within one interval. The comparison reads the in-memory watch cache (`GetShardStatus`), so a steady-state tick is an atomic load + map lookup + `EqualVT`, with no backend write, no full-cluster-status clone, and no fsync. The divergent path is byte-identical to before.
- **De-phase the tickers.** Each controller's first periodic tick fires after a uniformly random delay in `[0, interval)`, then at the fixed interval — the controllers de-phase permanently instead of ticking in lockstep forever.
- The local-metadata store-back moves inside the pending-delete branch (the only path that mutates the view within a tick), preserving the DeleteShard retry semantics without cloning the metadata twice per tick.

### Verification

- New `TestShardController_PeriodicTasksSkipUnchangedPersist` pins the skip through `GetShardStatus` pointer identity: every real persist stores a freshly cloned status object graph, so a skipped persist keeps the same pointer. Deterministic — no timers or counters. Verified to discriminate: it fails against the old unconditional persist at both steady-state assertions, and the divergence case still converges.
- The pending-delete persist path is covered by the existing `TestShardController_LeaderElectionShouldNotFailIfRemoveFails`, driven through the run loop.
- `go test -race` green on `oxiad/coordinator/...` and `tests/{coordinator,control,assignments}`.
- `golangci-lint` clean on both a current local version and the CI-pinned v2.6.2 (the `//nolint:gosec` on `rand.N` matches the existing `math/rand/v2` usage in the leader selector).
