### PR TITLE
fix: gate initial shard leader election on data-server handshake

### DIFF
--- a/oxiad/coordinator/runtime/controller/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller.go
@@ -47,6 +47,20 @@ const (
 	chanBufferSize = 100
 
 	DefaultPeriodicTasksInterval = 1 * time.Minute
+
+	// ensembleReadinessPollInterval is how often the initial leader election
+	// re-checks whether the shard's ensemble has completed the coordinator
+	// handshake before it starts.
+	ensembleReadinessPollInterval = 10 * time.Millisecond
+	// ensembleReadinessQuorumGrace is how long, after a quorum of the ensemble
+	// is handshake-bound, the initial election keeps waiting for the remaining
+	// members before proceeding anyway.
+	ensembleReadinessQuorumGrace = 100 * time.Millisecond
+	// ensembleReadinessMaxWait caps the total time the initial election waits
+	// for handshakes, so an unreachable data server (no quorum) cannot wedge
+	// startup; past it the election proceeds and its retry loop surfaces the
+	// problem.
+	ensembleReadinessMaxWait = 5 * time.Second
 )
 
 var _ ShardController = &shardController{}
@@ -74,6 +88,13 @@ func NoOpSupportedFeaturesSupplier([]*proto.DataServerIdentity) map[string][]pro
 	return map[string][]proto.Feature{}
 }
 
