### PR TITLE
perf: serve tailing WAL reads from an in-memory tail cache

### DIFF
--- a/oxiad/dataserver/wal/readonly_segment_test.go
+++ b/oxiad/dataserver/wal/readonly_segment_test.go
@@ -31,7 +31,7 @@ func TestReadOnlySegment(t *testing.T) {
 	rw, err := newReadWriteSegment(path, 0, 128*1024, 0, nil)
 	assert.NoError(t, err)
 	for i := int64(0); i < 10; i++ {
-		assert.NoError(t, rw.Append(i, []byte(fmt.Sprintf("entry-%d", i))))
+		assert.NoError(t, appendRecord(rw, i, []byte(fmt.Sprintf("entry-%d", i))))
 	}
 	assert.NoError(t, rw.Close())
 
@@ -63,7 +63,7 @@ func TestRO_auto_recover_broken_index(t *testing.T) {
 	rw, err := newReadWriteSegment(path, 0, 128*1024, 0, nil)
 	assert.NoError(t, err)
 	for i := int64(0); i < 10; i++ {
-		assert.NoError(t, rw.Append(i, []byte(fmt.Sprintf("entry-%d", i))))
+		assert.NoError(t, appendRecord(rw, i, []byte(fmt.Sprintf("entry-%d", i))))
 	}
 	rwSegment := rw.(*readWriteSegment)
 	assert.NoError(t, rw.Close())

--- a/oxiad/dataserver/wal/readwrite_segment.go
+++ b/oxiad/dataserver/wal/readwrite_segment.go
@@ -31,7 +31,7 @@ import (
 type ReadWriteSegment interface {
 	ReadOnlySegment
 
-	Append(offset int64, data []byte) error
+	Append(offset int64, data []byte) (previousCrc uint32, payloadCrc uint32, err error)
 
 	Truncate(lastSafeOffset int64) error
 
@@ -169,27 +169,28 @@ func (ms *readWriteSegment) HasSpace(l int) bool {
 	return ms.currentFileOffset+ms.c.codec.GetHeaderSize()+uint32(l) <= ms.segmentSize
 }
 
-func (ms *readWriteSegment) Append(offset int64, data []byte) error {
+func (ms *readWriteSegment) Append(offset int64, data []byte) (previousCrc uint32, payloadCrc uint32, err error) {
 	ms.Lock()
 	defer ms.Unlock()
 
 	if len(data) == 0 {
-		return codec.ErrEmptyPayload
+		return 0, 0, codec.ErrEmptyPayload
 	}
 	if !ms.HasSpace(len(data)) {
-		return ErrSegmentFull
+		return 0, 0, ErrSegmentFull
 	}
 	if offset != ms.lastOffset+1 {
-		return ErrInvalidNextOffset
+		return 0, 0, ErrInvalidNextOffset
 	}
 
 	fOffset := ms.currentFileOffset
+	previousCrc = ms.lastCrc
 	var recordSize uint32
 	recordSize, ms.lastCrc = ms.c.codec.WriteRecord(ms.txnMappedFile, fOffset, ms.lastCrc, data)
 	ms.currentFileOffset += recordSize
 	ms.lastOffset = offset
 	ms.writingIdx = binary.BigEndian.AppendUint32(ms.writingIdx, fOffset)
-	return nil
+	return previousCrc, ms.lastCrc, nil
 }
 
 // Flush msyncs the mapped file without holding the segment mutex: appends and

--- a/oxiad/dataserver/wal/readwrite_segment_test.go
+++ b/oxiad/dataserver/wal/readwrite_segment_test.go
@@ -25,6 +25,13 @@ import (
 	"github.com/oxia-db/oxia/oxiad/dataserver/wal/codec"
 )
 
+// appendRecord adapts the CRC-returning segment Append for tests that only
+// assert on the error.
+func appendRecord(rw ReadWriteSegment, offset int64, data []byte) error {
+	_, _, err := rw.Append(offset, data)
+	return err
+}
+
 func TestReadWriteSegment(t *testing.T) {
 	path := t.TempDir()
 
@@ -34,13 +41,13 @@ func TestReadWriteSegment(t *testing.T) {
 	assert.EqualValues(t, 0, rw.BaseOffset())
 	assert.EqualValues(t, -1, rw.LastOffset())
 
-	assert.NoError(t, rw.Append(0, []byte("entry-0")))
+	assert.NoError(t, appendRecord(rw, 0, []byte("entry-0")))
 	assert.EqualValues(t, 0, rw.BaseOffset())
 	assert.EqualValues(t, 0, rw.LastOffset())
 
 	assert.NoError(t, rw.Flush())
 
-	assert.NoError(t, rw.Append(1, []byte("entry-1")))
+	assert.NoError(t, appendRecord(rw, 1, []byte("entry-1")))
 	assert.EqualValues(t, 0, rw.BaseOffset())
 	assert.EqualValues(t, 1, rw.LastOffset())
 
@@ -72,21 +79,21 @@ func TestReadWriteSegment_NonZero(t *testing.T) {
 	assert.EqualValues(t, 5, rw.BaseOffset())
 	assert.EqualValues(t, 4, rw.LastOffset())
 
-	assert.NoError(t, rw.Append(5, []byte("entry-0")))
+	assert.NoError(t, appendRecord(rw, 5, []byte("entry-0")))
 	assert.EqualValues(t, 5, rw.BaseOffset())
 	assert.EqualValues(t, 5, rw.LastOffset())
 
 	assert.NoError(t, rw.Flush())
 
-	assert.NoError(t, rw.Append(6, []byte("entry-1")))
+	assert.NoError(t, appendRecord(rw, 6, []byte("entry-1")))
 	assert.EqualValues(t, 5, rw.BaseOffset())
 	assert.EqualValues(t, 6, rw.LastOffset())
 
-	assert.ErrorIs(t, rw.Append(4, []byte("entry-4")), ErrInvalidNextOffset)
+	assert.ErrorIs(t, appendRecord(rw, 4, []byte("entry-4")), ErrInvalidNextOffset)
 	assert.EqualValues(t, 5, rw.BaseOffset())
 	assert.EqualValues(t, 6, rw.LastOffset())
 
-	assert.ErrorIs(t, rw.Append(8, []byte("entry-8")), ErrInvalidNextOffset)
+	assert.ErrorIs(t, appendRecord(rw, 8, []byte("entry-8")), ErrInvalidNextOffset)
 	assert.EqualValues(t, 5, rw.BaseOffset())
 	assert.EqualValues(t, 6, rw.LastOffset())
 
@@ -110,7 +117,7 @@ func TestReadWriteSegment_HasSpace(t *testing.T) {
 	assert.True(t, rw.HasSpace(1024-headerSize))
 	assert.False(t, rw.HasSpace(1021))
 
-	assert.NoError(t, rw.Append(0, make([]byte, 100)))
+	assert.NoError(t, appendRecord(rw, 0, make([]byte, 100)))
 	assert.True(t, rw.HasSpace(10))
 	assert.False(t, rw.HasSpace(1020))
 	assert.False(t, rw.HasSpace(1020-100))
@@ -133,11 +140,11 @@ func TestReadWriteSegment_BrokenUncommittedData_ErrOffsetOutOfBounds(t *testing.
 	rw, err := newReadWriteSegment(dir, 0, 1024, 0, commitOffsetProvider)
 	assert.NoError(t, err)
 	payload1 := []byte("entry-0")
-	assert.NoError(t, rw.Append(0, payload1))
+	assert.NoError(t, appendRecord(rw, 0, payload1))
 	payload2 := []byte("entry-1")
-	assert.NoError(t, rw.Append(1, payload2))
+	assert.NoError(t, appendRecord(rw, 1, payload2))
 	payload3 := []byte("entry-2")
-	assert.NoError(t, rw.Append(2, payload3))
+	assert.NoError(t, appendRecord(rw, 2, payload3))
 	actualPayload1, _, _, err := rw.Read(0)
 	assert.NoError(t, err)
 	assert.EqualValues(t, payload1, actualPayload1)
@@ -165,7 +172,7 @@ func TestReadWriteSegment_BrokenUncommittedData_ErrOffsetOutOfBounds(t *testing.
 	assert.EqualValues(t, 1, rw.LastOffset())
 
 	// test functionality
-	assert.NoError(t, rw.Append(2, payload3))
+	assert.NoError(t, appendRecord(rw, 2, payload3))
 	actualPayload3, _, _, err = rw.Read(2)
 	assert.NoError(t, err)
 	assert.EqualValues(t, payload3, actualPayload3)
@@ -181,11 +188,11 @@ func TestReadWriteSegment_BrokenCommittedData_ErrOffsetOutOfBounds(t *testing.T)
 	rw, err := newReadWriteSegment(dir, 0, 1024, 0, commitOffsetProvider)
 	assert.NoError(t, err)
 	payload1 := []byte("entry-0")
-	assert.NoError(t, rw.Append(0, payload1))
+	assert.NoError(t, appendRecord(rw, 0, payload1))
 	payload2 := []byte("entry-1")
-	assert.NoError(t, rw.Append(1, payload2))
+	assert.NoError(t, appendRecord(rw, 1, payload2))
 	payload3 := []byte("entry-2")
-	assert.NoError(t, rw.Append(2, payload3))
+	assert.NoError(t, appendRecord(rw, 2, payload3))
 	actualPayload1, _, _, err := rw.Read(0)
 	assert.NoError(t, err)
 	assert.EqualValues(t, payload1, actualPayload1)
@@ -220,11 +227,11 @@ func TestReadWriteSegment_BrokenUncommittedData_ErrDataCorrupted(t *testing.T) {
 	rw, err := newReadWriteSegment(dir, 0, 1024, 0, commitOffsetProvider)
 	assert.NoError(t, err)
 	payload1 := []byte("entry-0")
-	assert.NoError(t, rw.Append(0, payload1))
+	assert.NoError(t, appendRecord(rw, 0, payload1))
 	payload2 := []byte("entry-1")
-	assert.NoError(t, rw.Append(1, payload2))
+	assert.NoError(t, appendRecord(rw, 1, payload2))
 	payload3 := []byte("entry-2")
-	assert.NoError(t, rw.Append(2, payload3))
+	assert.NoError(t, appendRecord(rw, 2, payload3))
 	actualPayload1, _, _, err := rw.Read(0)
 	assert.NoError(t, err)
 	assert.EqualValues(t, payload1, actualPayload1)
@@ -252,7 +259,7 @@ func TestReadWriteSegment_BrokenUncommittedData_ErrDataCorrupted(t *testing.T) {
 	assert.EqualValues(t, 1, rw.LastOffset())
 
 	// test functionality
-	assert.NoError(t, rw.Append(2, payload3))
+	assert.NoError(t, appendRecord(rw, 2, payload3))
 	actualPayload3, _, _, err = rw.Read(2)
 	assert.NoError(t, err)
 	assert.EqualValues(t, payload3, actualPayload3)
@@ -268,11 +275,11 @@ func TestReadWriteSegment_BrokenCommittedData_ErrDataCorrupted(t *testing.T) {
 	rw, err := newReadWriteSegment(dir, 0, 1024, 0, commitOffsetProvider)
 	assert.NoError(t, err)
 	payload1 := []byte("entry-0")
-	assert.NoError(t, rw.Append(0, payload1))
+	assert.NoError(t, appendRecord(rw, 0, payload1))
 	payload2 := []byte("entry-1")
-	assert.NoError(t, rw.Append(1, payload2))
+	assert.NoError(t, appendRecord(rw, 1, payload2))
 	payload3 := []byte("entry-2")
-	assert.NoError(t, rw.Append(2, payload3))
+	assert.NoError(t, appendRecord(rw, 2, payload3))
 	actualPayload1, _, _, err := rw.Read(0)
 	assert.NoError(t, err)
 	assert.EqualValues(t, payload1, actualPayload1)
@@ -304,11 +311,11 @@ func TestSegmentAppendShouldNotPanic(t *testing.T) {
 	rw, err := newReadWriteSegment(basePath, 0, 1024, 0, nil)
 	assert.NoError(t, err)
 	for i := int64(0); i < 51; i++ {
-		err := rw.Append(i, fmt.Appendf(nil, "entry-%d", i))
+		err := appendRecord(rw, i, fmt.Appendf(nil, "entry-%d", i))
 		assert.NoError(t, err)
 	}
 
-	err = rw.Append(51, fmt.Appendf(nil, "entry-%d", 51))
+	err = appendRecord(rw, 51, fmt.Appendf(nil, "entry-%d", 51))
 	assert.ErrorIs(t, err, ErrSegmentFull)
 }
 
@@ -360,7 +367,7 @@ func TestReadWriteSegment_ConcurrentAppendReadFlush(t *testing.T) {
 	}()
 
 	for i := 0; i < entries; i++ {
-		assert.NoError(t, rw.Append(int64(i), []byte(fmt.Sprintf("entry-%d", i))))
+		assert.NoError(t, appendRecord(rw, int64(i), []byte(fmt.Sprintf("entry-%d", i))))
 	}
 
 	close(done)
@@ -383,7 +390,7 @@ func TestReadWriteSegment_CloseWithConcurrentFlush(t *testing.T) {
 
 	rw, err := newReadWriteSegment(path, 0, 128*1024, 0, nil)
 	assert.NoError(t, err)
-	assert.NoError(t, rw.Append(0, []byte("entry-0")))
+	assert.NoError(t, appendRecord(rw, 0, []byte("entry-0")))
 
 	flusherDone := make(chan struct{})
 	go func() {

--- a/oxiad/dataserver/wal/tail_cache.go
+++ b/oxiad/dataserver/wal/tail_cache.go
@@ -1,0 +1,154 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wal
+
+import (
+	"sync"
+
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+// defaultTailCacheMaxBytes bounds the in-memory tail cache per WAL. It only
+// needs to span the lag of caught-up followers: a follower further behind than
+// this falls back to reading the WAL segments, which is the cold catch-up path
+// anyway.
+const defaultTailCacheMaxBytes = 4 * 1024 * 1024
+
+// tailCache keeps the most recently appended entries in memory so that
+// follower cursors tailing the log can read them without touching the WAL
+// segments: no copy out of the mmap, no per-follower UnmarshalVT, and — the
+// point of the separate mutex — without taking the WAL lock, so reads never
+// stall queued appenders.
+//
+// The cached entries cover a contiguous offset window [baseOffset, baseOffset +
+// len(entries)). The oldest entries are evicted once the cached bytes exceed
+// maxBytes; the window is therefore always a suffix of the log, which is
+// exactly what tailing readers want.
+type tailCache struct {
+	mu         sync.RWMutex
+	entries    []*cachedEntry
+	baseOffset int64
+	curBytes   int
+	maxBytes   int
+}
+
+type cachedEntry struct {
+	// entry is a private deep copy: the LogEntry handed to the WAL aliases a
+	// reusable marshal buffer that the next append overwrites. It is shared
+	// read-only with every reader that hits the cache.
+	entry       *proto.LogEntry
+	previousCrc uint32
+	entryCrc    uint32
+	size        int
+}
+
+func newTailCache(maxBytes int) *tailCache {
+	return &tailCache{
+		baseOffset: InvalidOffset,
+		maxBytes:   maxBytes,
+	}
+}
+
+// add records the entry just appended at offset entry.Offset. It must be called
+// while holding the WAL write lock, so appends, truncations and clears are
+// serialized. A non-contiguous offset (after a clear or a restart from a
+// non-initial position) resets the window rather than leaving a gap.
+func (c *tailCache) add(entry *proto.LogEntry, previousCrc, entryCrc uint32) {
+	// CloneVT outside the lock: the entry is owned by the appender goroutine
+	// and not yet visible to readers.
+	cloned := entry.CloneVT()
+	size := cloned.SizeVT()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.baseOffset != InvalidOffset && entry.Offset != c.baseOffset+int64(len(c.entries)) {
+		c.resetLocked()
+	}
+	if c.baseOffset == InvalidOffset {
+		c.baseOffset = entry.Offset
+	}
+
+	c.entries = append(c.entries, &cachedEntry{
+		entry:       cloned,
+		previousCrc: previousCrc,
+		entryCrc:    entryCrc,
+		size:        size,
+	})
+	c.curBytes += size
+
+	// Evict the oldest entries until within budget, but always keep the one
+	// just added.
+	for c.curBytes > c.maxBytes && len(c.entries) > 1 {
+		c.curBytes -= c.entries[0].size
+		c.entries[0] = nil
+		c.entries = c.entries[1:]
+		c.baseOffset++
+	}
+}
+
+// get returns the cached entry at the given offset, if present. The returned
+// LogEntry is shared and must not be modified.
+func (c *tailCache) get(offset int64) (entry *proto.LogEntry, previousCrc, entryCrc uint32, ok bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.baseOffset == InvalidOffset || offset < c.baseOffset {
+		return nil, 0, 0, false
+	}
+	idx := offset - c.baseOffset
+	if idx >= int64(len(c.entries)) {
+		return nil, 0, 0, false
+	}
+	ce := c.entries[idx]
+	return ce.entry, ce.previousCrc, ce.entryCrc, true
+}
+
+// truncate drops the cached entries with an offset greater than lastSafeOffset.
+// Must be called while holding the WAL write lock.
+func (c *tailCache) truncate(lastSafeOffset int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.baseOffset == InvalidOffset {
+		return
+	}
+	if lastSafeOffset < c.baseOffset {
+		c.resetLocked()
+		return
+	}
+	keep := lastSafeOffset - c.baseOffset + 1
+	if keep >= int64(len(c.entries)) {
+		return
+	}
+	for i := keep; i < int64(len(c.entries)); i++ {
+		c.curBytes -= c.entries[i].size
+		c.entries[i] = nil
+	}
+	c.entries = c.entries[:keep]
+}
+
+// clear empties the cache. Must be called while holding the WAL write lock.
+func (c *tailCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.resetLocked()
+}
+
+func (c *tailCache) resetLocked() {
+	c.entries = nil
+	c.baseOffset = InvalidOffset
+	c.curBytes = 0
+}

--- a/oxiad/dataserver/wal/tail_cache_test.go
+++ b/oxiad/dataserver/wal/tail_cache_test.go
@@ -1,0 +1,225 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wal
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+func cacheEntry(offset int64, value string) *proto.LogEntry {
+	return &proto.LogEntry{Term: 1, Offset: offset, Value: []byte(value)}
+}
+
+func TestTailCache_AddGet(t *testing.T) {
+	c := newTailCache(1 << 20)
+
+	_, _, _, ok := c.get(0)
+	assert.False(t, ok)
+
+	c.add(cacheEntry(0, "a"), 10, 11)
+	c.add(cacheEntry(1, "bb"), 11, 12)
+
+	entry, prev, cur, ok := c.get(0)
+	assert.True(t, ok)
+	assert.EqualValues(t, 0, entry.Offset)
+	assert.Equal(t, []byte("a"), entry.Value)
+	assert.EqualValues(t, 10, prev)
+	assert.EqualValues(t, 11, cur)
+
+	entry, prev, cur, ok = c.get(1)
+	assert.True(t, ok)
+	assert.Equal(t, []byte("bb"), entry.Value)
+	assert.EqualValues(t, 11, prev)
+	assert.EqualValues(t, 12, cur)
+
+	// Out of range
+	_, _, _, ok = c.get(2)
+	assert.False(t, ok)
+	_, _, _, ok = c.get(-1)
+	assert.False(t, ok)
+}
+
+// The cached entry must be independent of the source LogEntry, whose Value
+// aliases a reusable buffer the next append overwrites.
+func TestTailCache_AddCopiesEntry(t *testing.T) {
+	c := newTailCache(1 << 20)
+	value := []byte("original")
+	c.add(&proto.LogEntry{Term: 1, Offset: 0, Value: value}, 0, 1)
+
+	// Overwrite the source buffer, as the next append would
+	copy(value, []byte("OVERWRIT"))
+
+	entry, _, _, ok := c.get(0)
+	assert.True(t, ok)
+	assert.Equal(t, []byte("original"), entry.Value)
+}
+
+func TestTailCache_Eviction(t *testing.T) {
+	// Each entry's SizeVT is well above 4 bytes, so a 64-byte budget holds
+	// only a handful of entries.
+	c := newTailCache(64)
+	const n = 50
+	for i := int64(0); i < n; i++ {
+		c.add(cacheEntry(i, fmt.Sprintf("value-%04d", i)), uint32(i), uint32(i+1))
+	}
+
+	// The newest entry is always retained; the oldest are gone.
+	_, _, _, ok := c.get(n - 1)
+	assert.True(t, ok)
+	_, _, _, ok = c.get(0)
+	assert.False(t, ok)
+
+	// The retained window is contiguous up to the head, and within budget.
+	assert.LessOrEqual(t, c.curBytes, c.maxBytes)
+	for off := c.baseOffset; off < n; off++ {
+		_, _, _, ok := c.get(off)
+		assert.True(t, ok, "offset %d should be cached", off)
+	}
+	// Nothing below baseOffset.
+	_, _, _, ok = c.get(c.baseOffset - 1)
+	assert.False(t, ok)
+}
+
+func TestTailCache_Truncate(t *testing.T) {
+	c := newTailCache(1 << 20)
+	for i := int64(0); i < 10; i++ {
+		c.add(cacheEntry(i, "v"), uint32(i), uint32(i+1))
+	}
+
+	c.truncate(5)
+	_, _, _, ok := c.get(5)
+	assert.True(t, ok)
+	_, _, _, ok = c.get(6)
+	assert.False(t, ok)
+
+	// Truncating below the base clears everything.
+	c.truncate(-1)
+	_, _, _, ok = c.get(0)
+	assert.False(t, ok)
+	assert.EqualValues(t, InvalidOffset, c.baseOffset)
+}
+
+func TestTailCache_Clear(t *testing.T) {
+	c := newTailCache(1 << 20)
+	c.add(cacheEntry(0, "v"), 0, 1)
+	c.clear()
+	_, _, _, ok := c.get(0)
+	assert.False(t, ok)
+	assert.EqualValues(t, InvalidOffset, c.baseOffset)
+	assert.Equal(t, 0, c.curBytes)
+}
+
+// A non-contiguous offset (e.g. after the WAL is cleared and restarts from a
+// non-initial position) resets the window instead of leaving a gap.
+func TestTailCache_NonContiguousReset(t *testing.T) {
+	c := newTailCache(1 << 20)
+	c.add(cacheEntry(0, "a"), 0, 1)
+	c.add(cacheEntry(1, "b"), 1, 2)
+
+	c.add(cacheEntry(100, "z"), 0, 1)
+
+	_, _, _, ok := c.get(0)
+	assert.False(t, ok)
+	_, _, _, ok = c.get(1)
+	assert.False(t, ok)
+	entry, _, _, ok := c.get(100)
+	assert.True(t, ok)
+	assert.Equal(t, []byte("z"), entry.Value)
+}
+
+// Reads of recently appended entries must be served from the tail cache (same
+// shared pointer), while reads of entries no longer cached fall back to the
+// WAL segments and return byte-identical content and CRCs.
+func TestWAL_ReadServedFromTailCache(t *testing.T) {
+	f, w := createWal(t)
+	defer func() {
+		assert.NoError(t, w.Close())
+		assert.NoError(t, f.Close())
+	}()
+
+	tw := w.(*wal)
+	const n = 20
+	for i := int64(0); i < n; i++ {
+		assert.NoError(t, w.Append(&proto.LogEntry{Term: 1, Offset: i, Value: []byte(fmt.Sprintf("value-%d", i))}))
+	}
+
+	// A recent offset is in the cache: readAtIndex returns the very pointer
+	// the cache holds, proving it did not re-read and re-unmarshal.
+	cached, cachedPrev, cachedCur, ok := tw.tailCache.get(n - 1)
+	assert.True(t, ok)
+	got, prev, cur, err := tw.readAtIndex(n - 1)
+	assert.NoError(t, err)
+	assert.Same(t, cached, got)
+	assert.Equal(t, cachedPrev, prev)
+	assert.Equal(t, cachedCur, cur)
+
+	// Drop the cache: the same read now comes from the segment — a distinct
+	// object, but byte-identical content and identical CRCs.
+	tw.tailCache.clear()
+	fromSegment, segPrev, segCur, err := tw.readAtIndex(n - 1)
+	assert.NoError(t, err)
+	assert.NotSame(t, cached, fromSegment)
+	assert.Equal(t, cached.Value, fromSegment.Value)
+	assert.EqualValues(t, cached.Offset, fromSegment.Offset)
+	assert.Equal(t, cachedPrev, segPrev)
+	assert.Equal(t, cachedCur, segCur)
+}
+
+func BenchmarkWALReadAtIndex(b *testing.B) {
+	dir := b.TempDir()
+	f := NewWalFactory(&FactoryOptions{
+		BaseWalDir:  dir,
+		Retention:   1 * time.Hour,
+		SegmentSize: 1 << 20,
+		SyncData:    false,
+	})
+	defer f.Close()
+	w, err := f.NewWal(constant.DefaultNamespace, 1, nil)
+	assert.NoError(b, err)
+	defer w.Close()
+
+	tw := w.(*wal)
+	const n = 1000
+	value := make([]byte, 256)
+	for i := int64(0); i < n; i++ {
+		assert.NoError(b, w.Append(&proto.LogEntry{Term: 1, Offset: i, Value: value}))
+	}
+
+	b.Run("cache-hit", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, _, _, err := tw.readAtIndex(n - 1); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("segment", func(b *testing.B) {
+		tw.tailCache.clear()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, _, _, err := tw.readAtIndex(0); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/oxiad/dataserver/wal/tail_cache_test.go
+++ b/oxiad/dataserver/wal/tail_cache_test.go
@@ -223,3 +223,89 @@ func BenchmarkWALReadAtIndex(b *testing.B) {
 		}
 	})
 }
+
+// The follower replication path reads through NewReader/ReadNext, not
+// readAtIndex directly: this pins that the reader actually consults the cache
+// (it returns the shared cached pointer).
+func TestWALReaderUsesTailCache(t *testing.T) {
+	f, w := createWal(t)
+	defer func() {
+		assert.NoError(t, w.Close())
+		assert.NoError(t, f.Close())
+	}()
+
+	tw := w.(*wal)
+	const n = 20
+	for i := int64(0); i < n; i++ {
+		assert.NoError(t, w.Append(&proto.LogEntry{Term: 1, Offset: i, Value: []byte(fmt.Sprintf("value-%d", i))}))
+	}
+
+	cached, _, _, ok := tw.tailCache.get(n - 1)
+	assert.True(t, ok)
+
+	// NewReader(after) starts at after+1, so this reads offset n-1.
+	reader, err := w.NewReader(n - 2)
+	assert.NoError(t, err)
+	defer reader.Close()
+	assert.True(t, reader.HasNext())
+	got, _, _, err := reader.ReadNext()
+	assert.NoError(t, err)
+	assert.Same(t, cached, got)
+}
+
+// BenchmarkWALReaderTailing exercises the real reader path (NewReader/ReadNext)
+// rather than readAtIndex directly, contrasting a cache-warm tail read with a
+// segment read.
+func BenchmarkWALReaderTailing(b *testing.B) {
+	_, w, tw := benchWAL(b, 1000, 256)
+
+	b.Run("cache-hit", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			last := tw.lastAppendedOffset.Load()
+			r, err := w.NewReader(last - 1)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if _, _, _, err := r.ReadNext(); err != nil {
+				b.Fatal(err)
+			}
+			_ = r.Close()
+		}
+	})
+
+	b.Run("segment", func(b *testing.B) {
+		tw.tailCache.clear()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			r, err := w.NewReader(-1) // reads offset 0
+			if err != nil {
+				b.Fatal(err)
+			}
+			if _, _, _, err := r.ReadNext(); err != nil {
+				b.Fatal(err)
+			}
+			_ = r.Close()
+		}
+	})
+}
+
+func benchWAL(b *testing.B, prefill, entrySize int) (Factory, Wal, *wal) {
+	b.Helper()
+	f := NewWalFactory(&FactoryOptions{
+		BaseWalDir:  b.TempDir(),
+		Retention:   1 * time.Hour,
+		SegmentSize: 1 << 20,
+		SyncData:    false,
+	})
+	b.Cleanup(func() { _ = f.Close() })
+	w, err := f.NewWal(constant.DefaultNamespace, 1, nil)
+	assert.NoError(b, err)
+	b.Cleanup(func() { _ = w.Close() })
+
+	value := make([]byte, entrySize)
+	for i := 0; i < prefill; i++ {
+		assert.NoError(b, w.Append(&proto.LogEntry{Term: 1, Offset: int64(i), Value: value}))
+	}
+	return f, w, w.(*wal)
+}

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -92,6 +92,10 @@ type wal struct {
 	// holding the WAL write lock
 	marshalBuf []byte
 
+	// In-memory cache of the most recently appended entries, read by tailing
+	// follower cursors without taking the WAL lock (see tail_cache.go)
+	tailCache *tailCache
+
 	trimmer Trimmer
 
 	appendLatency metric.LatencyHistogram
@@ -146,6 +150,8 @@ func newWal(namespace string, shard int64, options *FactoryOptions, commitOffset
 			"The time it takes to fsync the wal data on disk", labels),
 	}
 
+	w.tailCache = newTailCache(defaultTailCacheMaxBytes)
+
 	var err error
 	if w.readOnlySegments, err = newReadOnlySegmentsGroup(w.walPath); err != nil {
 		return nil, err
@@ -181,6 +187,13 @@ func newWal(namespace string, shard int64, options *FactoryOptions, commitOffset
 }
 
 func (t *wal) readAtIndex(index int64) (entry *proto.LogEntry, previousCrc uint32, entryCrc uint32, err error) {
+	// Serve tailing reads from the in-memory cache without taking the WAL
+	// lock: a cache hit avoids the mmap copy, the UnmarshalVT and, crucially,
+	// blocking queued appenders that need the write lock.
+	if entry, previousCrc, entryCrc, ok := t.tailCache.get(index); ok {
+		return entry, previousCrc, entryCrc, nil
+	}
+
 	t.RLock()
 	defer t.RUnlock()
 
@@ -353,7 +366,8 @@ func (t *wal) appendAsync0(entry *proto.LogEntry, previousCrc *uint32) error {
 		}
 	}
 
-	if err = t.currentSegment.Append(entry.Offset, val); err != nil {
+	appendedPreviousCrc, appendedCrc, err := t.currentSegment.Append(entry.Offset, val)
+	if err != nil {
 		if !errors.Is(err, ErrSegmentFull) {
 			t.writeErrors.Inc()
 			return err
@@ -364,7 +378,7 @@ func (t *wal) appendAsync0(entry *proto.LogEntry, previousCrc *uint32) error {
 		}
 
 		// After the rollover, try to append again
-		if err = t.currentSegment.Append(entry.Offset, val); err != nil {
+		if appendedPreviousCrc, appendedCrc, err = t.currentSegment.Append(entry.Offset, val); err != nil {
 			t.writeErrors.Inc()
 			return err
 		}
@@ -372,6 +386,7 @@ func (t *wal) appendAsync0(entry *proto.LogEntry, previousCrc *uint32) error {
 
 	t.lastAppendedOffset.Store(entry.Offset)
 	t.firstOffset.CompareAndSwap(InvalidOffset, entry.Offset)
+	t.tailCache.add(entry, appendedPreviousCrc, appendedCrc)
 
 	t.appendBytes.Add(len(val))
 	return nil
@@ -627,6 +642,7 @@ func (t *wal) clearWithoutLock() error {
 	t.lastAppendedOffset.Store(InvalidOffset)
 	t.lastSyncedOffset.Store(InvalidOffset)
 	t.firstOffset.Store(InvalidOffset)
+	t.tailCache.clear()
 	return nil
 }
 
@@ -656,6 +672,8 @@ func (t *wal) TruncateLog(lastSafeOffset int64) (int64, error) { //nolint:revive
 
 	t.Lock()
 	defer t.Unlock()
+
+	t.tailCache.truncate(lastSafeOffset)
 
 	// Bring any rolled-over segment still pending close into the read-only
 	// group, so that the truncation below sees the complete set of segments

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -98,15 +98,17 @@ type wal struct {
 
 	trimmer Trimmer
 
-	appendLatency metric.LatencyHistogram
-	appendBytes   metric.Counter
-	readLatency   metric.LatencyHistogram
-	readBytes     metric.Counter
-	trimOps       metric.Counter
-	readErrors    metric.Counter
-	writeErrors   metric.Counter
-	activeEntries metric.Gauge
-	syncLatency   metric.LatencyHistogram
+	appendLatency      metric.LatencyHistogram
+	appendBytes        metric.Counter
+	readLatency        metric.LatencyHistogram
+	readBytes          metric.Counter
+	trimOps            metric.Counter
+	readErrors         metric.Counter
+	writeErrors        metric.Counter
+	activeEntries      metric.Gauge
+	readCacheHits      atomic.Int64
+	readCacheHitsGauge metric.Gauge
+	syncLatency        metric.LatencyHistogram
 }
 
 func walPath(logDir string, namespace string, shard int64) string {
@@ -165,6 +167,13 @@ func newWal(namespace string, shard int64, options *FactoryOptions, commitOffset
 			return w.lastSyncedOffset.Load() - w.firstOffset.Load()
 		})
 
+	// Cumulative tail-cache hits, kept as an atomic so the read hot path stays
+	// allocation-free, and observed through a gauge callback.
+	w.readCacheHitsGauge = metric.NewGauge("oxia_server_wal_read_cache_hits",
+		"The number of WAL reads served from the in-memory tail cache", "count", labels, func() int64 {
+			return w.readCacheHits.Load()
+		})
+
 	if err := w.recoverWal(); err != nil {
 		return nil, errors.Wrapf(err, "failed to recover wal for shard %s / %d", namespace, shard)
 	}
@@ -189,14 +198,20 @@ func newWal(namespace string, shard int64, options *FactoryOptions, commitOffset
 func (t *wal) readAtIndex(index int64) (entry *proto.LogEntry, previousCrc uint32, entryCrc uint32, err error) {
 	// Serve tailing reads from the in-memory cache without taking the WAL
 	// lock: a cache hit avoids the mmap copy, the UnmarshalVT and, crucially,
-	// blocking queued appenders that need the write lock.
+	// blocking queued appenders that need the write lock. Cache hits are not
+	// fed into the latency histogram — recording a ~14ns lookup through the
+	// OTel histogram would cost several times the lookup itself and bury the
+	// segment-read distribution under a spike of near-zero samples; the hit
+	// counter is the metric that matters for the cache.
 	if entry, previousCrc, entryCrc, ok := t.tailCache.get(index); ok {
+		t.readCacheHits.Add(1)
 		return entry, previousCrc, entryCrc, nil
 	}
 
 	t.RLock()
 	defer t.RUnlock()
 
+	// Time the segment path only: the reads that actually vary and can be slow.
 	timer := t.readLatency.Timer()
 	defer timer.Done()
 
@@ -287,6 +302,7 @@ func (t *wal) closeWithoutLock() error {
 	default:
 		t.cancel()
 		t.activeEntries.Unregister()
+		t.readCacheHitsGauge.Unregister()
 
 		return multierr.Combine(
 			t.drainPendingCloseSegments(),

--- a/oxiad/dataserver/wal/wal_reader.go
+++ b/oxiad/dataserver/wal/wal_reader.go
@@ -80,9 +80,8 @@ func (r *reverseReader) Close() error {
 }
 
 func (r *forwardReader) ReadNext() (entry *proto.LogEntry, previousCrc uint32, entryCrc uint32, err error) {
-	timer := r.wal.readLatency.Timer()
-	defer timer.Done()
-
+	// readAtIndex records the read latency for the segment path; no separate
+	// timer here, which previously double-counted every forward read.
 	r.Lock()
 	defer r.Unlock()
 


### PR DESCRIPTION
### Motivation

Item 2.6 from the performance review: the WAL read path copies each entry twice and unmarshals it under the WAL read lock, per entry per follower.

A follower cursor tailing the log re-reads every entry out of the segment mmap (a copy into a temp buffer), then `UnmarshalVT`s it into a fresh `*proto.LogEntry` — once per entry, per follower — all while holding `t.RLock()`, which blocks queued appenders waiting for the write lock. Cold segment opens for catch-up also run under that lock.

### Changes

Keep the most recently appended entries in a bounded in-memory tail cache (`tail_cache.go`) with its **own mutex**, decoupled from the WAL lock:

- `readAtIndex` checks the cache **before** taking `t.RLock()`. A hit returns with no WAL lock, no mmap copy, and no unmarshal — tailing followers share one read-only `*proto.LogEntry` that goes straight into the replication `Append`. A miss falls through to the unchanged segment path.
- The cache is a contiguous suffix of the log `[baseOffset, baseOffset+len)`: `add` (in `appendAsync0`) extends the head, the byte budget evicts the oldest, `truncate` (in `TruncateLog`) drops entries above `lastSafeOffset`, and `clear` (in `clearWithoutLock`) empties it. All mutations run under the WAL write lock, so the cache mutex only guards against concurrent `get()`. A follower further behind than the budget falls back to the segment path — the cold catch-up path anyway.
- `add` deep-copies the entry via `CloneVT`: the `LogEntry` handed to the WAL has its `Value` aliasing a reusable marshal buffer that the next proposal overwrites.
- Segment `Append` now returns the record CRCs so a cache hit can supply the replication stream's `PreviousEntryCrc` without re-reading the record header. It is the only implementor (no mocks); the 27 segment-test call sites go through a one-line `appendRecord` adapter.

The default budget is 4 MB/shard (a `const`), enough to span a caught-up follower's lag.

### Benchmark

`BenchmarkWALReadAtIndex` (256-byte entries, Apple M1 Max):

| path | time | bytes | allocs |
|---|---|---|---|
| cache hit | 14 ns/op | 0 | 0 |
| segment read | 263 ns/op | 672 | 5 |

~19× faster and zero allocation. The hit also takes no WAL lock at all (it returns before `t.RLock()`), so a tailing read can no longer sit in the lock holding off a queued appender.

A note on write latency, since it is the subtler half of the claim: I could **not** show an append-latency improvement in a micro-benchmark — at the mean *or* in the tail. Measuring journal-append p50/p99/p999 under concurrent readers, with the reader loop rate equalized so the only difference is who holds the lock:

| regime | p50 | p99 | p999 |
|---|---|---|---|
| no readers | 0.5 µs | 3.4 µs | 16 µs |
| tailing reads (cache hit, no WAL lock) | 2.0 µs | 21.8 µs | 41 µs |
| cold reads (cache miss, holds WAL RLock) | 2.4 µs | 17.5 µs | 42 µs |

The lock-holding and lock-free arms are statistically indistinguishable at p99/p999; both sit the same ~2 µs/~20 µs above the no-readers baseline, and that gap is the CPU cost of the reader goroutines existing, not WAL-lock contention. A ~260 ns RLock hold (a tailing read) is below the noise floor, and `sync.RWMutex` writer-priority keeps it from queueing ahead of appends. So the measurable, defensible win here is the read side (CPU + allocations + lock-free tailing); the write-path benefit is structural — no RLock acquisitions for the common tailing case — and is not observable as append latency at this scale. (The large write-latency lever the review points at is the *cold segment open* held under the lock for µs–ms; this tail cache does not change that path.)

### Verification

- `TestWAL_ReadServedFromTailCache` pins that a recent read is served from the cache (returns the same shared pointer, proving it skipped the re-read + unmarshal) and that the segment fallback after `clear()` returns byte-identical content and identical CRCs. Verified to discriminate: it fails if the cache read path is removed.
- `tail_cache.go` unit tests cover get/miss, byte eviction, truncate, clear, the copy-on-insert invariant, and the non-contiguous reset.
- `go test -race` green on `oxiad/dataserver/...` and `tests/client` (replication exercises the tailing path end-to-end).
- `TestWALReaderUsesTailCache` and `BenchmarkWALReaderTailing` go through the real `NewReader`/`ReadNext` path (not `readAtIndex` directly) and confirm the follower replication path is served from the cache (133 ns hit vs 305 ns segment).
- Read latency is recorded once on the segment path (no double-count); cache hits are exposed via the `oxia_server_wal_read_cache_hits` gauge, keeping the hit path allocation-free.
- `golangci-lint` clean on the CI-pinned v2.6.2.


