### PR TITLE
fix: quiet assignment initialization retry

### DIFF
--- a/oxiad/coordinator/runtime/controller/dataserver/dataserver_controller.go
+++ b/oxiad/coordinator/runtime/controller/dataserver/dataserver_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	controllerapi "github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
 
+	"github.com/oxia-db/oxia/common/constant"
 	commonobject "github.com/oxia-db/oxia/common/object"
 
 	"github.com/oxia-db/oxia/common/metric"
@@ -178,7 +179,14 @@ func (n *controller) sendAssignmentsDispatchWithRetries() {
 			}
 		}
 	}, n.dispatchAssignmentsBackoff, func(err error, duration time.Duration) {
-		if !errors.Is(err, context.Canceled) {
+		switch {
+		case errors.Is(err, context.Canceled):
+		case errors.Is(err, constant.ErrNotInitialized):
+			n.logger.Debug(
+				"Waiting for data server initialization before sending assignments",
+				slog.Duration("retry-after", duration),
+			)
+		default:
 			n.logger.Warn(
 				"Failed to send assignments updates to storage data server",
 				slog.Duration("retry-after", duration),

--- a/oxiad/coordinator/runtime/controller/dataserver/dataserver_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/dataserver/dataserver_controller_test.go
@@ -190,3 +190,43 @@ func TestDataServerController_ShardsAssignments(t *testing.T) {
 
 	assert.NoError(t, nc.Close())
 }
+
+func TestDataServerController_RetriesLatestAssignmentsAfterSendError(t *testing.T) {
+	addr := &proto.DataServerIdentity{
+		Public:   "my-server:9190",
+		Internal: "my-server:8190",
+	}
+	dataServer := &proto.DataServer{Identity: addr, Metadata: &proto.DataServerMetadata{}}
+
+	sap := mockutils.NewShardAssignmentsProvider()
+	nal := mockutils.NewNodeAvailabilityListener()
+	rpc := mockutils.NewRpcProvider()
+	node := rpc.GetNode(addr)
+	node.ShardAssignmentsStream.SetError(errors.New("failed to send"))
+
+	nc := newController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 10*time.Millisecond)
+	defer func() {
+		assert.NoError(t, nc.Close())
+	}()
+
+	resp := &proto.ShardAssignments{
+		Namespaces: map[string]*proto.NamespaceShardsAssignment{
+			constant.DefaultNamespace: {
+				Assignments: []*proto.ShardAssignment{{
+					Shard:  0,
+					Leader: "leader-0",
+				}},
+				ShardKeyRouter: proto.ShardKeyRouter_XXHASH3,
+			},
+		},
+	}
+
+	sap.Set(resp)
+
+	select {
+	case update := <-node.ShardAssignmentsStream.Updates:
+		assert.Equal(t, resp, update)
+	case <-time.After(10 * time.Second):
+		assert.Fail(t, "did not retry latest assignments after send error")
+	}
+}


### PR DESCRIPTION
## Motivation

The coordinator can start the data server assignment stream before the data server has finished binding the coordinator instance id through `Handshake`. In that short startup window, `PushShardAssignments` can return `ErrNotInitialized`.

That condition is already retried by the existing assignment retry loop, so it should not be logged as a warning. This keeps retry behavior unchanged: canceled retries stay silent, expected initialization retries log at debug, and real assignment failures still log at warn.

The retry loop must also continue to retry the latest assignment after send errors without waiting for a new assignment update. The added test locks in that behavior.

## Modifications

- Handle assignment retry notification errors with a single `switch`.
- Keep `context.Canceled` silent.
- Log `constant.ErrNotInitialized` at debug while the retry loop continues.
- Preserve warn-level logging for other assignment dispatch failures.
- Add coverage that a send error retries the latest assignment without requiring another update.

## Testing

- `go test -count=1 ./oxiad/coordinator/runtime/controller/dataserver`
- `make lint`