+// DataServerReadinessSupplier reports how many of the given data servers have
+// completed the coordinator handshake and are therefore ready to accept
+// internal RPCs such as NewTerm. It is used to gate the initial leader
+// election so it does not race ahead of the handshake, which would otherwise be
+// rejected with "server not initialized yet". A nil supplier disables the gate.
+type DataServerReadinessSupplier = func(dataServers []*proto.DataServerIdentity) int
+
 type shardController struct {
 	namespace       string
 	shard           int64
@@ -86,6 +107,7 @@ type shardController struct {
 	eventListener                       ShardEventListener
 	metadataStore                       coordmetadata.Metadata
 	dataServerSupportedFeaturesSupplier DataServerSupportedFeaturesSupplier
+	dataServerReadiness                 DataServerReadinessSupplier
 
 	electionOp          chan *action.ElectionAction
 	deleteOp            chan any
@@ -123,6 +145,7 @@ func NewShardController(
 	shardMetadata *proto.ShardMetadata,
 	metadataStore coordmetadata.Metadata,
 	dataServerSupportedFeaturesSupplier DataServerSupportedFeaturesSupplier,
+	dataServerReadiness DataServerReadinessSupplier,
 	eventListener ShardEventListener,
 	rpcProvider rpc.Provider,
 	periodTasksInterval time.Duration) ShardController {
@@ -135,6 +158,7 @@ func NewShardController(
 		rpc:                                 rpcProvider,
 		metadataStore:                       metadataStore,
 		dataServerSupportedFeaturesSupplier: dataServerSupportedFeaturesSupplier,
+		dataServerReadiness:                 dataServerReadiness,
 		eventListener:                       eventListener,
 		leaderSelector:                      leaderselector.NewSelector(),
 		electionOp:                          make(chan *action.ElectionAction, chanBufferSize),
@@ -223,6 +247,7 @@ func (s *shardController) run(initShardMeta *proto.ShardMetadata) {
 		s.logger.Info("Child shard during split, waiting for split to complete")
 		s.waitForSplitComplete()
 	case initShardMeta.Leader == nil || initShardMeta.GetStatusOrDefault() != proto.ShardStatusSteadyState:
+		s.waitForEnsembleReady(initShardMeta.Ensemble)
 		s.onElectLeader(nil)
 	default:
 		s.logger.Info(
@@ -230,6 +255,7 @@ func (s *shardController) run(initShardMeta *proto.ShardMetadata) {
 			slog.Any("current-leader", initShardMeta.Leader),
 		)
 
+		s.waitForEnsembleReady(initShardMeta.Ensemble)
 		if !s.verifyCurrentEnsemble(initShardMeta) {
 			s.onElectLeader(nil)
 		} else {
@@ -381,6 +407,64 @@ func (s *shardController) verifyCurrentEnsemble(initShardMeta *proto.ShardMetada
 
 	s.logger.Info("All data servers look good. No need to trigger new leader election")
 	return true
+}
+
+// waitForEnsembleReady blocks until the shard's ensemble has completed the
+// coordinator handshake, so the first leader election (and its pre-flight
+// verification) does not race ahead of the data servers binding the
+// coordinator instance id — internal RPCs are rejected with "server not
+// initialized yet" until that binding exists.
+//
+// To stay available when some data servers are slow or unreachable, it returns
+// as soon as the whole ensemble is bound, or once a quorum is bound and a short
+// grace period for the stragglers has elapsed, or after an overall safety
+// timeout (after which the election proceeds and its own retry loop surfaces
+// any remaining problem).
+func (s *shardController) waitForEnsembleReady(ensemble []*proto.DataServerIdentity) {
+	if s.dataServerReadiness == nil || len(ensemble) == 0 {
+		return
+	}
+	total := len(ensemble)
+	majority := total/2 + 1
+
+	if s.dataServerReadiness(ensemble) >= total {
+		return
+	}
+	s.logger.Debug("Waiting for ensemble data servers to complete handshake before electing")
+
+	ticker := time.NewTicker(ensembleReadinessPollInterval)
+	defer ticker.Stop()
+	overall := time.NewTimer(ensembleReadinessMaxWait)
+	defer overall.Stop()
+
+	var quorumGrace *time.Timer
+	var quorumGraceC <-chan time.Time
+	defer func() {
+		if quorumGrace != nil {
+			quorumGrace.Stop()
+		}
+	}()
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-overall.C:
+			s.logger.Warn("Timed out waiting for ensemble data servers to complete handshake; electing anyway")
+			return
+		case <-quorumGraceC:
+			return
+		case <-ticker.C:
+			ready := s.dataServerReadiness(ensemble)
+			if ready >= total {
+				return
+			}
+			if ready >= majority && quorumGrace == nil {
+				quorumGrace = time.NewTimer(ensembleReadinessQuorumGrace)
+				quorumGraceC = quorumGrace.C
+			}
+		}
+	}
 }
 
 func (s *shardController) onElectLeader(changeEnsembleAction *action.ChangeEnsembleAction) *proto.DataServerIdentity {

--- a/oxiad/coordinator/runtime/controller/shard_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/shard_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -164,7 +165,7 @@ func TestShardController(t *testing.T) {
 		Term:     1,
 		Leader:   nil,
 		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
-	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
+	}, metadata, NoOpSupportedFeaturesSupplier, nil, nil, rpc, DefaultPeriodicTasksInterval)
 
 	// Shard controller should initiate a leader election
 	// and newTerm each server
@@ -242,7 +243,7 @@ func TestShardController_StartingWithLeaderAlreadyPresent(t *testing.T) {
 		Term:     1,
 		Leader:   s1,
 		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
-	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
+	}, metadata, NoOpSupportedFeaturesSupplier, nil, nil, rpc, DefaultPeriodicTasksInterval)
 
 	n1.expectGetStatusRequest(t, shard)
 	n1.GetStatusResponse(1, proto.ServingStatus_LEADER, 0, 0)
@@ -254,6 +255,64 @@ func TestShardController_StartingWithLeaderAlreadyPresent(t *testing.T) {
 	n1.expectNoMoreNewTermRequest(t)
 	n2.expectNoMoreNewTermRequest(t)
 	n3.expectNoMoreNewTermRequest(t)
+
+	assert.NoError(t, sc.Close())
+}
+
+// TestShardController_GatesElectionUntilHandshakeComplete verifies that the
+// initial leader election does not fire NewTerm until the ensemble's data
+// servers have completed the coordinator handshake. This prevents the startup
+// race where NewTerm beats the handshake and gets rejected with
+// "server not initialized yet".
+func TestShardController_GatesElectionUntilHandshakeComplete(t *testing.T) {
+	var shard int64 = 5
+	rpc := newMockRpcProvider()
+
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
+
+	metadata := newTestMetadata(t, memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled), &proto.ClusterConfiguration{})
+
+	// Readiness is controlled by the test: no data server is handshake-bound yet.
+	var readyCount atomic.Int32
+	readiness := func(ensemble []*proto.DataServerIdentity) int {
+		return int(readyCount.Load())
+	}
+
+	sc := NewShardController(constant.DefaultNamespace, shard, namespaceConfig, &proto.ShardMetadata{
+		Status:   proto.ShardStatusUnknown,
+		Term:     1,
+		Leader:   nil,
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
+	}, metadata, NoOpSupportedFeaturesSupplier, readiness, nil, rpc, DefaultPeriodicTasksInterval)
+
+	// While the ensemble has not completed the handshake, no election is
+	// attempted. Checking one node is enough: an election would NewTerm the
+	// whole ensemble. The negative wait stays well under ensembleReadinessMaxWait.
+	rpc.GetNode(s1).expectNoMoreNewTermRequest(t)
+
+	// Prepare the election responses, then mark the whole ensemble as
+	// handshake-bound. The gate releases and the election proceeds.
+	rpc.GetNode(s1).NewTermResponse(1, 0, nil)
+	rpc.GetNode(s2).NewTermResponse(1, -1, nil)
+	rpc.GetNode(s3).NewTermResponse(1, -1, nil)
+	rpc.GetNode(s1).BecomeLeaderResponse(nil)
+
+	readyCount.Store(3)
+
+	rpc.GetNode(s1).expectNewTermRequest(t, shard, 2, true)
+	rpc.GetNode(s2).expectNewTermRequest(t, shard, 2, true)
+	rpc.GetNode(s3).expectNewTermRequest(t, shard, 2, true)
+
+	// s1 has the highest offset, so it becomes the leader.
+	rpc.GetNode(s1).expectBecomeLeaderRequest(t, shard, 2, 3)
+
+	assert.Eventually(t, func() bool {
+		return sc.Metadata().Status() == proto.ShardStatusSteadyState
+	}, 10*time.Second, 100*time.Millisecond)
+	assert.EqualValues(t, 2, sc.Metadata().Term())
+	assert.Equal(t, s1, sc.Metadata().Leader())
 
 	assert.NoError(t, sc.Close())
 }
@@ -273,7 +332,7 @@ func TestShardController_NewTermWithNonRespondingServer(t *testing.T) {
 		Term:     1,
 		Leader:   nil,
 		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
-	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
+	}, metadata, NoOpSupportedFeaturesSupplier, nil, nil, rpc, DefaultPeriodicTasksInterval)
 
 	timeStart := time.Now()
 
@@ -320,7 +379,7 @@ func TestShardController_NewTermFollowerUntilItRecovers(t *testing.T) {
 		Term:     1,
 		Leader:   nil,
 		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
-	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
+	}, metadata, NoOpSupportedFeaturesSupplier, nil, nil, rpc, DefaultPeriodicTasksInterval)
 
 	// s3 is failing, though we can still elect a leader
 	rpc.GetNode(s1).NewTermResponse(1, 0, nil)
@@ -375,7 +434,7 @@ func TestShardController_VerifyFollowersWereAllFenced(t *testing.T) {
 		Term:     4,
 		Leader:   s1,
 		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
-	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
+	}, metadata, NoOpSupportedFeaturesSupplier, nil, nil, rpc, DefaultPeriodicTasksInterval)
 
 	n1.expectGetStatusRequest(t, 5)
 	n1.GetStatusResponse(4, proto.ServingStatus_LEADER, 0, 0)
