### PR TITLE
fix: reject empty WAL index files

### DIFF
--- a/oxiad/dataserver/wal/codec/v1.go
+++ b/oxiad/dataserver/wal/codec/v1.go
@@ -146,6 +146,9 @@ func (*V1) ReadIndex(path string) ([]byte, error) {
 	if err = idFile.Close(); err != nil {
 		return nil, errors.Wrapf(err, "failed to close segment index file %s", path)
 	}
+	if len(indexBuf) == 0 {
+		return nil, errors.Wrapf(ErrDataCorrupted, "index file %s has no entries", path)
+	}
 	return indexBuf, nil
 }
 

--- a/oxiad/dataserver/wal/codec/v1_test.go
+++ b/oxiad/dataserver/wal/codec/v1_test.go
@@ -61,6 +61,14 @@ func TestV1_WriteReadIndex(t *testing.T) {
 	}
 }
 
+func TestV1_ReadEmptyIndex(t *testing.T) {
+	p := path.Join(t.TempDir(), "empty-index"+v1.GetIdxExtension())
+	assert.NoError(t, v1.WriteIndex(p, nil))
+
+	_, err := v1.ReadIndex(p)
+	assert.ErrorIs(t, err, ErrDataCorrupted)
+}
+
 func TestV1_RecoverIndex(t *testing.T) {
 	elementsNum := 5
 

--- a/oxiad/dataserver/wal/codec/v2.go
+++ b/oxiad/dataserver/wal/codec/v2.go
@@ -190,6 +190,9 @@ func (v *V2) ReadIndex(path string) ([]byte, error) {
 	if len(indexBuf) < int(v.GetIndexHeaderSize()) {
 		return nil, errors.Wrapf(ErrDataCorrupted, "index file %s is too short: %d bytes", path, len(indexBuf))
 	}
+	if len(indexBuf) == int(v.GetIndexHeaderSize()) {
+		return nil, errors.Wrapf(ErrDataCorrupted, "index file %s has no entries", path)
+	}
 	expectedCrc := ReadInt(indexBuf, 0)
 	actualCrc := crc.Checksum(0).Update(indexBuf[v.GetIndexHeaderSize():]).Value()
 	if expectedCrc != actualCrc {

--- a/oxiad/dataserver/wal/codec/v2_test.go
+++ b/oxiad/dataserver/wal/codec/v2_test.go
@@ -311,12 +311,18 @@ func TestV2_IndexBroken(t *testing.T) {
 }
 
 func TestV2_ReadEmptyIndex(t *testing.T) {
-	dir := os.TempDir()
-	fileName := "empty-index"
-	p := path.Join(dir, fileName+v2.GetIdxExtension())
+	p := path.Join(t.TempDir(), "empty-index"+v2.GetIdxExtension())
+	assert.NoError(t, v2.WriteIndex(p, nil))
+
+	_, err := v2.ReadIndex(p)
+	assert.ErrorIs(t, err, ErrDataCorrupted)
+}
+
+func TestV2_ReadEmptyIndexFile(t *testing.T) {
+	p := path.Join(t.TempDir(), "empty-index-file"+v2.GetIdxExtension())
 
 	// Create empty file
-	err := os.WriteFile(p, []byte{}, 0644)
+	err := os.WriteFile(p, nil, 0644)
 	assert.NoError(t, err)
 
 	_, err = v2.ReadIndex(p)

--- a/oxiad/dataserver/wal/readonly_segment.go
+++ b/oxiad/dataserver/wal/readonly_segment.go
@@ -88,20 +88,17 @@ func newReadOnlySegment(basePath string, baseOffset int64) (ReadOnlySegment, err
 			ms.txnFile.Close())
 	}
 
-	if ms.idx, err = ms.c.codec.ReadIndex(ms.c.idxPath); err != nil || len(ms.idx) == 0 {
+	if ms.idx, err = ms.c.codec.ReadIndex(ms.c.idxPath); err != nil {
 		// A missing index file is expected when the process crashed between a
-		// rollover and the sync round that closes the rolled-over segment. An
-		// empty index file is the stale leftover of a close that ran while the
-		// segment had no entries yet, before a later reopen appended entries to
-		// the txn file. In both cases, rebuild the index from the txn file,
-		// like for a corrupted one
-		if err != nil && !errors.Is(err, codec.ErrDataCorrupted) && !errors.Is(err, os.ErrNotExist) {
+		// rollover and the sync round that closes the rolled-over segment:
+		// rebuild it from the txn file, like for a corrupted one
+		if !errors.Is(err, codec.ErrDataCorrupted) && !errors.Is(err, os.ErrNotExist) {
 			return nil, multierr.Combine(
 				errors.Wrapf(err, "failed to decode segment index file %s", ms.c.idxPath),
 				ms.txnMappedFile.Unmap(),
 				ms.txnFile.Close())
 		}
-		slog.Warn("The segment index file is missing, empty or corrupted and the index is being rebuilt.",
+		slog.Warn("The segment index file is missing or corrupted and the index is being rebuilt.",
 			slog.String("path", ms.c.idxPath))
 		// recover from txn
 		if ms.idx, _, _, _, err = ms.c.codec.RecoverIndex(ms.txnMappedFile, 0,

--- a/oxiad/dataserver/wal/readonly_segment_test.go
+++ b/oxiad/dataserver/wal/readonly_segment_test.go
@@ -57,10 +57,8 @@ func TestReadOnlySegment(t *testing.T) {
 	assert.NoError(t, ro.Close())
 }
 
-// A valid but empty index file — the stale leftover of a close that ran while
-// the segment had no entries, before a later reopen appended entries to the
-// txn file — must trigger an index rebuild, not be trusted (it used to panic
-// with a slice out of bounds).
+// An empty index file must trigger an index rebuild, not be trusted (it used
+// to panic with a slice out of bounds).
 func TestRO_auto_recover_empty_index(t *testing.T) {
 	path := t.TempDir()
 
@@ -102,14 +100,10 @@ func TestRO_EmptySegment(t *testing.T) {
 	rwSegment := rw.(*readWriteSegment)
 	assert.NoError(t, rw.Close())
 
-	// The close of the empty segment wrote an empty index file
-	ro, err := newReadOnlySegment(path, 0)
-	assert.Nil(t, ro)
-	assert.ErrorIs(t, err, ErrEmptySegment)
+	_, err = os.Stat(rwSegment.c.idxPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
 
-	// Same without the index file
-	assert.NoError(t, os.Remove(rwSegment.c.idxPath))
-	ro, err = newReadOnlySegment(path, 0)
+	ro, err := newReadOnlySegment(path, 0)
 	assert.Nil(t, ro)
 	assert.ErrorIs(t, err, ErrEmptySegment)
 }

--- a/oxiad/dataserver/wal/readwrite_segment.go
+++ b/oxiad/dataserver/wal/readwrite_segment.go
@@ -256,9 +256,10 @@ func (ms *readWriteSegment) Close() error {
 	err := multierr.Combine(
 		ms.txnMappedFile.Unmap(),
 		ms.txnFile.Close(),
-		// Write index file
-		ms.c.codec.WriteIndex(ms.c.idxPath, ms.writingIdx),
 	)
+	if len(ms.writingIdx) > 0 {
+		err = multierr.Append(err, ms.c.codec.WriteIndex(ms.c.idxPath, ms.writingIdx))
+	}
 	codec.ReturnIndexBuf(&ms.writingIdx)
 	return err
 }
@@ -266,7 +267,7 @@ func (ms *readWriteSegment) Close() error {
 func (ms *readWriteSegment) Delete() error {
 	return multierr.Combine(
 		ms.Close(),
-		os.Remove(ms.c.idxPath),
+		codec.RemoveFileIfExists(ms.c.idxPath),
 		os.Remove(ms.c.txnPath),
 	)
 }

--- a/oxiad/dataserver/wal/readwrite_segment_test.go
+++ b/oxiad/dataserver/wal/readwrite_segment_test.go
@@ -386,6 +386,7 @@ func TestReadWriteSegment_ReopenRemovesStaleIndex(t *testing.T) {
 	rw, err := newReadWriteSegment(path, 0, 128*1024, 0, nil)
 	assert.NoError(t, err)
 	idxPath := rw.(*readWriteSegment).c.idxPath
+	assert.NoError(t, rw.Append(0, []byte("entry-0")))
 	assert.NoError(t, rw.Close())
 
 	_, err = os.Stat(idxPath)
@@ -396,13 +397,13 @@ func TestReadWriteSegment_ReopenRemovesStaleIndex(t *testing.T) {
 	_, err = os.Stat(idxPath)
 	assert.ErrorIs(t, err, os.ErrNotExist)
 
-	assert.NoError(t, rw.Append(0, []byte("entry-0")))
+	assert.NoError(t, rw.Append(1, []byte("entry-1")))
 	assert.NoError(t, rw.Close())
 
 	// The close wrote a fresh index for the appended entries
 	ro, err := newReadOnlySegment(path, 0)
 	assert.NoError(t, err)
-	assert.EqualValues(t, 0, ro.LastOffset())
+	assert.EqualValues(t, 1, ro.LastOffset())
 	assert.NoError(t, ro.Close())
 }
 


### PR DESCRIPTION
## Motivation
PR #1228 fixed WAL recovery for missing, stale, or empty segment indexes, but the implementation had to treat a successfully decoded empty index as a special case. That made the read-only segment open path harder to reason about: a persisted index with no entries was accepted by the codec and then rejected later by WAL-specific logic.

A closed segment index with zero entries is not useful. This change makes that invariant explicit: empty persisted index files are invalid and get handled through the existing corrupted-index rebuild path. That removes the mixed ReadIndex error-or-empty condition while keeping empty txn recovery as a read-only segment concern.

## Modifications
- Reject empty V1 and V2 persisted index files with codec.ErrDataCorrupted.
- Stop writing index files when a read-write segment has no entries.
- Simplify read-only segment index loading to rebuild only on ReadIndex errors.
- Allow read-write segment deletion when no index file was written for an empty segment.
- Update WAL and codec tests for empty index behavior.

## Testing
- go test -count=1 ./dataserver/wal ./dataserver/wal/codec