### PR TITLE
fix: avoid blocking best-effort shard election enqueue

### DIFF
--- a/oxiad/coordinator/runtime/controller/shard/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller.go
@@ -208,28 +208,16 @@ func (s *controller) Election(electionAction *action.ElectionAction) string {
 	}
 	clonedAction := electionAction.Clone()
 	clonedAction.Waiter.Add(1)
-	select {
-	case s.electionOp <- clonedAction:
-	case <-s.ctx.Done():
+	if !channel.PushNoBlock(s.electionOp, clonedAction) {
 		s.terminationMu.RUnlock()
+		clonedAction.Waiter.Done()
+		s.logger.Debug("Discarding leader election because queue is full")
 		return ""
 	}
 	s.terminationMu.RUnlock()
 
-	done := make(chan struct{})
-	go func() {
-		clonedAction.Waiter.Wait()
-		close(done)
-	}()
-	// The shard controller might start terminating while the election operation
-	// is still queued: don't keep the caller blocked on an operation that will
-	// never be processed.
-	select {
-	case <-done:
-		return clonedAction.NewLeader
-	case <-s.ctx.Done():
-		return ""
-	}
+	clonedAction.Waiter.Wait()
+	return clonedAction.NewLeader
 }
 
 func (s *controller) run() {
@@ -597,13 +585,12 @@ func (s *controller) SyncServerAddress() {
 	s.logger.Info("server address changed, start a new leader election")
 	group := &sync.WaitGroup{}
 	group.Add(1)
-	select {
-	case s.electionOp <- &action.ElectionAction{
+	if !channel.PushNoBlock(s.electionOp, &action.ElectionAction{
 		Shard:  s.shard,
 		Waiter: group,
-	}:
-	case <-s.ctx.Done():
+	}) {
 		group.Done()
+		s.logger.Debug("Discarding sync-server-address election because queue is full")
 	}
 }
 

--- a/oxiad/coordinator/runtime/controller/shard/shard_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller_test.go
@@ -1050,6 +1050,81 @@ func TestController_PeriodicTasksSkipUnchangedPersist(t *testing.T) {
 	assert.Same(t, borrowedBefore.UnsafeBorrow(), borrowedAfter.UnsafeBorrow())
 }
 
+func TestController_ElectionDiscardsWhenQueueIsFull(t *testing.T) {
+	var shard int64 = 5
+	s := &controller{
+		shard:      shard,
+		electionOp: make(chan *action.ElectionAction, chanBufferSize),
+		logger:     slog.Default(),
+	}
+	for range chanBufferSize {
+		group := &sync.WaitGroup{}
+		group.Add(1)
+		s.electionOp <- &action.ElectionAction{
+			Shard:  shard,
+			Waiter: group,
+		}
+	}
+
+	done := make(chan string)
+	go func() {
+		done <- s.Election(&action.ElectionAction{Shard: shard})
+	}()
+
+	select {
+	case newLeader := <-done:
+		assert.Empty(t, newLeader)
+	case <-time.After(time.Second):
+		t.Fatal("Election blocked on a full election queue")
+	}
+	assert.Len(t, s.electionOp, chanBufferSize)
+}
+
+func TestController_SyncServerAddressDiscardsElectionWhenQueueIsFull(t *testing.T) {
+	var shard int64 = 5
+	metadata := newTestMetadata(t, memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled, ""), &proto.ClusterConfiguration{})
+
+	serverName := "s1"
+	oldIdentity := &proto.DataServerIdentity{Name: &serverName, Public: "old-public:9091", Internal: "old-internal:8191"}
+	newIdentity := &proto.DataServerIdentity{Name: &serverName, Public: "new-public:9091", Internal: "new-internal:8191"}
+	assert.NoError(t, metadata.CreateDataServer(&proto.DataServer{Identity: newIdentity}))
+	storeTestShardMetadata(t, metadata, constant.DefaultNamespace, shard, namespaceConfig, &proto.ShardMetadata{
+		Status:   proto.ShardStatusSteadyState,
+		Term:     1,
+		Leader:   oldIdentity,
+		Ensemble: []*proto.DataServerIdentity{oldIdentity},
+	})
+
+	s := &controller{
+		namespace:     constant.DefaultNamespace,
+		shard:         shard,
+		metadataStore: metadata,
+		electionOp:    make(chan *action.ElectionAction, chanBufferSize),
+		logger:        slog.Default(),
+	}
+	for range chanBufferSize {
+		group := &sync.WaitGroup{}
+		group.Add(1)
+		s.electionOp <- &action.ElectionAction{
+			Shard:  shard,
+			Waiter: group,
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.SyncServerAddress()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("SyncServerAddress blocked on a full election queue")
+	}
+	assert.Len(t, s.electionOp, chanBufferSize)
+}
+
 func TestController_DeleteShardAllowsNilEventListener(t *testing.T) {
 	var shard int64 = 5
 	rpc := mockutils.NewRpcProvider()


### PR DESCRIPTION
## Motivation
Shard controller close relies on `terminationMu` as an enqueue barrier. Enqueue paths should not hold that barrier while waiting for channel capacity, because that can delay or block shutdown if the channel is full.

Leader-election requests are retriable and can be superseded by later controller events. When the per-shard election queue is already full, the controller should discard the new request instead of blocking the caller while holding the read side of the termination barrier.

## Modifications
- Changed `Election` to use `channel.PushNoBlock` and return an empty leader when the election queue is full.
- Changed `SyncServerAddress` to use `channel.PushNoBlock` and discard the sync-triggered election when the queue is full.
- Simplified `Election` by waiting directly on the queued cloned action instead of spawning a goroutine around `WaitGroup.Wait`.
- Added regression tests that fill the election queue and verify both `Election` and `SyncServerAddress` do not block.

## Testing
- `go test ./oxiad/coordinator/runtime/controller/shard -count=1`
- `go test ./oxiad/coordinator/runtime -count=1`
