### PR TITLE
fix: don't log stream op failures when the client transport is closing

### DIFF
--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -299,15 +300,27 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 }
 
 // warnOnStreamError logs failures of streaming data operations, except the
-// expected ones: the client going away or its deadline expiring.
+// expected ones: the client going away or its deadline expiring. A send that
+// fails because the client connection is shutting down is also expected and
+// is only logged at debug level.
 func (s *publicRpcServer) warnOnStreamError(operation string, err error) {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return
 	}
-	s.log.Warn(
-		"Failed to perform "+operation+" operation",
-		slog.Any("error", err),
-	)
+	msg := "Failed to perform " + operation + " operation"
+	if isTransportClosingError(err) {
+		s.log.Debug(msg, slog.Any("error", err))
+		return
+	}
+	s.log.Warn(msg, slog.Any("error", err))
+}
+
+// isTransportClosingError recognizes the status error that a stream send
+// returns when the client connection is shutting down. gRPC exposes no
+// sentinel for it, so match on code and message.
+func isTransportClosingError(err error) bool {
+	return status.Code(err) == codes.Unavailable &&
+		strings.Contains(status.Convert(err).Message(), "transport is closing")
 }
 
 func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClient_ReadServer) error {

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -300,19 +300,13 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 }
 
 // warnOnStreamError logs failures of streaming data operations, except the
-// expected ones: the client going away or its deadline expiring. A send that
-// fails because the client connection is shutting down is also expected and
-// is only logged at debug level.
+// expected ones: the client going away, its deadline expiring, or its
+// connection shutting down.
 func (s *publicRpcServer) warnOnStreamError(operation string, err error) {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || isTransportClosingError(err) {
 		return
 	}
-	msg := "Failed to perform " + operation + " operation"
-	if isTransportClosingError(err) {
-		s.log.Debug(msg, slog.Any("error", err))
-		return
-	}
-	s.log.Warn(msg, slog.Any("error", err))
+	s.log.Warn("Failed to perform operation", slog.String("operation", operation), slog.Any("error", err))
 }
 
 // isTransportClosingError recognizes the status error that a stream send

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"strings"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -300,21 +299,14 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 }
 
 // warnOnStreamError logs failures of streaming data operations, except the
-// expected ones: the client going away, its deadline expiring, or its
-// connection shutting down.
-func (s *publicRpcServer) warnOnStreamError(operation string, err error) {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || isTransportClosingError(err) {
+// expected ones. The stream context ends whenever the client goes away — it
+// cancels the RPC, its deadline expires, or its connection shuts down — so
+// failures with a done context are not worth a warning.
+func (s *publicRpcServer) warnOnStreamError(ctx context.Context, operation string, err error) {
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return
 	}
 	s.log.Warn("Failed to perform operation", slog.String("operation", operation), slog.Any("error", err))
-}
-
-// isTransportClosingError recognizes the status error that a stream send
-// returns when the client connection is shutting down. gRPC exposes no
-// sentinel for it, so match on code and message.
-func isTransportClosingError(err error) bool {
-	return status.Code(err) == codes.Unavailable &&
-		strings.Contains(status.Convert(err).Message(), "transport is closing")
 }
 
 func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClient_ReadServer) error {
@@ -340,7 +332,7 @@ func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClie
 		err = batcher.Flush()
 	}
 	if err != nil {
-		s.warnOnStreamError("read", err)
+		s.warnOnStreamError(ctx, "read", err)
 		return constant.IntoGrpcStatusError(err)
 	}
 	return nil
@@ -367,7 +359,7 @@ func (s *publicRpcServer) List(request *proto.ListRequest, stream proto.OxiaClie
 		err = batcher.Flush()
 	}
 	if err != nil {
-		s.warnOnStreamError("list", err)
+		s.warnOnStreamError(ctx, "list", err)
 		return constant.IntoGrpcStatusError(err)
 	}
 	return nil
