### PR TITLE
ci: run maelstrom with partition nemesis, bump to 0.2.4

### DIFF
--- a/.github/workflows/ci-build-test.yaml
+++ b/.github/workflows/ci-build-test.yaml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAELSTROM_VERSION: "0.2.3"
+  MAELSTROM_VERSION: "0.2.4"
   GO_LICENSE_VERSION: "latest"
   GOLANGCI_LINT_VERSION: "v2.6.2"
 
@@ -198,7 +198,7 @@ jobs:
         run: |
           cd maelstrom
           ./maelstrom test -w lin-kv  --bin ../bin/oxia-maelstrom \
-                --time-limit 60  --concurrency 2n  --latency 10 --latency-dist uniform
+                --time-limit 60  --concurrency 2n  --latency 10 --latency-dist uniform --nemesis partition
 
       - name: Upload test results
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## What

- Add `--nemesis partition` to the Maelstrom CI job so the `lin-kv` linearizability check runs against an unstable network, not just a healthy one.
- Bump `MAELSTROM_VERSION` `0.2.3` → `0.2.4`.

## Why

CI previously exercised Maelstrom only on a fault-free cluster, so partition-recovery paths (leader election, ensemble reconfiguration) were never validated. `partition` is the only fault Maelstrom can inject — its DB layer reifies only `db/DB`, not `db/Process`/`db/Pause`, so `kill`/`pause` aren't available (and its CLI hardcodes `nemeses #{:partition}` through 0.2.4 and main).

## Dependency

Enabling partition surfaces an `add-follower-req` the coordinator sends to a leader during ensemble reconfiguration. The Maelstrom shim previously panicked on it; that was fixed in #1218, already on `main`, so this partition run completes cleanly.

## Testing

- 0.2.4 ships the `maelstrom.tar.bz2` release asset the CI download step expects.
- The partition run itself is exercised by this job on CI.