### PR TITLE
fix: avoid stuck shard assignment streams

### DIFF
--- a/oxiad/coordinator/management_server_test.go
+++ b/oxiad/coordinator/management_server_test.go
@@ -32,6 +32,7 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/proto"
+	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	coordoption "github.com/oxia-db/oxia/oxiad/coordinator/option"
 	coordruntime "github.com/oxia-db/oxia/oxiad/coordinator/runtime"
@@ -80,8 +81,8 @@ func (*testRuntime) LeaderElected(int64, *proto.DataServerIdentity, []*proto.Dat
 
 func (*testRuntime) ShardDeleted(int64) {}
 
-func (*testRuntime) WaitForNextUpdate(context.Context, *proto.ShardAssignments) (*proto.ShardAssignments, error) {
-	return nil, context.Canceled
+func (*testRuntime) SubscribeShardAssignments() *commonwatch.Receiver[*proto.ShardAssignments] {
+	return commonwatch.New(&proto.ShardAssignments{}).Subscribe()
 }
 
 func (*testRuntime) BecameUnavailable(*proto.DataServerIdentity) {}

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -278,8 +278,8 @@ func (*mockNamespaceRuntime) LeaderElected(int64, *proto.DataServerIdentity, []*
 
 func (*mockNamespaceRuntime) ShardDeleted(int64) {}
 
-func (*mockNamespaceRuntime) WaitForNextUpdate(context.Context, *proto.ShardAssignments) (*proto.ShardAssignments, error) {
-	return nil, context.Canceled
+func (*mockNamespaceRuntime) SubscribeShardAssignments() *commonwatch.Receiver[*proto.ShardAssignments] {
+	return commonwatch.New(&proto.ShardAssignments{}).Subscribe()
 }
 
 func (*mockNamespaceRuntime) BecameUnavailable(*proto.DataServerIdentity) {}

--- a/oxiad/coordinator/runtime/controller/dataserver/dataserver_controller.go
+++ b/oxiad/coordinator/runtime/controller/dataserver/dataserver_controller.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	grpcstatus "google.golang.org/grpc/status"
+	pb "google.golang.org/protobuf/proto"
 
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	controllerapi "github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
@@ -140,6 +141,8 @@ func (n *controller) Close() error {
 }
 
 func (n *controller) sendAssignmentsDispatchWithRetries() {
+	receiver := n.SubscribeShardAssignments()
+
 	_ = backoff.RetryNotify(func() error {
 		n.logger.Debug("Ready to send assignments")
 
@@ -151,31 +154,24 @@ func (n *controller) sendAssignmentsDispatchWithRetries() {
 		streamCtx := stream.Context()
 		var assignments *proto.ShardAssignments
 		for {
-			select {
-			case <-n.ctx.Done():
-				return nil
-			case <-streamCtx.Done():
-				return streamCtx.Err()
-			default:
-				n.logger.Debug(
-					"Waiting for next assignments update",
-					slog.Any("current-assignments", assignments),
-				)
-				if assignments, err = n.WaitForNextUpdate(streamCtx, assignments); err != nil {
-					n.logger.Debug("Failed to send assignments", slog.Any("error", err))
-					return err
-				}
-				if assignments == nil {
-					continue
-				}
-
-				n.logger.Debug("Sending assignments", slog.Any("assignments", assignments))
-				if err := stream.Send(assignments); err != nil {
+			latest := receiver.Load()
+			if latest != nil && !pb.Equal(assignments, latest) {
+				n.logger.Debug("Sending assignments", slog.Any("assignments", latest))
+				if err := stream.Send(latest); err != nil {
 					n.logger.Debug("Failed to send assignments", slog.Any("error", err))
 					return err
 				}
 				n.logger.Debug("Send assignments completed successfully")
 				n.dispatchAssignmentsBackoff.Reset()
+				assignments = latest
+			}
+
+			select {
+			case <-n.ctx.Done():
+				return nil
+			case <-streamCtx.Done():
+				return streamCtx.Err()
+			case <-receiver.Changed():
 			}
 		}
 	}, n.dispatchAssignmentsBackoff, func(err error, duration time.Duration) {

--- a/oxiad/coordinator/runtime/controller/dataserver/dataserver_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/dataserver/dataserver_controller_test.go
@@ -22,11 +22,23 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	pb "google.golang.org/protobuf/proto"
 
 	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller/mockutils"
 )
+
+func expectShardAssignmentsUpdate(t *testing.T, updates <-chan *proto.ShardAssignments, expected *proto.ShardAssignments) {
+	t.Helper()
+
+	select {
+	case update := <-updates:
+		assert.True(t, pb.Equal(expected, update), "expected %v, got %v", expected, update)
+	case <-time.After(10 * time.Second):
+		assert.Fail(t, "did not receive shard assignments update")
+	}
+}
 
 func TestDataServerController_HealthCheck(t *testing.T) {
 	addr := &proto.DataServerIdentity{
@@ -144,6 +156,7 @@ func TestDataServerController_ShardsAssignments(t *testing.T) {
 	nc := newController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 1*time.Second)
 
 	node := rpc.GetNode(addr)
+	expectShardAssignmentsUpdate(t, node.ShardAssignmentsStream.Updates, &proto.ShardAssignments{})
 
 	resp := &proto.ShardAssignments{
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
@@ -161,9 +174,7 @@ func TestDataServerController_ShardsAssignments(t *testing.T) {
 	}
 
 	sap.Set(resp)
-
-	update := <-node.ShardAssignmentsStream.Updates
-	assert.Equal(t, resp, update)
+	expectShardAssignmentsUpdate(t, node.ShardAssignmentsStream.Updates, resp)
 
 	// Simulate 1 single stream send error
 	node.ShardAssignmentsStream.SetError(errors.New("failed to send"))
@@ -184,9 +195,7 @@ func TestDataServerController_ShardsAssignments(t *testing.T) {
 	}
 
 	sap.Set(resp2)
-
-	update = <-node.ShardAssignmentsStream.Updates
-	assert.Equal(t, resp2, update)
+	expectShardAssignmentsUpdate(t, node.ShardAssignmentsStream.Updates, resp2)
 
 	assert.NoError(t, nc.Close())
 }
@@ -203,12 +212,6 @@ func TestDataServerController_RetriesLatestAssignmentsAfterSendError(t *testing.
 	rpc := mockutils.NewRpcProvider()
 	node := rpc.GetNode(addr)
 	node.ShardAssignmentsStream.SetError(errors.New("failed to send"))
-
-	nc := newController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 10*time.Millisecond)
-	defer func() {
-		assert.NoError(t, nc.Close())
-	}()
-
 	resp := &proto.ShardAssignments{
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			constant.DefaultNamespace: {
@@ -223,10 +226,10 @@ func TestDataServerController_RetriesLatestAssignmentsAfterSendError(t *testing.
 
 	sap.Set(resp)
 
-	select {
-	case update := <-node.ShardAssignmentsStream.Updates:
-		assert.Equal(t, resp, update)
-	case <-time.After(10 * time.Second):
-		assert.Fail(t, "did not retry latest assignments after send error")
-	}
+	nc := newController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 10*time.Millisecond)
+	defer func() {
+		assert.NoError(t, nc.Close())
+	}()
+
+	expectShardAssignmentsUpdate(t, node.ShardAssignmentsStream.Updates, resp)
 }

--- a/oxiad/coordinator/runtime/controller/interfaces.go
+++ b/oxiad/coordinator/runtime/controller/interfaces.go
@@ -15,9 +15,8 @@
 package controller
 
 import (
-	"context"
-
 	commonproto "github.com/oxia-db/oxia/common/proto"
+	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 )
 
 type ShardSplitter interface {
@@ -37,7 +36,7 @@ type ShardSplitEventListener interface {
 }
 
 type ShardAssignmentsProvider interface {
-	WaitForNextUpdate(ctx context.Context, currentValue *commonproto.ShardAssignments) (*commonproto.ShardAssignments, error)
+	SubscribeShardAssignments() *commonwatch.Receiver[*commonproto.ShardAssignments]
 }
 
 type DataServerEventListener interface {

--- a/oxiad/coordinator/runtime/controller/mockutils/mock.go
+++ b/oxiad/coordinator/runtime/controller/mockutils/mock.go
@@ -26,12 +26,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
-	pb "google.golang.org/protobuf/proto"
 
 	"github.com/oxia-db/oxia/oxiad/common/feature"
 
-	"github.com/oxia-db/oxia/common/concurrent"
 	"github.com/oxia-db/oxia/oxiad/common/logging"
+	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 
 	"github.com/oxia-db/oxia/common/proto"
 )
@@ -46,39 +45,21 @@ var (
 )
 
 type ShardAssignmentsProvider struct {
-	sync.Mutex
-	cond    concurrent.ConditionContext
-	current *proto.ShardAssignments
+	watch *commonwatch.Watch[*proto.ShardAssignments]
 }
 
 func NewShardAssignmentsProvider() *ShardAssignmentsProvider {
-	sap := &ShardAssignmentsProvider{
-		current: nil,
+	return &ShardAssignmentsProvider{
+		watch: commonwatch.New(&proto.ShardAssignments{}),
 	}
-
-	sap.cond = concurrent.NewConditionContext(sap)
-	return sap
 }
 
 func (sap *ShardAssignmentsProvider) Set(value *proto.ShardAssignments) {
-	sap.Lock()
-	defer sap.Unlock()
-
-	sap.current = value
-	sap.cond.Broadcast()
+	sap.watch.Publish(value)
 }
 
-func (sap *ShardAssignmentsProvider) WaitForNextUpdate(ctx context.Context, currentValue *proto.ShardAssignments) (*proto.ShardAssignments, error) {
-	sap.Lock()
-	defer sap.Unlock()
-
-	for pb.Equal(currentValue, sap.current) {
-		if err := sap.cond.Wait(ctx); err != nil {
-			return nil, err
-		}
-	}
-
-	return sap.current, nil
+func (sap *ShardAssignmentsProvider) SubscribeShardAssignments() *commonwatch.Receiver[*proto.ShardAssignments] {
+	return sap.watch.Subscribe()
 }
 
 type NodeAvailabilityListener struct {

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -398,25 +398,8 @@ func (c *runtime) BecameUnavailable(node *proto.DataServerIdentity) {
 	}
 }
 
-func (c *runtime) WaitForNextUpdate(ctx context.Context, currentValue *proto.ShardAssignments) (*proto.ShardAssignments, error) {
-	receiver := c.assignmentsWatch.Subscribe()
-	latest := c.assignmentsWatch.Load()
-	if !pb.Equal(currentValue, latest) {
-		return latest, nil
-	}
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-receiver.Changed():
-		}
-
-		latest = receiver.Load()
-		if !pb.Equal(currentValue, latest) {
-			return latest, nil
-		}
-	}
+func (c *runtime) SubscribeShardAssignments() *commonwatch.Receiver[*proto.ShardAssignments] {
+	return c.assignmentsWatch.Subscribe()
 }
 
 func (c *runtime) startBackgroundActionWorker() {


### PR DESCRIPTION
## Motivation
Shard assignment delivery uses a long-lived client-streaming RPC from the coordinator to each data server. During startup, a stream can fail or be rejected while the assignment snapshot itself has not changed. The coordinator previously hid stream cancellation behind a blocking assignment-watch helper, so it could keep waiting for another assignment update instead of noticing that the stream needed to retry.

This can leave a data server without its initial assignment update and keep its readiness probe failing even though the coordinator has no new assignment event to publish. The fix keeps the stream long-lived, but makes stream shutdown and assignment updates part of the same controller loop.

## Modifications
- Replace the blocking assignment wait helper with a runtime assignment subscription.
- Update the data-server controller to subscribe once, send the latest assignment snapshot on each stream, and select on coordinator shutdown, stream shutdown, and assignment changes together.
- Update controller/runtime test mocks for the subscription API.

## Testing
- go test ./oxiad/coordinator/runtime/controller/dataserver -count=1
- go test ./oxiad/coordinator/runtime -count=1
- go test ./oxiad/coordinator/reconciler ./oxiad/coordinator -count=1
- go test ./oxiad/coordinator/runtime/controller/... -count=1
- go test ./oxiad/coordinator/... -run 'TestDataServerController|TestRuntime|TestManagement|TestNamespace' -count=1