### PR TITLE
fix: drain assignment stream to detect server-side termination

### DIFF
--- a/oxiad/coordinator/runtime/controller/dataserver/dataserver_controller.go
+++ b/oxiad/coordinator/runtime/controller/dataserver/dataserver_controller.go
@@ -152,6 +152,27 @@ func (n *controller) sendAssignmentsDispatchWithRetries() {
 			return err
 		}
 		streamCtx := stream.Context()
+
+		// The coordinator only ever sends on this stream and never reads it, so a
+		// server-side termination that leaves the underlying connection healthy
+		// (e.g. an initialization rejection or an idle-stream reset from an L7 hop)
+		// would otherwise go unnoticed until the next assignment change, leaving a
+		// freshly-started data server without its initial assignment. Drain the
+		// stream in the background: RecvMsg returns as soon as the server ends the
+		// RPC, which cancels streamCtx and wakes the loop below to re-establish it.
+		var drainWg sync.WaitGroup
+		drainWg.Add(1)
+		go func() {
+			defer drainWg.Done()
+			var resp proto.CoordinationShardAssignmentsResponse
+			for {
+				if err := stream.RecvMsg(&resp); err != nil {
+					return
+				}
+			}
+		}()
+		defer drainWg.Wait()
+
 		var assignments *proto.ShardAssignments
 		for {
 			latest := receiver.Load()

--- a/oxiad/coordinator/runtime/controller/dataserver/dataserver_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/dataserver/dataserver_controller_test.go
@@ -233,3 +233,98 @@ func TestDataServerController_RetriesLatestAssignmentsAfterSendError(t *testing.
 
 	expectShardAssignmentsUpdate(t, node.ShardAssignmentsStream.Updates, resp)
 }
+
+// TestDataServerController_ReestablishesStreamAfterServerEnd reproduces the bug
+// behind the "stuck shard assignment streams" fix: the server ends the assignment
+// RPC while the underlying connection stays healthy and the assignment snapshot is
+// unchanged. Because the coordinator only ever sends on the stream, this is noticed
+// only by the background drain (RecvMsg); the controller must then re-establish the
+// stream and re-send the latest (unchanged) snapshot.
+func TestDataServerController_ReestablishesStreamAfterServerEnd(t *testing.T) {
+	addr := &proto.DataServerIdentity{
+		Public:   "my-server:9190",
+		Internal: "my-server:8190",
+	}
+	dataServer := &proto.DataServer{Identity: addr, Metadata: &proto.DataServerMetadata{}}
+
+	sap := mockutils.NewShardAssignmentsProvider()
+	nal := mockutils.NewNodeAvailabilityListener()
+	rpc := mockutils.NewRpcProvider()
+	nc := newController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 10*time.Millisecond)
+	defer func() {
+		assert.NoError(t, nc.Close())
+	}()
+
+	node := rpc.GetNode(addr)
+	expectShardAssignmentsUpdate(t, node.ShardAssignmentsStream.Updates, &proto.ShardAssignments{})
+
+	resp := &proto.ShardAssignments{
+		Namespaces: map[string]*proto.NamespaceShardsAssignment{
+			constant.DefaultNamespace: {
+				Assignments: []*proto.ShardAssignment{{
+					Shard:  0,
+					Leader: "leader-0",
+				}},
+				ShardKeyRouter: proto.ShardKeyRouter_XXHASH3,
+			},
+		},
+	}
+	sap.Set(resp)
+	expectShardAssignmentsUpdate(t, node.ShardAssignmentsStream.Updates, resp)
+
+	// Server ends the RPC without any new assignment being published.
+	node.ShardAssignmentsStream.EndStream()
+
+	// The controller must reconnect and re-send the same (unchanged) snapshot.
+	expectShardAssignmentsUpdate(t, node.ShardAssignmentsStream.Updates, resp)
+}
+
+// TestDataServerController_RecoversFromStreamEstablishmentRejection covers the
+// other facet named in the fix's motivation: the stream is rejected at establishment
+// time (e.g. before the data server is initialized). The dispatch loop must keep
+// retrying and deliver the assignment once establishment succeeds.
+func TestDataServerController_RecoversFromStreamEstablishmentRejection(t *testing.T) {
+	addr := &proto.DataServerIdentity{
+		Public:   "my-server:9190",
+		Internal: "my-server:8190",
+	}
+	dataServer := &proto.DataServer{Identity: addr, Metadata: &proto.DataServerMetadata{}}
+
+	sap := mockutils.NewShardAssignmentsProvider()
+	nal := mockutils.NewNodeAvailabilityListener()
+	rpc := mockutils.NewRpcProvider()
+
+	// Reject stream establishment up front.
+	rpc.FailNode(addr, errors.New("data server not initialized"))
+
+	resp := &proto.ShardAssignments{
+		Namespaces: map[string]*proto.NamespaceShardsAssignment{
+			constant.DefaultNamespace: {
+				Assignments: []*proto.ShardAssignment{{
+					Shard:  0,
+					Leader: "leader-0",
+				}},
+				ShardKeyRouter: proto.ShardKeyRouter_XXHASH3,
+			},
+		},
+	}
+	sap.Set(resp)
+
+	nc := newController(context.Background(), dataServer, sap, nal, rpc, "test-instance", 10*time.Millisecond)
+	defer func() {
+		assert.NoError(t, nc.Close())
+	}()
+
+	node := rpc.GetNode(addr)
+
+	// While establishment keeps failing, no assignment can be delivered.
+	select {
+	case <-node.ShardAssignmentsStream.Updates:
+		assert.Fail(t, "should not deliver assignments while stream establishment is rejected")
+	case <-time.After(1 * time.Second):
+	}
+
+	rpc.RecoverNode(addr)
+
+	expectShardAssignmentsUpdate(t, node.ShardAssignmentsStream.Updates, resp)
+}

