### PR TITLE
fix: recover WAL segments with empty or stale index instead of panicking

### DIFF
--- a/oxiad/dataserver/wal/codec/v1.go
+++ b/oxiad/dataserver/wal/codec/v1.go
@@ -124,7 +124,9 @@ func (*V1) WriteIndex(path string, index []byte) error {
 	}
 
 	if _, err = idxFile.Write(index); err != nil {
-		return errors.Wrapf(err, "failed write index file %s", path)
+		return multierr.Combine(
+			errors.Wrapf(err, "failed write index file %s", path),
+			idxFile.Close())
 	}
 	return idxFile.Close()
 }

--- a/oxiad/dataserver/wal/codec/v1.go
+++ b/oxiad/dataserver/wal/codec/v1.go
@@ -118,7 +118,7 @@ func (*V1) WriteRecord(buf []byte, startOffset uint32, _ uint32, payload []byte)
 }
 
 func (*V1) WriteIndex(path string, index []byte) error {
-	idxFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
+	idxFile, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open index file %s", path)
 	}

--- a/oxiad/dataserver/wal/codec/v2.go
+++ b/oxiad/dataserver/wal/codec/v2.go
@@ -156,7 +156,7 @@ func (*V2) WriteRecord(buf []byte, startOffset uint32, previousCrc uint32, paylo
 }
 
 func (v *V2) WriteIndex(path string, index []byte) error {
-	idxFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
+	idxFile, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open index file %s", path)
 	}

--- a/oxiad/dataserver/wal/codec/v2.go
+++ b/oxiad/dataserver/wal/codec/v2.go
@@ -165,7 +165,9 @@ func (v *V2) WriteIndex(path string, index []byte) error {
 	binary.BigEndian.PutUint32(buf[0:], indexCrc)
 	copy(buf[v.GetIndexHeaderSize():], index)
 	if _, err = idxFile.Write(buf); err != nil {
-		return errors.Wrapf(err, "failed write index file %s", path)
+		return multierr.Combine(
+			errors.Wrapf(err, "failed write index file %s", path),
+			idxFile.Close())
 	}
 	return idxFile.Close()
 }