@@ -421,7 +480,7 @@ func TestShardController_NotificationsDisabled(t *testing.T) {
 		Term:     1,
 		Leader:   nil,
 		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
-	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
+	}, metadata, NoOpSupportedFeaturesSupplier, nil, nil, rpc, DefaultPeriodicTasksInterval)
 
 	// Shard controller should initiate a leader election
 	// and newTerm each server
@@ -454,7 +513,7 @@ func TestShardController_SwapNodeWithLeaderElectionFailure(t *testing.T) {
 		Term:     1,
 		Leader:   nil,
 		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
-	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, DefaultPeriodicTasksInterval)
+	}, metadata, NoOpSupportedFeaturesSupplier, nil, nil, rpc, DefaultPeriodicTasksInterval)
 
 	// Do initial election
 	rpc.GetNode(s1).NewTermResponse(1, 0, nil)
@@ -552,7 +611,7 @@ func TestShardController_LeaderElectionShouldNotFailIfRemoveFails(t *testing.T) 
 		Term:     1,
 		Leader:   nil,
 		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
-	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, 1*time.Second)
+	}, metadata, NoOpSupportedFeaturesSupplier, nil, nil, rpc, 1*time.Second)
 
 	// Do initial election
 	rpc.GetNode(s1).NewTermResponse(1, 0, nil)
