### PR TITLE
fix: handle AddFollower request in maelstrom harness

### DIFF
--- a/oxiad/maelstrom/grpc_provider.go
+++ b/oxiad/maelstrom/grpc_provider.go
@@ -89,6 +89,13 @@ func (m *maelstromGrpcProvider) HandleOxiaRequest(msgType MsgType, msg *Message[
 			m.sendResponse(msg, MsgTypeBecomeLeaderResponse, blr)
 		}
 
+	case MsgTypeAddFollowerRequest:
+		if afr, err := m.getService(oxiaCoordination).(proto.OxiaCoordinationServer).AddFollower(context.Background(), message.(*proto.AddFollowerRequest)); err != nil {
+			sendError(msg.Body.MsgId, msg.Src, err)
+		} else {
+			m.sendResponse(msg, MsgTypeAddFollowerResponse, afr)
+		}
+
 	case MsgTypeTruncateRequest:
 		if tr, err := m.getService(oxiaLogReplication).(proto.OxiaLogReplicationServer).Truncate(context.Background(), message.(*proto.TruncateRequest)); err != nil {
 			sendError(msg.Body.MsgId, msg.Src, err)


### PR DESCRIPTION
## Problem

Running the Maelstrom test suite with `--nemesis partition` crashes a node with:

```
panic: unknown msgType: add-follower-req
    main.(*maelstromGrpcProvider).HandleOxiaRequest(...)
        oxiad/maelstrom/grpc_provider.go:109
```

The leader node dies, and the run then stalls with every subsequent operation timing out (`:net-timeout`) because the shard has lost its leader.

## Root cause

`HandleOxiaRequest`'s switch handled `NewTerm`, `BecomeLeader`, `Truncate`, `GetStatus`, and `HealthCheck`, but had **no case for `add-follower-req`**, so it fell through to `default:` and panicked.

The coordinator issues an `AddFollower` RPC only when re-adding a follower to an *existing* leader term (ensemble reconfiguration). Steady-state runs establish the ensemble via `NewTerm` + `BecomeLeader` and never take that path, which is why the crash only surfaces under `--nemesis partition`, when the coordinator re-adds a follower after connectivity is restored.

Everything else for `AddFollower` was already wired up — request/response classification (`oxiaRequests`/`oxiaResponses`), proto type mapping, and the coordinator client that *sends* it. Only the server-side handler case was missing.

## Fix

Add the missing `case MsgTypeAddFollowerRequest`, dispatching to `OxiaCoordinationServer.AddFollower` exactly like the sibling `NewTerm`/`BecomeLeader`/`GetStatus` cases.

## Testing

- `go build -tags disable_trap -o bin/oxia-maelstrom ./oxiad/maelstrom` compiles clean.
- Only touches the Maelstrom test harness; no production code paths affected.