### PR TITLE
fix: stop leaked notifications-trimmer goroutine in follower cursor tests

### DIFF
--- a/oxiad/dataserver/controller/lead/follower_cursor_test.go
+++ b/oxiad/dataserver/controller/lead/follower_cursor_test.go
@@ -127,6 +127,10 @@ func TestFollowerCursor(t *testing.T) {
 	assert.EqualValues(t, 0, req.CommitOffset)
 
 	assert.NoError(t, fc.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, wf.Close())
+	assert.NoError(t, db.Close())
+	assert.NoError(t, kvf.Close())
 }
 
 func TestFollowerCursor_SendSnapshot(t *testing.T) {
@@ -216,6 +220,10 @@ func TestFollowerCursor_SendSnapshot(t *testing.T) {
 	assert.EqualValues(t, n, firstAppend.Entry.Offset)
 
 	assert.NoError(t, fc.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, wf.Close())
+	assert.NoError(t, db.Close())
+	assert.NoError(t, kvf.Close())
 }
 
 func TestFollowerCursor_StreamToEmptyFollowerWhenWalComplete(t *testing.T) {
@@ -273,6 +281,10 @@ func TestFollowerCursor_StreamToEmptyFollowerWhenWalComplete(t *testing.T) {
 	assert.Empty(t, stream.SendSnapshotStream.Requests)
 
 	assert.NoError(t, fc.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, wf.Close())
+	assert.NoError(t, db.Close())
+	assert.NoError(t, kvf.Close())
 }
 
 func TestFollowerCursor_CloseWaitsForInFlightSnapshot(t *testing.T) {


### PR DESCRIPTION
## Problem

`TestFollowerCursor_SendSnapshot` (and its sibling follower-cursor tests) were intermittently flaky under parallel load, failing during a snapshot send with:

```
open /var/folders/.../shard-2/000004.sst: no such file or directory
```

through `notificationsTrimmer.trimNotifications → getFirstLast → Pebble.KeyRangeScan → Pebble.RangeScan → pebble Iterator.First`. The tests pass in isolation but failed during full parallel runs (the `lead` package once took ~302s vs ~13s standalone) and once hung the whole package.

## Root cause

`TestFollowerCursor`, `TestFollowerCursor_SendSnapshot` and `TestFollowerCursor_StreamToEmptyFollowerWhenWalComplete` create a `database.DB` (plus WAL and KV factory) but only close the follower cursor — never the DB. `database.NewDB` starts a background `notificationsTrimmer` goroutine that is only stopped by `db.Close()`, so the goroutine outlived the test.

Once `t.TempDir()` cleanup removed the Pebble data directory, the orphaned trimmer kept scanning the DB on its interval and, under file-cache pressure in a long parallel run, failed to re-open an SST that had been deleted — producing the error above and occasionally wedging the package.

This is a test-harness defect, not a production bug. In production `db.Close()` cancels the trimmer's context and waits for the goroutine to exit *before* `kv.Close()`, and `leaderController.Close()` tears down in order follower → wal → db. Pebble's own iterator/version ref-counting prevents a live iterator from losing an SST to compaction, so the missing file can only come from the test's temp-dir removal.

## Fix

Close the WAL, WAL factory, DB and KV factory at the end of each leaking test, matching the cleanup already present in `TestFollowerCursor_CloseWaitsForInFlightSnapshot` and the production teardown order (`follower → wal → db`).

## Verification

- Reproduced the leak deterministically (the `notificationsTrimmer.run` goroutine survives the test body) and the exact reported error (trimmer scanning a removed data dir → `…000004.sst: no such file or directory`, same stack).
- With the fix, running all four follower-cursor tests as subtests leaves the trimmer-goroutine count at baseline — no leak.
- `go test ./oxiad/dataserver/controller/lead/ -run TestFollowerCursor -race -count=20` passes; the full `lead` package passes with `-race`.
