### PR TITLE
refactor: rename coordinator leader accessor

### DIFF
--- a/oxiad/coordinator/management_server.go
+++ b/oxiad/coordinator/management_server.go
@@ -62,7 +62,7 @@ func (management *managementServer) redirectError() error {
 		return constant.IntoGrpcStatusError(constant.ErrNotInitialized)
 	}
 
-	leaderInfo, err := metadata.GetLeaderInfo()
+	leaderInfo, err := metadata.GetLeader()
 	if err != nil || leaderInfo == nil {
 		return constant.IntoGrpcStatusError(constant.ErrNotInitialized)
 	}

--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -60,7 +60,7 @@ func (p *testLeaderMetadata) GetSelf() (*proto.Coordinator, error) {
 	return p.self.CloneVT(), nil
 }
 
-func (p *testLeaderMetadata) GetLeaderInfo() (*proto.Coordinator, error) {
+func (p *testLeaderMetadata) GetLeader() (*proto.Coordinator, error) {
 	return p.info, p.err
 }
 

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -40,7 +40,7 @@ type Metadata interface {
 
 	WaitToBecomeLeader() (lost <-chan struct{}, err error)
 	GetSelf() (*commonproto.Coordinator, error)
-	GetLeaderInfo() (*commonproto.Coordinator, error)
+	GetLeader() (*commonproto.Coordinator, error)
 	GetInstanceID() string
 	ReserveShardIDs(count uint32) int64
 
@@ -188,7 +188,7 @@ func (m *coordinatorMetadata) GetSelf() (*commonproto.Coordinator, error) {
 	return coordinator.CloneVT(), nil
 }
 
-func (m *coordinatorMetadata) GetLeaderInfo() (*commonproto.Coordinator, error) {
+func (m *coordinatorMetadata) GetLeader() (*commonproto.Coordinator, error) {
 	name, err := m.statusProvider.GetLeaderName()
 	if err != nil {
 		return nil, err

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -252,7 +252,7 @@ func (*mockNamespaceMetadata) GetSelf() (*proto.Coordinator, error) {
 	return nil, nil //nolint:nilnil
 }
 
-func (*mockNamespaceMetadata) GetLeaderInfo() (*proto.Coordinator, error) {
+func (*mockNamespaceMetadata) GetLeader() (*proto.Coordinator, error) {
 	return nil, nil //nolint:nilnil
 }
 

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -58,7 +58,7 @@ func (*mockMetadata) GetSelf() (*proto.Coordinator, error) {
 	return nil, nil //nolint:nilnil
 }
 
-func (*mockMetadata) GetLeaderInfo() (*proto.Coordinator, error) {
+func (*mockMetadata) GetLeader() (*proto.Coordinator, error) {
 	return nil, nil //nolint:nilnil
 }
 


### PR DESCRIPTION
## Motivation

The coordinator metadata accessor `GetLeaderInfo` returns the current coordinator leader. The `Info` suffix does not add meaning and makes call sites more verbose than necessary.

## Modifications

- Rename `Metadata.GetLeaderInfo()` to `Metadata.GetLeader()`.
- Update the coordinator management server and test mocks to use the new method name.

## Testing

- `go test ./oxiad/coordinator/... -count=1`
- `git diff --check`
