### PR TITLE
fix: reduce session creation/close logging to debug level

### DIFF
--- a/oxiad/dataserver/controller/lead/session.go
+++ b/oxiad/dataserver/controller/lead/session.go
@@ -76,7 +76,7 @@ func startSession(sessionId SessionId, sessionMetadata *proto.SessionMetadata, s
 		"shard":           fmt.Sprintf("%d", sm.shardId),
 	}, s.waitForHeartbeats)
 
-	s.log.Info("Session started", slog.Duration("session-timeout", s.timeout))
+	s.log.Debug("Session started", slog.Duration("session-timeout", s.timeout))
 	return s
 }
 

--- a/oxiad/dataserver/controller/lead/session_manager.go
+++ b/oxiad/dataserver/controller/lead/session_manager.go
@@ -223,7 +223,7 @@ func (sm *sessionManager) CloseSession(request *proto.CloseSessionRequest) (*pro
 	sm.removeSession(s.id)
 	sm.Unlock()
 
-	s.log.Info("Session closing")
+	s.log.Debug("Session closing")
 	s.Close()
 	err = s.delete()
 	if err != nil {


### PR DESCRIPTION
### Motivation

Session creation and close are routine, per-client events that can be frequent under normal operation, generating noisy info-level logs on the data servers.

### Modifications

- Lower `Session started` (`session.go`) from info to debug
- Lower `Session closing` (`session_manager.go`) from info to debug

The once-per-leader-initialization `All sessions` count log is left at info.