@@ -671,7 +730,7 @@ func TestShardController_ShardsDataLostWithChangeEnsemble(t *testing.T) {
 		Term:     1,
 		Leader:   nil,
 		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
-	}, metadata, NoOpSupportedFeaturesSupplier, nil, rpc, 1*time.Second)
+	}, metadata, NoOpSupportedFeaturesSupplier, nil, nil, rpc, 1*time.Second)
 
 	// Do initial election
 	rpc.GetNode(s1).NewTermResponse(1, 0, nil)
@@ -782,7 +841,7 @@ func TestShardController_FeatureNegotiation_AllNodesSupport(t *testing.T) {
 		Term:     1,
 		Leader:   nil,
 		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
-	}, metadata, featureSupplier, nil, rpc, DefaultPeriodicTasksInterval)
+	}, metadata, featureSupplier, nil, nil, rpc, DefaultPeriodicTasksInterval)
 
 	rpc.GetNode(s1).NewTermResponse(1, 0, nil)
 	rpc.GetNode(s2).NewTermResponse(1, -1, nil)
@@ -837,7 +896,7 @@ func TestShardController_FeatureNegotiation_MixedVersions(t *testing.T) {
 		Term:     1,
 		Leader:   nil,
 		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
-	}, metadata, featureSupplier, nil, rpc, DefaultPeriodicTasksInterval)
+	}, metadata, featureSupplier, nil, nil, rpc, DefaultPeriodicTasksInterval)
 
 	rpc.GetNode(s1).NewTermResponse(1, 0, nil)
 	rpc.GetNode(s2).NewTermResponse(1, -1, nil)

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -240,19 +240,31 @@ func (c *runtime) findDataServerFeatures(dataServers []*proto.DataServerIdentity
 }
 
 // countReadyDataServers reports how many of the given data servers have
