### PR TITLE
fix: send assignments after dataserver handshake

### DIFF
--- a/oxiad/coordinator/runtime/controller/dataserver_controller.go
+++ b/oxiad/coordinator/runtime/controller/dataserver_controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/oxia-db/oxia/common/process"
 	"github.com/oxia-db/oxia/common/proto"
 	commontime "github.com/oxia-db/oxia/common/time"
+	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 )
 
 type DataServerStatus uint32
@@ -52,8 +53,10 @@ const (
 	defaultInitialRetryBackoff = 10 * time.Second
 )
 
+var errDataServerNotReadyForAssignments = errors.New("data server is not ready for assignments")
+
 type ShardAssignmentsProvider interface {
-	WaitForNextUpdate(ctx context.Context, currentValue *proto.ShardAssignments) (*proto.ShardAssignments, error)
+	SubscribeShardAssignments() *commonwatch.Receiver[*proto.ShardAssignments]
 }
 
 // The DataServerController takes care of checking the health-status of each dataServer
@@ -130,6 +133,9 @@ func (n *dataServerController) Close() error {
 
 func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
 	_ = backoff.RetryNotify(func() error {
+		if err := n.checkReadyForAssignments(); err != nil {
+			return err
+		}
 		n.logger.Debug("Ready to send assignments")
 
 		stream, err := n.rpc.PushShardAssignments(n.ctx, n.dataServer.GetIdentity())
@@ -138,7 +144,8 @@ func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
 			return err
 		}
 		streamCtx := stream.Context()
-		var assignments *proto.ShardAssignments
+		receiver := n.SubscribeShardAssignments()
+		assignments := receiver.Load()
 		for {
 			select {
 			case <-n.ctx.Done():
@@ -146,28 +153,34 @@ func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
 			case <-streamCtx.Done():
 				return streamCtx.Err()
 			default:
-				n.logger.Debug(
-					"Waiting for next assignments update",
-					slog.Any("current-assignments", assignments),
-				)
-				if assignments, err = n.WaitForNextUpdate(streamCtx, assignments); err != nil {
-					n.logger.Debug("Failed to send assignments", slog.Any("error", err))
-					return err
-				}
-				if assignments == nil {
-					continue
-				}
+			}
 
-				n.logger.Debug("Sending assignments", slog.Any("assignments", assignments))
-				if err := stream.Send(assignments); err != nil {
-					n.logger.Debug("Failed to send assignments", slog.Any("error", err))
-					return err
-				}
-				n.logger.Debug("Send assignments completed successfully")
-				n.dispatchAssignmentsBackoff.Reset()
+			n.logger.Debug("Sending assignments", slog.Any("assignments", assignments))
+			if err := stream.Send(assignments); err != nil {
+				n.logger.Debug("Failed to send assignments", slog.Any("error", err))
+				return err
+			}
+			n.logger.Debug("Send assignments completed successfully")
+			n.dispatchAssignmentsBackoff.Reset()
+
+			select {
+			case <-n.ctx.Done():
+				return nil
+			case <-streamCtx.Done():
+				return streamCtx.Err()
+			case <-receiver.Changed():
+				assignments = receiver.Load()
 			}
 		}
 	}, n.dispatchAssignmentsBackoff, func(err error, duration time.Duration) {
+		if errors.Is(err, errDataServerNotReadyForAssignments) {
+			n.logger.Info(
+				"Waiting for data server to be ready before sending assignments",
+				slog.Any("status", n.Status()),
+				slog.Duration("retry-after", duration),
+			)
+			return
+		}
 		if !errors.Is(err, context.Canceled) {
 			n.logger.Warn(
 				"Failed to send assignments updates to storage data server",
@@ -176,6 +189,21 @@ func (n *dataServerController) sendAssignmentsDispatchWithRetries() {
 			)
 		}
 	})
+}
+
+func (n *dataServerController) checkReadyForAssignments() error {
+	select {
+	case <-n.ctx.Done():
+		return n.ctx.Err()
+	default:
+	}
+
+	switch n.Status() {
+	case Running, Draining:
+		return nil
+	default:
+		return errDataServerNotReadyForAssignments
+	}
 }
 
 func (n *dataServerController) doHealthPing(healthClient grpc_health_v1.HealthClient) error {

--- a/oxiad/coordinator/runtime/controller/mock_test.go
+++ b/oxiad/coordinator/runtime/controller/mock_test.go
@@ -26,12 +26,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
-	pb "google.golang.org/protobuf/proto"
 
 	"github.com/oxia-db/oxia/oxiad/common/feature"
 
-	"github.com/oxia-db/oxia/common/concurrent"
 	"github.com/oxia-db/oxia/oxiad/common/logging"
+	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 
 	"github.com/oxia-db/oxia/common/proto"
 )
