### PR TITLE
fix: close read-only WAL file on mmap error

### DIFF
--- a/oxiad/dataserver/wal/readonly_segment.go
+++ b/oxiad/dataserver/wal/readonly_segment.go
@@ -83,7 +83,9 @@ func newReadOnlySegment(basePath string, baseOffset int64) (ReadOnlySegment, err
 	}
 
 	if ms.txnMappedFile, err = mmap.MapRegion(ms.txnFile, -1, mmap.RDONLY, 0, 0); err != nil {
-		return nil, errors.Wrapf(err, "failed to map segment txn file %s", ms.c.txnPath)
+		return nil, multierr.Append(
+			errors.Wrapf(err, "failed to map segment txn file %s", ms.c.txnPath),
+			ms.txnFile.Close())
 	}
 
 	if ms.idx, err = ms.c.codec.ReadIndex(ms.c.idxPath); err != nil || len(ms.idx) == 0 {


### PR DESCRIPTION
## Motivation
When opening a read-only WAL segment, the txn file is opened before mapping it with mmap. If the mmap call fails, the current error path returns without closing the already-open file descriptor. Closing it on that path avoids leaking the descriptor while preserving the original mmap error context.

## Modifications
- Close the read-only segment txn file when `mmap.MapRegion` fails.
- Combine the mmap error with any close error using `multierr`.

## Testing
- `go test ./dataserver/wal`