### PR TITLE
perf: marshal the new entry directly into the Pebble batch arena

### DIFF
--- a/oxiad/dataserver/controller/lead/session_manager_test.go
+++ b/oxiad/dataserver/controller/lead/session_manager_test.go
@@ -93,10 +93,12 @@ func (m mockWriteBatch) Close() error {
 
 func (m mockWriteBatch) PutMarshalable(key string, v kvstore.ProtoMarshalable) error {
 	data := make([]byte, v.SizeVT())
-	if _, err := v.MarshalToSizedBufferVT(data); err != nil {
+	n, err := v.MarshalToSizedBufferVT(data)
+	if err != nil {
 		return err
 	}
-	return m.Put(key, data)
+	// The valid bytes are the suffix of the buffer
+	return m.Put(key, data[len(data)-n:])
 }
 
 func (m mockWriteBatch) Put(key string, value []byte) error {

--- a/oxiad/dataserver/controller/lead/session_manager_test.go
+++ b/oxiad/dataserver/controller/lead/session_manager_test.go
@@ -91,6 +91,14 @@ func (m mockWriteBatch) Close() error {
 	return nil
 }
 
+func (m mockWriteBatch) PutMarshalable(key string, v kvstore.ProtoMarshalable) error {
+	data := make([]byte, v.SizeVT())
+	if _, err := v.MarshalToSizedBufferVT(data); err != nil {
+		return err
+	}
+	return m.Put(key, data)
+}
+
 func (m mockWriteBatch) Put(key string, value []byte) error {
 	val, found := m[key]
 	if found {

--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -776,12 +776,9 @@ func (d *db) applyPut(batch kvstore.WriteBatch, baseVersionId *atomic.Int64, not
 
 	defer se.ReturnToVTPool()
 
-	ser, err := se.MarshalVT()
-	if err != nil {
-		return nil, err
-	}
-
-	if err = batch.Put(putReq.Key, ser); err != nil {
+	// Marshal the entry directly into the batch arena: marshal-then-Put would
+	// allocate an intermediate buffer and copy the entry twice
+	if err = batch.PutMarshalable(putReq.Key, se); err != nil {
 		return nil, err
 	}
 

--- a/oxiad/dataserver/database/kvstore/kv.go
+++ b/oxiad/dataserver/database/kvstore/kv.go
@@ -31,10 +31,22 @@ var (
 
 )
 
+// ProtoMarshalable is the subset of the vtproto message API that allows
+// marshaling directly into a caller-provided buffer.
+type ProtoMarshalable interface {
+	SizeVT() int
+	MarshalToSizedBufferVT(dAtA []byte) (int, error)
+}
+
 type WriteBatch interface {
 	io.Closer
 
 	Put(key string, value []byte) error
+	// PutMarshalable marshals m directly into the batch's arena, avoiding the
+	// intermediate buffer and second copy of marshal-then-Put. If it returns
+	// an error the batch contents are undefined: discard the batch without
+	// committing.
+	PutMarshalable(key string, m ProtoMarshalable) error
 	Delete(key string) error
 	Get(key string) ([]byte, io.Closer, error)
 	FindLower(key string) (lowerKey string, err error)

--- a/oxiad/dataserver/database/kvstore/kv_pebble.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble.go
@@ -634,6 +634,21 @@ func (b *PebbleBatch) Put(key string, value []byte) error {
 	return err
 }
 
+func (b *PebbleBatch) PutMarshalable(key string, m ProtoMarshalable) error {
+	encodedKey := b.p.keyEncoder.Encode(key)
+	op := b.b.SetDeferred(len(encodedKey), m.SizeVT())
+	copy(op.Key, encodedKey)
+	if _, err := m.MarshalToSizedBufferVT(op.Value); err != nil {
+		b.p.writeErrors.Inc()
+		return err
+	}
+	if err := op.Finish(); err != nil {
+		b.p.writeErrors.Inc()
+		return err
+	}
+	return nil
+}
+
 func (b *PebbleBatch) Delete(key string) error {
 	err := b.b.Delete(b.p.keyEncoder.Encode(key), b.p.writeOptions)
 	if err != nil {

--- a/oxiad/dataserver/database/kvstore/kv_pebble.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble.go
@@ -638,9 +638,16 @@ func (b *PebbleBatch) PutMarshalable(key string, m ProtoMarshalable) error {
 	encodedKey := b.p.keyEncoder.Encode(key)
 	op := b.b.SetDeferred(len(encodedKey), m.SizeVT())
 	copy(op.Key, encodedKey)
-	if _, err := m.MarshalToSizedBufferVT(op.Value); err != nil {
+	n, err := m.MarshalToSizedBufferVT(op.Value)
+	if err != nil {
 		b.p.writeErrors.Inc()
 		return err
+	}
+	if n != len(op.Value) {
+		// The record length is fixed once reserved: a partial fill would
+		// leave garbage bytes in the committed value
+		b.p.writeErrors.Inc()
+		return errors.Errorf("kv: marshaled size %d does not match the reserved record size %d", n, len(op.Value))
 	}
 	if err := op.Finish(); err != nil {
 		b.p.writeErrors.Inc()

--- a/oxiad/dataserver/database/kvstore/kv_pebble_setdeferred_bench_test.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble_setdeferred_bench_test.go
@@ -1,0 +1,100 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvstore
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/cockroachdb/pebble/v2/vfs"
+
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+// Isolates pebble Set (marshal to a fresh buffer, then copy into the batch)
+// against SetDeferred (marshal directly into the batch arena) on an in-memory
+// FS, mirroring the applyPut sequence: indexed batch, version-check Get, put,
+// commit. This is the difference between WriteBatch.Put with a pre-marshaled
+// buffer and WriteBatch.PutMarshalable.
+func BenchmarkPebbleSetVsSetDeferred(b *testing.B) {
+	for _, valueSize := range []int{128, 4096, 65536} {
+		value := bytes.Repeat([]byte("x"), valueSize)
+		sessionId := int64(42)
+		se := &proto.StorageEntry{
+			Value:                 value,
+			VersionId:             7,
+			ModificationsCount:    3,
+			CreationTimestamp:     100,
+			ModificationTimestamp: 200,
+			SessionId:             &sessionId,
+		}
+		key := []byte("bench-key")
+
+		runOne := func(b *testing.B, deferred bool) {
+			b.Helper()
+			db, err := pebble.Open("", &pebble.Options{
+				FS:         vfs.NewMem(),
+				DisableWAL: true,
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer db.Close()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				batch := db.NewIndexedBatch()
+
+				// version-check read, as applyPut does
+				if v, closer, err := batch.Get(key); err == nil {
+					_ = v
+					_ = closer.Close()
+				}
+
+				if deferred {
+					op := batch.SetDeferred(len(key), se.SizeVT())
+					copy(op.Key, key)
+					if _, err := se.MarshalToSizedBufferVT(op.Value); err != nil {
+						b.Fatal(err)
+					}
+					if err := op.Finish(); err != nil {
+						b.Fatal(err)
+					}
+				} else {
+					ser, err := se.MarshalVT()
+					if err != nil {
+						b.Fatal(err)
+					}
+					if err := batch.Set(key, ser, pebble.NoSync); err != nil {
+						b.Fatal(err)
+					}
+				}
+
+				if err := batch.Commit(pebble.NoSync); err != nil {
+					b.Fatal(err)
+				}
+				if err := batch.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+
+		b.Run(fmt.Sprintf("set/value-%d", valueSize), func(b *testing.B) { runOne(b, false) })
+		b.Run(fmt.Sprintf("setDeferred/value-%d", valueSize), func(b *testing.B) { runOne(b, true) })
+	}
+}

--- a/oxiad/dataserver/database/kvstore/kv_pebble_setdeferred_bench_test.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble_setdeferred_bench_test.go
@@ -16,6 +16,7 @@ package kvstore
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -64,6 +65,8 @@ func BenchmarkPebbleSetVsSetDeferred(b *testing.B) {
 				if v, closer, err := batch.Get(key); err == nil {
 					_ = v
 					_ = closer.Close()
+				} else if !errors.Is(err, pebble.ErrNotFound) {
+					b.Fatal(err)
 				}
 
 				if deferred {

--- a/oxiad/dataserver/database/kvstore/kv_pebble_test.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble_test.go
@@ -321,6 +321,61 @@ func TestPebbbleGetWithinBatch(t *testing.T) {
 	assert.NoError(t, factory.Close())
 }
 
+// PutMarshalable writes through pebble SetDeferred instead of Set: the entry
+// must be readable back, byte-identical to a regular marshal, both within the
+// same indexed batch (read-your-writes) and after the commit.
+func TestPebblePutMarshalableWithinBatch(t *testing.T) {
+	factory, err := NewPebbleKVFactory(NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	kv, err := factory.NewKV(constant.DefaultNamespace, 1, proto.KeySortingType_HIERARCHICAL)
+	assert.NoError(t, err)
+
+	sessionId := int64(42)
+	entry := &proto.StorageEntry{
+		Value:                 []byte("payload"),
+		VersionId:             7,
+		ModificationsCount:    3,
+		CreationTimestamp:     100,
+		ModificationTimestamp: 200,
+		SessionId:             &sessionId,
+	}
+	expected, err := entry.MarshalVT()
+	assert.NoError(t, err)
+
+	wb := kv.NewWriteBatch()
+	assert.NoError(t, wb.PutMarshalable("a", entry))
+
+	// Read-your-writes within the same indexed batch
+	value, closer, err := wb.Get("a")
+	assert.NoError(t, err)
+	assert.Equal(t, expected, value)
+	assert.NoError(t, closer.Close())
+
+	// Overwrite within the same batch through the same path
+	entry.VersionId = 8
+	expected2, err := entry.MarshalVT()
+	assert.NoError(t, err)
+	assert.NoError(t, wb.PutMarshalable("a", entry))
+
+	value, closer, err = wb.Get("a")
+	assert.NoError(t, err)
+	assert.Equal(t, expected2, value)
+	assert.NoError(t, closer.Close())
+
+	assert.NoError(t, wb.Commit())
+	assert.NoError(t, wb.Close())
+
+	// Visible after commit
+	storedKey, value, closer, err := kv.Get("a", ComparisonEqual, NoInternalKeys)
+	assert.NoError(t, err)
+	assert.Equal(t, "a", storedKey)
+	assert.Equal(t, expected2, value)
+	assert.NoError(t, closer.Close())
+
+	assert.NoError(t, kv.Close())
+	assert.NoError(t, factory.Close())
+}
+
 func TestPebbbleDurability(t *testing.T) {
 	options := NewFactoryOptionsForTest(t)
 


### PR DESCRIPTION
### Motivation

Item 2.3 (second half, follow-up to #1188): the new entry is marshaled into a fresh buffer and then copied a second time into the write batch.

`applyPut` did `se.MarshalVT()` (allocate + fill) followed by `batch.Put` → pebble `Batch.Set`, which copies the buffer into the batch arena. Pebble's `Set` is itself implemented as `SetDeferred` + `copy` + index-add, so the intermediate buffer exists only to be copied off of.

### Changes

New `WriteBatch.PutMarshalable(key, m)`: reserve the record in the batch arena via pebble `SetDeferred(keyLen, SizeVT())`, let vtproto `MarshalToSizedBufferVT` fill the value slice in place, then `Finish()` — which performs the same skiplist index-add that `Set` inlines, so read-your-writes on indexed batches is unchanged. The produced batch bytes are identical; one buffer and one copy cheaper per put.

Error contract (documented on the interface): a failed marshal leaves the reserved record garbage, so the batch must be discarded without committing — which is what the only caller does (an `applyPut` error fails the whole `ProcessWrite` and the batch is never committed).

### Benchmark

This was initially dropped because the disk-backed 64KB overwrite benchmark regressed ~28% on macOS. Isolating the change on an in-memory FS shows that was flush-pacing noise of the benchmark, not the put path — the new `BenchmarkPebbleSetVsSetDeferred` (in-memory pebble, mirroring the applyPut sequence: indexed batch, version-check get, put, commit):

| value size | `Set` (marshal+copy) | `SetDeferred` (direct) | delta |
|---|---|---|---|
| 128 B | 967 ns / 420 B | 892 ns / 259 B | −8% |
| 4 KB | 2.1 µs / 5.2 KB | 1.1 µs / 0.3 KB | **−49% time, −94% garbage** |
| 64 KB | 16.0 µs / 81 KB | 4.9 µs / 4.2 KB | **−70% time, −95% garbage** |

The full oxia put path on an in-memory FS (local patch, interleaved A/B): −20% time at 4 KB, −40% at 64 KB, −89% garbage per overwrite. On-disk runs are flush-dominated at large values and show ±28% swings either direction that vanish on short runs.

### Verification

- The batch bytes are identical to `Set`'s by construction, and the index-add in `Finish()` is the same code `Set` inlines — sessions and sequences read their own batch writes in the existing tests, which exercise the indexed path.
- `go test -race` green on `oxiad/dataserver/database/...`, `kvstore`, and `controller/lead`.
- `golangci-lint` clean on the CI-pinned v2.6.2.
