### PR TITLE
fix: propagate commit offset to split observers parked at the wal head

### DIFF
--- a/oxiad/dataserver/controller/follow/log_synchronizer.go
+++ b/oxiad/dataserver/controller/follow/log_synchronizer.go
@@ -133,6 +133,24 @@ func (ls *LogSynchronizer) append0(syncCond chan struct{}, onAppend func(), req 
 	// This runs once per replicated entry: skip the attribute boxing entirely
 	// when debug logging is off, and check the level once for both call sites.
 	debugEnabled := ls.log.Enabled(context.Background(), slog.LevelDebug)
+
+	if req.Entry == nil {
+		// Entry-less commit-offset advertisement: the leader sends it to an
+		// observer parked at the head of the wal when the commit offset
+		// advances with no new entries to piggyback it on. Nothing to append:
+		// take the new commit offset and wake up the syncer, which in turn
+		// nudges the state applier.
+		if debugEnabled {
+			ls.log.Debug(
+				"Received commit-offset advertisement",
+				slog.Int64("commit-offset", req.CommitOffset),
+			)
+		}
+		ls.advertisedCommitOffset.Store(req.CommitOffset)
+		channel.PushNoBlock(syncCond, struct{}{})
+		return nil
+	}
+
 	if debugEnabled {
 		ls.log.Debug(
 			"Add entry",

--- a/oxiad/dataserver/controller/follow/log_synchronizer_test.go
+++ b/oxiad/dataserver/controller/follow/log_synchronizer_test.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -114,4 +115,62 @@ func TestLogSynchronizer_DuplicateAckOnlySynced(t *testing.T) {
 	assert.EqualValues(t, 4, response.Offset)
 	assert.GreaterOrEqual(t, w.syncCalls.Load(), int64(1))
 	assert.EqualValues(t, 4, w.synced.Load())
+}
+
+// An entry-less Append is a commit-offset advertisement (sent by the leader to
+// an observer parked at the head of the wal): it must take the new commit
+// offset and wake up the applier chain, without appending anything to the wal
+// and without acking.
+func TestLogSynchronizer_CommitOffsetAdvertisement(t *testing.T) {
+	w := &stubWal{}
+	w.appended.Store(0)
+	w.synced.Store(0)
+
+	lastAppendedOffset := &atomic.Int64{}
+	lastAppendedOffset.Store(0)
+	advertisedCommitOffset := &atomic.Int64{}
+	advertisedCommitOffset.Store(wal.InvalidOffset)
+
+	stateApplierCond := make(chan struct{}, 1)
+	stream := rpc.NewMockServerReplicateStream()
+	ls := NewLogSynchronizer(LogSynchronizerParams{
+		Log:                    slog.Default(),
+		Namespace:              "test",
+		ShardId:                0,
+		Term:                   1,
+		Wal:                    w,
+		AdvertisedCommitOffset: advertisedCommitOffset,
+		LastAppendedOffset:     lastAppendedOffset,
+		WriteLatencyHisto: metric.NewLatencyHistogram("oxia_test_commit_advertisement",
+			"test", map[string]any{}),
+		StateApplierCond: stateApplierCond,
+		Stream:           stream,
+		OnAppend:         func() {},
+	})
+	defer func() {
+		// Unblock the appender goroutine's Recv before closing
+		stream.Cancel()
+		assert.NoError(t, ls.Close())
+	}()
+
+	stream.AddRequest(&proto.Append{
+		Term:                    1,
+		CommitOffset:            0,
+		CumulativeAcksSupported: true,
+	})
+
+	assert.Eventually(t, func() bool {
+		return advertisedCommitOffset.Load() == 0
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// The state applier gets woken up (through the syncer)
+	select {
+	case <-stateApplierCond:
+	case <-time.After(10 * time.Second):
+		t.Fatal("state applier was not woken up")
+	}
+
+	// Nothing was appended and no ack was sent
+	assert.EqualValues(t, 0, lastAppendedOffset.Load())
+	assert.Empty(t, stream.Responses)
 }

--- a/oxiad/dataserver/controller/lead/follower_cursor.go
+++ b/oxiad/dataserver/controller/lead/follower_cursor.go
@@ -424,6 +424,9 @@ func (fc *followerCursor) sendSnapshot() error {
 }
 
 func (fc *followerCursor) streamEntriesLoop(ctx context.Context, reader wal.Reader, currentOffset int64) error {
+	// The commit offset last advertised to the follower on this stream,
+	// piggybacked on the entries sent so far
+	lastSentCommitOffset := wal.InvalidOffset
 	for {
 		if fc.closed.Load() {
 			return nil
@@ -432,7 +435,8 @@ func (fc *followerCursor) streamEntriesLoop(ctx context.Context, reader wal.Read
 		if !reader.HasNext() {
 			// We have reached the head of the wal
 			// Wait for more entries to be written
-			if err := fc.ackTracker.WaitForHeadOffset(ctx, currentOffset+1); err != nil {
+			var err error
+			if lastSentCommitOffset, err = fc.waitAtHead(ctx, reader, currentOffset, lastSentCommitOffset); err != nil {
 				if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
 					return nil
 				}
@@ -454,10 +458,11 @@ func (fc *followerCursor) streamEntriesLoop(ctx context.Context, reader wal.Read
 			)
 		}
 
+		commitOffset := fc.ackTracker.CommitOffset()
 		if err = fc.stream.Send(&proto.Append{
 			Term:             fc.term,
 			Entry:            le,
-			CommitOffset:     fc.ackTracker.CommitOffset(),
+			CommitOffset:     commitOffset,
 			PreviousEntryCrc: &previousCrc,
 			// This leader accounts acks cumulatively: the follower can
 			// coalesce the acks of a whole sync round into one message
@@ -471,7 +476,47 @@ func (fc *followerCursor) streamEntriesLoop(ctx context.Context, reader wal.Read
 
 		fc.lastPushed.Store(le.Offset)
 		currentOffset = le.Offset
+		lastSentCommitOffset = commitOffset
 	}
+}
+
+// waitAtHead parks the cursor once it has reached the head of the wal, until
+// an entry past currentOffset is written. An observer cursor additionally
+// wakes up when the commit offset advances beyond lastSentCommitOffset and
+// advertises it to the follower with an entry-less Append: the observer
+// (split child) commit offset is capped at what was advertised, and the split
+// catch-up depends on it reaching the leader's commit offset even when no
+// more writes arrive to piggyback it on. Regular followers don't get the
+// advertisement: they only use the commit offset to reduce apply lag, and
+// older-version followers don't handle an Append without an entry. An
+// observer is never on an older version: it only exists for shard splits,
+// where both ends run split-capable servers.
+// It returns the commit offset last advertised to the follower.
+func (fc *followerCursor) waitAtHead(ctx context.Context, reader wal.Reader, currentOffset int64,
+	lastSentCommitOffset int64) (int64, error) {
+	if !fc.observer {
+		return lastSentCommitOffset, fc.ackTracker.WaitForHeadOffset(ctx, currentOffset+1)
+	}
+
+	if err := fc.ackTracker.WaitForHeadOffsetOrCommitAdvance(ctx, currentOffset+1, lastSentCommitOffset); err != nil {
+		return lastSentCommitOffset, err
+	}
+
+	commitOffset := fc.ackTracker.CommitOffset()
+	if commitOffset <= lastSentCommitOffset || reader.HasNext() {
+		// Nothing to advertise, or a new entry is available and will carry
+		// the commit offset itself
+		return lastSentCommitOffset, nil
+	}
+
+	if err := fc.stream.Send(&proto.Append{
+		Term:                    fc.term,
+		CommitOffset:            commitOffset,
+		CumulativeAcksSupported: true,
+	}); err != nil {
+		return lastSentCommitOffset, err
+	}
+	return commitOffset, nil
 }
 
 func (fc *followerCursor) streamEntries() error {

--- a/oxiad/dataserver/controller/lead/follower_cursor_test.go
+++ b/oxiad/dataserver/controller/lead/follower_cursor_test.go
@@ -456,3 +456,68 @@ func (*blockingSnapshotStream) SendMsg(any) error {
 func (*blockingSnapshotStream) RecvMsg(any) error {
 	return io.EOF
 }
+
+// An observer cursor parked at the head of the wal must advertise a commit
+// offset advancement with an entry-less Append: with no more writes arriving,
+// the observer (split child) would otherwise never learn the commit offset and
+// the split catch-up phase would stall.
+func TestObserverFollowerCursor_AdvertisesCommitOffsetAtHead(t *testing.T) {
+	var term int64 = 1
+	var shard int64 = 2
+
+	stream := rpc.NewMockRpcClient()
+	ackTracker := NewQuorumAckTracker(3, wal.InvalidOffset, wal.InvalidOffset)
+	kvf, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	db, err := database.NewDB(constant.DefaultNamespace, shard, kvf, proto.KeySortingType_HIERARCHICAL, 1*time.Hour, time2.SystemClock)
+	assert.NoError(t, err)
+	wf := wal.NewWalFactory(&wal.FactoryOptions{BaseWalDir: t.TempDir()})
+	w, err := wf.NewWal(constant.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+
+	assert.NoError(t, w.Append(&proto.LogEntry{
+		Term:   1,
+		Offset: 0,
+		Value:  []byte("v1"),
+	}))
+
+	// A regular follower acking through the quorum tracker
+	regular, err := ackTracker.NewCursorAcker(wal.InvalidOffset)
+	assert.NoError(t, err)
+
+	fc, err := NewObserverFollowerCursor("child-1", term, constant.DefaultNamespace, shard, stream, ackTracker,
+		w, db, wal.InvalidOffset, &proto.Int32HashRange{MinHashInclusive: 0, MaxHashInclusive: 100})
+	assert.NoError(t, err)
+
+	// The observer streams entry 0 with the commit offset of that moment (-1)
+	// and parks at the head of the wal
+	req := <-stream.AppendReqs
+	assert.EqualValues(t, 0, req.Entry.Offset)
+	assert.Equal(t, wal.InvalidOffset, req.CommitOffset)
+
+	// The quorum ack advances the commit offset with no new writes
+	ackTracker.AdvanceHeadOffset(0)
+	regular.Ack(0)
+	assert.EqualValues(t, 0, ackTracker.CommitOffset())
+
+	// The parked observer sends the advertisement on its own
+	req = <-stream.AppendReqs
+	assert.Nil(t, req.Entry)
+	assert.EqualValues(t, 0, req.CommitOffset)
+	assert.EqualValues(t, term, req.Term)
+
+	// No repeated advertisement while nothing advances
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case req = <-stream.AppendReqs:
+		t.Fatalf("unexpected append: %+v", req)
+	default:
+		// Expected. There should be nothing in the channel
+	}
+
+	assert.NoError(t, fc.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, wf.Close())
+	assert.NoError(t, db.Close())
+	assert.NoError(t, kvf.Close())
+}

--- a/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
+++ b/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
@@ -90,6 +90,13 @@ type QuorumAckTracker interface {
 	// Waits until the specified entry is written on the wal
 	WaitForHeadOffset(ctx context.Context, offset int64) error
 
+	// WaitForHeadOffsetOrCommitAdvance
+	// Waits until the head offset reaches `headOffset` or the commit offset
+	// advances beyond `commitOffset`. Used by observer cursors parked at the
+	// head of the wal: with no new entries to piggyback it on, a commit
+	// advancement must be propagated to the follower on its own.
+	WaitForHeadOffsetOrCommitAdvance(ctx context.Context, headOffset int64, commitOffset int64) error
+
 	// NewCursorAcker creates a tracker for a new cursor
 	// The `ackOffset` is the previous last-acked position for the cursor
 	NewCursorAcker(ackOffset int64) (CursorAcker, error)
@@ -97,8 +104,11 @@ type QuorumAckTracker interface {
 
 type quorumAckTracker struct {
 	sync.Mutex
-	waitingRequests   []waitingRequest
-	waitForHeadOffset concurrent.ConditionContext
+	waitingRequests []waitingRequest
+
+	// Signaled whenever the head offset or the commit offset advances,
+	// and on close. Waiters re-check their own predicate.
+	progressCond concurrent.ConditionContext
 
 	replicationFactor uint32
 	requiredAcks      uint32
@@ -158,7 +168,7 @@ func NewQuorumAckTracker(replicationFactor uint32, headOffset int64, commitOffse
 		q.tracker[offset] = &BitSet{}
 	}
 
-	q.waitForHeadOffset = concurrent.NewConditionContext(q)
+	q.progressCond = concurrent.NewConditionContext(q)
 	q.commitSignal = make(chan struct{}, 1)
 	q.callbacksDone = make(chan struct{})
 	go q.runCallbacks()
@@ -227,7 +237,7 @@ func (q *quorumAckTracker) AdvanceHeadOffset(headOffset int64) {
 	}
 
 	q.headOffset.Store(headOffset)
-	q.waitForHeadOffset.Broadcast()
+	q.progressCond.Broadcast()
 
 	if q.requiredAcks == 0 {
 		q.notifyCommitOffsetAdvanced(headOffset)
@@ -253,7 +263,20 @@ func (q *quorumAckTracker) WaitForHeadOffset(ctx context.Context, offset int64) 
 	defer q.Unlock()
 
 	for !q.closed && q.headOffset.Load() < offset {
-		if err := q.waitForHeadOffset.Wait(ctx); err != nil {
+		if err := q.progressCond.Wait(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (q *quorumAckTracker) WaitForHeadOffsetOrCommitAdvance(ctx context.Context, headOffset int64, commitOffset int64) error {
+	q.Lock()
+	defer q.Unlock()
+
+	for !q.closed && q.headOffset.Load() < headOffset && q.commitOffset.Load() <= commitOffset {
+		if err := q.progressCond.Wait(ctx); err != nil {
 			return err
 		}
 	}
@@ -311,6 +334,7 @@ func (q *quorumAckTracker) insertWaitingRequest(r waitingRequest) {
 
 func (q *quorumAckTracker) notifyCommitOffsetAdvanced(commitOffset int64) {
 	q.commitOffset.Store(commitOffset)
+	q.progressCond.Broadcast()
 
 	if len(q.waitingRequests) > 0 {
 		channel.PushNoBlock(q.commitSignal, struct{}{})
@@ -321,7 +345,7 @@ func (q *quorumAckTracker) Close() error {
 	q.Lock()
 	alreadyClosed := q.closed
 	q.closed = true
-	q.waitForHeadOffset.Broadcast()
+	q.progressCond.Broadcast()
 	q.Unlock()
 
 	if !alreadyClosed {

--- a/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
+++ b/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
@@ -237,11 +237,13 @@ func (q *quorumAckTracker) AdvanceHeadOffset(headOffset int64) {
 	}
 
 	q.headOffset.Store(headOffset)
-	q.progressCond.Broadcast()
 
 	if q.requiredAcks == 0 {
+		// The commit offset advances together with the head offset:
+		// notifyCommitOffsetAdvanced broadcasts progressCond for both.
 		q.notifyCommitOffsetAdvanced(headOffset)
 	} else {
+		q.progressCond.Broadcast()
 		q.tracker[headOffset] = &BitSet{}
 	}
 }

--- a/oxiad/dataserver/controller/lead/quorum_ack_tracker_test.go
+++ b/oxiad/dataserver/controller/lead/quorum_ack_tracker_test.go
@@ -538,3 +538,66 @@ func TestQuorumAckTracker_CumulativeAckQuorum(t *testing.T) {
 	c2.Ack(5)
 	assert.EqualValues(t, 5, at.CommitOffset())
 }
+
+// A waiter parked at the head of the wal must also wake up when the commit
+// offset advances, even though no new entry gets written.
+func TestQuorumAckTracker_WaitForHeadOffsetOrCommitAdvance(t *testing.T) {
+	at := NewQuorumAckTracker(3, 0, wal.InvalidOffset)
+
+	ch := make(chan error)
+	go func() {
+		ch <- at.WaitForHeadOffsetOrCommitAdvance(context.Background(), 1, wal.InvalidOffset)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-ch:
+		assert.Fail(t, "should not be ready")
+	default:
+		// Expected. There should be nothing in the channel
+	}
+
+	// The quorum ack on entry 0 advances the commit offset with no new entry:
+	// the waiter must wake up
+	c1, err := at.NewCursorAcker(wal.InvalidOffset)
+	assert.NoError(t, err)
+	c1.Ack(0)
+	assert.EqualValues(t, 0, at.CommitOffset())
+
+	assert.Eventually(t, func() bool {
+		select {
+		case err := <-ch:
+			assert.NoError(t, err)
+			return true
+		default:
+			return false
+		}
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// An already-advanced commit offset satisfies the wait immediately
+	assert.NoError(t, at.WaitForHeadOffsetOrCommitAdvance(context.Background(), 1, wal.InvalidOffset))
+
+	// A new entry keeps waking it up as well
+	go func() {
+		ch <- at.WaitForHeadOffsetOrCommitAdvance(context.Background(), 1, 0)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-ch:
+		assert.Fail(t, "should not be ready")
+	default:
+		// Expected. There should be nothing in the channel
+	}
+
+	at.AdvanceHeadOffset(1)
+	assert.Eventually(t, func() bool {
+		select {
+		case err := <-ch:
+			assert.NoError(t, err)
+			return true
+		default:
+			return false
+		}
+	}, 10*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
### Motivation

`TestCoordinator_ShardSplit_ConcurrentSplitRejected` flakes at a ~5% rate on `main`. Root cause: a split-child observer cursor only learns the leader's commit offset piggybacked on the `Append` entries it receives. When the observer reaches the head of the WAL and the commit offset advances afterwards (the quorum ack of the last entry is processed after that entry was already streamed), no further `Append` is sent unless new writes arrive. The child's commit offset then stays behind, the split CatchUp phase keeps polling for a target the child can never reach (`CatchUp round timed out, retrying ... target=0` every 10s), and the split times out and aborts after 120s.

Failing-run signature: `Successfully attached cursor follower component=observer-cursor ... ack-offset=-1` followed by two minutes of CatchUp timeouts with no errors or elections in between.

### Changes

- **`QuorumAckTracker`**: signal the condition (renamed to `progressCond`) on commit-offset advancement too, and add `WaitForHeadOffsetOrCommitAdvance()` so a parked cursor wakes up on either kind of progress. With no waiters the extra broadcast is a single atomic load, so there is no hot-path cost while cursors are busy streaming.
- **`followerCursor`**: an observer parked at the head of the WAL now sends an entry-less `Append` advertising the new commit offset. Regular followers are unchanged: they only use the commit offset to reduce apply lag (which self-heals on the next write), and older-version followers don't handle an `Append` without an entry. Observers cannot be mixed-version since they only exist for shard splits.
- **`LogSynchronizer`**: handle an entry-less `Append` by storing the advertised commit offset and waking the syncer, which nudges the state applier. Routed through the sync round so entries are never applied before they are durable in the local WAL.

### Verification

- 80 consecutive runs of `TestCoordinator_ShardSplit_ConcurrentSplitRejected` all passing (previously ~1 failure per 15-25 runs)
- 30 consecutive runs of the sibling `TestCoordinator_ShardSplit_Notifications` all passing
- New unit tests at all three layers (tracker wait, observer cursor advertisement, entry-less Append handling)
- Full `make test` suite green, `golangci-lint` v2.6.2 clean