### PR TITLE
test: add end-to-end auto-split test (+ configurable collection interval)

### DIFF
--- a/common/proto/metadata.pb.go
+++ b/common/proto/metadata.pb.go
@@ -644,6 +644,7 @@ type AutoSplitConfig struct {
 	StabilizationPeriod   string                 `protobuf:"bytes,4,opt,name=stabilization_period,json=stabilizationPeriod,proto3" json:"stabilization_period,omitempty"`
 	CooldownPeriod        string                 `protobuf:"bytes,5,opt,name=cooldown_period,json=cooldownPeriod,proto3" json:"cooldown_period,omitempty"`
 	MaxShardsPerNamespace uint32                 `protobuf:"varint,6,opt,name=max_shards_per_namespace,json=maxShardsPerNamespace,proto3" json:"max_shards_per_namespace,omitempty"`
+	CollectionInterval    string                 `protobuf:"bytes,7,opt,name=collection_interval,json=collectionInterval,proto3" json:"collection_interval,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -718,6 +719,13 @@ func (x *AutoSplitConfig) GetMaxShardsPerNamespace() uint32 {
 		return x.MaxShardsPerNamespace
 	}
 	return 0
+}
+
+func (x *AutoSplitConfig) GetCollectionInterval() string {
+	if x != nil {
+		return x.CollectionInterval
+	}
+	return ""
 }
 
 type ClusterConfiguration struct {
@@ -1215,14 +1223,15 @@ const file_metadata_proto_rawDesc = "" +
 	"\x16_notifications_enabled\"d\n" +
 	"\fLoadBalancer\x12+\n" +
 	"\x11schedule_interval\x18\x01 \x01(\tR\x10scheduleInterval\x12'\n" +
-	"\x0fquarantine_time\x18\x02 \x01(\tR\x0equarantineTime\"\x99\x02\n" +
+	"\x0fquarantine_time\x18\x02 \x01(\tR\x0equarantineTime\"\xca\x02\n" +
 	"\x0fAutoSplitConfig\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12)\n" +
 	"\x11max_shard_size_mb\x18\x02 \x01(\rR\x0emaxShardSizeMb\x12,\n" +
 	"\x12max_throughput_ops\x18\x03 \x01(\rR\x10maxThroughputOps\x121\n" +
 	"\x14stabilization_period\x18\x04 \x01(\tR\x13stabilizationPeriod\x12'\n" +
 	"\x0fcooldown_period\x18\x05 \x01(\tR\x0ecooldownPeriod\x127\n" +
-	"\x18max_shards_per_namespace\x18\x06 \x01(\rR\x15maxShardsPerNamespace\"\xe3\x04\n" +
+	"\x18max_shards_per_namespace\x18\x06 \x01(\rR\x15maxShardsPerNamespace\x12/\n" +
+	"\x13collection_interval\x18\a \x01(\tR\x12collectionInterval\"\xe3\x04\n" +
 	"\x14ClusterConfiguration\x12;\n" +
 	"\n" +
 	"namespaces\x18\x01 \x03(\v2\x1b.io.oxia.proto.v1.NamespaceR\n" +

--- a/common/proto/metadata.proto
+++ b/common/proto/metadata.proto
@@ -78,6 +78,7 @@ message AutoSplitConfig {
   string stabilization_period = 4;
   string cooldown_period = 5;
   uint32 max_shards_per_namespace = 6;
+  string collection_interval = 7;
 }
 
 message ClusterConfiguration {

--- a/common/proto/metadata_ext.go
+++ b/common/proto/metadata_ext.go
@@ -35,6 +35,8 @@ const (
 	defaultAutoSplitCooldownPeriod             = 5 * time.Minute
 	defaultAutoSplitStabilizationString        = "1m"
 	defaultAutoSplitCooldownString             = "5m"
+	defaultAutoSplitCollectionInterval         = 30 * time.Second
+	defaultAutoSplitCollectionString           = "30s"
 	defaultMaxShardsPerNamespace        uint32 = 64
 
 	AntiAffinityModeUnknown = ""
@@ -282,6 +284,9 @@ func (cc *ClusterConfiguration) validateDurations() error {
 		if _, err := autoSplit.GetCooldownPeriodDuration(); err != nil {
 			return fmt.Errorf("cluster configuration: invalid autoSplit.cooldownPeriod: %w", err)
 		}
+		if _, err := autoSplit.GetCollectionIntervalDuration(); err != nil {
+			return fmt.Errorf("cluster configuration: invalid autoSplit.collectionInterval: %w", err)
+		}
 	}
 
 	return nil
@@ -428,6 +433,24 @@ func (c *AutoSplitConfig) GetCooldownPeriodDurationOrDefault() time.Duration {
 	return duration
 }
 
+func (c *AutoSplitConfig) GetCollectionIntervalDuration() (time.Duration, error) {
+	if c == nil || c.GetCollectionInterval() == "" {
+		return 0, nil
+	}
+	return time.ParseDuration(c.GetCollectionInterval())
+}
+
+func (c *AutoSplitConfig) GetCollectionIntervalDurationOrDefault() time.Duration {
+	if c == nil {
+		return defaultAutoSplitCollectionInterval
+	}
+	duration, err := c.GetCollectionIntervalDuration()
+	if err != nil || duration == 0 {
+		return defaultAutoSplitCollectionInterval
+	}
+	return duration
+}
+
 func (c *AutoSplitConfig) GetMaxShardSizeMBOrDefault() uint32 {
 	if c == nil || c.GetMaxShardSizeMb() == 0 {
 		return defaultAutoSplitMaxShardSizeMB
@@ -456,6 +479,7 @@ func (cc *ClusterConfiguration) GetAutoSplitWithDefaults() *AutoSplitConfig {
 		StabilizationPeriod:   defaultAutoSplitStabilizationString,
 		CooldownPeriod:        defaultAutoSplitCooldownString,
 		MaxShardsPerNamespace: defaultMaxShardsPerNamespace,
+		CollectionInterval:    defaultAutoSplitCollectionString,
 	}
 
 	if cc == nil || cc.GetAutoSplit() == nil {
@@ -478,6 +502,9 @@ func (cc *ClusterConfiguration) GetAutoSplitWithDefaults() *AutoSplitConfig {
 	}
 	if v := src.GetMaxShardsPerNamespace(); v != 0 {
 		as.MaxShardsPerNamespace = v
+	}
+	if v := src.GetCollectionInterval(); v != "" {
+		as.CollectionInterval = v
 	}
 
 	return as

--- a/common/proto/metadata_ext.go
+++ b/common/proto/metadata_ext.go
@@ -284,8 +284,11 @@ func (cc *ClusterConfiguration) validateDurations() error {
 		if _, err := autoSplit.GetCooldownPeriodDuration(); err != nil {
 			return fmt.Errorf("cluster configuration: invalid autoSplit.cooldownPeriod: %w", err)
 		}
-		if _, err := autoSplit.GetCollectionIntervalDuration(); err != nil {
+		if d, err := autoSplit.GetCollectionIntervalDuration(); err != nil {
 			return fmt.Errorf("cluster configuration: invalid autoSplit.collectionInterval: %w", err)
+		} else if d < 0 {
+			return fmt.Errorf("cluster configuration: autoSplit.collectionInterval must not be negative: %q",
+				autoSplit.GetCollectionInterval())
 		}
 	}
 
@@ -445,7 +448,9 @@ func (c *AutoSplitConfig) GetCollectionIntervalDurationOrDefault() time.Duration
 		return defaultAutoSplitCollectionInterval
 	}
 	duration, err := c.GetCollectionIntervalDuration()
-	if err != nil || duration == 0 {
+	// A non-positive interval would panic time.NewTicker, so fall back to the
+	// default defensively even if validation was somehow bypassed.
+	if err != nil || duration <= 0 {
 		return defaultAutoSplitCollectionInterval
 	}
 	return duration

--- a/common/proto/metadata_ext_autosplit_test.go
+++ b/common/proto/metadata_ext_autosplit_test.go
@@ -106,6 +106,9 @@ func TestAutoSplitConfig_CollectionInterval_Default(t *testing.T) {
 	assert.Equal(t, 30*time.Second, (*AutoSplitConfig)(nil).GetCollectionIntervalDurationOrDefault())
 	assert.Equal(t, 30*time.Second, (&AutoSplitConfig{}).GetCollectionIntervalDurationOrDefault())
 	assert.Equal(t, 30*time.Second, (&AutoSplitConfig{CollectionInterval: "bad"}).GetCollectionIntervalDurationOrDefault())
+	// A non-positive interval would panic time.NewTicker; it must default.
+	assert.Equal(t, 30*time.Second, (&AutoSplitConfig{CollectionInterval: "-1s"}).GetCollectionIntervalDurationOrDefault())
+	assert.Equal(t, 30*time.Second, (&AutoSplitConfig{CollectionInterval: "0s"}).GetCollectionIntervalDurationOrDefault())
 }
 
 func TestClusterConfiguration_Validate_AutoSplitDurations(t *testing.T) {
@@ -143,6 +146,12 @@ func TestClusterConfiguration_Validate_AutoSplitDurations(t *testing.T) {
 	t.Run("malformed collectionInterval is rejected", func(t *testing.T) {
 		cc := base()
 		cc.AutoSplit = &AutoSplitConfig{Enabled: true, CollectionInterval: "200"}
+		assert.ErrorContains(t, cc.Validate(), "collectionInterval")
+	})
+
+	t.Run("negative collectionInterval is rejected", func(t *testing.T) {
+		cc := base()
+		cc.AutoSplit = &AutoSplitConfig{Enabled: true, CollectionInterval: "-1s"}
 		assert.ErrorContains(t, cc.Validate(), "collectionInterval")
 	})
 }

--- a/common/proto/metadata_ext_autosplit_test.go
+++ b/common/proto/metadata_ext_autosplit_test.go
@@ -94,6 +94,20 @@ func TestClusterConfiguration_GetAutoSplitWithDefaults(t *testing.T) {
 	})
 }
 
+func TestAutoSplitConfig_CollectionInterval(t *testing.T) {
+	c := &AutoSplitConfig{CollectionInterval: "500ms"}
+	d, err := c.GetCollectionIntervalDuration()
+	assert.NoError(t, err)
+	assert.Equal(t, 500*time.Millisecond, d)
+	assert.Equal(t, 500*time.Millisecond, c.GetCollectionIntervalDurationOrDefault())
+}
+
+func TestAutoSplitConfig_CollectionInterval_Default(t *testing.T) {
+	assert.Equal(t, 30*time.Second, (*AutoSplitConfig)(nil).GetCollectionIntervalDurationOrDefault())
+	assert.Equal(t, 30*time.Second, (&AutoSplitConfig{}).GetCollectionIntervalDurationOrDefault())
+	assert.Equal(t, 30*time.Second, (&AutoSplitConfig{CollectionInterval: "bad"}).GetCollectionIntervalDurationOrDefault())
+}
+
 func TestClusterConfiguration_Validate_AutoSplitDurations(t *testing.T) {
 	base := func() *ClusterConfiguration {
 		return &ClusterConfiguration{
@@ -124,5 +138,11 @@ func TestClusterConfiguration_Validate_AutoSplitDurations(t *testing.T) {
 		cc := base()
 		cc.AutoSplit = &AutoSplitConfig{Enabled: true, CooldownPeriod: "5min"}
 		assert.ErrorContains(t, cc.Validate(), "cooldownPeriod")
+	})
+
+	t.Run("malformed collectionInterval is rejected", func(t *testing.T) {
+		cc := base()
+		cc.AutoSplit = &AutoSplitConfig{Enabled: true, CollectionInterval: "200"}
+		assert.ErrorContains(t, cc.Validate(), "collectionInterval")
 	})
 }

--- a/common/proto/metadata_vtproto.pb.go
+++ b/common/proto/metadata_vtproto.pb.go
@@ -205,6 +205,7 @@ func (m *AutoSplitConfig) CloneVT() *AutoSplitConfig {
 	r.StabilizationPeriod = m.StabilizationPeriod
 	r.CooldownPeriod = m.CooldownPeriod
 	r.MaxShardsPerNamespace = m.MaxShardsPerNamespace
+	r.CollectionInterval = m.CollectionInterval
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -655,6 +656,9 @@ func (this *AutoSplitConfig) EqualVT(that *AutoSplitConfig) bool {
 		return false
 	}
 	if this.MaxShardsPerNamespace != that.MaxShardsPerNamespace {
+		return false
+	}
+	if this.CollectionInterval != that.CollectionInterval {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1479,6 +1483,13 @@ func (m *AutoSplitConfig) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.CollectionInterval) > 0 {
+		i -= len(m.CollectionInterval)
+		copy(dAtA[i:], m.CollectionInterval)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CollectionInterval)))
+		i--
+		dAtA[i] = 0x3a
+	}
 	if m.MaxShardsPerNamespace != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.MaxShardsPerNamespace))
 		i--
@@ -2211,6 +2222,10 @@ func (m *AutoSplitConfig) SizeVT() (n int) {
 	}
 	if m.MaxShardsPerNamespace != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.MaxShardsPerNamespace))
+	}
+	l = len(m.CollectionInterval)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -3088,6 +3103,10 @@ func (m *DataServerStatus) UnmarshalVT(dAtA []byte) error {
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
 				}
+				var elementCount int
+				if elementCount != 0 && len(m.SupportedFeatures) == 0 {
+					m.SupportedFeatures = make([]Feature, 0, elementCount)
+				}
 				for iNdEx < postIndex {
 					var v Feature
 					for shift := uint(0); ; shift += 7 {
@@ -3739,6 +3758,38 @@ func (m *AutoSplitConfig) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CollectionInterval", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CollectionInterval = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -5989,6 +6040,10 @@ func (m *DataServerStatus) UnmarshalVTUnsafe(dAtA []byte) error {
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
 				}
+				var elementCount int
+				if elementCount != 0 && len(m.SupportedFeatures) == 0 {
+					m.SupportedFeatures = make([]Feature, 0, elementCount)
+				}
 				for iNdEx < postIndex {
 					var v Feature
 					for shift := uint(0); ; shift += 7 {
@@ -6672,6 +6727,42 @@ func (m *AutoSplitConfig) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CollectionInterval", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.CollectionInterval = stringValue
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/oxiad/coordinator/runtime/autosplit/monitor.go
+++ b/oxiad/coordinator/runtime/autosplit/monitor.go
@@ -89,7 +89,7 @@ func NewMonitor(
 	splitter controller.ShardSplitter,
 	collectionInterval time.Duration,
 ) *Monitor {
-	if collectionInterval == 0 {
+	if collectionInterval <= 0 {
 		collectionInterval = DefaultCollectionInterval
 	}
 	labels := map[string]any{}

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -959,7 +959,8 @@ func New(
 	})
 	c.loadBalancer.Start()
 
-	c.autoSplitMonitor = autosplit.NewMonitor(c.metadata, c.rpc, c, autosplit.DefaultCollectionInterval)
+	autoSplitInterval := c.metadata.GetConfig().UnsafeBorrow().GetAutoSplitWithDefaults().GetCollectionIntervalDurationOrDefault()
+	c.autoSplitMonitor = autosplit.NewMonitor(c.metadata, c.rpc, c, autoSplitInterval)
 	c.autoSplitMonitor.Start()
 
 	return c, nil

--- a/tests/coordinator/auto_split_e2e_test.go
+++ b/tests/coordinator/auto_split_e2e_test.go
@@ -1,0 +1,189 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxia"
+	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	metadatacodec "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common/codec"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
+	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
+	"github.com/oxia-db/oxia/tests/mock"
+)
+
+// TestCoordinator_AutoSplit drives the full auto-split pipeline end to end:
+// a cluster is configured with auto-split enabled and a low size threshold,
+// enough data is written to exceed it, and the test asserts that the
+// coordinator splits the shard on its own (no manual InitiateSplit call).
+func TestCoordinator_AutoSplit(t *testing.T) {
+	// Servers run under t.Context() and are torn down at test end; we only need
+	// their addresses here.
+	_, sa1 := newServer(t)
+	_, sa2 := newServer(t)
+	_, sa3 := newServer(t)
+
+	metadataProvider := memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled, "")
+	clusterConfig := newClusterConfig([]*proto.Namespace{{
+		Name:              constant.DefaultNamespace,
+		ReplicationFactor: 3,
+		InitialShardCount: 1,
+	}}, []*proto.DataServerIdentity{sa1, sa2, sa3})
+
+	// Enable auto-split with a low size threshold and a fast poll interval so
+	// the test triggers quickly. Stabilization is 0 (split on the first
+	// over-threshold sample). MaxShardsPerNamespace caps the namespace at two
+	// shards, so the oversized shard splits exactly once and the guard-rail
+	// then prevents the (still-large) children from cascading further — giving
+	// a deterministic end state and exercising the guard-rail end to end.
+	clusterConfig.AutoSplit = &proto.AutoSplitConfig{
+		Enabled:               true,
+		MaxShardSizeMb:        1,
+		MaxShardsPerNamespace: 2,
+		StabilizationPeriod:   "0s",
+		CooldownPeriod:        "1s",
+		CollectionInterval:    "200ms",
+	}
+
+	configProvider := memory.NewProvider(metadatacodec.ClusterConfigCodec, metadatacommon.WatchEnabled, "")
+	_, err := configProvider.Store(provider.Versioned[*proto.ClusterConfiguration]{
+		Value:   clusterConfig,
+		Version: metadatacommon.NotExists,
+	})
+	require.NoError(t, err)
+
+	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
+	metadata := coordinatorInstance.Metadata()
+
+	// Wait for the initial single shard to reach steady state.
+	require.Eventually(t, func() bool {
+		shard := mock.StatusSnapshot(t, metadata).Namespaces[constant.DefaultNamespace].Shards[0]
+		return shard.GetStatusOrDefault() == proto.ShardStatusSteadyState
+	}, 30*time.Second, 100*time.Millisecond)
+
+	client, err := oxia.NewSyncClient(sa1.Public)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Write enough incompressible data to push the shard's on-disk size well
+	// past the 1 MiB threshold. Random values defeat Pebble compression so the
+	// size registers regardless of flush timing.
+	rng := rand.New(rand.NewSource(1))
+	const (
+		numKeys   = 512
+		valueSize = 8 * 1024 // 8 KiB each -> ~4 MiB total, 4x the threshold
+	)
+	writtenKeys := make(map[string][]byte, numKeys)
+	for i := 0; i < numKeys; i++ {
+		key := fmt.Sprintf("key-%04d", i)
+		value := make([]byte, valueSize)
+		rng.Read(value)
+		_, _, err := client.Put(ctx, key, value)
+		require.NoError(t, err)
+		writtenKeys[key] = value
+	}
+	require.NoError(t, client.Close())
+
+	// The coordinator's auto-split monitor should detect the oversized shard
+	// and split it on its own. Wait until the original shard 0 is gone and the
+	// shard set has settled (a large shard may split more than once): every
+	// shard steady-state with a leader and no split metadata, and the set
+	// unchanged across several consecutive polls.
+	var settledIDs []int64
+	stablePolls := 0
+	require.Eventually(t, func() bool {
+		ns, ok := mock.StatusSnapshot(t, metadata).Namespaces[constant.DefaultNamespace]
+		if !ok {
+			return false
+		}
+		if _, parentExists := ns.Shards[0]; parentExists {
+			stablePolls = 0
+			return false
+		}
+		ids := make([]int64, 0, len(ns.Shards))
+		for id, meta := range ns.Shards {
+			if meta.GetStatusOrDefault() != proto.ShardStatusSteadyState || meta.Leader == nil || meta.Split != nil {
+				stablePolls = 0
+				return false
+			}
+			ids = append(ids, id)
+		}
+		slices.Sort(ids)
+		if slices.Equal(ids, settledIDs) {
+			stablePolls++
+		} else {
+			settledIDs = ids
+			stablePolls = 0
+		}
+		// Require the parent to have split into at least two shards and the set
+		// to hold steady for ~1.5s so any cascade has finished.
+		return len(settledIDs) >= 2 && stablePolls >= 3
+	}, 3*time.Minute, 500*time.Millisecond)
+
+	// The resulting shards must tile the entire original hash range
+	// [0, MaxUint32] contiguously with no gaps or overlaps.
+	status := mock.StatusSnapshot(t, metadata)
+	ns := status.Namespaces[constant.DefaultNamespace]
+	ranges := make([]*proto.HashRange, 0, len(settledIDs))
+	for _, id := range settledIDs {
+		ranges = append(ranges, ns.Shards[id].GetInt32HashRange())
+	}
+	slices.SortFunc(ranges, func(a, b *proto.HashRange) int {
+		return int(a.GetMin()) - int(b.GetMin())
+	})
+	assert.EqualValues(t, 0, ranges[0].GetMin(), "coverage must start at 0")
+	assert.EqualValues(t, math.MaxUint32, ranges[len(ranges)-1].GetMax(), "coverage must end at MaxUint32")
+	for i := 1; i < len(ranges); i++ {
+		assert.EqualValues(t, ranges[i-1].GetMax()+1, ranges[i].GetMin(),
+			"shard ranges must be contiguous between index %d and %d", i-1, i)
+	}
+
+	// All previously written data must still be readable through a fresh
+	// client that picks up the new (child) shard assignments.
+	var readClient oxia.SyncClient
+	require.Eventually(t, func() bool {
+		readClient, err = oxia.NewSyncClient(sa1.Public)
+		if err != nil {
+			return false
+		}
+		if _, _, _, err = readClient.Get(ctx, "key-0000"); err != nil {
+			_ = readClient.Close()
+			return false
+		}
+		return true
+	}, 30*time.Second, 500*time.Millisecond)
+	defer func() { assert.NoError(t, readClient.Close()) }()
+
+	for key, expected := range writtenKeys {
+		_, value, _, err := readClient.Get(ctx, key)
+		if !assert.NoError(t, err, "get key %s", key) {
+			continue
+		}
+		assert.Equal(t, expected, value, "value mismatch for key %s", key)
+	}
+}

--- a/tests/coordinator/auto_split_e2e_test.go
+++ b/tests/coordinator/auto_split_e2e_test.go
@@ -15,6 +15,7 @@
 package coordinator
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"math"
@@ -154,7 +155,7 @@ func TestCoordinator_AutoSplit(t *testing.T) {
 		ranges = append(ranges, ns.Shards[id].GetInt32HashRange())
 	}
 	slices.SortFunc(ranges, func(a, b *proto.HashRange) int {
-		return int(a.GetMin()) - int(b.GetMin())
+		return cmp.Compare(a.GetMin(), b.GetMin())
 	})
 	assert.EqualValues(t, 0, ranges[0].GetMin(), "coverage must start at 0")
 	assert.EqualValues(t, math.MaxUint32, ranges[len(ranges)-1].GetMax(), "coverage must end at MaxUint32")


### PR DESCRIPTION
## Summary

Adds the end-to-end validation for auto-split (design Phase 5) plus the small config knob it needs.

1. **Configurable collection interval** — a new `collection_interval` field on `AutoSplitConfig` lets the monitor's poll cadence be tuned per cluster (default `30s`, following the existing `LoadBalancer` duration pattern). The runtime derives the monitor interval from cluster config, and `ClusterConfiguration.Validate()` rejects a malformed value. This also resolves the earlier review note about the hard-coded interval.

2. **End-to-end auto-split test** (`tests/coordinator/auto_split_e2e_test.go`) — brings up a 3-node cluster with auto-split enabled (1 MiB size threshold, `200ms` poll interval, `max_shards_per_namespace: 2`), writes ~4 MiB of incompressible data, and asserts the coordinator splits the oversized shard **on its own** (no manual `InitiateSplit`). It then verifies the resulting shards tile the full hash range `[0, MaxUint32]` contiguously and that every written key is still readable through a fresh client.

The 2-shard cap makes the outcome deterministic — the oversized shard splits exactly once, and the guard-rail then prevents the (still-large) children from cascading — while also exercising the `max_shards_per_namespace` guard-rail end to end.

## Test plan
- [x] `TestCoordinator_AutoSplit` passes, including with `-race`, and is stable across repeated runs (~16-18s each).
- [x] Existing `TestCoordinator_ShardSplit` (manual split) still passes — no regression.
- [x] Unit tests for the new `collection_interval` helper + validation; full `common/proto` and `autosplit` suites pass with `-race`.
- [x] `gofmt`, `go vet`, `golangci-lint` clean on changed files.
- [x] Proto regenerated with protoc 34.1 (matching CI); only the `metadata` generated files change.