-// completed the coordinator handshake (Status == Running). Shard controllers
-// use it to hold the initial leader election until the ensemble's data servers
-// are handshake-bound, avoiding the startup race where NewTerm is rejected with
-// "server not initialized yet".
+// completed the coordinator handshake. Shard controllers use it to hold the
+// initial leader election until the ensemble's data servers are handshake-bound,
+// avoiding the startup race where NewTerm is rejected with "server not
+// initialized yet".
+//
+// A node both Running and Draining counts as ready: a node removed from the
+// cluster config is moved to drainingNodes (with Status Draining) but may still
+// belong to a shard ensemble that could not be rebalanced (e.g. an RF=1 shard).
+// It already completed the handshake, so it can be fenced and must not stall the
+// gate on the overall timeout.
 func (c *runtime) countReadyDataServers(dataServers []*proto.DataServerIdentity) int {
 	c.RLock()
 	defer c.RUnlock()
 
 	ready := 0
 	for _, dataServer := range dataServers {
-		if serverController, exist := c.dataServerControllers[dataServer.GetNameOrDefault()]; exist &&
-			serverController.Status() == controller.Running {
-			ready++
+		name := dataServer.GetNameOrDefault()
+		serverController, exist := c.dataServerControllers[name]
+		if !exist {
+			serverController, exist = c.drainingNodes[name]
+		}
+		if exist {
+			if status := serverController.Status(); status == controller.Running || status == controller.Draining {
+				ready++
+			}
 		}
 	}
 	return ready

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -189,7 +189,7 @@ func (c *runtime) CreateNamespace(name string, namespaceConfig *proto.Namespace)
 
 	for shard, shardMetadata := range namespaceStatus.GetShards() {
 		c.shardControllers[shard] = controller.NewShardController(name, shard, namespaceConfig,
-			shardMetadata, c.metadata, c.findDataServerFeatures,
+			shardMetadata, c.metadata, c.findDataServerFeatures, c.countReadyDataServers,
 			c, c.rpc, controller.DefaultPeriodicTasksInterval)
 		slog.Info("Added new shard", slog.Int64("shard", shard),
 			slog.String("namespace", name), slog.Any("shard-metadata", shardMetadata))
@@ -237,6 +237,25 @@ func (c *runtime) findDataServerFeatures(dataServers []*proto.DataServerIdentity
 		}
 	}
 	return features
+}
+
+// countReadyDataServers reports how many of the given data servers have
+// completed the coordinator handshake (Status == Running). Shard controllers
+// use it to hold the initial leader election until the ensemble's data servers
+// are handshake-bound, avoiding the startup race where NewTerm is rejected with
+// "server not initialized yet".
+func (c *runtime) countReadyDataServers(dataServers []*proto.DataServerIdentity) int {
+	c.RLock()
+	defer c.RUnlock()
+
+	ready := 0
+	for _, dataServer := range dataServers {
+		if serverController, exist := c.dataServerControllers[dataServer.GetNameOrDefault()]; exist &&
+			serverController.Status() == controller.Running {
+			ready++
+		}
+	}
+	return ready
 }
 
 func dataServersToCandidatesAndMetadata(dataServers map[string]commonobject.Borrowed[*proto.DataServer]) (
@@ -668,7 +687,7 @@ func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoin
 	for _, childId := range []int64{leftChildId, rightChildId} {
 		childMeta := nsCloned.Shards[childId]
 		c.shardControllers[childId] = controller.NewShardController(namespace, childId, nsConfig,
-			childMeta, c.metadata, c.findDataServerFeatures,
+			childMeta, c.metadata, c.findDataServerFeatures, c.countReadyDataServers,
 			c, c.rpc, controller.DefaultPeriodicTasksInterval)
 	}
 
@@ -870,7 +889,7 @@ func New(
 				nsConfig = borrowedNsConfig.UnsafeBorrow()
 			}
 			c.shardControllers[shard] = controller.NewShardController(ns, shard, nsConfig,
-				shardMetadata, c.metadata, c.findDataServerFeatures,
+				shardMetadata, c.metadata, c.findDataServerFeatures, c.countReadyDataServers,
 				c, c.rpc, controller.DefaultPeriodicTasksInterval)
 		}
 	}

--- a/oxiad/coordinator/runtime/runtime_test.go
+++ b/oxiad/coordinator/runtime/runtime_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
+)
+
+// statusOnlyDataServerController is a DataServerController stub that only
+// implements Status; countReadyDataServers touches nothing else.
+type statusOnlyDataServerController struct {
+	controller.DataServerController
+	status controller.DataServerStatus
+}
+
+func (s statusOnlyDataServerController) Status() controller.DataServerStatus { return s.status }
+
+func TestCountReadyDataServers(t *testing.T) {
+	running := &proto.DataServerIdentity{Internal: "running", Public: "running"}
+	notRunning := &proto.DataServerIdentity{Internal: "not-running", Public: "not-running"}
+	draining := &proto.DataServerIdentity{Internal: "draining", Public: "draining"}
+	unknown := &proto.DataServerIdentity{Internal: "unknown", Public: "unknown"}
+
+	c := &runtime{
+		dataServerControllers: map[string]controller.DataServerController{
+			running.GetNameOrDefault():    statusOnlyDataServerController{status: controller.Running},
+			notRunning.GetNameOrDefault(): statusOnlyDataServerController{status: controller.NotRunning},
+		},
+		drainingNodes: map[string]controller.DataServerController{
+			draining.GetNameOrDefault(): statusOnlyDataServerController{status: controller.Draining},
+		},
+	}
+
+	// Running counts; NotRunning and unknown nodes do not.
+	assert.Equal(t, 1, c.countReadyDataServers([]*proto.DataServerIdentity{running, notRunning, unknown}))
+
+	// A draining node already completed the handshake, so it counts as ready.
+	// This keeps an RF=1 shard whose only ensemble member was removed from the
+	// config (and moved to drainingNodes) from stalling the election gate.
+	assert.Equal(t, 1, c.countReadyDataServers([]*proto.DataServerIdentity{draining}))
+
+	// Mixed ensemble: running + draining are ready, not-running is not.
+	assert.Equal(t, 2, c.countReadyDataServers([]*proto.DataServerIdentity{running, draining, notRunning}))
+}

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -664,11 +664,17 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 		return len(c.ListDataServer()) == 3
 	}, 10*time.Second, 10*time.Millisecond)
 
