### PR TITLE
fix: guard change ensemble feature compatibility

### DIFF
--- a/oxiad/coordinator/runtime/controller/shard/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/pkg/errors"
 	gproto "google.golang.org/protobuf/proto"
 
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
@@ -559,9 +560,64 @@ func (s *controller) onChangeEnsemble(changeEnsembleAction *action.ChangeEnsembl
 			return
 		}
 	}
+	if err = s.validateChangeEnsembleFeatures(changeEnsembleAction); err != nil {
+		return
+	}
 	// todo: support optimized ensemble change to avoid start a new election
 	s.onElectLeader(changeEnsembleAction)
 }
+
+func (s *controller) validateChangeEnsembleFeatures(changeEnsembleAction *action.ChangeEnsembleAction) error {
+	borrowedMeta, exists := s.metadataStore.GetShardStatus(s.namespace, s.shard)
+	if !exists {
+		return nil
+	}
+	ensemble := borrowedMeta.UnsafeBorrow().Ensemble
+	ensembleFeatures := s.dataServerSupportedFeaturesSupplier(ensemble)
+	if len(ensembleFeatures) < len(ensemble) {
+		s.logger.Warn(
+			"Change ensemble feature validation skipped: current ensemble feature information is incomplete",
+			slog.Int("expected-nodes", len(ensemble)),
+			slog.Int("known-nodes", len(ensembleFeatures)),
+		)
+		return nil
+	}
+
+	requiredFeatures := negotiate(ensembleFeatures)
+	if len(requiredFeatures) == 0 {
+		return nil
+	}
+
+	to := changeEnsembleAction.To
+	targetFeatures := s.dataServerSupportedFeaturesSupplier([]*proto.DataServerIdentity{to})[to.GetNameOrDefault()]
+	if missing := featuresMissing(requiredFeatures, targetFeatures); len(missing) > 0 {
+		s.logger.Warn(
+			"Change ensemble rejected: target node does not support features required by the current ensemble",
+			slog.Any("to", to),
+			slog.Any("required-features", requiredFeatures),
+			slog.Any("missing-features", missing),
+		)
+		return errors.Wrapf(ErrIncompatibleChangeEnsemble,
+			"target node %s does not support features %v", to.GetNameOrDefault(), missing)
+	}
+	return nil
+}
+
+func featuresMissing(required []proto.Feature, available []proto.Feature) []proto.Feature {
+	availableSet := make(map[proto.Feature]struct{}, len(available))
+	for _, feature := range available {
+		availableSet[feature] = struct{}{}
+	}
+
+	var missing []proto.Feature
+	for _, feature := range required {
+		if _, ok := availableSet[feature]; !ok {
+			missing = append(missing, feature)
+		}
+	}
+	return missing
+}
+
 func (s *controller) SyncServerAddress() {
 	s.terminationMu.RLock()
 	defer s.terminationMu.RUnlock()

--- a/oxiad/coordinator/runtime/controller/shard/shard_controller_election.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller_election.go
@@ -45,8 +45,9 @@ import (
 )
 
 var (
-	ErrNotReadyForChangeEnsemble = errors.New("shard is not ready for change ensemble, please retry later")
-	ErrFollowerNotCaughtUp       = errors.New("follower not caught up yet")
+	ErrNotReadyForChangeEnsemble  = errors.New("shard is not ready for change ensemble, please retry later")
+	ErrIncompatibleChangeEnsemble = errors.New("change ensemble target does not support shard features")
+	ErrFollowerNotCaughtUp        = errors.New("follower not caught up yet")
 )
 
 type Election struct {

--- a/oxiad/coordinator/runtime/controller/shard/shard_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller_test.go
@@ -1015,6 +1015,61 @@ func TestController_FeatureNegotiation_MixedVersions(t *testing.T) {
 	sc.Close()
 }
 
+func TestController_ChangeEnsembleRejectsTargetMissingCurrentFeatures(t *testing.T) {
+	var shard int64 = 5
+	rpc := mockutils.NewRpcProvider()
+
+	s1 := &proto.DataServerIdentity{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := &proto.DataServerIdentity{Public: "s3:9091", Internal: "s3:8191"}
+	s4 := &proto.DataServerIdentity{Public: "s4:9091", Internal: "s4:8191"}
+
+	featuresByNode := map[string][]proto.Feature{
+		s1.GetNameOrDefault(): {proto.Feature_FEATURE_DB_CHECKSUM},
+		s2.GetNameOrDefault(): {proto.Feature_FEATURE_DB_CHECKSUM},
+		s3.GetNameOrDefault(): {proto.Feature_FEATURE_DB_CHECKSUM},
+		s4.GetNameOrDefault(): {},
+	}
+	featureSupplier := func(servers []*proto.DataServerIdentity) map[string][]proto.Feature {
+		result := make(map[string][]proto.Feature, len(servers))
+		for _, server := range servers {
+			result[server.GetNameOrDefault()] = featuresByNode[server.GetNameOrDefault()]
+		}
+		return result
+	}
+
+	metadata := newTestMetadata(
+		t,
+		memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled, ""),
+		&proto.ClusterConfiguration{},
+	)
+
+	sc := newTestController(t, metadata, constant.DefaultNamespace, shard, namespaceConfig, &proto.ShardMetadata{
+		Status:   proto.ShardStatusSteadyState,
+		Term:     2,
+		Leader:   s1,
+		Ensemble: []*proto.DataServerIdentity{s1, s2, s3},
+	}, featureSupplier, rpc, DefaultPeriodicTasksInterval)
+
+	rpc.GetNode(s1).ExpectGetStatusRequest(t, shard)
+	rpc.GetNode(s1).GetStatusResponse(2, proto.ServingStatus_LEADER, 0, 0)
+	rpc.GetNode(s2).ExpectGetStatusRequest(t, shard)
+	rpc.GetNode(s2).GetStatusResponse(2, proto.ServingStatus_FOLLOWER, 0, 0)
+	rpc.GetNode(s3).ExpectGetStatusRequest(t, shard)
+	rpc.GetNode(s3).GetStatusResponse(2, proto.ServingStatus_FOLLOWER, 0, 0)
+
+	rpc.GetNode(s1).ExpectNoMoreNewTermRequest(t)
+
+	swap := action.NewChangeEnsembleAction(shard, s3, s4)
+	sc.ChangeEnsemble(swap)
+	_, err := swap.Wait()
+	assert.ErrorIs(t, err, ErrIncompatibleChangeEnsemble)
+
+	rpc.GetNode(s4).ExpectNoMoreNewTermRequest(t)
+
+	assert.NoError(t, sc.Close())
+}
+
 // Each UpdateShardStatus persists the full cluster status, so re-writing it
 // for every shard on every periodic tick costs O(shards^2) bytes per interval
 // on the metadata backend. The periodic task must not persist when it has no


### PR DESCRIPTION
## Motivation

Feature negotiation only enables a feature when every member of the shard ensemble advertises support for it. After a shard is running with a feature-capable ensemble, a later change-ensemble action could swap in an older data server and start a new election with a downgraded negotiated feature set. That allows the coordinator to choose a target that does not satisfy the feature capability expected by the current ensemble.

Rejecting the incompatible swap before fencing keeps the current ensemble serving and enforces the placement invariant that old data servers are not selected into feature-capable shard ensembles.

## Modifications

- Validate change-ensemble targets against the current ensemble's negotiated supported feature set before starting the election.
- Return a dedicated `ErrIncompatibleChangeEnsemble` error when the target is missing required features.
- Add coverage that an old target is rejected without sending it a `NewTerm` request.

## Testing

- `go test ./oxiad/coordinator/runtime/controller/shard`
