### PR TITLE
fix: allow empty namespace assignments

### DIFF
--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -795,19 +795,26 @@ func NewCoordinator(meta metadata.Provider,
 		c.Info("Checking cluster config", slog.Any("clusterConfig", clusterConfig))
 	}
 	clusterStatus, _, _ = c.statusResource.ApplyChanges(clusterConfig, c.selectNewEnsemble)
-
-	// init shard controller
-	for ns, shards := range clusterStatus.Namespaces {
-		for shard := range shards.Shards {
-			shardMetadata := shards.Shards[shard]
-			var nsConfig *model.NamespaceConfig
-			var exist bool
-			if nsConfig, exist = c.configResource.NamespaceConfig(ns); !exist {
-				nsConfig = &model.NamespaceConfig{}
+	if len(clusterStatus.Namespaces) == 0 {
+		// No shard controllers will run leader election and publish assignments,
+		// so send the empty assignment set now to make data servers ready.
+		c.Lock()
+		c.computeNewAssignments()
+		c.Unlock()
+	} else {
+		// init shard controller
+		for ns, shards := range clusterStatus.Namespaces {
+			for shard := range shards.Shards {
+				shardMetadata := shards.Shards[shard]
+				var nsConfig *model.NamespaceConfig
+				var exist bool
+				if nsConfig, exist = c.configResource.NamespaceConfig(ns); !exist {
+					nsConfig = &model.NamespaceConfig{}
+				}
+				c.shardControllers[shard] = controller.NewShardController(ns, shard, nsConfig,
+					shardMetadata, c.configResource, c.statusResource, c.findDataServerFeatures,
+					c, c.rpc, controller.DefaultPeriodicTasksInterval)
 			}
-			c.shardControllers[shard] = controller.NewShardController(ns, shard, nsConfig,
-				shardMetadata, c.configResource, c.statusResource, c.findDataServerFeatures,
-				c, c.rpc, controller.DefaultPeriodicTasksInterval)
 		}
 	}
 

--- a/oxiad/coordinator/model/cluster_config.go
+++ b/oxiad/coordinator/model/cluster_config.go
@@ -81,10 +81,6 @@ func (cc *ClusterConfig) Validate() error {
 		return errors.New("cluster config: at least one server must be configured")
 	}
 
-	if len(cc.Namespaces) == 0 {
-		return errors.New("cluster config: at least one namespace must be configured")
-	}
-
 	for _, ns := range cc.Namespaces {
 		if err := validation.ValidateNamespace(ns.Name); err != nil {
 			return errors.Wrap(err, "cluster config")

--- a/oxiad/coordinator/model/cluster_config_test.go
+++ b/oxiad/coordinator/model/cluster_config_test.go
@@ -90,10 +90,12 @@ func TestValidate_NoServers(t *testing.T) {
 	assert.ErrorContains(t, cc.Validate(), "at least one server must be configured")
 }
 
-func TestValidate_NoNamespaces(t *testing.T) {
-	cc := validConfig()
-	cc.Namespaces = nil
-	assert.ErrorContains(t, cc.Validate(), "at least one namespace must be configured")
+func TestValidate_NoNamespacesAllowed(t *testing.T) {
+	for _, namespaces := range [][]NamespaceConfig{nil, {}} {
+		cc := validConfig()
+		cc.Namespaces = namespaces
+		assert.NoError(t, cc.Validate())
+	}
 }
 
 func TestValidate_EmptyNamespaceName(t *testing.T) {

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -25,8 +25,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/health/grpc_health_v1"
 
 	commonoption "github.com/oxia-db/oxia/oxiad/common/option"
+	oxiadcommonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/option"
 
@@ -438,6 +440,36 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	for _, serverObj := range servers {
 		assert.NoError(t, serverObj.Close())
 	}
+}
+
+func TestCoordinator_NoNamespacesSendsEmptyAssignments(t *testing.T) {
+	s1, sa1 := newServer(t)
+	defer s1.Close()
+
+	metadataProvider := metadata.NewMetadataProviderMemory()
+	clusterConfig := model.ClusterConfig{
+		Namespaces: []model.NamespaceConfig{},
+		Servers:    []model.Server{sa1},
+	}
+	clientPool := rpc.NewClientPool(nil, nil)
+	defer clientPool.Close()
+
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	require.NoError(t, err)
+	defer coordinatorInstance.Close()
+
+	healthClient, err := clientPool.GetHealthRpc(sa1.Public)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		response, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{
+			Service: oxiadcommonrpc.ReadinessProbeService,
+		})
+		return err == nil && response.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING
+	}, 10*time.Second, 10*time.Millisecond)
 }
 
 func TestCoordinator_DynamicallAddNamespace(t *testing.T) {


### PR DESCRIPTION
## Motivation
- The coordinator should allow clusters to start or restart with no configured namespaces.
- In that state, no shard controller runs leader election, so data servers still need an initialized empty assignment update to become ready.

## Modifications
- Remove the validation that required at least one namespace.
- Publish empty assignments during coordinator startup when the reconciled status has no namespaces.
- Add validation and e2e coverage for empty namespace configs.

## Testing
- `go test ./oxiad/coordinator/model ./oxiad/coordinator`
- `go test ./tests/coordinator -run 'TestCoordinator_(NoNamespacesSendsEmptyAssignments|DeleteNamespace)$' -count=1`