@@ -45,39 +44,21 @@ var (
 )
 
 type mockShardAssignmentsProvider struct {
-	sync.Mutex
-	cond    concurrent.ConditionContext
-	current *proto.ShardAssignments
+	assignments *commonwatch.Watch[*proto.ShardAssignments]
 }
 
 func newMockShardAssignmentsProvider() *mockShardAssignmentsProvider {
-	sap := &mockShardAssignmentsProvider{
-		current: nil,
+	return &mockShardAssignmentsProvider{
+		assignments: commonwatch.New(&proto.ShardAssignments{}),
 	}
-
-	sap.cond = concurrent.NewConditionContext(sap)
-	return sap
 }
 
 func (sap *mockShardAssignmentsProvider) set(value *proto.ShardAssignments) {
-	sap.Lock()
-	defer sap.Unlock()
-
-	sap.current = value
-	sap.cond.Broadcast()
+	sap.assignments.Publish(value)
 }
 
-func (sap *mockShardAssignmentsProvider) WaitForNextUpdate(ctx context.Context, currentValue *proto.ShardAssignments) (*proto.ShardAssignments, error) {
-	sap.Lock()
-	defer sap.Unlock()
-
-	for pb.Equal(currentValue, sap.current) {
-		if err := sap.cond.Wait(ctx); err != nil {
-			return nil, err
-		}
-	}
-
-	return sap.current, nil
+func (sap *mockShardAssignmentsProvider) SubscribeShardAssignments() *commonwatch.Receiver[*proto.ShardAssignments] {
+	return sap.assignments.Subscribe()
 }
 
 type mockNodeAvailabilityListener struct {

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -375,6 +375,10 @@ func (c *runtime) WaitForNextUpdate(ctx context.Context, currentValue *proto.Sha
 	}
 }
 
+func (c *runtime) SubscribeShardAssignments() *commonwatch.Receiver[*proto.ShardAssignments] {
+	return c.assignmentsWatch.Subscribe()
+}
+
 func (c *runtime) startBackgroundActionWorker() {
 	for {
 		select {

--- a/tests/coordinator/no_namespace_assignments_test.go
+++ b/tests/coordinator/no_namespace_assignments_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/oxia-db/oxia/common/proto"
+	clientrpc "github.com/oxia-db/oxia/common/rpc"
+	oxiadcommonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
+	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	metadatacodec "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common/codec"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
+	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
+)
+
+func TestCoordinator_NoNamespacesSendsEmptyAssignments(t *testing.T) {
+	s1, sa1 := newServer(t)
+	defer s1.Close()
+
+	metadataProvider := memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled)
+	clusterConfig := newClusterConfig([]*proto.Namespace{}, []*proto.DataServerIdentity{sa1})
+	configProvider := memory.NewProvider(metadatacodec.ClusterConfigCodec, metadatacommon.WatchEnabled)
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
+	require.NoError(t, err)
+
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
+	defer coordinatorInstance.Close()
+
+	clientPool := clientrpc.NewClientPool(nil, nil)
+	defer clientPool.Close()
+	healthClient, err := clientPool.GetHealthRpc(sa1.Public)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		response, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{
+			Service: oxiadcommonrpc.ReadinessProbeService,
+		})
+		return err == nil && response.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING
+	}, 10*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
## Motivation
- Data servers could receive assignment streams before completing the coordinator instance-id handshake.
- For an initial cluster config with no namespaces, the coordinator has no shard controllers to publish assignments later, so data servers could remain not ready.

## Modifications
- Return a retryable not-ready error until a data server reaches `Running` or `Draining`, with a dedicated log message for that expected startup state.
- Subscribe directly to the shard-assignment watch and send the current assignment set immediately when the stream opens.
- Add an e2e regression test that starts a coordinator with no namespaces and verifies the data server readiness probe becomes serving.

## Testing
- `go test ./oxiad/coordinator/runtime/controller`
- `go test ./oxiad/coordinator/runtime/...`
- `go test ./tests/coordinator -run TestCoordinator_NoNamespacesSendsEmptyAssignments -count=1`
