### PR TITLE
fix: enforce the notification read batch limit

### DIFF
--- a/oxiad/dataserver/database/db_notifications_test.go
+++ b/oxiad/dataserver/database/db_notifications_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/database/kvstore"
 
@@ -342,6 +343,44 @@ func TestDB_NotificationsDeleteRange(t *testing.T) {
 	assert.Equal(t, proto.NotificationType_KEY_RANGE_DELETED, n.Type)
 	assert.Equal(t, "c", *n.KeyRangeLast)
 	assert.Nil(t, n.VersionId)
+
+	assert.NoError(t, db.Close())
+	assert.NoError(t, factory.Close())
+}
+
+// A subscriber catching up from an old offset must receive the backlog in
+// bounded chunks, not the entire retention window in one slice: the dispatch
+// loop in the leader controller resumes from the last delivered offset + 1.
+func TestDB_NotificationsReadBatchLimit(t *testing.T) {
+	factory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	db, err := NewDB(constant.DefaultNamespace, 1, factory, proto.KeySortingType_NATURAL, 1*time.Hour, time2.SystemClock)
+	assert.NoError(t, err)
+
+	const total = maxNotificationBatchSize + 50
+	for i := 0; i < total; i++ {
+		_, err := db.ProcessWrite(&proto.WriteRequest{
+			Puts: []*proto.PutRequest{{Key: "a", Value: []byte("v")}},
+		}, int64(i), now(), NoOpCallback)
+		assert.NoError(t, err)
+	}
+
+	// First read is capped at maxNotificationBatchSize batches. require, not
+	// assert: with an uncapped read the resume below would ask for an offset
+	// past the backlog and block until the suite timeout.
+	notifications, err := db.ReadNextNotifications(context.Background(), 0)
+	require.NoError(t, err)
+	require.Equal(t, maxNotificationBatchSize, len(notifications))
+	assert.EqualValues(t, 0, notifications[0].Offset)
+	lastDelivered := notifications[len(notifications)-1].Offset
+	assert.EqualValues(t, maxNotificationBatchSize-1, lastDelivered)
+
+	// Resuming from the last delivered offset + 1 returns the remainder
+	rest, err := db.ReadNextNotifications(context.Background(), lastDelivered+1)
+	assert.NoError(t, err)
+	assert.Equal(t, total-maxNotificationBatchSize, len(rest))
+	assert.EqualValues(t, maxNotificationBatchSize, rest[0].Offset)
+	assert.EqualValues(t, total-1, rest[len(rest)-1].Offset)
 
 	assert.NoError(t, db.Close())
 	assert.NoError(t, factory.Close())

--- a/oxiad/dataserver/database/notifications_tracker.go
+++ b/oxiad/dataserver/database/notifications_tracker.go
@@ -194,7 +194,7 @@ func (nt *notificationsTracker) ReadNextNotifications(ctx context.Context, start
 	totalCount := 0
 	totalSize := 0
 
-	for count := 0; count < maxNotificationBatchSize && it.Valid(); it.Next() {
+	for ; len(res) < maxNotificationBatchSize && it.Valid(); it.Next() {
 		value, err := it.Value()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read notification batch")


### PR DESCRIPTION
### Motivation

Item 2.1 from the performance review: `ReadNextNotifications`' batch limit is dead code.

The loop guard compared a counter that nothing increments:

```go
for count := 0; count < maxNotificationBatchSize && it.Valid(); it.Next() {
```

so the cap of 100 never applied — the loop is bounded only by `it.Valid()`. A notification subscriber catching up from an old offset unmarshals and buffers the **entire retained backlog** into a single slice in one call. With the default 1h retention that is one `NotificationBatch` per committed write batch — a memory spike and a latency cliff per catch-up subscriber, paid inside the dispatch goroutine.

### Changes

Bound the loop on `len(res)`, which also removes the dead variable:

```go
for ; len(res) < maxNotificationBatchSize && it.Valid(); it.Next() {
```

Partial reads are safe with the existing caller: the dispatch loop in `leader_controller.go` advances `offset` per delivered batch and calls back with `offset + 1`, and `waitForNotifications` returns immediately while the subscriber is behind — so a catch-up now streams the backlog in 100-batch chunks instead of one unbounded slice.

### Verification

- New `TestDB_NotificationsReadBatchLimit`: 150 batches → the first read returns exactly 100 (offsets 0..99), resuming from the last delivered offset + 1 returns the remaining 50. Verified to discriminate: against the old loop it fails at 150≠100 — and the old code then *hangs*, because the resume call waits for an offset past the backlog; the test gates with `require` so a future regression fails fast instead of burning the suite timeout.
- `go test -race` green on `oxiad/dataserver/database/...`.
- `golangci-lint` clean on the CI-pinned v2.6.2.