-	// Wait for all shards to be ready
+	// Wait for all shards to be ready. With RF=1 the balancer cannot move the
+	// shard off the removed (but still running) leader, so the shard stays put
+	// in steady state at the term it was first elected with. A clean startup
+	// election lands at term 0 (term starts at -1, the first election bumps it
+	// once), so we only require a valid elected term here. This previously
+	// asserted Term > 0, which silently relied on the startup handshake race
+	// producing a spurious extra election that bumped the term to 1.
 	assert.Eventually(t, func() bool {
 		for _, ns := range mock.StatusSnapshot(t, metadata).Namespaces {
 			for _, shard := range ns.Shards {
-				return shard.Term > 0 && shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
+				return shard.Term >= 0 && shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
 			}
 		}
 		return true


### PR DESCRIPTION
## Motivation

When the coordinator starts and connects to already-running data servers, it logs a burst of transient warnings in the first ~200ms before self-healing on the 100ms retry:

- `FenceNewTerm failed error="oxia: server not initialized yet" ... shard=0`
- `Leader election has failed, retrying later error="election failed: quorum not reached: oxia: server not initialized yet; ..." retry-after=100ms shard=0 term=0`

Root cause: each per-node `dataServerController` performs a `Handshake` that binds the coordinator instance id into the data server's manifest. Until that binding exists, the data server's internal gRPC interceptor rejects every non-whitelisted RPC with `oxia: server not initialized yet`. Meanwhile the per-shard `shardController` starts leader election concurrently and independently — there is no ordering between "handshake the node" and "elect the shard", so the first `NewTerm`/`FenceNewTerm` round (and the `verifyCurrentEnsemble` probe on coordinator restart) can beat the handshake and get rejected. It is not a correctness bug (the 100ms retry recovers), but it is alarming log noise and a real ordering race.

## Modifications

- Gate the **initial** leader election (and its pre-flight `verifyCurrentEnsemble`) on the shard's ensemble data servers having reached the handshake-bound `Running` state, exposed from the runtime via a `countReadyDataServers` supplier injected into the shard controllers.
- The wait returns as soon as the whole ensemble is bound, or once a quorum is bound plus a short grace for stragglers, or after an overall safety timeout (so an unreachable data server cannot wedge startup — past it the election proceeds and its existing retry loop surfaces the problem), or on shutdown.
- Only the startup path is gated; failover and balancer-driven elections still go through `onElectLeader` unchanged, keeping recovery fast.
- `TestCoordinator_ShrinkCluster` asserted `shard.Term > 0` after a fresh-cluster start, which only held because the startup race triggered a spurious extra election that bumped the term to 1. With the race fixed, a clean RF=1 startup elects once at term 0 (and the balancer intentionally does not re-elect RF=1 on node removal), so the assertion is corrected to `Term >= 0`.
- Adds `TestShardController_GatesElectionUntilHandshakeComplete` asserting no `NewTerm` is sent until the ensemble reports handshake-bound.

## Relationship to #1196

Complementary and non-overlapping. #1196 gates the **assignment-push** path on the same handshake-bound signal (fixing the `Failed to send assignments … EOF` warning and the no-namespaces readiness case); this PR gates the **leader-election** path (the `FenceNewTerm failed` / `Leader election has failed` warnings). Verified empirically: with only this change the election warnings disappear but the assignment-push warnings remain (and vice-versa for #1196), so both are needed to fully clear the startup noise. The only textual overlap is `runtime.go`, in different regions. Both key off `dataServerController.Status() == Running` with no circular dependency, so they can land independently.

## Testing

- `go test ./oxiad/coordinator/runtime/...`
- `go test ./tests/coordinator -count=1` (full suite)
- `go test ./tests/{assignments,balancer,control,resolver} -count=1`
- `-race` on the gate logic and the runtime startup path
- golangci-lint v2.6.2 (CI-pinned): 0 issues
- On a single `TestCoordinator_ShrinkCluster` run: 0 `server not initialized yet` warnings on this branch vs many on `main`; one clean election at term 0 vs `main`'s fail→retry→term 1.
