### PR TITLE
fix: send assignments after dataserver handshake

### DIFF
--- a/oxiad/coordinator/runtime/controller/dataserver_controller.go
+++ b/oxiad/coordinator/runtime/controller/dataserver_controller.go
@@ -130,6 +130,9 @@ func (n *dataServerController) Close() error {
 
 func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
 	_ = backoff.RetryNotify(func() error {
+		if err := n.waitUntilReadyForAssignments(); err != nil {
+			return err
+		}
 		n.logger.Debug("Ready to send assignments")
 
 		stream, err := n.rpc.PushShardAssignments(n.ctx, n.dataServer.GetIdentity())
@@ -176,6 +179,25 @@ func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
 			)
 		}
 	})
+}
+
+func (n *dataServerController) waitUntilReadyForAssignments() error {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		switch n.Status() {
+		case Running, Draining:
+			return nil
+		case NotRunning:
+		}
+
+		select {
+		case <-n.ctx.Done():
+			return n.ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 func (n *dataServerController) doHealthPing(healthClient grpc_health_v1.HealthClient) error {

--- a/tests/coordinator/no_namespace_assignments_test.go
+++ b/tests/coordinator/no_namespace_assignments_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/oxia-db/oxia/common/proto"
+	clientrpc "github.com/oxia-db/oxia/common/rpc"
+	oxiadcommonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
+	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	metadatacodec "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common/codec"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
+	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
+)
+
+func TestCoordinator_NoNamespacesSendsEmptyAssignments(t *testing.T) {
+	s1, sa1 := newServer(t)
+	defer s1.Close()
+
+	metadataProvider := memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled)
+	clusterConfig := newClusterConfig([]*proto.Namespace{}, []*proto.DataServerIdentity{sa1})
+	configProvider := memory.NewProvider(metadatacodec.ClusterConfigCodec, metadatacommon.WatchEnabled)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
+	require.NoError(t, err)
+
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
+	defer coordinatorInstance.Close()
+
+	clientPool := clientrpc.NewClientPool(nil, nil)
+	defer clientPool.Close()
+	healthClient, err := clientPool.GetHealthRpc(sa1.Public)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		response, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{
+			Service: oxiadcommonrpc.ReadinessProbeService,
+		})
+		return err == nil && response.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING
+	}, 10*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
## Motivation
- Data servers could receive assignment streams before completing the coordinator instance-id handshake.
- For an initial cluster config with no namespaces, the coordinator has no shard controllers to publish assignments later, so data servers could remain not ready.

## Modifications
- Return a retryable not-ready error until a data server reaches `Running` or `Draining`, with a dedicated log message for that expected startup state.
- Subscribe directly to the shard-assignment watch and send the current assignment set immediately when the stream opens.
- Add an e2e regression test that starts a coordinator with no namespaces and verifies the data server readiness probe becomes serving.

## Testing
- `go test ./oxiad/coordinator/runtime/controller`
- `go test ./oxiad/coordinator/runtime/...`
- `go test ./tests/coordinator -run TestCoordinator_NoNamespacesSendsEmptyAssignments -count=1`
