### PR TITLE
test: close autosplit coordinator runtime

### DIFF
--- a/tests/coordinator/auto_split_e2e_test.go
+++ b/tests/coordinator/auto_split_e2e_test.go
@@ -79,6 +79,7 @@ func TestCoordinator_AutoSplit(t *testing.T) {
 	require.NoError(t, err)
 
 	coordinatorInstance := newCoordinatorInstance(t, metadataProvider, configProvider, rpc2.NewRpcProviderFactory(nil))
+	defer func() { assert.NoError(t, coordinatorInstance.Close()) }()
 	metadata := coordinatorInstance.Metadata()
 
 	// Wait for the initial single shard to reach steady state.


### PR DESCRIPTION
## Motivation
The coordinator CI failure was caused by `TestCoordinator_AutoSplit` leaving its coordinator runtime running after the test completed. Its auto-split monitor and shard controllers could continue mutating coordinator metadata while later tests in the package were already running, which made the package intermittently panic with `metadata bad version`.

This keeps the production metadata bad-version guard intact and fixes the test lifecycle issue directly.

## Modifications
- Close the AutoSplit coordinator runtime with a deferred assertion before the test exits.

## Testing
- `go test ./tests/coordinator -count=1`