### PR TITLE
perf: skip debug-log attribute boxing on hot paths when the level is off

### DIFF
--- a/oxiad/dataserver/controller/follow/log_synchronizer.go
+++ b/oxiad/dataserver/controller/follow/log_synchronizer.go
@@ -130,22 +130,29 @@ func (ls *LogSynchronizer) append0(syncCond chan struct{}, onAppend func(), req 
 
 	ls.cumulativeAcks.Store(req.CumulativeAcksSupported)
 
-	ls.log.Debug(
-		"Add entry",
-		slog.Int64("commit-offset", req.CommitOffset),
-		slog.Int64("offset", req.Entry.Offset),
-	)
+	// This runs once per replicated entry: skip the attribute boxing entirely
+	// when debug logging is off, and check the level once for both call sites.
+	debugEnabled := ls.log.Enabled(context.Background(), slog.LevelDebug)
+	if debugEnabled {
+		ls.log.Debug(
+			"Add entry",
+			slog.Int64("commit-offset", req.CommitOffset),
+			slog.Int64("offset", req.Entry.Offset),
+		)
+	}
 
 	onAppend()
 
 	lastAppendedOffset := ls.lastAppendedOffset.Load()
 	if req.Entry.Offset <= lastAppendedOffset {
 		// This was a duplicated request. We already have this entry
-		ls.log.Debug(
-			"Ignoring duplicated entry",
-			slog.Int64("commit-offset", req.CommitOffset),
-			slog.Int64("offset", req.Entry.Offset),
-		)
+		if debugEnabled {
+			ls.log.Debug(
+				"Ignoring duplicated entry",
+				slog.Int64("commit-offset", req.CommitOffset),
+				slog.Int64("offset", req.Entry.Offset),
+			)
+		}
 
 		// Only request a re-ack for what is already synced: the leader
 		// accounts the ack, cumulatively, as durable. A duplicate that is

--- a/oxiad/dataserver/controller/lead/follower_cursor.go
+++ b/oxiad/dataserver/controller/lead/follower_cursor.go
@@ -447,7 +447,7 @@ func (fc *followerCursor) streamEntriesLoop(ctx context.Context, reader wal.Read
 			return err
 		}
 
-		if fc.log.Enabled(fc.ctx, slog.LevelDebug) {
+		if fc.log.Enabled(ctx, slog.LevelDebug) {
 			fc.log.Debug(
 				"Sending entries to follower",
 				slog.Int64("offset", le.Offset),

--- a/oxiad/dataserver/controller/lead/follower_cursor.go
+++ b/oxiad/dataserver/controller/lead/follower_cursor.go
@@ -447,10 +447,12 @@ func (fc *followerCursor) streamEntriesLoop(ctx context.Context, reader wal.Read
 			return err
 		}
 
-		fc.log.Debug(
-			"Sending entries to follower",
-			slog.Int64("offset", le.Offset),
-		)
+		if fc.log.Enabled(fc.ctx, slog.LevelDebug) {
+			fc.log.Debug(
+				"Sending entries to follower",
+				slog.Int64("offset", le.Offset),
+			)
+		}
 
 		if err = fc.stream.Send(&proto.Append{
 			Term:             fc.term,
@@ -550,10 +552,12 @@ func (fc *followerCursor) receiveAcks(cancel context.CancelFunc, stream proto.Ox
 			return nil
 		}
 
-		fc.log.Debug(
-			"Received ack",
-			slog.Int64("offset", res.Offset),
-		)
+		if fc.log.Enabled(fc.ctx, slog.LevelDebug) {
+			fc.log.Debug(
+				"Received ack",
+				slog.Int64("offset", res.Offset),
+			)
+		}
 		fc.cursorAcker.Ack(res.Offset)
 
 		fc.ackOffset.Store(res.Offset)

--- a/oxiad/dataserver/controller/lead/leader_controller.go
+++ b/oxiad/dataserver/controller/lead/leader_controller.go
@@ -781,7 +781,9 @@ func (lc *leaderController) Read(ctx context.Context, request *proto.ReadRequest
 				"peer":  commonrpc.GetPeer(ctx),
 			},
 			func() {
-				lc.log.Debug("Received read request", slog.Int64("term", lc.term.Load()))
+				if lc.log.Enabled(ctx, slog.LevelDebug) {
+					lc.log.Debug("Received read request", slog.Int64("term", lc.term.Load()))
+				}
 				var response *proto.GetResponse
 				var err error
 
@@ -843,7 +845,9 @@ func (lc *leaderController) list(ctx context.Context, request *proto.ListRequest
 			"peer":  commonrpc.GetPeer(ctx),
 		},
 		func() {
-			lc.log.Debug("Received list request", slog.Int64("term", lc.term.Load()), slog.Any("request", request))
+			if lc.log.Enabled(ctx, slog.LevelDebug) {
+				lc.log.Debug("Received list request", slog.Int64("term", lc.term.Load()), slog.Any("request", request))
+			}
 
 			var it kvstore.KeyIterator
 			var err error
@@ -902,7 +906,9 @@ func (lc *leaderController) RangeScan(ctx context.Context, request *proto.RangeS
 				"peer":  commonrpc.GetPeer(ctx),
 			},
 			func() {
-				lc.log.Debug("Received range-scan request", slog.Int64("term", lc.term.Load()), slog.Any("request", request))
+				if lc.log.Enabled(ctx, slog.LevelDebug) {
+					lc.log.Debug("Received range-scan request", slog.Int64("term", lc.term.Load()), slog.Any("request", request))
+				}
 
 				var it database.RangeScanIterator
 				var err error
@@ -919,25 +925,29 @@ func (lc *leaderController) RangeScan(ctx context.Context, request *proto.RangeS
 					return
 				}
 
-				var gr *proto.GetResponse
-				for ; it.Valid(); it.Next() {
-					if gr, err = it.Value(); err != nil {
-						break
-					}
-					if err = cb.OnNext(gr); err != nil {
-						break
-					}
-					if err = ctx.Err(); err != nil {
-						break
-					}
-				}
-
+				err = rangeScanIterate(ctx, it, cb)
 				err = multierr.Combine(err, it.Close())
 				cb.OnComplete(err)
 			},
 		)
 	})
 	lc.RUnlock()
+}
+
+func rangeScanIterate(ctx context.Context, it database.RangeScanIterator, cb concurrent.StreamCallback[*proto.GetResponse]) error {
+	for ; it.Valid(); it.Next() {
+		gr, err := it.Value()
+		if err != nil {
+			return err
+		}
+		if err := cb.OnNext(gr); err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (lc *leaderController) WriteBlock(ctx context.Context, request *proto.WriteRequest) (*proto.WriteResponse, error) {

--- a/oxiad/dataserver/controller/lead/session_test.go
+++ b/oxiad/dataserver/controller/lead/session_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func drainChannel(ch <-chan bool) {
-	for range ch { //nolint:revive
+	for range ch {
 	}
 }
 

--- a/oxiad/dataserver/controller/lead/session_test.go
+++ b/oxiad/dataserver/controller/lead/session_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func drainChannel(ch <-chan bool) {
-	for range ch {
+	for range ch { //nolint:revive
 	}
 }
 

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -299,23 +299,22 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 }
 
 func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClient_ReadServer) error {
-	if s.log.Enabled(stream.Context(), slog.LevelDebug) {
+	ctx := stream.Context()
+	if s.log.Enabled(ctx, slog.LevelDebug) {
 		s.log.Debug(
 			"Read request",
-			slog.String("peer", rpc.GetPeer(stream.Context())),
+			slog.String("peer", rpc.GetPeer(ctx)),
 			slog.Any("req", request),
 		)
 	}
 
-	lc, err := s.resolveLeader(stream.Context(), request.Shard)
+	lc, err := s.resolveLeader(ctx, request.Shard)
 	if err != nil {
 		return err
 	}
 
-	ctx := stream.Context()
-
 	finish := make(chan error, 1)
-	lc.Read(stream.Context(), request, concurrent.NewBatchStreamOnce[*proto.GetResponse](maxTotalReadCount, maxTotalReadValueSize,
+	lc.Read(ctx, request, concurrent.NewBatchStreamOnce[*proto.GetResponse](maxTotalReadCount, maxTotalReadValueSize,
 		func(result *proto.GetResponse) int { return protowire.SizeBytes(len(result.Value)) },
 		func(container []*proto.GetResponse) error { return stream.Send(&proto.ReadResponse{Gets: container}) },
 		func(err error) { finish <- err },
@@ -339,18 +338,18 @@ func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClie
 }
 
 func (s *publicRpcServer) List(request *proto.ListRequest, stream proto.OxiaClient_ListServer) error {
-	if s.log.Enabled(stream.Context(), slog.LevelDebug) {
+	ctx := stream.Context()
+	if s.log.Enabled(ctx, slog.LevelDebug) {
 		s.log.Debug(
 			"List request",
-			slog.String("peer", rpc.GetPeer(stream.Context())),
+			slog.String("peer", rpc.GetPeer(ctx)),
 			slog.Any("req", request),
 		)
 	}
-	lc, err := s.resolveLeader(stream.Context(), request.Shard)
+	lc, err := s.resolveLeader(ctx, request.Shard)
 	if err != nil {
 		return err
 	}
-	ctx := stream.Context()
 	finish := make(chan error, 1)
 	lc.List(ctx, request, concurrent.NewBatchStreamOnce[string](maxTotalListKeyCount, maxTotalListKeySize,
 		func(key string) int { return protowire.SizeBytes(len(key)) },
@@ -375,18 +374,18 @@ func (s *publicRpcServer) List(request *proto.ListRequest, stream proto.OxiaClie
 }
 
 func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream proto.OxiaClient_RangeScanServer) error {
-	if s.log.Enabled(stream.Context(), slog.LevelDebug) {
+	ctx := stream.Context()
+	if s.log.Enabled(ctx, slog.LevelDebug) {
 		s.log.Debug(
 			"RangeScan request",
-			slog.String("peer", rpc.GetPeer(stream.Context())),
+			slog.String("peer", rpc.GetPeer(ctx)),
 			slog.Any("req", request),
 		)
 	}
-	ctx := stream.Context()
 
 	var lc lead.LeaderController
 	var err error
-	if lc, err = s.resolveLeader(stream.Context(), request.Shard); err != nil {
+	if lc, err = s.resolveLeader(ctx, request.Shard); err != nil {
 		return err
 	}
 

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -144,11 +144,13 @@ func (s *publicRpcServer) GetShardAssignments(req *proto.ShardAssignmentsRequest
 }
 
 func (s *publicRpcServer) Write(ctx context.Context, write *proto.WriteRequest) (*proto.WriteResponse, error) {
-	s.log.Debug(
-		"Write request",
-		slog.String("peer", rpc.GetPeer(ctx)),
-		slog.Any("req", write),
-	)
+	if s.log.Enabled(ctx, slog.LevelDebug) {
+		s.log.Debug(
+			"Write request",
+			slog.String("peer", rpc.GetPeer(ctx)),
+			slog.Any("req", write),
+		)
+	}
 
 	lc, err := s.resolveLeader(ctx, write.Shard)
 	if err != nil {
@@ -297,11 +299,13 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 }
 
 func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClient_ReadServer) error {
-	s.log.Debug(
-		"Read request",
-		slog.String("peer", rpc.GetPeer(stream.Context())),
-		slog.Any("req", request),
-	)
+	if s.log.Enabled(stream.Context(), slog.LevelDebug) {
+		s.log.Debug(
+			"Read request",
+			slog.String("peer", rpc.GetPeer(stream.Context())),
+			slog.Any("req", request),
+		)
+	}
 
 	lc, err := s.resolveLeader(stream.Context(), request.Shard)
 	if err != nil {
@@ -335,11 +339,13 @@ func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClie
 }
 
 func (s *publicRpcServer) List(request *proto.ListRequest, stream proto.OxiaClient_ListServer) error {
-	s.log.Debug(
-		"List request",
-		slog.String("peer", rpc.GetPeer(stream.Context())),
-		slog.Any("req", request),
-	)
+	if s.log.Enabled(stream.Context(), slog.LevelDebug) {
+		s.log.Debug(
+			"List request",
+			slog.String("peer", rpc.GetPeer(stream.Context())),
+			slog.Any("req", request),
+		)
+	}
 	lc, err := s.resolveLeader(stream.Context(), request.Shard)
 	if err != nil {
 		return err
@@ -369,11 +375,13 @@ func (s *publicRpcServer) List(request *proto.ListRequest, stream proto.OxiaClie
 }
 
 func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream proto.OxiaClient_RangeScanServer) error {
-	s.log.Debug(
-		"RangeScan request",
-		slog.String("peer", rpc.GetPeer(stream.Context())),
-		slog.Any("req", request),
-	)
+	if s.log.Enabled(stream.Context(), slog.LevelDebug) {
+		s.log.Debug(
+			"RangeScan request",
+			slog.String("peer", rpc.GetPeer(stream.Context())),
+			slog.Any("req", request),
+		)
+	}
 	ctx := stream.Context()
 
 	var lc lead.LeaderController
@@ -480,12 +488,14 @@ func (s *publicRpcServer) CreateSession(ctx context.Context, req *proto.CreateSe
 }
 
 func (s *publicRpcServer) KeepAlive(ctx context.Context, req *proto.SessionHeartbeat) (*proto.KeepAliveResponse, error) {
-	s.log.Debug(
-		"Session keep alive",
-		slog.Int64("shard", req.Shard),
-		slog.Int64("session", req.SessionId),
-		slog.String("peer", rpc.GetPeer(ctx)),
-	)
+	if s.log.Enabled(ctx, slog.LevelDebug) {
+		s.log.Debug(
+			"Session keep alive",
+			slog.Int64("shard", req.Shard),
+			slog.Int64("session", req.SessionId),
+			slog.String("peer", rpc.GetPeer(ctx)),
+		)
+	}
 	lc, err := s.resolveLeader(ctx, &req.Shard)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Motivation

Item 1.8 from the performance review: disabled-level `slog.Debug` calls allocate on every entry across the write/read pipeline.

`slog.Debug`'s variadic `...any` parameter heap-allocates an interface box per attribute **at the call site**, before slog's level check runs. This is structural, not a missing compiler optimization: the key-value sugar path in the stdlib's `argsToAttr` (`return Any(x, args[1])`) stores the interface values into the `Record` that escapes to `Handler.Handle`, so escape analysis marks the parameter as leaking for every caller — including calls that pass only typed `Attr`s. `-gcflags=-m` confirms: the variadic array is stack-allocated, but each `Attr`→`any` box "escapes to heap".

Measured on a disabled logger (Apple M1 Max, Go 1.26): `Debug` with two attrs costs **53 ns + 96 B + 2 allocs per call**; the same call behind `log.Enabled()` costs **3.4 ns, 0 allocs** (`LogAttrs` was the considered alternative at 10.6 ns / 0 allocs — the guard is cheaper and matches the review's suggestion).

### Changes

Guard only the per-entry and per-operation sites; cold paths (elections, stream setup, session lifecycle) are untouched:

- `log_synchronizer.go` — the per-replicated-entry "Add entry" / "Ignoring duplicated entry" pair; the level is checked once per append and reused for both sites.
- `follower_cursor.go` — per-entry "Sending entries to follower", per-ack "Received ack". Snapshot-path logs (per chunk, recovery-only) stay as they are.
- `leader_controller.go` — per-op read/list/range-scan request logs. The guard pushed `RangeScan` to cognitive complexity 26 (limit 25), so the iteration loop moved verbatim into a `rangeScanIterate` helper.
- `public_rpc_server.go` — Write, Read, List, RangeScan, KeepAlive. `rpc.GetPeer(ctx)` (metadata lookup + formatting) now also runs only under the guard.

The second commit restores a `//nolint:revive` in `session_test.go` that a newer local golangci-lint (via the repo's `fix: true`) auto-deleted as unused — the CI-pinned v2.6.2 revive still flags that empty for-range block.

### Verification

- Net effect per write op: roughly 4 hot Debug sites × 2 allocs ≈ 8 fewer heap allocations and ~400 B less garbage per replicated entry path, plus the same on read/scan ops — zero behavior change when debug logging is enabled.
- `go test -race` green on `oxiad/dataserver/...` and `tests/client` (exercises every guarded path end-to-end).
- `golangci-lint` clean on the CI-pinned v2.6.2 (run with `--fix=false`); the newer local version's findings are pre-existing in untouched files.