--- a/oxiad/dataserver/wal/readonly_segment.go
+++ b/oxiad/dataserver/wal/readonly_segment.go
@@ -94,7 +94,10 @@ func newReadOnlySegment(basePath string, baseOffset int64) (ReadOnlySegment, err
 		// the txn file. In both cases, rebuild the index from the txn file,
 		// like for a corrupted one
 		if err != nil && !errors.Is(err, codec.ErrDataCorrupted) && !errors.Is(err, os.ErrNotExist) {
-			return nil, errors.Wrapf(err, "failed to decode segment index file %s", ms.c.idxPath)
+			return nil, multierr.Combine(
+				errors.Wrapf(err, "failed to decode segment index file %s", ms.c.idxPath),
+				ms.txnMappedFile.Unmap(),
+				ms.txnFile.Close())
 		}
 		slog.Warn("The segment index file is missing, empty or corrupted and the index is being rebuilt.",
 			slog.String("path", ms.c.idxPath))
@@ -102,7 +105,10 @@ func newReadOnlySegment(basePath string, baseOffset int64) (ReadOnlySegment, err
 		if ms.idx, _, _, _, err = ms.c.codec.RecoverIndex(ms.txnMappedFile, 0,
 			ms.c.baseOffset, nil); err != nil {
 			slog.Error("The segment index file rebuild failed.", slog.String("path", ms.c.idxPath))
-			return nil, errors.Wrapf(err, "failed to rebuild segment index file %s", ms.c.idxPath)
+			return nil, multierr.Combine(
+				errors.Wrapf(err, "failed to rebuild segment index file %s", ms.c.idxPath),
+				ms.txnMappedFile.Unmap(),
+				ms.txnFile.Close())
 		}
 		if len(ms.idx) > 0 {
 			slog.Info("The segment index file has been rebuilt.", slog.String("path", ms.c.idxPath))
@@ -129,7 +135,7 @@ func newReadOnlySegment(basePath string, baseOffset int64) (ReadOnlySegment, err
 	// recover the last crc
 	fo := fileOffset(ms.idx, ms.c.baseOffset, ms.lastOffset)
 	if _, _, ms.lastCrc, err = ms.c.codec.ReadHeaderWithValidation(ms.txnMappedFile, fo); err != nil {
-		return nil, err
+		return nil, multierr.Combine(err, ms.txnMappedFile.Unmap(), ms.txnFile.Close())
 	}
 	return ms, nil
 }

--- a/oxiad/dataserver/wal/readonly_segment.go
+++ b/oxiad/dataserver/wal/readonly_segment.go
@@ -86,14 +86,17 @@ func newReadOnlySegment(basePath string, baseOffset int64) (ReadOnlySegment, err
 		return nil, errors.Wrapf(err, "failed to map segment txn file %s", ms.c.txnPath)
 	}
 
-	if ms.idx, err = ms.c.codec.ReadIndex(ms.c.idxPath); err != nil {
+	if ms.idx, err = ms.c.codec.ReadIndex(ms.c.idxPath); err != nil || len(ms.idx) == 0 {
 		// A missing index file is expected when the process crashed between a
-		// rollover and the sync round that closes the rolled-over segment:
-		// rebuild it from the txn file, like for a corrupted one
-		if !errors.Is(err, codec.ErrDataCorrupted) && !errors.Is(err, os.ErrNotExist) {
+		// rollover and the sync round that closes the rolled-over segment. An
+		// empty index file is the stale leftover of a close that ran while the
+		// segment had no entries yet, before a later reopen appended entries to
+		// the txn file. In both cases, rebuild the index from the txn file,
+		// like for a corrupted one
+		if err != nil && !errors.Is(err, codec.ErrDataCorrupted) && !errors.Is(err, os.ErrNotExist) {
 			return nil, errors.Wrapf(err, "failed to decode segment index file %s", ms.c.idxPath)
 		}
-		slog.Warn("The segment index file is missing or corrupted and the index is being rebuilt.",
+		slog.Warn("The segment index file is missing, empty or corrupted and the index is being rebuilt.",
 			slog.String("path", ms.c.idxPath))
 		// recover from txn
 		if ms.idx, _, _, _, err = ms.c.codec.RecoverIndex(ms.txnMappedFile, 0,
@@ -101,11 +104,24 @@ func newReadOnlySegment(basePath string, baseOffset int64) (ReadOnlySegment, err
 			slog.Error("The segment index file rebuild failed.", slog.String("path", ms.c.idxPath))
 			return nil, errors.Wrapf(err, "failed to rebuild segment index file %s", ms.c.idxPath)
 		}
-		slog.Info("The segment index file has been rebuilt.", slog.String("path", ms.c.idxPath))
-		if err := ms.c.codec.WriteIndex(ms.c.idxPath, ms.idx); err != nil {
-			slog.Warn("write recovered segment index failed. it can continue work but will retry writing after restart.",
-				slog.String("path", ms.c.idxPath))
+		if len(ms.idx) > 0 {
+			slog.Info("The segment index file has been rebuilt.", slog.String("path", ms.c.idxPath))
+			if err := ms.c.codec.WriteIndex(ms.c.idxPath, ms.idx); err != nil {
+				slog.Warn("write recovered segment index failed. it can continue work but will retry writing after restart.",
+					slog.String("path", ms.c.idxPath))
+			}
 		}
+	}
+
+	if len(ms.idx) == 0 {
+		// The txn file holds no entries: the segment cannot serve reads. The
+		// wal recovery discards such segments from the tail of the log: their
+		// content, if ever written, was lost by a crash before being synced
+		// and acknowledged
+		return nil, multierr.Combine(
+			errors.Wrapf(ErrEmptySegment, "segment file %s", ms.c.txnPath),
+			ms.txnMappedFile.Unmap(),
+			ms.txnFile.Close())
 	}
 
 	ms.lastOffset = ms.c.baseOffset + int64(len(ms.idx)/4-1)

--- a/oxiad/dataserver/wal/readonly_segment_test.go
+++ b/oxiad/dataserver/wal/readonly_segment_test.go
@@ -57,6 +57,63 @@ func TestReadOnlySegment(t *testing.T) {
 	assert.NoError(t, ro.Close())
 }
 
+// A valid but empty index file — the stale leftover of a close that ran while
+// the segment had no entries, before a later reopen appended entries to the
+// txn file — must trigger an index rebuild, not be trusted (it used to panic
+// with a slice out of bounds).
+func TestRO_auto_recover_empty_index(t *testing.T) {
+	path := t.TempDir()
+
+	rw, err := newReadWriteSegment(path, 0, 128*1024, 0, nil)
+	assert.NoError(t, err)
+	for i := int64(0); i < 10; i++ {
+		assert.NoError(t, rw.Append(i, []byte(fmt.Sprintf("entry-%d", i))))
+	}
+	rwSegment := rw.(*readWriteSegment)
+	assert.NoError(t, rw.Close())
+
+	// Replace the index with a valid empty one, as written by the close of a
+	// previous, then-empty incarnation of the segment
+	assert.NoError(t, os.Remove(rwSegment.c.idxPath))
+	assert.NoError(t, rwSegment.c.codec.WriteIndex(rwSegment.c.idxPath, nil))
+
+	ro, err := newReadOnlySegment(path, 0)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, ro.BaseOffset())
+	assert.EqualValues(t, 9, ro.LastOffset())
+
+	for i := int64(0); i < 10; i++ {
+		data, _, _, err := ro.Read(i)
+		assert.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("entry-%d", i), string(data))
+	}
+
+	assert.NoError(t, ro.Close())
+}
+
+// A segment whose txn file holds no entries cannot be opened for reads: it
+// must fail with ErrEmptySegment (it used to panic with a slice out of
+// bounds), regardless of whether an index file is present.
+func TestRO_EmptySegment(t *testing.T) {
+	path := t.TempDir()
+
+	rw, err := newReadWriteSegment(path, 0, 128*1024, 0, nil)
+	assert.NoError(t, err)
+	rwSegment := rw.(*readWriteSegment)
+	assert.NoError(t, rw.Close())
+
+	// The close of the empty segment wrote an empty index file
+	ro, err := newReadOnlySegment(path, 0)
+	assert.Nil(t, ro)
+	assert.ErrorIs(t, err, ErrEmptySegment)
+
+	// Same without the index file
+	assert.NoError(t, os.Remove(rwSegment.c.idxPath))
+	ro, err = newReadOnlySegment(path, 0)
+	assert.Nil(t, ro)
+	assert.ErrorIs(t, err, ErrEmptySegment)
+}
+
 func TestRO_auto_recover_broken_index(t *testing.T) {
 	path := t.TempDir()
 

--- a/oxiad/dataserver/wal/readwrite_segment.go
+++ b/oxiad/dataserver/wal/readwrite_segment.go
@@ -102,6 +102,18 @@ func newReadWriteSegment(basePath string, baseOffset int64, segmentSize uint32, 
 		ms.pendingFileSync.Store(true)
 	}
 
+	// An index file next to a segment reopened for writes belongs to a previous
+	// incarnation of the segment and goes stale with the first new append:
+	// remove it, so that a crash before the Close that rewrites it cannot
+	// leave it lying next to newer txn data. Close writes a fresh one.
+	if c.segmentExists {
+		if err = codec.RemoveFileIfExists(c.idxPath); err != nil {
+			return nil, multierr.Append(
+				errors.Wrapf(err, "failed to remove stale segment index file %s", c.idxPath),
+				ms.txnFile.Close())
+		}
+	}
+
 	if ms.txnMappedFile, err = mmap.MapRegion(ms.txnFile, int(segmentSize), mmap.RDWR, 0, 0); err != nil {
 		return nil, multierr.Append(
 			errors.Wrapf(err, "failed to map segment file %s", ms.c.txnPath),

--- a/oxiad/dataserver/wal/readwrite_segment_test.go
+++ b/oxiad/dataserver/wal/readwrite_segment_test.go
@@ -17,6 +17,7 @@ package wal
 import (
 	"encoding/binary"
 	"fmt"
+	"os"
 	"runtime"
 	"testing"
 
@@ -374,6 +375,35 @@ func TestReadWriteSegment_ConcurrentAppendReadFlush(t *testing.T) {
 	}
 
 	assert.NoError(t, rw.Close())
+}
+
+// Reopening a segment for writes removes the index file left by its previous
+// incarnation: the index goes stale with the first new append, and a crash
+// before the Close that rewrites it would leave it next to newer txn data.
+func TestReadWriteSegment_ReopenRemovesStaleIndex(t *testing.T) {
+	path := t.TempDir()
+
+	rw, err := newReadWriteSegment(path, 0, 128*1024, 0, nil)
+	assert.NoError(t, err)
+	idxPath := rw.(*readWriteSegment).c.idxPath
+	assert.NoError(t, rw.Close())
+
+	_, err = os.Stat(idxPath)
+	assert.NoError(t, err)
+
+	rw, err = newReadWriteSegment(path, 0, 128*1024, 0, nil)
+	assert.NoError(t, err)
+	_, err = os.Stat(idxPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	assert.NoError(t, rw.Append(0, []byte("entry-0")))
+	assert.NoError(t, rw.Close())
+
+	// The close wrote a fresh index for the appended entries
+	ro, err := newReadOnlySegment(path, 0)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, ro.LastOffset())
+	assert.NoError(t, ro.Close())
 }
 
 // Closing the segment must wait for an in-flight msync: the mapping cannot be

--- a/oxiad/dataserver/wal/wal.go
+++ b/oxiad/dataserver/wal/wal.go
@@ -29,6 +29,7 @@ var (
 	ErrReaderClosed      = errors.New("oxia: reader already closed")
 	ErrInvalidNextOffset = errors.New("oxia: invalid next offset in wal")
 	ErrSegmentFull       = errors.New("oxia: current segment is full")
+	ErrEmptySegment      = errors.New("oxia: segment has no entries")
 
 	InvalidTerm   int64 = -1
 	InvalidOffset int64 = -1

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -17,6 +17,7 @@ package wal
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -737,21 +738,29 @@ func (t *wal) recoverWal() error {
 	}
 
 	var firstSegment, lastSegment int64
-	var lastCrc uint32
-	if len(segments) > 0 {
+	lastCrc := constant.U32Zero
+	for len(segments) > 0 {
 		firstSegment = segments[0]
 		lastSegment = segments[len(segments)-1]
-		if firstSegment != lastSegment {
-			if lastCrc, err = t.readOnlySegments.GetLastCrc(lastSegment); err != nil {
-				return err
-			}
-		} else {
-			lastCrc = constant.U32Zero
+		if firstSegment == lastSegment {
+			break
 		}
-	} else {
-		firstSegment = 0
-		lastSegment = 0
-		lastCrc = constant.U32Zero
+		if lastCrc, err = t.readOnlySegments.GetLastCrc(lastSegment); err == nil {
+			break
+		}
+		if !errors.Is(err, ErrEmptySegment) {
+			return err
+		}
+		// The segment preceding lastSegment has no recoverable entries: its
+		// content was lost by a crash before being synced. The entries of
+		// lastSegment sit after that gap and were never acknowledged either,
+		// since the sync rounds close the rolled-over segments in order,
+		// before acknowledging: discard it and recover from one segment
+		// further back
+		if err = t.discardTrailingSegment(lastSegment); err != nil {
+			return err
+		}
+		segments = segments[:len(segments)-1]
 	}
 
 	if t.currentSegment, err = newReadWriteSegment(t.walPath, lastSegment, t.segmentSize,
@@ -773,6 +782,33 @@ func (t *wal) recoverWal() error {
 	}
 
 	return nil
+}
+
+// discardTrailingSegment removes the files of a trailing segment whose entries
+// cannot be recovered, and rebuilds the read-only group over the remaining
+// segments, so that the segment now becoming the last one is no longer served
+// as read-only: it gets reopened as the read-write segment instead.
+func (t *wal) discardTrailingSegment(baseOffset int64) error {
+	slog.Warn("Discarding trailing wal segment that follows a segment with no entries.",
+		slog.String("wal-path", t.walPath),
+		slog.Int64("base-offset", baseOffset))
+
+	c, err := newSegmentConfig(t.walPath, baseOffset)
+	if err != nil {
+		return err
+	}
+	if err = multierr.Combine(
+		codec.RemoveFileIfExists(c.idxPath),
+		codec.RemoveFileIfExists(c.txnPath),
+	); err != nil {
+		return err
+	}
+
+	if err = t.readOnlySegments.Close(); err != nil {
+		return err
+	}
+	t.readOnlySegments, err = newReadOnlySegmentsGroup(t.walPath)
+	return err
 }
 
 func listAllSegments(walPath string) (segments []int64, err error) {

--- a/oxiad/dataserver/wal/wal_test.go
+++ b/oxiad/dataserver/wal/wal_test.go
@@ -887,6 +887,145 @@ func TestWal_ReadOnlySegmentMissingIndex(t *testing.T) {
 	assert.NoError(t, f.Close())
 }
 
+// A power loss can leave a rolled-over segment file with none of its content
+// on disk (all zeroes, no index): recovery must discard the trailing segments
+// sitting after the gap — their entries were never acknowledged — and resume
+// from the last segment with recoverable entries (it used to panic with a
+// slice out of bounds).
+func TestWal_RecoverAfterLostRolledOverSegment(t *testing.T) {
+	dir := t.TempDir()
+	f := NewWalFactory(&FactoryOptions{
+		BaseWalDir:  dir,
+		Retention:   1 * time.Hour,
+		SegmentSize: 128 * 1024,
+		SyncData:    true,
+	})
+	w, err := f.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+
+	payload := strings.Repeat("x", 1024)
+	var entries []string
+	for i := 0; i < 300; i++ {
+		value := fmt.Sprintf("%s-%d", payload, i)
+		entries = append(entries, value)
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term: 1, Offset: int64(i), Value: []byte(value)}))
+	}
+	assert.NoError(t, w.Close())
+
+	basePath := walPath(dir, constant.DefaultNamespace, shard)
+	segments, err := listAllSegments(basePath)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, len(segments), 3)
+
+	// Simulate the power loss: the second-to-last segment never reached the
+	// disk (all zeroes, no index), while the last segment kept its content
+	lost := segments[len(segments)-2]
+	lostConfig, err := newSegmentConfig(basePath, lost)
+	assert.NoError(t, err)
+	info, err := os.Stat(lostConfig.txnPath)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(lostConfig.txnPath, make([]byte, info.Size()), 0644))
+	assert.NoError(t, os.Remove(lostConfig.idxPath))
+	lastConfig, err := newSegmentConfig(basePath, segments[len(segments)-1])
+	assert.NoError(t, err)
+	assert.NoError(t, os.Remove(lastConfig.idxPath))
+
+	// Reopen: everything before the lost segment is recovered, the trailing
+	// segment after the gap is discarded
+	w, err = f.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, w.FirstOffset())
+	assert.EqualValues(t, lost-1, w.LastOffset())
+	_, err = os.Stat(lastConfig.txnPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	// The wal accepts appends continuing right after the recovered offsets
+	entries = entries[:lost]
+	for i := lost; i < lost+10; i++ {
+		value := fmt.Sprintf("recovered-%d", i)
+		entries = append(entries, value)
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term: 2, Offset: i, Value: []byte(value)}))
+	}
+
+	r, err := w.NewReader(InvalidOffset)
+	assert.NoError(t, err)
+	assertReaderReads(t, r, entries)
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+
+	// And everything survives another reopen
+	w, err = f.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+	assert.EqualValues(t, lost+9, w.LastOffset())
+	r, err = w.NewReader(InvalidOffset)
+	assert.NoError(t, err)
+	assertReaderReads(t, r, entries)
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, f.Close())
+}
+
+// A power loss wiping the content of every segment leaves the wal with no
+// recoverable entries: it must reopen empty, positioned at its first segment.
+func TestWal_RecoverAfterAllSegmentsContentLost(t *testing.T) {
+	dir := t.TempDir()
+	f := NewWalFactory(&FactoryOptions{
+		BaseWalDir:  dir,
+		Retention:   1 * time.Hour,
+		SegmentSize: 128 * 1024,
+		SyncData:    true,
+	})
+	w, err := f.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+
+	payload := strings.Repeat("x", 1024)
+	for i := 0; i < 300; i++ {
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term: 1, Offset: int64(i), Value: []byte(fmt.Sprintf("%s-%d", payload, i))}))
+	}
+	assert.NoError(t, w.Close())
+
+	basePath := walPath(dir, constant.DefaultNamespace, shard)
+	segments, err := listAllSegments(basePath)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, len(segments), 3)
+	for _, segment := range segments {
+		c, err := newSegmentConfig(basePath, segment)
+		assert.NoError(t, err)
+		info, err := os.Stat(c.txnPath)
+		assert.NoError(t, err)
+		assert.NoError(t, os.WriteFile(c.txnPath, make([]byte, info.Size()), 0644))
+		assert.NoError(t, codec.RemoveFileIfExists(c.idxPath))
+	}
+
+	w, err = f.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, InvalidOffset, w.FirstOffset())
+	assert.Equal(t, InvalidOffset, w.LastOffset())
+
+	// Only the first segment file survives, and the wal is appendable from
+	// scratch
+	remaining, err := listAllSegments(basePath)
+	assert.NoError(t, err)
+	assert.Equal(t, []int64{0}, remaining)
+
+	var entries []string
+	for i := 0; i < 10; i++ {
+		value := fmt.Sprintf("entry-%d", i)
+		entries = append(entries, value)
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term: 2, Offset: int64(i), Value: []byte(value)}))
+	}
+	r, err := w.NewReader(InvalidOffset)
+	assert.NoError(t, err)
+	assertReaderReads(t, r, entries)
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, f.Close())
+}
+
 // Truncating to an offset below all the retained segments clears the wal:
 // the clear used to re-acquire the wal lock already held by TruncateLog,
 // deadlocking the wal permanently (this test would time out).


