### PR TITLE
perf: skip copying the old value when only the entry metadata is needed

### DIFF
--- a/oxiad/dataserver/controller/lead/secondary_indexes.go
+++ b/oxiad/dataserver/controller/lead/secondary_indexes.go
@@ -94,7 +94,7 @@ func (secondaryIndexesUpdateCallbackS) OnPut(batch kvstore.WriteBatch, _ *databa
 }
 
 func (secondaryIndexesUpdateCallbackS) OnDelete(batch kvstore.WriteBatch, _ *database.Notifications, key string) error {
-	se, err := database.GetStorageEntry(batch, key)
+	se, err := database.GetStorageEntryMetadata(batch, key)
 	if err != nil {
 		if errors.Is(err, kvstore.ErrKeyNotFound) {
 			return nil

--- a/oxiad/dataserver/controller/lead/session_manager.go
+++ b/oxiad/dataserver/controller/lead/session_manager.go
@@ -385,7 +385,7 @@ func deleteShadow(batch kvstore.WriteBatch, _ *database.Notifications, key strin
 }
 
 func (s *sessionManagerUpdateOperationCallbackS) OnDelete(batch kvstore.WriteBatch, notification *database.Notifications, key string) error {
-	se, err := database.GetStorageEntry(batch, key)
+	se, err := database.GetStorageEntryMetadata(batch, key)
 	if err != nil {
 		if errors.Is(err, kvstore.ErrKeyNotFound) {
 			return nil

--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -913,29 +913,25 @@ func applyGet(kv kvstore.KV, getReq *proto.GetRequest) (*proto.GetResponse, erro
 	}
 
 	var se *proto.StorageEntry
+	var deserializeErr error
 	if getReq.IncludeValue {
 		// If we need to return the value we cannot pool the objects, because
 		// the Value slice would be returned to pool
 		se = &proto.StorageEntry{}
+		deserializeErr = Deserialize(value, se)
 	} else {
+		// Metadata-only read: skip copying the value that would be dropped
 		se = proto.StorageEntryFromVTPool()
 		defer se.ReturnToVTPool()
+		deserializeErr = DeserializeMetadata(value, se)
 	}
 
-	if err = multierr.Append(
-		Deserialize(value, se),
-		closer.Close(),
-	); err != nil {
+	if err = multierr.Append(deserializeErr, closer.Close()); err != nil {
 		return nil, err
 	}
 
-	resValue := se.Value
-	if !getReq.IncludeValue {
-		resValue = nil
-	}
-
 	res := &proto.GetResponse{
-		Value: resValue,
+		Value: se.Value,
 		Version: &proto.Version{
 			VersionId:          se.VersionId,
 			ModificationsCount: se.ModificationsCount,
@@ -953,7 +949,13 @@ func applyGet(kv kvstore.KV, getReq *proto.GetRequest) (*proto.GetResponse, erro
 	return res, nil
 }
 
-func GetStorageEntry(batch kvstore.WriteBatch, key string) (*proto.StorageEntry, error) {
+// GetStorageEntryMetadata reads the storage entry for key, skipping the value
+// payload: the returned entry has Value nil and owns the rest of its fields.
+// All the consumers of an existing entry (version checks, session shadows,
+// secondary-index cleanup) only need the metadata, and copying the old value
+// just to discard it costs a full memcpy per overwrite — and pins
+// max-value-sized buffers in the entry pool.
+func GetStorageEntryMetadata(batch kvstore.WriteBatch, key string) (*proto.StorageEntry, error) {
 	value, closer, err := batch.Get(key)
 	if err != nil {
 		return nil, err
@@ -962,7 +964,7 @@ func GetStorageEntry(batch kvstore.WriteBatch, key string) (*proto.StorageEntry,
 	se := proto.StorageEntryFromVTPool()
 
 	if err = multierr.Append(
-		Deserialize(value, se),
+		DeserializeMetadata(value, se),
 		closer.Close(),
 	); err != nil {
 		se.ReturnToVTPool()
@@ -972,7 +974,7 @@ func GetStorageEntry(batch kvstore.WriteBatch, key string) (*proto.StorageEntry,
 }
 
 func checkExpectedVersionId(batch kvstore.WriteBatch, key string, expectedVersionId *int64) (*proto.StorageEntry, error) {
-	se, err := GetStorageEntry(batch, key)
+	se, err := GetStorageEntryMetadata(batch, key)
 	if err != nil {
 		if errors.Is(err, kvstore.ErrKeyNotFound) {
 			if expectedVersionId == nil || *expectedVersionId == -1 {
@@ -991,6 +993,30 @@ func checkExpectedVersionId(batch kvstore.WriteBatch, key string, expectedVersio
 	}
 
 	return se, nil
+}
+
+// DeserializeMetadata fills se from buf without copying the value payload:
+// the unmarshal aliases buf, then every field that must outlive buf is copied
+// out and Value is dropped.
+func DeserializeMetadata(buf []byte, se *proto.StorageEntry) error {
+	if err := se.UnmarshalVTUnsafe(buf); err != nil {
+		return errors.Wrap(err, "failed to Deserialize storage entry")
+	}
+
+	se.Value = nil
+	if se.ClientIdentity != nil {
+		ci := strings.Clone(*se.ClientIdentity)
+		se.ClientIdentity = &ci
+	}
+	if se.PartitionKey != nil {
+		pk := strings.Clone(*se.PartitionKey)
+		se.PartitionKey = &pk
+	}
+	for _, si := range se.SecondaryIndexes {
+		si.IndexName = strings.Clone(si.IndexName)
+		si.SecondaryKey = strings.Clone(si.SecondaryKey)
+	}
+	return nil
 }
 
 func Deserialize(value []byte, se *proto.StorageEntry) error {

--- a/oxiad/dataserver/database/db_benchmark_put_test.go
+++ b/oxiad/dataserver/database/db_benchmark_put_test.go
@@ -1,0 +1,60 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+	time2 "github.com/oxia-db/oxia/common/time"
+
+	"github.com/oxia-db/oxia/oxiad/dataserver/database/kvstore"
+)
+
+// Overwriting an existing key exercises the version-check read of the old
+// entry plus the marshal of the new one — the two copy hot spots of the
+// put path.
+func BenchmarkPutOverwrite(b *testing.B) {
+	for _, valueSize := range []int{128, 4096, 65536} {
+		b.Run(fmt.Sprintf("value-%d", valueSize), func(b *testing.B) {
+			factory, err := kvstore.NewPebbleKVFactory(&kvstore.FactoryOptions{DataDir: b.TempDir()})
+			assert.NoError(b, err)
+			db, err := NewDB(constant.DefaultNamespace, 1, factory, proto.KeySortingType_NATURAL, 0, time2.SystemClock)
+			assert.NoError(b, err)
+			defer db.Close()
+
+			value := bytes.Repeat([]byte("x"), valueSize)
+			write := &proto.WriteRequest{Puts: []*proto.PutRequest{{
+				Key:   "bench-key",
+				Value: value,
+			}}}
+			timestamp := uint64(time.Now().UnixMilli())
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := range b.N {
+				if _, err := db.ProcessWrite(write, int64(i), timestamp, NoOpCallback); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/oxiad/dataserver/database/db_test.go
+++ b/oxiad/dataserver/database/db_test.go
@@ -1462,3 +1462,47 @@ func TestDB_ShowInternalKeys(t *testing.T) {
 	assert.NoError(t, db.Close())
 	assert.NoError(t, factory.Close())
 }
+
+// The deserialized metadata aliases nothing: the source buffer is Pebble-owned
+// memory that is released right after deserialization, so every retained field
+// must survive the buffer being overwritten. Value is intentionally dropped.
+func TestDeserializeMetadata(t *testing.T) {
+	sessionId := int64(42)
+	clientIdentity := "client-1"
+	partitionKey := "part-key"
+	entry := &proto.StorageEntry{
+		Value:                 []byte("payload-bytes"),
+		VersionId:             7,
+		ModificationsCount:    3,
+		CreationTimestamp:     100,
+		ModificationTimestamp: 200,
+		SessionId:             &sessionId,
+		ClientIdentity:        &clientIdentity,
+		PartitionKey:          &partitionKey,
+		SecondaryIndexes: []*proto.SecondaryIndex{
+			{IndexName: "idx", SecondaryKey: "sk"},
+		},
+	}
+	buf, err := entry.MarshalVT()
+	assert.NoError(t, err)
+
+	se := proto.StorageEntryFromVTPool()
+	defer se.ReturnToVTPool()
+	assert.NoError(t, DeserializeMetadata(buf, se))
+
+	for i := range buf {
+		buf[i] = 0xAA
+	}
+
+	assert.Nil(t, se.Value)
+	assert.EqualValues(t, 7, se.VersionId)
+	assert.EqualValues(t, 3, se.ModificationsCount)
+	assert.EqualValues(t, 100, se.CreationTimestamp)
+	assert.EqualValues(t, 200, se.ModificationTimestamp)
+	assert.EqualValues(t, 42, *se.SessionId)
+	assert.Equal(t, "client-1", *se.ClientIdentity)
+	assert.Equal(t, "part-key", *se.PartitionKey)
+	assert.Equal(t, 1, len(se.SecondaryIndexes))
+	assert.Equal(t, "idx", se.SecondaryIndexes[0].IndexName)
+	assert.Equal(t, "sk", se.SecondaryIndexes[0].SecondaryKey)
+}


### PR DESCRIPTION
### Motivation

Item 2.3 (first half) from the performance review: every put copies the old value just to read version metadata.

`applyPut`'s version check (and the delete path, and gets with `IncludeValue=false`) read the previous entry through a full `UnmarshalVT` — copying the entire previous value into the pooled entry and then immediately discarding it (`applyPut` overwrites `se.Value` with the new value on the next line). That is a wasted full-value memcpy + allocation per overwrite, and it pins max-value-sized buffers in the entry `sync.Pool`.

### Changes

New `DeserializeMetadata` / `GetStorageEntryMetadata`: deserialize the old entry with the aliasing `UnmarshalVTUnsafe` (zero copies), drop `Value` outright, and clone out the only fields that must outlive the Pebble buffer — client identity, partition key, and the secondary-index strings.

Caller audit (all five converted): the put version check overwrites the value; the delete version check never reads it; the session-shadow cleanup needs `SessionId` (scalar); the secondary-index cleanup needs `IndexName`/`SecondaryKey` (cloned); `applyGet` with `IncludeValue=false` discarded it. `applyGet` with `IncludeValue=true` keeps the full `Deserialize` on an unpooled entry, unchanged.

### Benchmark

New `BenchmarkPutOverwrite` (overwrite the same key; Apple M1 Max, medians):

| value size | time | garbage per op |
|---|---|---|
| 128 B | 5.6 → 5.4 µs | 2.9 → 2.8 KB |
| 4 KB | ~unchanged | 12.1 → **8.0 KB** (−34%) |
| 64 KB | ~unchanged (flush-dominated) | 151 → **86 KB** (−43%) |

Latency is unchanged on this machine (memcpy is cheap on M1); the win is GC pressure on the write hot path — the garbage drop is exactly the old-value size. The remaining large contributor is the marshal buffer for the new entry; marshaling directly into the batch arena via pebble `SetDeferred` is measured and prepared as a separate follow-up PR.

### Verification

- `TestDeserializeMetadata` pins that nothing retained aliases the source buffer: it overwrites the buffer with `0xAA` after deserializing and asserts every field. Verified to discriminate — a clone-less `UnmarshalVTUnsafe` variant fails with visible `\xaa` garbage in the string fields.
- `go test -race` green on `oxiad/dataserver/database/...`, `kvstore`, `controller/lead`, and `tests/client` (sessions/ephemerals and secondary indexes exercise every converted path end-to-end).
- `golangci-lint` clean on the CI-pinned v2.6.2.
