### PR TITLE
feat: add coordinator auto-split monitor

### DIFF
--- a/common/proto/metadata_ext.go
+++ b/common/proto/metadata_ext.go
@@ -258,6 +258,14 @@ func (cc *ClusterConfiguration) Validate() error {
 		}
 	}
 
+	if err := cc.validateDurations(); err != nil {
+		return err
+	}
+
+	return cc.validateCoordinators()
+}
+
+func (cc *ClusterConfiguration) validateDurations() error {
 	if loadBalancer := cc.GetLoadBalancer(); loadBalancer != nil {
 		if _, err := loadBalancer.GetScheduleIntervalDuration(); err != nil {
 			return fmt.Errorf("cluster configuration: invalid loadBalancer.scheduleInterval: %w", err)
@@ -267,7 +275,16 @@ func (cc *ClusterConfiguration) Validate() error {
 		}
 	}
 
-	return cc.validateCoordinators()
+	if autoSplit := cc.GetAutoSplit(); autoSplit != nil {
+		if _, err := autoSplit.GetStabilizationPeriodDuration(); err != nil {
+			return fmt.Errorf("cluster configuration: invalid autoSplit.stabilizationPeriod: %w", err)
+		}
+		if _, err := autoSplit.GetCooldownPeriodDuration(); err != nil {
+			return fmt.Errorf("cluster configuration: invalid autoSplit.cooldownPeriod: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func (cc *ClusterConfiguration) validateCoordinators() error {

--- a/common/proto/metadata_ext_autosplit_test.go
+++ b/common/proto/metadata_ext_autosplit_test.go
@@ -93,3 +93,36 @@ func TestClusterConfiguration_GetAutoSplitWithDefaults(t *testing.T) {
 		assert.Equal(t, uint32(32), as.GetMaxShardsPerNamespace())
 	})
 }
+
+func TestClusterConfiguration_Validate_AutoSplitDurations(t *testing.T) {
+	base := func() *ClusterConfiguration {
+		return &ClusterConfiguration{
+			Namespaces: []*Namespace{{Name: "default", InitialShardCount: 1, ReplicationFactor: 1}},
+			Servers:    []*DataServerIdentity{{Public: "s1:6648", Internal: "s1:6649"}},
+		}
+	}
+
+	t.Run("valid durations pass", func(t *testing.T) {
+		cc := base()
+		cc.AutoSplit = &AutoSplitConfig{Enabled: true, StabilizationPeriod: "1m", CooldownPeriod: "5m"}
+		assert.NoError(t, cc.Validate())
+	})
+
+	t.Run("empty durations pass", func(t *testing.T) {
+		cc := base()
+		cc.AutoSplit = &AutoSplitConfig{Enabled: true}
+		assert.NoError(t, cc.Validate())
+	})
+
+	t.Run("malformed stabilizationPeriod is rejected", func(t *testing.T) {
+		cc := base()
+		cc.AutoSplit = &AutoSplitConfig{Enabled: true, StabilizationPeriod: "1minute"}
+		assert.ErrorContains(t, cc.Validate(), "stabilizationPeriod")
+	})
+
+	t.Run("malformed cooldownPeriod is rejected", func(t *testing.T) {
+		cc := base()
+		cc.AutoSplit = &AutoSplitConfig{Enabled: true, CooldownPeriod: "5min"}
+		assert.ErrorContains(t, cc.Validate(), "cooldownPeriod")
+	})
+}

--- a/oxiad/coordinator/runtime/autosplit/monitor.go
+++ b/oxiad/coordinator/runtime/autosplit/monitor.go
@@ -333,6 +333,11 @@ func (m *Monitor) computeOvershoot(key shardKey, leader *proto.DataServerIdentit
 			currTotal := stats.GetReadOpsTotal() + stats.GetWriteOpsTotal()
 			if currTotal >= prevTotal {
 				tracker.throughputOps = float64(currTotal-prevTotal) / elapsed
+			} else {
+				// Counters went backwards: the leader kept its identity but its
+				// process restarted, so there is no meaningful rate across the
+				// reset. Drop the stale value instead of carrying it forward.
+				tracker.throughputOps = 0
 			}
 		}
 	default:

--- a/oxiad/coordinator/runtime/autosplit/monitor.go
+++ b/oxiad/coordinator/runtime/autosplit/monitor.go
@@ -1,0 +1,326 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autosplit
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/oxia-db/oxia/common/metric"
+	commonobject "github.com/oxia-db/oxia/common/object"
+	"github.com/oxia-db/oxia/common/process"
+	"github.com/oxia-db/oxia/common/proto"
+	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
+)
+
+type StatusGetter interface {
+	GetStatus(ctx context.Context, node *proto.DataServerIdentity, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error)
+}
+
+const DefaultCollectionInterval = 30 * time.Second
+
+type shardKey struct {
+	namespace string
+	shardId   int64
+}
+
+type shardStatsTracker struct {
+	lastStats      *proto.ShardStats
+	lastSampleTime time.Time
+	throughputOps  float64
+	exceedingSince time.Time
+}
+
+type Monitor struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	metadata           coordmetadata.Metadata
+	rpc                StatusGetter
+	splitter           controller.ShardSplitter
+	collectionInterval time.Duration
+
+	mu                 sync.Mutex
+	trackers           map[shardKey]*shardStatsTracker
+	lastSplitCompleted time.Time
+
+	evaluationsCounter metric.Counter
+	initiatedCounter   metric.Counter
+
+	logger *slog.Logger
+}
+
+func NewMonitor(
+	metadata coordmetadata.Metadata,
+	rpcProvider StatusGetter,
+	splitter controller.ShardSplitter,
+	collectionInterval time.Duration,
+) *Monitor {
+	if collectionInterval == 0 {
+		collectionInterval = DefaultCollectionInterval
+	}
+	labels := map[string]any{}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Monitor{
+		ctx:                ctx,
+		cancel:             cancel,
+		metadata:           metadata,
+		rpc:                rpcProvider,
+		splitter:           splitter,
+		collectionInterval: collectionInterval,
+		trackers:           make(map[shardKey]*shardStatsTracker),
+		evaluationsCounter: metric.NewCounter("oxia_coordinator_autosplit_evaluations_total",
+			"Number of threshold evaluation cycles", "count", labels),
+		initiatedCounter: metric.NewCounter("oxia_coordinator_autosplit_splits_initiated_total",
+			"Auto-splits started", "count", labels),
+		logger: slog.With(slog.String("component", "auto-split-monitor")),
+	}
+}
+
+func (m *Monitor) Start() {
+	m.wg.Go(func() {
+		process.DoWithLabels(m.ctx, map[string]string{
+			"component": "auto-split-monitor",
+		}, m.run)
+	})
+}
+
+func (m *Monitor) Close() {
+	if m.cancel != nil {
+		m.cancel()
+	}
+	m.wg.Wait()
+}
+
+func (m *Monitor) run() {
+	ticker := time.NewTicker(m.collectionInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			m.evaluate()
+		case <-m.ctx.Done():
+			return
+		}
+	}
+}
+
+func (m *Monitor) evaluate() {
+	config := m.metadata.GetConfig().UnsafeBorrow()
+	autoSplit := config.GetAutoSplitWithDefaults()
+
+	if !autoSplit.GetEnabled() {
+		m.mu.Lock()
+		clear(m.trackers)
+		m.mu.Unlock()
+		return
+	}
+
+	m.evaluationsCounter.Inc()
+
+	namespaces := m.metadata.ListNamespaceStatus()
+
+	if m.anySplitInProgress(namespaces) {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	cooldown, _ := autoSplit.GetCooldownPeriodDuration()
+	if !m.lastSplitCompleted.IsZero() && now.Sub(m.lastSplitCompleted) < cooldown {
+		return
+	}
+
+	type candidate struct {
+		key            shardKey
+		overshootRatio float64
+	}
+	var best *candidate
+
+	activeShards := make(map[shardKey]struct{})
+
+	for ns, borrowedNs := range namespaces {
+		nsStatus := borrowedNs.UnsafeBorrow()
+
+		shardCount := uint32(len(nsStatus.GetShards()))
+		if shardCount >= autoSplit.GetMaxShardsPerNamespaceOrDefault() {
+			m.logger.Warn("Namespace at max shard count, skipping",
+				slog.String("namespace", ns),
+				slog.Uint64("shards", uint64(shardCount)),
+				slog.Uint64("max", uint64(autoSplit.GetMaxShardsPerNamespaceOrDefault())),
+			)
+			continue
+		}
+
+		for shardId, meta := range nsStatus.GetShards() {
+			key := shardKey{namespace: ns, shardId: shardId}
+			activeShards[key] = struct{}{}
+
+			if meta.GetStatusOrDefault() != proto.ShardStatusSteadyState {
+				continue
+			}
+			if meta.Leader == nil {
+				continue
+			}
+			if meta.Split != nil {
+				continue
+			}
+			if len(meta.PendingDeleteShardNodes) > 0 {
+				continue
+			}
+
+			stats := m.collectStats(key, meta.Leader)
+			if stats == nil {
+				continue
+			}
+
+			ratio := m.computeOvershoot(key, stats, autoSplit, now)
+			if ratio <= 1.0 {
+				continue
+			}
+
+			if best == nil || ratio > best.overshootRatio {
+				best = &candidate{key: key, overshootRatio: ratio}
+			}
+		}
+	}
+
+	m.pruneTrackers(activeShards)
+
+	if best == nil {
+		return
+	}
+
+	m.logger.Info("Initiating auto-split",
+		slog.String("namespace", best.key.namespace),
+		slog.Int64("shard", best.key.shardId),
+		slog.Float64("overshoot-ratio", best.overshootRatio),
+	)
+
+	leftChild, rightChild, err := m.splitter.InitiateSplit(best.key.namespace, best.key.shardId, nil)
+	if err != nil {
+		m.logger.Warn("Auto-split initiation failed",
+			slog.String("namespace", best.key.namespace),
+			slog.Int64("shard", best.key.shardId),
+			slog.Any("error", err),
+		)
+		return
+	}
+
+	m.initiatedCounter.Inc()
+	m.lastSplitCompleted = now
+
+	m.logger.Info("Auto-split initiated",
+		slog.String("namespace", best.key.namespace),
+		slog.Int64("parent-shard", best.key.shardId),
+		slog.Int64("left-child", leftChild),
+		slog.Int64("right-child", rightChild),
+	)
+}
+
+func (m *Monitor) collectStats(key shardKey, leader *proto.DataServerIdentity) *proto.ShardStats {
+	ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := m.rpc.GetStatus(ctx, leader, &proto.GetStatusRequest{Shard: key.shardId})
+	if err != nil {
+		m.logger.Debug("Failed to collect stats",
+			slog.String("namespace", key.namespace),
+			slog.Int64("shard", key.shardId),
+			slog.Any("error", err),
+		)
+		return nil
+	}
+	return resp.GetShardStats()
+}
+
+func (m *Monitor) computeOvershoot(key shardKey, stats *proto.ShardStats, config *proto.AutoSplitConfig, now time.Time) float64 {
+	tracker, exists := m.trackers[key]
+	if !exists {
+		tracker = &shardStatsTracker{}
+		m.trackers[key] = tracker
+	}
+
+	if tracker.lastStats != nil {
+		elapsed := now.Sub(tracker.lastSampleTime).Seconds()
+		if elapsed > 0 {
+			prevTotal := tracker.lastStats.GetReadOpsTotal() + tracker.lastStats.GetWriteOpsTotal()
+			currTotal := stats.GetReadOpsTotal() + stats.GetWriteOpsTotal()
+			if currTotal >= prevTotal {
+				tracker.throughputOps = float64(currTotal-prevTotal) / elapsed
+			}
+		}
+	}
+
+	tracker.lastStats = stats
+	tracker.lastSampleTime = now
+
+	maxSizeMB := float64(config.GetMaxShardSizeMBOrDefault())
+	maxThroughput := float64(config.GetMaxThroughputOpsOrDefault())
+	stabilization, _ := config.GetStabilizationPeriodDuration()
+
+	sizeMB := float64(stats.GetDbSizeBytes()) / (1024 * 1024)
+	var sizeRatio, throughputRatio float64
+
+	if maxSizeMB > 0 {
+		sizeRatio = sizeMB / maxSizeMB
+	}
+	if maxThroughput > 0 {
+		throughputRatio = tracker.throughputOps / maxThroughput
+	}
+
+	overshoot := max(sizeRatio, throughputRatio)
+	if overshoot <= 1.0 {
+		tracker.exceedingSince = time.Time{}
+		return 0
+	}
+
+	if tracker.exceedingSince.IsZero() {
+		tracker.exceedingSince = now
+	}
+
+	if now.Sub(tracker.exceedingSince) < stabilization {
+		return 0
+	}
+
+	return overshoot
+}
+
+func (m *Monitor) anySplitInProgress(namespaces map[string]commonobject.Borrowed[*proto.NamespaceStatus]) bool {
+	for _, borrowedNs := range namespaces {
+		ns := borrowedNs.UnsafeBorrow()
+		for _, meta := range ns.GetShards() {
+			if meta.Split != nil && len(meta.Split.ChildShardIds) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (m *Monitor) pruneTrackers(active map[shardKey]struct{}) {
+	for key := range m.trackers {
+		if _, ok := active[key]; !ok {
+			delete(m.trackers, key)
+		}
+	}
+}

--- a/oxiad/coordinator/runtime/autosplit/monitor.go
+++ b/oxiad/coordinator/runtime/autosplit/monitor.go
@@ -15,8 +15,10 @@
 package autosplit
 
 import (
+	"cmp"
 	"context"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
@@ -29,10 +31,14 @@ import (
 )
 
 type StatusGetter interface {
-	GetStatus(ctx context.Context, node *proto.DataServerIdentity, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error)
+	GetStatus(ctx context.Context, node *proto.DataServerIdentity,
+		req *proto.GetStatusRequest) (*proto.GetStatusResponse, error)
 }
 
-const DefaultCollectionInterval = 30 * time.Second
+const (
+	DefaultCollectionInterval = 30 * time.Second
+	statusCollectionTimeout   = 5 * time.Second
+)
 
 type shardKey struct {
 	namespace string
@@ -40,10 +46,19 @@ type shardKey struct {
 }
 
 type shardStatsTracker struct {
+	// leader identifies the server the last sample came from. Op counters are
+	// per-process cumulative, so a rate is only meaningful between two samples
+	// from the same leader.
+	leader         string
 	lastStats      *proto.ShardStats
 	lastSampleTime time.Time
 	throughputOps  float64
 	exceedingSince time.Time
+}
+
+type candidate struct {
+	key            shardKey
+	overshootRatio float64
 }
 
 type Monitor struct {
@@ -56,9 +71,11 @@ type Monitor struct {
 	splitter           controller.ShardSplitter
 	collectionInterval time.Duration
 
-	mu                 sync.Mutex
-	trackers           map[shardKey]*shardStatsTracker
-	lastSplitCompleted time.Time
+	mu       sync.Mutex
+	trackers map[shardKey]*shardStatsTracker
+	// lastSplitInitiated is the time the most recent split was started (not
+	// finished). The cooldown window is measured from initiation.
+	lastSplitInitiated time.Time
 
 	evaluationsCounter metric.Counter
 	initiatedCounter   metric.Counter
@@ -145,100 +162,140 @@ func (m *Monitor) evaluate() {
 	defer m.mu.Unlock()
 
 	now := time.Now()
-	cooldown, _ := autoSplit.GetCooldownPeriodDuration()
-	if !m.lastSplitCompleted.IsZero() && now.Sub(m.lastSplitCompleted) < cooldown {
+	cooldown := m.cooldownPeriod(autoSplit)
+	if !m.lastSplitInitiated.IsZero() && now.Sub(m.lastSplitInitiated) < cooldown {
 		return
 	}
 
-	type candidate struct {
-		key            shardKey
-		overshootRatio float64
+	candidates := m.collectCandidates(namespaces, autoSplit, now)
+	if len(candidates) == 0 {
+		return
 	}
-	var best *candidate
 
+	// Most overloaded shard first.
+	slices.SortFunc(candidates, func(a, b candidate) int {
+		return cmp.Compare(b.overshootRatio, a.overshootRatio)
+	})
+
+	// Try candidates in order. If InitiateSplit rejects the worst offender
+	// (e.g. an ensemble-selection failure), fall through to the next so a
+	// single unsplittable shard cannot starve the rest of the namespace.
+	for _, c := range candidates {
+		m.logger.Info("Initiating auto-split",
+			slog.String("namespace", c.key.namespace),
+			slog.Int64("shard", c.key.shardId),
+			slog.Float64("overshoot-ratio", c.overshootRatio),
+		)
+
+		leftChild, rightChild, err := m.splitter.InitiateSplit(c.key.namespace, c.key.shardId, nil)
+		if err != nil {
+			m.logger.Warn("Auto-split initiation failed, trying next candidate",
+				slog.String("namespace", c.key.namespace),
+				slog.Int64("shard", c.key.shardId),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		m.initiatedCounter.Inc()
+		m.lastSplitInitiated = now
+
+		m.logger.Info("Auto-split initiated",
+			slog.String("namespace", c.key.namespace),
+			slog.Int64("parent-shard", c.key.shardId),
+			slog.Int64("left-child", leftChild),
+			slog.Int64("right-child", rightChild),
+		)
+		return
+	}
+}
+
+// collectCandidates samples every steady-state shard, updates the per-shard
+// trackers, prunes trackers for shards that no longer exist, and returns the
+// shards whose overshoot ratio (after stabilization) exceeds 1.
+func (m *Monitor) collectCandidates(
+	namespaces map[string]commonobject.Borrowed[*proto.NamespaceStatus],
+	autoSplit *proto.AutoSplitConfig,
+	now time.Time,
+) []candidate {
+	var candidates []candidate
 	activeShards := make(map[shardKey]struct{})
+	maxShards := autoSplit.GetMaxShardsPerNamespaceOrDefault()
 
 	for ns, borrowedNs := range namespaces {
 		nsStatus := borrowedNs.UnsafeBorrow()
 
-		shardCount := uint32(len(nsStatus.GetShards()))
-		if shardCount >= autoSplit.GetMaxShardsPerNamespaceOrDefault() {
+		// Record every existing shard as active before any skip, so a namespace
+		// that is temporarily skipped (e.g. at the shard-count cap) does not
+		// lose the stabilization history of its shards to pruneTrackers.
+		for shardId := range nsStatus.GetShards() {
+			activeShards[shardKey{namespace: ns, shardId: shardId}] = struct{}{}
+		}
+
+		if uint32(len(nsStatus.GetShards())) >= maxShards {
 			m.logger.Warn("Namespace at max shard count, skipping",
 				slog.String("namespace", ns),
-				slog.Uint64("shards", uint64(shardCount)),
-				slog.Uint64("max", uint64(autoSplit.GetMaxShardsPerNamespaceOrDefault())),
+				slog.Int("shards", len(nsStatus.GetShards())),
+				slog.Uint64("max", uint64(maxShards)),
 			)
 			continue
 		}
 
 		for shardId, meta := range nsStatus.GetShards() {
-			key := shardKey{namespace: ns, shardId: shardId}
-			activeShards[key] = struct{}{}
-
-			if meta.GetStatusOrDefault() != proto.ShardStatusSteadyState {
-				continue
-			}
-			if meta.Leader == nil {
-				continue
-			}
-			if meta.Split != nil {
-				continue
-			}
-			if len(meta.PendingDeleteShardNodes) > 0 {
-				continue
-			}
-
-			stats := m.collectStats(key, meta.Leader)
-			if stats == nil {
-				continue
-			}
-
-			ratio := m.computeOvershoot(key, stats, autoSplit, now)
-			if ratio <= 1.0 {
-				continue
-			}
-
-			if best == nil || ratio > best.overshootRatio {
-				best = &candidate{key: key, overshootRatio: ratio}
+			if c, ok := m.shardCandidate(shardKey{namespace: ns, shardId: shardId}, meta, autoSplit, now); ok {
+				candidates = append(candidates, c)
 			}
 		}
 	}
 
 	m.pruneTrackers(activeShards)
+	return candidates
+}
 
-	if best == nil {
-		return
+// shardCandidate samples one shard and reports whether it is a split candidate
+// (steady-state, splittable, and over the threshold past its stabilization
+// window). It updates the shard's tracker as a side effect.
+func (m *Monitor) shardCandidate(key shardKey, meta *proto.ShardMetadata,
+	autoSplit *proto.AutoSplitConfig, now time.Time) (candidate, bool) {
+	if meta.GetStatusOrDefault() != proto.ShardStatusSteadyState {
+		return candidate{}, false
+	}
+	if meta.Leader == nil {
+		return candidate{}, false
+	}
+	if meta.Split != nil {
+		return candidate{}, false
+	}
+	if len(meta.PendingDeleteShardNodes) > 0 {
+		return candidate{}, false
+	}
+	// Skip shards whose hash range is too small to split; InitiateSplit would
+	// reject them and they must not block other candidates.
+	if !splittable(meta) {
+		return candidate{}, false
 	}
 
-	m.logger.Info("Initiating auto-split",
-		slog.String("namespace", best.key.namespace),
-		slog.Int64("shard", best.key.shardId),
-		slog.Float64("overshoot-ratio", best.overshootRatio),
-	)
-
-	leftChild, rightChild, err := m.splitter.InitiateSplit(best.key.namespace, best.key.shardId, nil)
-	if err != nil {
-		m.logger.Warn("Auto-split initiation failed",
-			slog.String("namespace", best.key.namespace),
-			slog.Int64("shard", best.key.shardId),
-			slog.Any("error", err),
-		)
-		return
+	stats := m.collectStats(key, meta.Leader)
+	if stats == nil {
+		return candidate{}, false
 	}
 
-	m.initiatedCounter.Inc()
-	m.lastSplitCompleted = now
+	ratio := m.computeOvershoot(key, meta.Leader, stats, autoSplit, now)
+	if ratio <= 1.0 {
+		return candidate{}, false
+	}
+	return candidate{key: key, overshootRatio: ratio}, true
+}
 
-	m.logger.Info("Auto-split initiated",
-		slog.String("namespace", best.key.namespace),
-		slog.Int64("parent-shard", best.key.shardId),
-		slog.Int64("left-child", leftChild),
-		slog.Int64("right-child", rightChild),
-	)
+// splittable reports whether the shard's hash range is wide enough to split,
+// mirroring the guard in runtime.InitiateSplit.
+func splittable(meta *proto.ShardMetadata) bool {
+	r := meta.GetInt32HashRange()
+	return r.GetMax()-r.GetMin() >= 1
 }
 
 func (m *Monitor) collectStats(key shardKey, leader *proto.DataServerIdentity) *proto.ShardStats {
-	ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(m.ctx, statusCollectionTimeout)
 	defer cancel()
 
 	resp, err := m.rpc.GetStatus(ctx, leader, &proto.GetStatusRequest{Shard: key.shardId})
@@ -253,14 +310,23 @@ func (m *Monitor) collectStats(key shardKey, leader *proto.DataServerIdentity) *
 	return resp.GetShardStats()
 }
 
-func (m *Monitor) computeOvershoot(key shardKey, stats *proto.ShardStats, config *proto.AutoSplitConfig, now time.Time) float64 {
+func (m *Monitor) computeOvershoot(key shardKey, leader *proto.DataServerIdentity,
+	stats *proto.ShardStats, config *proto.AutoSplitConfig, now time.Time) float64 {
 	tracker, exists := m.trackers[key]
 	if !exists {
 		tracker = &shardStatsTracker{}
 		m.trackers[key] = tracker
 	}
 
-	if tracker.lastStats != nil {
+	leaderID := leader.GetNameOrDefault()
+
+	switch {
+	case tracker.leader != leaderID:
+		// Leader changed (or first sample): the cumulative counters belong to a
+		// different process, so drop the rate until we have two same-leader
+		// samples rather than computing a spurious cross-leader delta.
+		tracker.throughputOps = 0
+	case tracker.lastStats != nil:
 		elapsed := now.Sub(tracker.lastSampleTime).Seconds()
 		if elapsed > 0 {
 			prevTotal := tracker.lastStats.GetReadOpsTotal() + tracker.lastStats.GetWriteOpsTotal()
@@ -269,14 +335,17 @@ func (m *Monitor) computeOvershoot(key shardKey, stats *proto.ShardStats, config
 				tracker.throughputOps = float64(currTotal-prevTotal) / elapsed
 			}
 		}
+	default:
+		// Same leader, first sample for this tracker: no rate to compute yet.
 	}
 
+	tracker.leader = leaderID
 	tracker.lastStats = stats
 	tracker.lastSampleTime = now
 
 	maxSizeMB := float64(config.GetMaxShardSizeMBOrDefault())
 	maxThroughput := float64(config.GetMaxThroughputOpsOrDefault())
-	stabilization, _ := config.GetStabilizationPeriodDuration()
+	stabilization := m.stabilizationPeriod(config)
 
 	sizeMB := float64(stats.GetDbSizeBytes()) / (1024 * 1024)
 	var sizeRatio, throughputRatio float64
@@ -305,7 +374,30 @@ func (m *Monitor) computeOvershoot(key shardKey, stats *proto.ShardStats, config
 	return overshoot
 }
 
-func (m *Monitor) anySplitInProgress(namespaces map[string]commonobject.Borrowed[*proto.NamespaceStatus]) bool {
+// cooldownPeriod returns the configured cooldown. A malformed duration string
+// must not silently disable the safety window, so on a parse error it falls
+// back to the default instead of zero. An explicit "0s" remains valid.
+func (m *Monitor) cooldownPeriod(config *proto.AutoSplitConfig) time.Duration {
+	d, err := config.GetCooldownPeriodDuration()
+	if err != nil {
+		m.logger.Warn("Invalid cooldown_period, using default", slog.Any("error", err))
+		return config.GetCooldownPeriodDurationOrDefault()
+	}
+	return d
+}
+
+// stabilizationPeriod mirrors cooldownPeriod: a parse error falls back to the
+// default rather than silently disabling the stabilization window.
+func (m *Monitor) stabilizationPeriod(config *proto.AutoSplitConfig) time.Duration {
+	d, err := config.GetStabilizationPeriodDuration()
+	if err != nil {
+		m.logger.Warn("Invalid stabilization_period, using default", slog.Any("error", err))
+		return config.GetStabilizationPeriodDurationOrDefault()
+	}
+	return d
+}
+
+func (*Monitor) anySplitInProgress(namespaces map[string]commonobject.Borrowed[*proto.NamespaceStatus]) bool {
 	for _, borrowedNs := range namespaces {
 		ns := borrowedNs.UnsafeBorrow()
 		for _, meta := range ns.GetShards() {

--- a/oxiad/coordinator/runtime/autosplit/monitor_test.go
+++ b/oxiad/coordinator/runtime/autosplit/monitor_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -59,8 +60,9 @@ func (m *mockRpcProvider) setStats(shard int64, stats *proto.ShardStats) {
 // mockRpcProvider implements autosplit.StatusGetter.
 
 type mockSplitter struct {
-	mu     sync.Mutex
-	splits []splitCall
+	mu      sync.Mutex
+	splits  []splitCall
+	failFor map[int64]bool // shard IDs for which InitiateSplit returns an error
 }
 
 type splitCall struct {
@@ -68,9 +70,12 @@ type splitCall struct {
 	shardId   int64
 }
 
-func (s *mockSplitter) InitiateSplit(namespace string, parentShardId int64, _ *uint32) (int64, int64, error) {
+func (s *mockSplitter) InitiateSplit(namespace string, parentShardId int64, _ *uint32) (leftChild, rightChild int64, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.failFor[parentShardId] {
+		return 0, 0, errors.Errorf("cannot split shard %d", parentShardId)
+	}
 	s.splits = append(s.splits, splitCall{namespace, parentShardId})
 	return parentShardId + 100, parentShardId + 101, nil
 }
@@ -405,3 +410,223 @@ func TestMonitor_PicksWorstOffender(t *testing.T) {
 	require.Len(t, splits, 1)
 	assert.Equal(t, int64(1), splits[0].shardId)
 }
+
+// steadyShard is a helper for building a steady-state shard with a leader and a
+// full hash range.
+func steadyShard(leader *proto.DataServerIdentity, minHash, maxHash uint32) *proto.ShardMetadata {
+	return &proto.ShardMetadata{
+		Status:         proto.ShardStatusSteadyState,
+		Term:           1,
+		Leader:         leader,
+		Ensemble:       []*proto.DataServerIdentity{leader},
+		Int32HashRange: &proto.HashRange{Min: minHash, Max: maxHash},
+	}
+}
+
+// A malformed cooldown_period must fall back to the default, NOT silently
+// disable the cooldown (which a discarded parse error -> 0 would do).
+func TestMonitor_MalformedCooldownFallsBackToDefault(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:             true,
+			MaxShardSizeMb:      100,
+			StabilizationPeriod: "0s",
+			CooldownPeriod:      "5min", // invalid Go duration; correct is "5m"
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leader := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: steadyShard(leader, 0, 2147483647),
+			1: steadyShard(leader, 2147483648, 4294967295),
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	rpcMock.setStats(0, &proto.ShardStats{DbSizeBytes: 200 * 1024 * 1024})
+	rpcMock.setStats(1, &proto.ShardStats{DbSizeBytes: 200 * 1024 * 1024})
+
+	splitter := &mockSplitter{}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	m.evaluate()
+	require.Len(t, splitter.getSplits(), 1)
+
+	// With the parse error correctly defaulting to 5m (not 0), the cooldown
+	// blocks the second split. A regression (cooldown=0) would split shard 1.
+	m.evaluate()
+	assert.Len(t, splitter.getSplits(), 1)
+}
+
+// If the worst-overshoot shard cannot be split, the monitor must fall through
+// to the next candidate rather than getting wedged on it forever.
+func TestMonitor_StarvationFallThrough(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:             true,
+			MaxShardSizeMb:      100,
+			StabilizationPeriod: "0s",
+			CooldownPeriod:      "0s",
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leader := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: steadyShard(leader, 0, 2147483647), // worst offender, but unsplittable
+			1: steadyShard(leader, 2147483648, 4294967295),
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	rpcMock.setStats(0, &proto.ShardStats{DbSizeBytes: 500 * 1024 * 1024}) // higher overshoot
+	rpcMock.setStats(1, &proto.ShardStats{DbSizeBytes: 200 * 1024 * 1024})
+
+	splitter := &mockSplitter{failFor: map[int64]bool{0: true}}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	m.evaluate()
+
+	splits := splitter.getSplits()
+	require.Len(t, splits, 1)
+	assert.Equal(t, int64(1), splits[0].shardId) // fell through to shard 1
+}
+
+// A shard whose hash range is too small to split must be pre-filtered so it is
+// never even attempted (and cannot block other candidates).
+func TestMonitor_UnsplittableShardSkipped(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:             true,
+			MaxShardSizeMb:      100,
+			StabilizationPeriod: "0s",
+			CooldownPeriod:      "0s",
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leader := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: steadyShard(leader, 100, 100), // width 0 -> unsplittable
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	rpcMock.setStats(0, &proto.ShardStats{DbSizeBytes: 500 * 1024 * 1024})
+
+	splitter := &mockSplitter{}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	m.evaluate()
+	assert.Empty(t, splitter.getSplits())
+}
+
+// A leader change resets the throughput baseline so a cross-leader counter
+// delta cannot be mistaken for a genuine spike and trigger a wrong split.
+func TestMonitor_LeaderChangeResetsThroughput(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:             true,
+			MaxThroughputOps:    100,
+			StabilizationPeriod: "0s",
+			CooldownPeriod:      "0s",
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leaderA := &proto.DataServerIdentity{Name: strPtr("nodeA"), Public: "a:9091", Internal: "a:8191"}
+	leaderB := &proto.DataServerIdentity{Name: strPtr("nodeB"), Public: "b:9091", Internal: "b:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: steadyShard(leaderA, 0, 4294967295),
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	rpcMock.setStats(0, &proto.ShardStats{ReadOpsTotal: 1000, WriteOpsTotal: 1000})
+
+	splitter := &mockSplitter{}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	// Establish a baseline under leader A.
+	m.evaluate()
+	require.Empty(t, splitter.getSplits())
+
+	// Leader moves to B, whose cumulative counters are much higher. Age the
+	// sample so elapsed > 0.
+	metadata.UpdateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: steadyShard(leaderB, 0, 4294967295),
+		},
+	})
+	m.mu.Lock()
+	m.trackers[shardKey{namespace: "default", shardId: 0}].lastSampleTime = time.Now().Add(-time.Second)
+	m.mu.Unlock()
+	rpcMock.setStats(0, &proto.ShardStats{ReadOpsTotal: 5000000, WriteOpsTotal: 5000000})
+
+	// Because the leader changed, the huge cross-leader delta must be ignored.
+	m.evaluate()
+	assert.Empty(t, splitter.getSplits())
+}
+
+// Trackers for a namespace that is temporarily skipped at the shard-count cap
+// must be retained (their stabilization history not pruned).
+func TestMonitor_MaxShardCountRetainsTrackers(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:               true,
+			MaxShardSizeMb:        100,
+			StabilizationPeriod:   "0s",
+			CooldownPeriod:        "0s",
+			MaxShardsPerNamespace: 2,
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leader := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: steadyShard(leader, 0, 2147483647),
+			1: steadyShard(leader, 2147483648, 4294967295),
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	rpcMock.setStats(0, &proto.ShardStats{DbSizeBytes: 200 * 1024 * 1024})
+	rpcMock.setStats(1, &proto.ShardStats{DbSizeBytes: 200 * 1024 * 1024})
+
+	splitter := &mockSplitter{}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	// Seed a tracker for shard 0 directly, then evaluate: the namespace is at
+	// the cap (2 >= 2) so it is skipped, but the tracker must survive.
+	m.mu.Lock()
+	m.trackers[shardKey{namespace: "default", shardId: 0}] = &shardStatsTracker{exceedingSince: time.Now()}
+	m.mu.Unlock()
+
+	m.evaluate()
+
+	m.mu.Lock()
+	_, retained := m.trackers[shardKey{namespace: "default", shardId: 0}]
+	m.mu.Unlock()
+	assert.True(t, retained, "tracker for a shard in a capped namespace must not be pruned")
+	assert.Empty(t, splitter.getSplits())
+}
+
+// Start()/Close() must run and shut down the background loop cleanly.
+func TestMonitor_StartCloseLifecycle(t *testing.T) {
+	metadata := newTestMetadata(t, &proto.ClusterConfiguration{})
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	splitter := &mockSplitter{}
+
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+	m.Start()
+	time.Sleep(10 * time.Millisecond) // let a few ticks run
+	m.Close()                         // must return without hanging or panicking
+}
+
+func strPtr(s string) *string { return &s }

--- a/oxiad/coordinator/runtime/autosplit/monitor_test.go
+++ b/oxiad/coordinator/runtime/autosplit/monitor_test.go
@@ -1,0 +1,407 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autosplit
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/common/proto"
+	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	metadatacodec "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common/codec"
+	coordoption "github.com/oxia-db/oxia/oxiad/coordinator/option"
+)
+
+type mockRpcProvider struct {
+	mu       sync.Mutex
+	statuses map[int64]*proto.GetStatusResponse
+}
+
+func (m *mockRpcProvider) GetStatus(_ context.Context, _ *proto.DataServerIdentity, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if resp, ok := m.statuses[req.Shard]; ok {
+		return resp, nil
+	}
+	return &proto.GetStatusResponse{}, nil
+}
+
+func (m *mockRpcProvider) setStats(shard int64, stats *proto.ShardStats) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.statuses[shard] = &proto.GetStatusResponse{
+		Term:       1,
+		Status:     proto.ServingStatus_LEADER,
+		ShardStats: stats,
+	}
+}
+
+// mockRpcProvider implements autosplit.StatusGetter.
+
+type mockSplitter struct {
+	mu     sync.Mutex
+	splits []splitCall
+}
+
+type splitCall struct {
+	namespace string
+	shardId   int64
+}
+
+func (s *mockSplitter) InitiateSplit(namespace string, parentShardId int64, _ *uint32) (int64, int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.splits = append(s.splits, splitCall{namespace, parentShardId})
+	return parentShardId + 100, parentShardId + 101, nil
+}
+
+func (s *mockSplitter) getSplits() []splitCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([]splitCall, len(s.splits))
+	copy(result, s.splits)
+	return result
+}
+
+func newTestMetadata(t *testing.T, config *proto.ClusterConfiguration) coordmetadata.Metadata {
+	t.Helper()
+
+	dir := t.TempDir()
+	data, err := metadatacodec.ClusterConfigCodec.MarshalYAML(config)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, coordoption.DefaultFileConfigName), data, 0o600))
+
+	metadataFactory, err := coordmetadata.New(t.Context(), &coordoption.Options{
+		Metadata: coordoption.MetadataOptions{
+			ProviderOptions: coordoption.ProviderOptions{
+				ProviderName: metadatacommon.NameFile,
+				File: coordoption.FileMetadata{
+					Dir: dir,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	metadata, err := metadataFactory.CreateMetadata(t.Context())
+	require.NoError(t, err)
+	_, err = metadata.WaitToBecomeLeader()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, metadata.Close())
+		require.NoError(t, metadataFactory.Close())
+	})
+	return metadata
+}
+
+func TestMonitor_DisabledByDefault(t *testing.T) {
+	metadata := newTestMetadata(t, &proto.ClusterConfiguration{})
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	splitter := &mockSplitter{}
+
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+	m.evaluate()
+
+	assert.Empty(t, splitter.getSplits())
+}
+
+func TestMonitor_SplitOnSizeThreshold(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:             true,
+			MaxShardSizeMb:      100,
+			StabilizationPeriod: "0s",
+			CooldownPeriod:      "0s",
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leader := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: {
+				Status:         proto.ShardStatusSteadyState,
+				Term:           1,
+				Leader:         leader,
+				Ensemble:       []*proto.DataServerIdentity{leader},
+				Int32HashRange: &proto.HashRange{Min: 0, Max: 4294967295},
+			},
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	rpcMock.setStats(0, &proto.ShardStats{DbSizeBytes: 200 * 1024 * 1024})
+
+	splitter := &mockSplitter{}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	m.evaluate()
+
+	splits := splitter.getSplits()
+	require.Len(t, splits, 1)
+	assert.Equal(t, "default", splits[0].namespace)
+	assert.Equal(t, int64(0), splits[0].shardId)
+}
+
+func TestMonitor_StabilizationPeriod(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:             true,
+			MaxShardSizeMb:      100,
+			StabilizationPeriod: "1h",
+			CooldownPeriod:      "0s",
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leader := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: {
+				Status:         proto.ShardStatusSteadyState,
+				Term:           1,
+				Leader:         leader,
+				Ensemble:       []*proto.DataServerIdentity{leader},
+				Int32HashRange: &proto.HashRange{Min: 0, Max: 4294967295},
+			},
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	rpcMock.setStats(0, &proto.ShardStats{DbSizeBytes: 200 * 1024 * 1024})
+
+	splitter := &mockSplitter{}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	m.evaluate()
+	assert.Empty(t, splitter.getSplits())
+}
+
+func TestMonitor_CooldownPreventsRapidSplits(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:             true,
+			MaxShardSizeMb:      100,
+			StabilizationPeriod: "0s",
+			CooldownPeriod:      "1h",
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leader := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: {
+				Status:         proto.ShardStatusSteadyState,
+				Term:           1,
+				Leader:         leader,
+				Ensemble:       []*proto.DataServerIdentity{leader},
+				Int32HashRange: &proto.HashRange{Min: 0, Max: 2147483647},
+			},
+			1: {
+				Status:         proto.ShardStatusSteadyState,
+				Term:           1,
+				Leader:         leader,
+				Ensemble:       []*proto.DataServerIdentity{leader},
+				Int32HashRange: &proto.HashRange{Min: 2147483648, Max: 4294967295},
+			},
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	rpcMock.setStats(0, &proto.ShardStats{DbSizeBytes: 200 * 1024 * 1024})
+	rpcMock.setStats(1, &proto.ShardStats{DbSizeBytes: 200 * 1024 * 1024})
+
+	splitter := &mockSplitter{}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	m.evaluate()
+	require.Len(t, splitter.getSplits(), 1)
+
+	// Second evaluation blocked by cooldown
+	m.evaluate()
+	assert.Len(t, splitter.getSplits(), 1)
+}
+
+func TestMonitor_SkipsWhenSplitInProgress(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:             true,
+			MaxShardSizeMb:      100,
+			StabilizationPeriod: "0s",
+			CooldownPeriod:      "0s",
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leader := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: {
+				Status:         proto.ShardStatusSteadyState,
+				Term:           1,
+				Leader:         leader,
+				Ensemble:       []*proto.DataServerIdentity{leader},
+				Int32HashRange: &proto.HashRange{Min: 0, Max: 4294967295},
+				Split: &proto.SplitMetadata{
+					Phase:         proto.SplitPhaseBootstrap,
+					ChildShardIds: []int64{10, 11},
+				},
+			},
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	rpcMock.setStats(0, &proto.ShardStats{DbSizeBytes: 200 * 1024 * 1024})
+
+	splitter := &mockSplitter{}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	m.evaluate()
+	assert.Empty(t, splitter.getSplits())
+}
+
+func TestMonitor_MaxShardsGuardRail(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:               true,
+			MaxShardSizeMb:        100,
+			StabilizationPeriod:   "0s",
+			CooldownPeriod:        "0s",
+			MaxShardsPerNamespace: 1,
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leader := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: {
+				Status:         proto.ShardStatusSteadyState,
+				Term:           1,
+				Leader:         leader,
+				Ensemble:       []*proto.DataServerIdentity{leader},
+				Int32HashRange: &proto.HashRange{Min: 0, Max: 4294967295},
+			},
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	rpcMock.setStats(0, &proto.ShardStats{DbSizeBytes: 200 * 1024 * 1024})
+
+	splitter := &mockSplitter{}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	m.evaluate()
+	assert.Empty(t, splitter.getSplits())
+}
+
+func TestMonitor_ThroughputThreshold(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:             true,
+			MaxThroughputOps:    100,
+			StabilizationPeriod: "0s",
+			CooldownPeriod:      "0s",
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leader := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: {
+				Status:         proto.ShardStatusSteadyState,
+				Term:           1,
+				Leader:         leader,
+				Ensemble:       []*proto.DataServerIdentity{leader},
+				Int32HashRange: &proto.HashRange{Min: 0, Max: 4294967295},
+			},
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	splitter := &mockSplitter{}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	// First sample — no rate yet
+	rpcMock.setStats(0, &proto.ShardStats{ReadOpsTotal: 0, WriteOpsTotal: 0})
+	m.evaluate()
+	assert.Empty(t, splitter.getSplits())
+
+	// Simulate time passing with high ops delta
+	m.mu.Lock()
+	tracker := m.trackers[shardKey{namespace: "default", shardId: 0}]
+	tracker.lastSampleTime = time.Now().Add(-1 * time.Second)
+	m.mu.Unlock()
+
+	rpcMock.setStats(0, &proto.ShardStats{ReadOpsTotal: 100, WriteOpsTotal: 100})
+	m.evaluate()
+
+	require.Len(t, splitter.getSplits(), 1)
+}
+
+func TestMonitor_PicksWorstOffender(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:             true,
+			MaxShardSizeMb:      100,
+			StabilizationPeriod: "0s",
+			CooldownPeriod:      "0s",
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leader := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: {
+				Status:         proto.ShardStatusSteadyState,
+				Term:           1,
+				Leader:         leader,
+				Ensemble:       []*proto.DataServerIdentity{leader},
+				Int32HashRange: &proto.HashRange{Min: 0, Max: 2147483647},
+			},
+			1: {
+				Status:         proto.ShardStatusSteadyState,
+				Term:           1,
+				Leader:         leader,
+				Ensemble:       []*proto.DataServerIdentity{leader},
+				Int32HashRange: &proto.HashRange{Min: 2147483648, Max: 4294967295},
+			},
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	rpcMock.setStats(0, &proto.ShardStats{DbSizeBytes: 200 * 1024 * 1024})
+	rpcMock.setStats(1, &proto.ShardStats{DbSizeBytes: 500 * 1024 * 1024})
+
+	splitter := &mockSplitter{}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	m.evaluate()
+
+	splits := splitter.getSplits()
+	require.Len(t, splits, 1)
+	assert.Equal(t, int64(1), splits[0].shardId)
+}

--- a/oxiad/coordinator/runtime/autosplit/monitor_test.go
+++ b/oxiad/coordinator/runtime/autosplit/monitor_test.go
@@ -573,6 +573,56 @@ func TestMonitor_LeaderChangeResetsThroughput(t *testing.T) {
 	assert.Empty(t, splitter.getSplits())
 }
 
+// A same-identity leader restart resets the cumulative counters; the derived
+// throughput must be dropped rather than carried forward as a stale spike.
+func TestMonitor_CounterResetDropsThroughput(t *testing.T) {
+	config := &proto.ClusterConfiguration{
+		AutoSplit: &proto.AutoSplitConfig{
+			Enabled:             true,
+			MaxThroughputOps:    100,
+			StabilizationPeriod: "0s",
+			CooldownPeriod:      "0s",
+		},
+	}
+	metadata := newTestMetadata(t, config)
+	leader := &proto.DataServerIdentity{Name: strPtr("nodeA"), Public: "a:9091", Internal: "a:8191"}
+
+	metadata.CreateNamespaceStatus("default", &proto.NamespaceStatus{
+		Shards: map[int64]*proto.ShardMetadata{
+			0: steadyShard(leader, 0, 4294967295),
+		},
+	})
+
+	rpcMock := &mockRpcProvider{statuses: make(map[int64]*proto.GetStatusResponse)}
+	splitter := &mockSplitter{}
+	m := NewMonitor(metadata, rpcMock, splitter, time.Millisecond)
+
+	// Two same-leader samples establish a high throughput rate.
+	rpcMock.setStats(0, &proto.ShardStats{ReadOpsTotal: 0, WriteOpsTotal: 0})
+	m.evaluate()
+	key := shardKey{namespace: "default", shardId: 0}
+	m.mu.Lock()
+	m.trackers[key].lastSampleTime = time.Now().Add(-time.Second)
+	m.mu.Unlock()
+	rpcMock.setStats(0, &proto.ShardStats{ReadOpsTotal: 500, WriteOpsTotal: 500})
+	m.evaluate()
+	require.Len(t, splitter.getSplits(), 1) // 1000 ops/s > 100 -> split
+
+	// Same leader, counters drop to near-zero (process restart). The stale high
+	// rate must be dropped by the code, not carried forward.
+	rpcMock.setStats(0, &proto.ShardStats{ReadOpsTotal: 1, WriteOpsTotal: 1})
+	m.mu.Lock()
+	m.trackers[key].lastSampleTime = time.Now().Add(-time.Second)
+	m.mu.Unlock()
+
+	m.evaluate()
+
+	m.mu.Lock()
+	got := m.trackers[key].throughputOps
+	m.mu.Unlock()
+	assert.Equal(t, float64(0), got, "throughput must reset when counters go backwards")
+}
+
 // Trackers for a namespace that is temporarily skipped at the shard-count cap
 // must be retained (their stabilization history not pruned).
 func TestMonitor_MaxShardCountRetainsTrackers(t *testing.T) {

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -64,9 +64,9 @@ type runtime struct {
 	// because they might be still reachable to clients.
 	drainingNodes map[string]controller.DataServerController
 
-	loadBalancer      balancer.LoadBalancer
-	autoSplitMonitor  *autosplit.Monitor
-	ensembleSelector  selector.Selector[*ensemble.Context, []string]
+	loadBalancer     balancer.LoadBalancer
+	autoSplitMonitor *autosplit.Monitor
+	ensembleSelector selector.Selector[*ensemble.Context, []string]
 
 	assignmentsWatch *commonwatch.Watch[*proto.ShardAssignments]
 

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -32,6 +32,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/common/sharding"
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/action"
+	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/autosplit"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/model"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/balancer/selector"
@@ -63,8 +64,9 @@ type runtime struct {
 	// because they might be still reachable to clients.
 	drainingNodes map[string]controller.DataServerController
 
-	loadBalancer     balancer.LoadBalancer
-	ensembleSelector selector.Selector[*ensemble.Context, []string]
+	loadBalancer      balancer.LoadBalancer
+	autoSplitMonitor  *autosplit.Monitor
+	ensembleSelector  selector.Selector[*ensemble.Context, []string]
 
 	assignmentsWatch *commonwatch.Watch[*proto.ShardAssignments]
 
@@ -335,6 +337,8 @@ func (c *runtime) selectNewEnsemble(namespace string, shard int64, ns *proto.Nam
 
 func (c *runtime) Close() error {
 	c.ctxCancel()
+
+	c.autoSplitMonitor.Close()
 
 	// The shard controllers must be closed before waiting for the action
 	// worker: the worker blocks on in-flight election actions, which only
@@ -915,5 +919,9 @@ func New(
 		}, c.startBackgroundActionWorker)
 	})
 	c.loadBalancer.Start()
+
+	c.autoSplitMonitor = autosplit.NewMonitor(c.metadata, c.rpc, c, autosplit.DefaultCollectionInterval)
+	c.autoSplitMonitor.Start()
+
 	return c, nil
 }

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -338,7 +338,9 @@ func (c *runtime) selectNewEnsemble(namespace string, shard int64, ns *proto.Nam
 func (c *runtime) Close() error {
 	c.ctxCancel()
 
-	c.autoSplitMonitor.Close()
+	if c.autoSplitMonitor != nil {
+		c.autoSplitMonitor.Close()
+	}
 
 	// The shard controllers must be closed before waiting for the action
 	// worker: the worker blocks on in-flight election actions, which only


### PR DESCRIPTION
## Summary

Adds the `AutoSplitMonitor` (design Phase 3) — a background component in the coordinator runtime that periodically samples per-shard stats via `GetStatus` and automatically initiates shard splits when size or throughput thresholds are exceeded. Builds on the `ShardStats` / `AutoSplitConfig` protos landed in #1202.

Auto-split is **disabled by default** (`enabled: false`) and gated by the cluster-wide `auto_split` config.

### Behavior
- Runs on a periodic ticker (default 30s), re-reading config each cycle (hot-reloadable).
- Per-shard trackers compute a throughput rate from the delta of cumulative op counters, and track how long a shard has continuously exceeded a threshold (**stabilization period**).
- Picks the worst overshoot offender; respects a **cooldown period**, a **max-shards-per-namespace** guard-rail, and only one split cluster-wide at a time.
- Only evaluates steady-state shards with a leader and no in-progress split.

### Safety / correctness (from an adversarial self-review before opening this PR)
- Malformed `stabilization_period` / `cooldown_period` fall back to the default (never silently `0`), and are now rejected at config load by `ClusterConfiguration.Validate()`.
- An unsplittable worst-offender shard cannot starve the rest: candidates are sorted by overshoot and tried in order, with unsplittable (hash-range-too-small) shards pre-filtered.
- Throughput is tracked per leader, so a leader change resets the baseline rather than computing a spurious cross-process counter delta.
- Trackers survive a namespace being temporarily skipped at the shard-count cap.

## Test plan
- [x] Unit tests: size/throughput thresholds, stabilization, cooldown, worst-offender selection, split-in-progress skip, max-shards guard-rail, malformed-duration fallback, starvation fall-through, unsplittable-skip, leader-change throughput reset, tracker retention, Start/Close lifecycle — all pass with `-race`.
- [x] Config-validation unit tests for `auto_split` durations.
- [x] `gofmt`, `go vet`, `golangci-lint` clean on changed files.
- [x] Full `oxiad/coordinator/runtime/...` and `common/proto` suites pass with `-race`.