### PR DESCRIPTION
### Problem

WAL recovery could panic, leaving the shard permanently unable to start:

```
panic: runtime error: slice bounds out of range [4294967292:0]

github.com/oxia-db/oxia/oxiad/dataserver/wal/codec.ReadInt(...)
	oxiad/dataserver/wal/codec/codec.go:167
github.com/oxia-db/oxia/oxiad/dataserver/wal.fileOffset(...)
	oxiad/dataserver/wal/readonly_segment.go:37
github.com/oxia-db/oxia/oxiad/dataserver/wal.newReadOnlySegment(...)
	oxiad/dataserver/wal/readonly_segment.go:114
...
github.com/oxia-db/oxia/oxiad/dataserver/wal.(*wal).recoverWal(...)
	oxiad/dataserver/wal/wal_impl.go:745
```

`4294967292` is `uint32(-4)`: `newReadOnlySegment` assumed every segment index has at least one entry, computed `lastOffset = baseOffset - 1` for an empty one, and sliced the empty index buffer out of bounds.

Two on-disk states lead there:

1. **Stale empty index** (observed in production, byte-level confirmed): a segment gets closed while still empty, writing a valid header-only index file. The wal is later reopened, the segment fills with entries and rolls over, and the process dies before the sync round rewrites the index. On restart `ReadIndex` returns a *valid empty* index, so the missing/corrupted-index rebuild path is skipped. The txn file still holds all the entries — nothing was actually lost.
2. **Power loss**: a rolled-over segment's txn file exists but none of its content ever reached the disk (all zeroes, no index). `RecoverIndex` legitimately rebuilds an empty index.

