### PR TITLE
perf: make no-waiter condition broadcasts allocation-free

### DIFF
--- a/common/concurrent/condition.go
+++ b/common/concurrent/condition.go
@@ -17,6 +17,7 @@ package concurrent
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 )
 
 // ConditionContext implements a condition variable, a rendezvous point
@@ -60,23 +61,33 @@ type ConditionContext interface {
 }
 
 type conditionContext struct {
-	sync.RWMutex
-	locker sync.Locker
+	// mu serializes Signal and Broadcast: a Signal send racing with the
+	// channel close in Broadcast would panic
+	mu      sync.Mutex
+	locker  sync.Locker
+	waiters atomic.Int32
 
-	ch chan bool
+	// ch is replaced on every Broadcast, so waiters read it with an atomic
+	// load instead of locking mu.
+	ch atomic.Pointer[chan struct{}]
 }
 
 func NewConditionContext(locker sync.Locker) ConditionContext {
-	return &conditionContext{
+	c := &conditionContext{
 		locker: locker,
-		ch:     make(chan bool, 1),
 	}
+	ch := make(chan struct{}, 1)
+	c.ch.Store(&ch)
+	return c
 }
 
 func (c *conditionContext) Wait(ctx context.Context) error {
-	c.RLock()
-	ch := c.ch
-	c.RUnlock()
+	// The waiter count is incremented while still holding c.locker, so a
+	// Broadcast that holds the same locker cannot miss this waiter
+	c.waiters.Add(1)
+	defer c.waiters.Add(-1)
+
+	ch := *c.ch.Load()
 
 	// While we're waiting on the condition, the mutex is unlocked and
 	// gets relocked just after the wait is done
@@ -91,21 +102,37 @@ func (c *conditionContext) Wait(ctx context.Context) error {
 }
 
 func (c *conditionContext) Signal() {
-	c.RLock()
-	defer c.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	// Signal to 1 single waiter, if any is there
 	select {
-	case c.ch <- true:
+	case *c.ch.Load() <- struct{}{}:
 	default:
 	}
 }
 
 func (c *conditionContext) Broadcast() {
-	c.Lock()
-	defer c.Unlock()
+	if c.waiters.Load() == 0 {
+		// Nobody is waiting: skip the channel close and re-allocation.
+		//
+		// This cannot miss a waiter as long as the condition state is
+		// mutated while holding c.locker. Wait() increments the counter
+		// before releasing c.locker, so a goroutine that started waiting
+		// before the state change is visible to this load, while one that
+		// starts waiting afterwards has already observed the new state
+		// when it checked the condition under c.locker.
+		return
+	}
 
-	// Broadcast closes the channel to wake every waiter
-	close(c.ch)
-	c.ch = make(chan bool, 1)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Broadcast closes the channel to wake every waiter. The new channel is
+	// stored before closing the old one, so a concurrent Wait loads either
+	// the channel being closed (immediate wakeup) or the new one
+	old := *c.ch.Load()
+	ch := make(chan struct{}, 1)
+	c.ch.Store(&ch)
+	close(old)
 }

--- a/common/concurrent/condition_test.go
+++ b/common/concurrent/condition_test.go
@@ -322,6 +322,16 @@ func BenchmarkCond32(b *testing.B) {
 	benchmarkCond(b, 32)
 }
 
+func BenchmarkCondBroadcastNoWaiters(b *testing.B) {
+	m := &sync.Mutex{}
+	c := NewConditionContext(m)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		c.Broadcast()
+	}
+}
+
 func benchmarkCond(b *testing.B, waiters int) {
 	b.Helper()
 


### PR DESCRIPTION
### Motivation

`ConditionContext.Broadcast()` sits on per-entry hot paths: `quorumAckTracker.AdvanceHeadOffset` calls it for every appended entry on the leader, and `notificationsTracker.UpdatedCommitOffset` for every commit-offset update. Meanwhile waiters are usually absent: notification subscribers often don't exist, and under load follower cursors are busy streaming rather than parked in `WaitForHeadOffset`. Yet every call paid a write lock, a channel close and a fresh channel allocation, waiters or not.

### Changes

- Track the number of parked waiters and return early from `Broadcast()` when there are none, turning the common case into a single atomic load with zero allocations.
- Replace the `RWMutex` with an `atomic.Pointer` for the wakeup channel, so `Wait()` subscribes lock-free (no more reader-count cache-line bouncing between concurrent waiters). A small mutex now only serializes `Signal`'s send against `Broadcast`'s close, which would otherwise panic.
- Use `chan struct{}` instead of `chan bool`.

### Correctness

`Wait()` increments the waiter counter **before releasing the caller's locker**, so for broadcasters that mutate the condition state under that locker (the cond-var contract, same as `sync.Cond`), the locker serializes the waiter's `[check predicate → register → unlock]` block against the broadcaster's `[mutate → broadcast]` block: a waiter registered before the state change is always visible to the fast-path check, and one arriving after has already observed the new state when it checked the predicate, so it doesn't need that wakeup. Callers that mutate state without holding the locker had the same (nanosecond) missed-wakeup window with the previous implementation — the exposure is unchanged.

The new channel is stored before the old one is closed, so a concurrent `Wait` loads either the channel being closed (immediate wakeup, caller re-checks in its loop) or the new one.

Verified with the stdlib-derived `sync.Cond` test suite plus the `quorumAckTracker`/`notificationsTracker` tests under `-race`.

### Benchmarks

Apple M1 Max, median of 6 runs:

| Benchmark | Before | After |
|---|---|---|
| `BenchmarkCondBroadcastNoWaiters` | 53.1 ns/op, 128 B, 1 alloc | **2.1 ns/op, 0 allocs** |
| `BenchmarkCond1` | 300 ns/op | 285 ns/op |
| `BenchmarkCond8` | 3225 ns/op | 2975 ns/op |
| `BenchmarkCond32` | 14900 ns/op | 12400 ns/op |

`BenchmarkCondBroadcastNoWaiters` is new in this PR; the pre-existing benchmarks only exercised broadcasts with parked waiters.