### PR TITLE
chore: quiet balance trigger log

### DIFF
--- a/oxiad/coordinator/runtime/balancer/scheduler.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler.go
@@ -443,7 +443,7 @@ func minEnsembleLeaders(status map[string]commonobject.Borrowed[*commonproto.Nam
 }
 
 func (r *nodeBasedBalancer) Trigger() {
-	r.logger.Info("manually trigger balance")
+	r.logger.Debug("trigger balance")
 	channel.PushNoBlock(r.triggerCh, nil)
 }
 


### PR DESCRIPTION
## Motivation

The load balancer trigger log currently emits at info level with the message `manually trigger balance`. The trigger is often called internally, so the wording is misleading and the info-level log can add noise during normal coordinator activity.

## Modifications

- Change the load balancer trigger log from info to debug.
- Rename the message from `manually trigger balance` to `trigger balance`.

## Testing

- `go test ./oxiad/coordinator/runtime/balancer -count=1`