### Changes

- `newReadOnlySegment`: rebuild the index from the txn file also when the index file is valid but empty, and fail with the new `ErrEmptySegment` instead of panicking when the txn file itself holds no recoverable entries.
- `newReadWriteSegment`: remove the index file left by a previous incarnation when reopening an existing segment for writes — it goes stale with the first new append and is rewritten on close anyway. This prevents the stale-index state from arising at all, including the stale-*short* variant (which would not panic, but would silently cap reads and hand out a mid-segment CRC as the chain seed).
- `recoverWal`: on `ErrEmptySegment`, discard the trailing segments that follow a segment with no recoverable entries and resume recovery from one segment further back. Their content was never acknowledged: the sync rounds flush and close rolled-over segments in order before advancing `lastSyncedOffset`, so an all-zeroes rolled segment implies no later offset was ever acked; the follower re-fetches those entries from the leader.
- `WriteIndex` (v1/v2): open with `O_TRUNC`, so rewriting a shorter index over an existing longer file cannot leave a garbage tail behind the CRC-covered content.

### Verification

- A throwaway harness replayed the actual production WAL files through `newWal`: the unfixed code reproduces the exact panic; the fixed code recovers the affected shard fully (index rebuilt from the txn file, every entry readable head to tail, zero data loss) and recovers the healthy shards identically to before, with no index rebuild.
- New regression tests cover both scenarios at the segment and wal level (`TestRO_auto_recover_empty_index`, `TestRO_EmptySegment`, `TestReadWriteSegment_ReopenRemovesStaleIndex`, `TestWal_RecoverAfterLostRolledOverSegment`, `TestWal_RecoverAfterAllSegmentsContentLost`); each was verified to hit the original panic against the unfixed code.
- Full `wal`, `codec` and `dataserver` suites pass with `-race`.