--- a/oxiad/coordinator/runtime/controller/mockutils/mock.go
+++ b/oxiad/coordinator/runtime/controller/mockutils/mock.go
@@ -17,6 +17,7 @@ package mockutils
 import (
 	"context"
 	"errors"
+	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -449,7 +450,7 @@ func (r *RpcProvider) PushShardAssignments(ctx context.Context, node *proto.Data
 	if n.err != nil {
 		return nil, n.err
 	}
-	n.ShardAssignmentsStream.ctx = ctx
+	n.ShardAssignmentsStream.start(ctx)
 	return n.ShardAssignmentsStream, nil
 }
 
@@ -621,8 +622,16 @@ func (r *RpcProvider) GetHealthClient(node *proto.DataServerIdentity) (grpc_heal
 }
 
 type ShardAssignmentClient struct {
-	ctx context.Context
 	sync.Mutex
+
+	// ctx/cancel model a single gRPC client stream: canceling it mirrors the
+	// stream context being torn down when the RPC finishes. ended is closed to
+	// model the server terminating the RPC while the connection stays healthy;
+	// only a RecvMsg call observes it and cancels ctx, exactly as real gRPC only
+	// surfaces a server-side end once the client reads the stream.
+	ctx    context.Context
+	cancel context.CancelFunc
+	ended  chan struct{}
 
 	err     error
 	Updates chan *proto.ShardAssignments
@@ -631,6 +640,39 @@ type ShardAssignmentClient struct {
 func newShardAssignmentClient() *ShardAssignmentClient {
 	return &ShardAssignmentClient{
 		Updates: make(chan *proto.ShardAssignments, 100),
+	}
+}
+
+// start binds a fresh per-stream context, modeling a newly established stream.
+func (m *ShardAssignmentClient) start(ctx context.Context) {
+	m.Lock()
+	defer m.Unlock()
+
+	if m.cancel != nil {
+		m.cancel()
+	}
+	m.ctx, m.cancel = context.WithCancel(ctx)
+	m.ended = make(chan struct{})
+}
+
+// EndStream models the server ending the RPC (or rejecting it) while the
+// underlying connection stays healthy. It does not cancel the stream context
+// directly: the coordinator only notices once its background drain calls RecvMsg.
+func (m *ShardAssignmentClient) EndStream() {
+	m.Lock()
+	defer m.Unlock()
+
+	m.endLocked()
+}
+
+func (m *ShardAssignmentClient) endLocked() {
+	if m.ended == nil {
+		return
+	}
+	select {
+	case <-m.ended:
+	default:
+		close(m.ended)
 	}
 }
 
@@ -648,6 +690,9 @@ func (m *ShardAssignmentClient) Send(response *proto.ShardAssignments) error {
 	if m.err != nil {
 		err := m.err
 		m.err = nil
+		// A send failure tears the stream down; end it so the background drain
+		// unblocks, mirroring real gRPC stream teardown.
+		m.endLocked()
 		return err
 	}
 
@@ -672,6 +717,9 @@ func (*ShardAssignmentClient) CloseSend() error {
 }
 
 func (m *ShardAssignmentClient) Context() context.Context {
+	m.Lock()
+	defer m.Unlock()
+
 	return m.ctx
 }
 
@@ -679,8 +727,23 @@ func (*ShardAssignmentClient) SendMsg(any) error {
 	panic(errNotImplemented)
 }
 
-func (*ShardAssignmentClient) RecvMsg(any) error {
-	panic(errNotImplemented)
+// RecvMsg blocks until the stream ends, then cancels the per-stream context to
+// model gRPC's finish() (which is what makes stream.Context() fire in production).
+func (m *ShardAssignmentClient) RecvMsg(any) error {
+	m.Lock()
+	ctx, cancel, ended := m.ctx, m.cancel, m.ended
+	m.Unlock()
+
+	if ctx == nil {
+		return errNotImplemented
+	}
+	select {
+	case <-ended:
+		cancel()
+		return io.EOF
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 type HealthClient struct {

--- a/oxiad/maelstrom/coordinator_rpc_client.go
+++ b/oxiad/maelstrom/coordinator_rpc_client.go
@@ -183,6 +183,15 @@ func (*maelstromShardAssignmentClient) CloseAndRecv() (*proto.CoordinationShardA
 	return &proto.CoordinationShardAssignmentsResponse{}, nil
 }
 
+// RecvMsg blocks until the stream context is cancelled. The coordinator drains
+// the assignment stream in the background to notice server-side teardown; in
+// Maelstrom the stream is torn down by cancelling its context (e.g. on a failed
+// health check), so block until then instead of BaseStream's panic stub.
+func (m *maelstromShardAssignmentClient) RecvMsg(any) error {
+	<-m.ctx.Done()
+	return m.ctx.Err()
+}
+
 type BaseStream struct {
 }
 


### PR DESCRIPTION
## Motivation

Follow-up to #1215. That change reworked shard-assignment dispatch, but the dispatch loop still relies on `stream.Context()` to notice a rejected or half-closed assignment stream. The coordinator is the *client* of this client-streaming RPC and only ever calls `Send` — it never reads the stream. In grpc-go a client stream's context is cancelled (via `cs.finish()`) only on a `Send`/`Recv` error, on `ClientConn` close, or when the parent context is cancelled. A server-side termination that leaves the underlying connection healthy (e.g. an initialization rejection, or an idle-stream reset from an L7/mesh hop) therefore does **not** cancel `streamCtx`.

When that happens while the assignment snapshot is unchanged, neither the old `WaitForNextUpdate` loop nor the current `receiver.Load()/Changed()` loop notices — both block on the same trio {`n.ctx.Done()`, `streamCtx.Done()`, `receiver.Changed()`}. A freshly-started data server can then be left without its initial assignment, keeping its readiness probe failing until the next cluster-wide assignment change.

Verified empirically against grpc-go v1.81.1 (over both bufconn and localhost TCP): `stream.Context()` does not fire when the server ends/rejects the RPC while the client is idle and never reads the stream.

## Modifications

- Drain the assignment stream in a background goroutine. `RecvMsg` returns as soon as the server ends the RPC, which triggers `cs.finish()` → cancels `streamCtx` → the existing `case <-streamCtx.Done()` re-establishes the stream and re-sends the latest snapshot. gRPC permits one concurrent `Send` goroutine plus one `Recv` goroutine on the same `ClientStream`; `defer drainWg.Wait()` joins the drain on every return path, and at most one drain goroutine is alive per controller.
- Make the mock assignment stream model gRPC teardown faithfully — a server-side end is surfaced only once the client reads the stream (the per-stream context is cancelled inside `RecvMsg`, mirroring `finish()`).

## Testing

- `TestDataServerController_ReestablishesStreamAfterServerEnd` — server ends the stream with an unchanged snapshot; asserts the controller re-establishes and re-sends. Hangs/fails at 10s without the drain goroutine.
- `TestDataServerController_RecoversFromStreamEstablishmentRejection` — covers the stream-establishment-rejection facet named in #1215's motivation.
- `go test -race ./oxiad/coordinator/runtime/controller/... ./oxiad/coordinator/runtime ./oxiad/coordinator/reconciler ./oxiad/coordinator`
- lint clean under golangci-lint v2.6.2; license headers pass.