@@ -399,7 +391,7 @@ func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream prot
 		err = batcher.Flush()
 	}
 	if err != nil {
-		s.warnOnStreamError("range-scan", err)
+		s.warnOnStreamError(ctx, "range-scan", err)
 		return constant.IntoGrpcStatusError(err)
 	}
 	return nil

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -429,14 +429,18 @@ func TestWarnOnStreamErrorSkipsClientDisconnectErrors(t *testing.T) {
 		log: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})),
 	}
 
-	server.warnOnStreamError("read", errors.New("unexpected failure"))
+	server.warnOnStreamError(context.Background(), "read", errors.New("unexpected failure"))
 	assert.Contains(t, buf.String(), "level=WARN")
 
+	// When the client goes away mid-stream, the transport cancels the stream
+	// context before the send error reaches the handler.
+	doneCtx, cancel := context.WithCancel(context.Background())
+	cancel()
 	buf.Reset()
-	server.warnOnStreamError("read", grpcstatus.Error(codes.Unavailable, "transport is closing"))
+	server.warnOnStreamError(doneCtx, "read", grpcstatus.Error(codes.Unavailable, "transport is closing"))
 	assert.Empty(t, buf.String())
 
 	buf.Reset()
-	server.warnOnStreamError("read", context.Canceled)
+	server.warnOnStreamError(context.Background(), "read", context.Canceled)
 	assert.Empty(t, buf.String())
 }

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -423,7 +423,7 @@ func TestResolveLeaderValidatesAuthorityBeforeLeaderLookup(t *testing.T) {
 	assert.Equal(t, codes.PermissionDenied, grpcstatus.Code(err))
 }
 
-func TestWarnOnStreamErrorLogsTransportClosingAtDebug(t *testing.T) {
+func TestWarnOnStreamErrorSkipsClientDisconnectErrors(t *testing.T) {
 	var buf bytes.Buffer
 	server := &publicRpcServer{
 		log: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})),
@@ -434,8 +434,7 @@ func TestWarnOnStreamErrorLogsTransportClosingAtDebug(t *testing.T) {
 
 	buf.Reset()
 	server.warnOnStreamError("read", grpcstatus.Error(codes.Unavailable, "transport is closing"))
-	assert.Contains(t, buf.String(), "level=DEBUG")
-	assert.NotContains(t, buf.String(), "level=WARN")
+	assert.Empty(t, buf.String())
 
 	buf.Reset()
 	server.warnOnStreamError("read", context.Canceled)

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -15,7 +15,9 @@
 package dataserver
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -419,4 +421,23 @@ func TestResolveLeaderValidatesAuthorityBeforeLeaderLookup(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, codes.PermissionDenied, grpcstatus.Code(err))
+}
+
+func TestWarnOnStreamErrorLogsTransportClosingAtDebug(t *testing.T) {
+	var buf bytes.Buffer
+	server := &publicRpcServer{
+		log: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+
+	server.warnOnStreamError("read", errors.New("unexpected failure"))
+	assert.Contains(t, buf.String(), "level=WARN")
+
+	buf.Reset()
+	server.warnOnStreamError("read", grpcstatus.Error(codes.Unavailable, "transport is closing"))
+	assert.Contains(t, buf.String(), "level=DEBUG")
+	assert.NotContains(t, buf.String(), "level=WARN")
+
+	buf.Reset()
+	server.warnOnStreamError("read", context.Canceled)
+	assert.Empty(t, buf.String())
 }


### PR DESCRIPTION
### Motivation

When a client connection goes away while a read/list/range-scan stream response is being sent, the handler logs a warning:

```
WRN Failed to perform read operation error={"error":"rpc error: code = Unavailable desc = transport is closing","kind":"*status.Error","stack":null} component=public-rpc-server
```

This is an expected client-disconnect condition, not a server-side problem, so it should not be logged as a warning.

### Modifications

- `warnOnStreamError` now also skips logging when the stream context has ended: the gRPC transport cancels it whenever the client cancels the RPC, its deadline expires, or its connection shuts down. This avoids matching on the "transport is closing" message string (gRPC converts the internal sentinel into a bare status error, so there is nothing typed to check on the error value) and also covers client-disconnect errors that surface as status errors, which the existing `errors.Is` checks do not match.
- Pass the operation name as a structured log attribute instead of building the message string.
- Added a unit test covering the warn vs. skip behavior.