### PR TITLE
perf: replace per-session goroutine with shared session-expiry scheduler

### DIFF
--- a/oxiad/dataserver/controller/lead/session.go
+++ b/oxiad/dataserver/controller/lead/session.go
@@ -144,6 +144,9 @@ func (sm *sessionManager) expiryLoop() {
 			// flight: collect again before going back to sleep.
 			continue
 		}
+		// No Stop+drain dance before Reset: with go >= 1.23 Reset flushes a
+		// pending fire, and a spurious wake-up would only cost one empty
+		// collect pass anyway.
 		timer.Reset(next)
 		select {
 		case <-sm.ctx.Done():

--- a/oxiad/dataserver/controller/lead/session.go
+++ b/oxiad/dataserver/controller/lead/session.go
@@ -15,142 +15,224 @@
 package lead
 
 import (
-	"context"
-	"fmt"
-	"io"
+	"container/heap"
 	"log/slog"
-	"sync"
+	"sync/atomic"
 	"time"
 
-	"github.com/oxia-db/oxia/common/process"
 	"github.com/oxia-db/oxia/common/proto"
 )
 
 // --- Session
 
+// session tracks one live client session on the shard leader. It is a small
+// passive record: expiry is driven by the manager's shared scheduler (see
+// expiryLoop) instead of a per-session goroutine and timer, so that holding
+// many live sessions stays cheap (https://github.com/oxia-db/oxia/issues/1235).
 type session struct {
-	io.Closer
-	sync.Mutex
-
-	ctx       context.Context
-	ctxCancel context.CancelFunc
-	latch     sync.WaitGroup
-
 	id             SessionId
 	clientIdentity string
-	shardId        int64
 	timeout        time.Duration
-	sm             *sessionManager
-	heartbeatCh    chan bool
-	log            *slog.Logger
+
+	// deadline is the expiry instant, in nanoseconds on the manager's
+	// monotonic clock (sessionManager.now). Heartbeats store a new value;
+	// the expiry scheduler loads it to decide whether the session is still
+	// alive.
+	deadline atomic.Int64
+
+	// heapDeadline is the deadline this session was queued with in the
+	// manager's expiry heap. It can lag behind deadline: heartbeats only
+	// update deadline, and the scheduler re-queues stale entries when they
+	// reach the top of the heap. Guarded by the manager's lock.
+	heapDeadline int64
+
+	// heapIdx is this session's position in the manager's expiry heap, -1
+	// when not queued. Guarded by the manager's lock.
+	heapIdx int
 }
 
+// heartbeat pushes the expiry deadline out to now+timeout. Lock-free: it is
+// called on the keep-alive hot path while holding only the manager's read
+// lock.
+func (s *session) heartbeat(now int64) {
+	s.deadline.Store(now + int64(s.timeout))
+}
+
+// startSession registers the session with the manager and queues it on the
+// expiry heap. The caller must hold the manager's write lock.
 func startSession(sessionId SessionId, sessionMetadata *proto.SessionMetadata, sm *sessionManager) *session {
 	s := &session{
-		latch: sync.WaitGroup{},
-
 		id:             sessionId,
 		clientIdentity: sessionMetadata.Identity,
 		timeout:        time.Duration(sessionMetadata.TimeoutMs) * time.Millisecond,
-		sm:             sm,
-		heartbeatCh:    make(chan bool, 1),
-
-		log: slog.With(
-			slog.String("client-identity", sessionMetadata.Identity),
-			slog.String("component", "session"),
-			slog.Int64("session-id", int64(sessionId)),
-			slog.String("namespace", sm.namespace),
-			slog.Int64("shard", sm.shardId),
-		),
+		heapIdx:        -1,
 	}
+	deadline := sm.now() + int64(s.timeout)
+	s.deadline.Store(deadline)
+	s.heapDeadline = deadline
+
 	sm.sessions[sessionId] = s
 	sm.activeSessions.Inc()
-	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
+	heap.Push(&sm.expiryHeap, s)
+	if sm.expiryHeap[0] == s {
+		// New earliest deadline: nudge the expiry scheduler to re-arm its
+		// timer.
+		sm.wake()
+	}
 
-	s.latch.Add(1)
-	go process.DoWithLabels(s.ctx, map[string]string{
-		"oxia":            "session",
-		"client-identity": sessionMetadata.Identity,
-		"session-id":      fmt.Sprintf("%d", sessionId),
-		"namespace":       sm.namespace,
-		"shard":           fmt.Sprintf("%d", sm.shardId),
-	}, s.waitForHeartbeats)
-
-	s.log.Debug("Session started", slog.Duration("session-timeout", s.timeout))
+	sm.log.Debug(
+		"Session started",
+		slog.Int64("session-id", int64(sessionId)),
+		slog.String("client-identity", s.clientIdentity),
+		slog.Duration("session-timeout", s.timeout),
+	)
 	return s
 }
 
-func (s *session) Close() {
-	s.close()
-	// wait until all the background goroutine gracefully shutdown
-	s.latch.Wait()
+// --- Expiry scheduler
+
+// expiryBatchSize caps how many expired sessions get deleted in a single
+// write: deleting a session record cascades to all its ephemeral keys, so the
+// batch is kept moderate while still amortizing the replication round-trip
+// during mass expiry.
+const expiryBatchSize = 128
+
+// idleExpiryWait is how long the scheduler sleeps when no deadline is queued;
+// queuing an earlier deadline nudges it awake before that.
+const idleExpiryWait = time.Hour
+
+// sessionHeap is a min-heap of sessions ordered by heapDeadline.
+type sessionHeap []*session
+
+func (h sessionHeap) Len() int           { return len(h) }
+func (h sessionHeap) Less(i, j int) bool { return h[i].heapDeadline < h[j].heapDeadline }
+
+func (h sessionHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].heapIdx = i
+	h[j].heapIdx = j
 }
 
-func (s *session) close() {
-	s.Lock()
-	s.ctxCancel()
-	if s.heartbeatCh != nil {
-		close(s.heartbeatCh)
-		s.heartbeatCh = nil
-	}
-	s.Unlock()
-	s.log.Debug("Session channels closed")
+func (h *sessionHeap) Push(x any) {
+	s := x.(*session) //nolint:revive
+	s.heapIdx = len(*h)
+	*h = append(*h, s)
 }
 
-func (s *session) delete() error {
-	_, err := s.sm.leaderController.WriteBlock(context.Background(), &proto.WriteRequest{
-		Shard:        &s.shardId,
-		Puts:         nil,
-		Deletes:      []*proto.DeleteRequest{{Key: SessionKey(s.id)}},
-		DeleteRanges: nil,
-	})
-	return err
+func (h *sessionHeap) Pop() any {
+	old := *h
+	n := len(old)
+	s := old[n-1]
+	old[n-1] = nil
+	s.heapIdx = -1
+	*h = old[:n-1]
+	return s
 }
 
-func (s *session) heartbeat() {
-	s.Lock()
-	defer s.Unlock()
-	if s.heartbeatCh != nil {
-		select {
-		case s.heartbeatCh <- true:
-		default:
-			// A heartbeat is already pending in the buffer; skip.
-		}
-	}
-}
-
-func (s *session) waitForHeartbeats() {
-	s.Lock()
-	heartbeatChannel := s.heartbeatCh
-	s.Unlock()
-	s.log.Debug("Waiting for heartbeats")
-	timeoutTimer := time.NewTimer(s.timeout)
-	defer func() {
-		timeoutTimer.Stop()
-		s.latch.Done()
-	}()
+// expiryLoop is the shared session-expiry scheduler: a single goroutine per
+// session manager that sleeps until the earliest queued deadline and expires
+// every session whose deadline has passed.
+func (sm *sessionManager) expiryLoop() {
+	defer sm.latch.Done()
+	timer := time.NewTimer(idleExpiryWait)
+	defer timer.Stop()
 	for {
+		due, next := sm.collectDueSessions()
+		if len(due) > 0 {
+			sm.expireSessions(due)
+			// More sessions may have become due while the deletes were in
+			// flight: collect again before going back to sleep.
+			continue
+		}
+		timer.Reset(next)
 		select {
-		case <-s.ctx.Done():
+		case <-sm.ctx.Done():
 			return
-		case heartbeat := <-heartbeatChannel:
-			if !heartbeat {
-				// The channel is closed, so the session must be closing
-				return
-			}
-			timeoutTimer.Reset(s.timeout)
-		case <-timeoutTimer.C:
-			s.log.Warn("Session expired")
-
-			s.close()
-			if err := s.delete(); err != nil {
-				s.log.Error("Failed to delete session", slog.Any("error", err))
-			}
-
-			s.sm.Lock()
-			s.sm.removeSession(s.id)
-			s.sm.expiredSessions.Inc()
-			s.sm.Unlock()
+		case <-sm.wakeCh:
+		case <-timer.C:
 		}
 	}
+}
+
+// collectDueSessions pops off the expiry heap every session whose deadline
+// has passed. Sessions whose deadline was pushed forward by heartbeats since
+// they were queued are re-queued at their current deadline instead. It also
+// returns how long the scheduler may sleep until the next queued deadline.
+func (sm *sessionManager) collectDueSessions() (due []*session, next time.Duration) {
+	sm.Lock()
+	defer sm.Unlock()
+	now := sm.now()
+	for len(sm.expiryHeap) > 0 {
+		s := sm.expiryHeap[0]
+		if s.heapDeadline > now {
+			return due, time.Duration(s.heapDeadline - now)
+		}
+		if deadline := s.deadline.Load(); deadline > now {
+			s.heapDeadline = deadline
+			heap.Fix(&sm.expiryHeap, 0)
+			continue
+		}
+		heap.Pop(&sm.expiryHeap)
+		due = append(due, s)
+	}
+	return due, idleExpiryWait
+}
+
+// expireSessions deletes the due sessions from the database in batches and
+// removes them from the manager, mirroring what the expiry path of the old
+// per-session goroutine used to do.
+func (sm *sessionManager) expireSessions(due []*session) {
+	for start := 0; start < len(due) && sm.ctx.Err() == nil; start += expiryBatchSize {
+		batch := due[start:min(start+expiryBatchSize, len(due))]
+		expired := sm.requeueRefreshed(batch)
+		if len(expired) == 0 {
+			continue
+		}
+
+		ids := make([]SessionId, len(expired))
+		for i, s := range expired {
+			ids[i] = s.id
+			sm.log.Warn(
+				"Session expired",
+				slog.Int64("session-id", int64(s.id)),
+				slog.String("client-identity", s.clientIdentity),
+			)
+		}
+		if err := sm.deleteSessions(ids); err != nil {
+			sm.log.Error(
+				"Failed to delete expired sessions",
+				slog.Any("error", err),
+				slog.Int("count", len(ids)),
+			)
+		}
+
+		sm.Lock()
+		for _, s := range expired {
+			sm.removeSession(s.id)
+			sm.expiredSessions.Inc()
+		}
+		sm.Unlock()
+	}
+}
+
+// requeueRefreshed gives popped sessions a last chance before their delete is
+// issued: any session that received a heartbeat while earlier batches were
+// being deleted goes back on the heap, the rest are confirmed expired.
+func (sm *sessionManager) requeueRefreshed(batch []*session) (expired []*session) {
+	sm.Lock()
+	defer sm.Unlock()
+	now := sm.now()
+	expired = make([]*session, 0, len(batch))
+	for _, s := range batch {
+		deadline := s.deadline.Load()
+		if deadline <= now {
+			expired = append(expired, s)
+			continue
+		}
+		if _, stillTracked := sm.sessions[s.id]; stillTracked {
+			s.heapDeadline = deadline
+			heap.Push(&sm.expiryHeap, s)
+		}
+	}
+	return expired
 }

--- a/oxiad/dataserver/controller/lead/session_bench_test.go
+++ b/oxiad/dataserver/controller/lead/session_bench_test.go
@@ -15,13 +15,10 @@
 package lead
 
 import (
-	"context"
-	"log/slog"
 	"runtime"
 	"testing"
 	"time"
 
-	"github.com/oxia-db/oxia/common/metric"
 	"github.com/oxia-db/oxia/common/proto"
 )
 
@@ -32,13 +29,7 @@ import (
 //
 //	go test -bench BenchmarkSessionFootprint -benchtime=100000x -run NONE ./oxiad/dataserver/controller/lead/
 func BenchmarkSessionFootprint(b *testing.B) {
-	sm := &sessionManager{
-		sessions: make(map[SessionId]*session),
-		log:      slog.Default(),
-		activeSessions: metric.NewUpDownCounter("oxia_bench_active_sessions",
-			"bench", "count", map[string]any{}),
-	}
-	sm.ctx, sm.cancel = context.WithCancel(context.Background())
+	sm := newBareSessionManager()
 
 	metadata := &proto.SessionMetadata{
 		TimeoutMs: uint32((10 * time.Minute).Milliseconds()),

--- a/oxiad/dataserver/controller/lead/session_bench_test.go
+++ b/oxiad/dataserver/controller/lead/session_bench_test.go
@@ -1,0 +1,75 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lead
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/oxia-db/oxia/common/metric"
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+// BenchmarkSessionFootprint measures the resident memory cost of holding live
+// sessions (see https://github.com/oxia-db/oxia/issues/1235). Run with a fixed
+// iteration count so the reported per-session numbers correspond to a known
+// population, e.g.:
+//
+//	go test -bench BenchmarkSessionFootprint -benchtime=100000x -run NONE ./oxiad/dataserver/controller/lead/
+func BenchmarkSessionFootprint(b *testing.B) {
+	sm := &sessionManager{
+		sessions: make(map[SessionId]*session),
+		log:      slog.Default(),
+		activeSessions: metric.NewUpDownCounter("oxia_bench_active_sessions",
+			"bench", "count", map[string]any{}),
+	}
+	sm.ctx, sm.cancel = context.WithCancel(context.Background())
+
+	metadata := &proto.SessionMetadata{
+		TimeoutMs: uint32((10 * time.Minute).Milliseconds()),
+		Identity:  "bench-client-identity",
+	}
+
+	goroutinesBefore := runtime.NumGoroutine()
+	runtime.GC() //nolint:revive // settle the heap so the before/after delta only measures sessions
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	b.ResetTimer()
+	sm.Lock()
+	for i := 0; i < b.N; i++ {
+		startSession(SessionId(i), metadata, sm)
+	}
+	sm.Unlock()
+	b.StopTimer()
+
+	runtime.GC() //nolint:revive // drop creation-time garbage, keeping only the live per-session state
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	heapPerSession := float64(int64(after.HeapAlloc)-int64(before.HeapAlloc)) / float64(b.N)
+	stackPerSession := float64(int64(after.StackInuse)-int64(before.StackInuse)) / float64(b.N)
+	b.ReportMetric(heapPerSession, "heap-B/session")
+	b.ReportMetric(stackPerSession, "stack-B/session")
+	b.ReportMetric(heapPerSession+stackPerSession, "total-B/session")
+	b.ReportMetric(float64(runtime.NumGoroutine()-goroutinesBefore)/float64(b.N), "goroutines/session")
+
+	if err := sm.Close(); err != nil {
+		b.Fatal(err)
+	}
+}

--- a/oxiad/dataserver/controller/lead/session_manager.go
+++ b/oxiad/dataserver/controller/lead/session_manager.go
@@ -15,6 +15,7 @@
 package lead
 
 import (
+	"container/heap"
 	"context"
 	"fmt"
 	"io"
@@ -31,6 +32,7 @@ import (
 
 	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/common/metric"
+	"github.com/oxia-db/oxia/common/process"
 	"github.com/oxia-db/oxia/common/proto"
 )
 
@@ -94,6 +96,17 @@ type sessionManager struct {
 	sessions         map[SessionId]*session
 	log              *slog.Logger
 
+	// expiryHeap orders the live sessions by expiry deadline; it is consumed
+	// by the expiry scheduler (expiryLoop) and guarded by the manager's lock.
+	expiryHeap sessionHeap
+	// wakeCh nudges the expiry scheduler when a deadline earlier than every
+	// queued one gets added.
+	wakeCh chan struct{}
+	// epoch is the base of the manager's monotonic clock: deadlines are
+	// nanoseconds since epoch, see now().
+	epoch time.Time
+	latch sync.WaitGroup
+
 	ctx    context.Context
 	cancel context.CancelFunc
 
@@ -107,6 +120,8 @@ func NewSessionManager(ctx context.Context, namespace string, shardId int64, con
 	labels := metric.LabelsForShard(namespace, shardId)
 	sm := &sessionManager{
 		sessions:         make(map[SessionId]*session),
+		wakeCh:           make(chan struct{}, 1),
+		epoch:            time.Now(),
 		namespace:        namespace,
 		shardId:          shardId,
 		leaderController: controller,
@@ -129,7 +144,29 @@ func NewSessionManager(ctx context.Context, namespace string, shardId int64, con
 
 	sm.ctx, sm.cancel = context.WithCancel(ctx)
 
+	sm.latch.Add(1)
+	go process.DoWithLabels(sm.ctx, map[string]string{
+		"oxia":      "session-expiry",
+		"namespace": namespace,
+		"shard":     fmt.Sprintf("%d", shardId),
+	}, sm.expiryLoop)
+
 	return sm
+}
+
+// now returns the manager's monotonic clock reading, in nanoseconds since the
+// manager was created. Session deadlines are instants on this clock, so they
+// are immune to wall-clock jumps, like the per-session timers they replace.
+func (sm *sessionManager) now() int64 {
+	return int64(time.Since(sm.epoch))
+}
+
+// wake nudges the expiry scheduler to re-evaluate the earliest deadline.
+func (sm *sessionManager) wake() {
+	select {
+	case sm.wakeCh <- struct{}{}:
+	default:
+	}
 }
 
 func (sm *sessionManager) CreateSession(request *proto.CreateSessionRequest) (*proto.CreateSessionResponse, error) {
@@ -177,17 +214,39 @@ func (sm *sessionManager) createSession(request *proto.CreateSessionRequest, min
 	return &proto.CreateSessionResponse{SessionId: int64(s.id)}, nil
 }
 
-// removeSession takes the session out of the map and decrements the
-// active-sessions counter. It must be called while holding the manager's write
-// lock. Removing an id that is no longer present is a no-op: the expiry path
-// and CloseSession can race on the same session, and the loser must not
-// decrement the counter a second time.
+// removeSession takes the session out of the map and the expiry heap, and
+// decrements the active-sessions counter. It must be called while holding the
+// manager's write lock. Removing an id that is no longer present is a no-op:
+// the expiry path and CloseSession can race on the same session, and the
+// loser must not decrement the counter a second time.
 func (sm *sessionManager) removeSession(id SessionId) {
-	if _, found := sm.sessions[id]; !found {
+	s, found := sm.sessions[id]
+	if !found {
 		return
 	}
 	delete(sm.sessions, id)
+	if s.heapIdx >= 0 {
+		// The expiry scheduler pops sessions before expiring them, so a
+		// session mid-expiry is already off the heap.
+		heap.Remove(&sm.expiryHeap, s.heapIdx)
+	}
 	sm.activeSessions.Dec()
+}
+
+// deleteSessions removes the session records from the database. Deleting a
+// session record cascades, through the storage update callback, to the
+// session's ephemeral keys and their shadows. Deleting an already-deleted
+// session is harmless: expiry and CloseSession may race on the same session.
+func (sm *sessionManager) deleteSessions(ids []SessionId) error {
+	deletes := make([]*proto.DeleteRequest, len(ids))
+	for i, id := range ids {
+		deletes[i] = &proto.DeleteRequest{Key: SessionKey(id)}
+	}
+	_, err := sm.leaderController.WriteBlock(context.Background(), &proto.WriteRequest{
+		Shard:   &sm.shardId,
+		Deletes: deletes,
+	})
+	return err
 }
 
 func (sm *sessionManager) getSession(sessionId int64) (*session, error) {
@@ -209,7 +268,7 @@ func (sm *sessionManager) KeepAlive(sessionId int64) error {
 	if err != nil {
 		return err
 	}
-	s.heartbeat()
+	s.heartbeat(sm.now())
 	return nil
 }
 
@@ -223,10 +282,12 @@ func (sm *sessionManager) CloseSession(request *proto.CloseSessionRequest) (*pro
 	sm.removeSession(s.id)
 	sm.Unlock()
 
-	s.log.Debug("Session closing")
-	s.Close()
-	err = s.delete()
-	if err != nil {
+	sm.log.Debug(
+		"Session closing",
+		slog.Int64("session-id", int64(s.id)),
+		slog.String("client-identity", s.clientIdentity),
+	)
+	if err = sm.deleteSessions([]SessionId{s.id}); err != nil {
 		return nil, err
 	}
 
@@ -310,22 +371,15 @@ func (sm *sessionManager) readSessions() (map[SessionId]*proto.SessionMetadata, 
 func (sm *sessionManager) Close() error {
 	sm.Lock()
 	sm.cancel()
-	sessions := make([]*session, 0, len(sm.sessions))
-	for _, s := range sm.sessions {
-		sessions = append(sessions, s)
-	}
-	for _, s := range sessions {
-		sm.removeSession(s.id)
+	for id := range sm.sessions {
+		sm.removeSession(id)
 	}
 	sm.Unlock()
 
-	// Close the sessions outside the manager lock: closing a session waits
-	// for its goroutine, and the expiry path of that goroutine acquires the
-	// manager lock — closing under the lock can deadlock with an in-flight
-	// expiry (same ordering as CloseSession above).
-	for _, s := range sessions {
-		s.Close()
-	}
+	// Wait for the expiry scheduler outside the manager lock: it acquires
+	// the lock to finish an in-flight expiry cycle — waiting under the lock
+	// would deadlock.
+	sm.latch.Wait()
 
 	return nil
 }

--- a/oxiad/dataserver/controller/lead/session_manager_test.go
+++ b/oxiad/dataserver/controller/lead/session_manager_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"testing"
 	"time"
 
@@ -481,6 +480,83 @@ func TestMultipleSessionsExpiry(t *testing.T) {
 	assert.NoError(t, walf.Close())
 }
 
+// A batch of sessions larger than expiryBatchSize expiring together must be
+// fully cleaned up, ephemeral keys included, through the chunked deletes of
+// the expiry scheduler.
+func TestSessionManager_MassExpiry(t *testing.T) {
+	shardId := int64(1)
+	kvf, walf, sManager, lc := createSessionManager(t)
+
+	const numSessions = 2*expiryBatchSize + 10
+	sessionIDs := make([]int64, 0, numSessions)
+	for i := 0; i < numSessions; i++ {
+		createResp, err := sManager.createSession(&proto.CreateSessionRequest{
+			Shard:            shardId,
+			SessionTimeoutMs: uint32(2000),
+			ClientIdentity:   fmt.Sprintf("session-%d", i),
+		}, 0)
+		assert.NoError(t, err)
+		sessionIDs = append(sessionIDs, createResp.SessionId)
+	}
+
+	sessionId := sessionIDs[0]
+	_, err := lc.WriteBlock(context.Background(), &proto.WriteRequest{
+		Shard: &shardId,
+		Puts: []*proto.PutRequest{{
+			Key:       "/mass-expiry-ephemeral",
+			Value:     []byte("hello"),
+			SessionId: &sessionId,
+		}},
+	})
+	assert.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		for _, id := range sessionIDs {
+			if getSessionMetadata(t, lc, id) != nil {
+				return false
+			}
+		}
+		return getData(t, lc, "/mass-expiry-ephemeral") == ""
+	}, 30*time.Second, 50*time.Millisecond)
+
+	assert.NoError(t, lc.Close())
+	assert.NoError(t, kvf.Close())
+	assert.NoError(t, walf.Close())
+}
+
+// Closing the leader controller while sessions are in the middle of expiring
+// must not deadlock or panic.
+func TestSessionManager_CloseDuringExpiry(t *testing.T) {
+	shardId := int64(1)
+	kvf, walf, sManager, lc := createSessionManager(t)
+
+	for i := 0; i < 100; i++ {
+		_, err := sManager.createSession(&proto.CreateSessionRequest{
+			Shard:            shardId,
+			SessionTimeoutMs: uint32(20),
+			ClientIdentity:   fmt.Sprintf("session-%d", i),
+		}, 0)
+		assert.NoError(t, err)
+	}
+
+	// Let some expirations get in flight, then close concurrently
+	time.Sleep(30 * time.Millisecond)
+
+	closeDone := make(chan struct{})
+	go func() {
+		assert.NoError(t, lc.Close())
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("leader controller close timed out during session expiry")
+	}
+
+	assert.NoError(t, kvf.Close())
+	assert.NoError(t, walf.Close())
+}
+
 func TestSessionManagerReopening(t *testing.T) {
 	shardId := int64(1)
 	// Invalid session timeout
@@ -736,38 +812,25 @@ func TestIsSessionKey(t *testing.T) {
 }
 
 // Closing the manager must not hold the manager lock while waiting for the
-// session goroutines: the expiry path of a session goroutine acquires the
-// manager lock, and a session in the middle of expiring would deadlock the
-// close.
+// expiry scheduler: the scheduler acquires the manager lock to finish an
+// in-flight expiry cycle, and waiting for it under the lock would deadlock
+// the close.
 func TestSessionManager_CloseWithInFlightExpiry(t *testing.T) {
-	sm := &sessionManager{
-		sessions: make(map[SessionId]*session),
-		activeSessions: metric.NewUpDownCounter("oxia_test_close_expiry_sessions", "test", "count",
-			map[string]any{}),
-	}
-	sm.ctx, sm.cancel = context.WithCancel(context.Background())
+	sm := newBareSessionManager()
+	newTestSession(sm, 1, 10*time.Minute)
 
-	s := &session{
-		id:  1,
-		sm:  sm,
-		log: slog.Default(),
-	}
-	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
-
-	// Mimics the tail of the session expiry path (waitForHeartbeats), which
-	// acquires the manager lock from the session goroutine. The session
-	// context is canceled by close(): with the close happening under the
-	// manager lock, this deterministically deadlocks.
-	s.latch.Add(1)
+	// Mimics the tail of the expiry scheduler mid-cycle: once the manager
+	// context is canceled by Close, it still needs the manager lock to
+	// finish. With Close waiting for the scheduler under the manager lock,
+	// this deterministically deadlocks.
+	sm.latch.Add(1)
 	go func() {
-		defer s.latch.Done()
-		<-s.ctx.Done()
+		defer sm.latch.Done()
+		<-sm.ctx.Done()
 		sm.Lock()
-		sm.removeSession(s.id)
+		sm.removeSession(1)
 		sm.Unlock()
 	}()
-	sm.sessions[s.id] = s
-	sm.activeSessions.Inc()
 
 	closeDone := make(chan struct{})
 	go func() {
@@ -816,12 +879,8 @@ func TestSessionManager_ActiveSessionsMetric(t *testing.T) {
 		return 0
 	}
 
-	sm := &sessionManager{
-		sessions:        make(map[SessionId]*session),
-		activeSessions:  metric.NewUpDownCounter(counterName, "test", "count", map[string]any{}),
-		expiredSessions: metric.NewCounter("oxia_test_expired_sessions", "test", "count", map[string]any{}),
-	}
-	sm.ctx, sm.cancel = context.WithCancel(context.Background())
+	sm := newBareSessionManager()
+	sm.activeSessions = metric.NewUpDownCounter(counterName, "test", "count", map[string]any{})
 
 	meta := &proto.SessionMetadata{TimeoutMs: uint32(10 * time.Minute / time.Millisecond)}
 	sm.Lock()
@@ -841,7 +900,6 @@ func TestSessionManager_ActiveSessionsMetric(t *testing.T) {
 	sm.Unlock()
 	assert.EqualValues(t, 1, readCounter())
 
-	s1.Close()
 	assert.NoError(t, sm.Close())
 	assert.EqualValues(t, 0, readCounter())
 }

--- a/oxiad/dataserver/controller/lead/session_test.go
+++ b/oxiad/dataserver/controller/lead/session_test.go
@@ -15,6 +15,7 @@
 package lead
 
 import (
+	"container/heap"
 	"context"
 	"log/slog"
 	"sync"
@@ -22,87 +23,225 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/metric"
+	"github.com/oxia-db/oxia/common/proto"
 )
 
-func drainChannel(ch <-chan bool) {
-	for range ch { //nolint:revive
+// newBareSessionManager builds a session manager for unit tests that never
+// touches the database: the expiry scheduler is not started, so sessions can
+// be created and inspected without a leader controller.
+func newBareSessionManager() *sessionManager {
+	sm := &sessionManager{
+		sessions: make(map[SessionId]*session),
+		wakeCh:   make(chan struct{}, 1),
+		epoch:    time.Now(),
+		log:      slog.Default(),
+		activeSessions: metric.NewUpDownCounter("oxia_test_bare_active_sessions", "test", "count",
+			map[string]any{}),
+		expiredSessions: metric.NewCounter("oxia_test_bare_expired_sessions", "test", "count",
+			map[string]any{}),
 	}
+	sm.ctx, sm.cancel = context.WithCancel(context.Background())
+	return sm
 }
 
-func TestSession_Heartbeat_NonBlocking(t *testing.T) {
-	s := &session{
-		heartbeatCh: make(chan bool, 1),
-		log:         slog.Default(),
-	}
-	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
-
-	// Fill the heartbeat channel buffer
-	s.heartbeatCh <- true
-
-	// Second heartbeat should not block (non-blocking select)
-	done := make(chan struct{})
-	go func() {
-		s.heartbeat()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// Success: heartbeat returned without blocking
-	case <-time.After(time.Second):
-		t.Fatal("heartbeat() blocked when channel buffer was full")
-	}
+func newTestSession(sm *sessionManager, id SessionId, timeout time.Duration) *session {
+	sm.Lock()
+	defer sm.Unlock()
+	return startSession(id, &proto.SessionMetadata{
+		TimeoutMs: uint32(timeout.Milliseconds()),
+		Identity:  "test-client",
+	}, sm)
 }
 
-func TestSession_Heartbeat_AfterClose(t *testing.T) {
-	ch := make(chan bool, 1)
-	s := &session{
-		heartbeatCh: ch,
-		log:         slog.Default(),
-	}
-	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
-	s.latch.Add(1)
+func TestSession_HeartbeatExtendsDeadline(t *testing.T) {
+	sm := newBareSessionManager()
+	defer func() { assert.NoError(t, sm.Close()) }()
 
-	// Drain heartbeats using local reference (mirrors waitForHeartbeats pattern)
-	go func() {
-		defer s.latch.Done()
-		drainChannel(ch)
-	}()
+	timeout := 10 * time.Second
+	s := newTestSession(sm, 1, timeout)
 
-	s.close()
-	s.latch.Wait()
+	// Pretend the deadline is about to pass, then heartbeat
+	s.deadline.Store(sm.now() + 1)
+	assert.NoError(t, sm.KeepAlive(1))
 
-	// Calling heartbeat after close should not panic
+	deadline := s.deadline.Load()
+	assert.Greater(t, deadline, sm.now())
+	assert.LessOrEqual(t, deadline, sm.now()+int64(timeout))
+}
+
+func TestSession_KeepAliveAfterRemove(t *testing.T) {
+	sm := newBareSessionManager()
+	defer func() { assert.NoError(t, sm.Close()) }()
+
+	s := newTestSession(sm, 1, 10*time.Second)
+
+	sm.Lock()
+	sm.removeSession(1)
+	sm.Unlock()
+
+	assert.ErrorIs(t, sm.KeepAlive(1), constant.ErrSessionNotFound)
+
+	// A raced heartbeat on an already-removed session must be harmless
 	assert.NotPanics(t, func() {
-		s.heartbeat()
+		s.heartbeat(sm.now())
 	})
 }
 
-func TestSession_Heartbeat_ConcurrentCloseAndHeartbeat(t *testing.T) {
-	// Run many iterations to increase chance of hitting the race
-	for i := 0; i < 100; i++ {
-		ch := make(chan bool, 1)
-		s := &session{
-			heartbeatCh: ch,
-			log:         slog.Default(),
+// startSession must nudge the expiry scheduler only when the new session's
+// deadline is earlier than every queued one; otherwise the scheduler's timer
+// is already armed to fire soon enough.
+func TestSession_StartNudgesSchedulerOnEarlierDeadline(t *testing.T) {
+	sm := newBareSessionManager()
+	defer func() { assert.NoError(t, sm.Close()) }()
+
+	drainWake := func() bool {
+		select {
+		case <-sm.wakeCh:
+			return true
+		default:
+			return false
 		}
-		s.ctx, s.ctxCancel = context.WithCancel(context.Background())
-		s.latch.Add(1)
-
-		// Drain using local reference (mirrors waitForHeartbeats pattern)
-		go func() {
-			defer s.latch.Done()
-			drainChannel(ch)
-		}()
-
-		var wg sync.WaitGroup
-		wg.Go(func() {
-			s.close()
-		})
-		wg.Go(func() {
-			s.heartbeat()
-		})
-		wg.Wait()
-		s.latch.Wait()
 	}
+
+	newTestSession(sm, 1, 10*time.Minute)
+	assert.True(t, drainWake(), "first session must wake the scheduler")
+
+	newTestSession(sm, 2, 20*time.Minute)
+	assert.False(t, drainWake(), "later deadline must not wake the scheduler")
+
+	newTestSession(sm, 3, 1*time.Minute)
+	assert.True(t, drainWake(), "earlier deadline must wake the scheduler")
+}
+
+func TestSessionManager_CollectDueSessions(t *testing.T) {
+	sm := newBareSessionManager()
+	defer func() { assert.NoError(t, sm.Close()) }()
+
+	due := newTestSession(sm, 1, 10*time.Second)
+	refreshed := newTestSession(sm, 2, 10*time.Second)
+	future := newTestSession(sm, 3, 10*time.Minute)
+
+	// Make sessions 1 and 2 due, then heartbeat session 2
+	now := sm.now()
+	sm.Lock()
+	due.deadline.Store(now - 1)
+	due.heapDeadline = now - 1
+	refreshed.heapDeadline = now - 1
+	heap.Init(&sm.expiryHeap)
+	sm.Unlock()
+	refreshed.heartbeat(sm.now())
+
+	collected, next := sm.collectDueSessions()
+	assert.Equal(t, []*session{due}, collected)
+
+	// The due session is off the heap, the others are still queued; the
+	// refreshed session was re-queued at its extended deadline, which makes
+	// it the new heap root
+	assert.Equal(t, -1, due.heapIdx)
+	assert.Len(t, sm.expiryHeap, 2)
+	assert.Equal(t, refreshed.deadline.Load(), refreshed.heapDeadline)
+	assert.Equal(t, refreshed, sm.expiryHeap[0])
+	assert.Equal(t, future, sm.expiryHeap[1])
+
+	// The scheduler sleeps until the earliest queued deadline
+	assert.Greater(t, next, time.Duration(0))
+	assert.LessOrEqual(t, next, 10*time.Second)
+}
+
+// A session popped as due can still be rescued before its delete is issued if
+// a heartbeat arrives in between; a session concurrently closed must not be
+// re-queued.
+func TestSessionManager_RequeueRefreshed(t *testing.T) {
+	sm := newBareSessionManager()
+	defer func() { assert.NoError(t, sm.Close()) }()
+
+	expired := newTestSession(sm, 1, 10*time.Second)
+	rescued := newTestSession(sm, 2, 10*time.Second)
+	closed := newTestSession(sm, 3, 10*time.Second)
+
+	// All three are popped as due
+	now := sm.now()
+	for _, s := range []*session{expired, rescued, closed} {
+		s.deadline.Store(now - 1)
+		s.heapDeadline = now - 1
+	}
+	collected, _ := sm.collectDueSessions()
+	assert.Len(t, collected, 3)
+	assert.Empty(t, sm.expiryHeap)
+
+	// Before the delete goes out: session 2 gets a heartbeat, session 3 gets
+	// closed
+	rescued.heartbeat(sm.now())
+	closed.deadline.Store(sm.now() + int64(10*time.Second))
+	sm.Lock()
+	sm.removeSession(closed.id)
+	sm.Unlock()
+
+	stillExpired := sm.requeueRefreshed(collected)
+	assert.Equal(t, []*session{expired}, stillExpired)
+
+	// Only the rescued session is back on the heap
+	assert.Len(t, sm.expiryHeap, 1)
+	assert.Equal(t, rescued, sm.expiryHeap[0])
+	assert.Equal(t, -1, closed.heapIdx)
+}
+
+func TestSessionHeap_Ordering(t *testing.T) {
+	sm := newBareSessionManager()
+	defer func() { assert.NoError(t, sm.Close()) }()
+
+	newTestSession(sm, 1, 30*time.Second)
+	newTestSession(sm, 2, 10*time.Second)
+	newTestSession(sm, 3, 20*time.Second)
+
+	// Indexes are kept consistent while the heap reorders
+	for i, s := range sm.expiryHeap {
+		assert.Equal(t, i, s.heapIdx)
+	}
+
+	var popped []SessionId
+	sm.Lock()
+	for len(sm.expiryHeap) > 0 {
+		s := heap.Pop(&sm.expiryHeap).(*session)
+		assert.Equal(t, -1, s.heapIdx)
+		popped = append(popped, s.id)
+	}
+	sm.Unlock()
+	assert.Equal(t, []SessionId{2, 3, 1}, popped)
+}
+
+// Heartbeats race against session removal and the scheduler's collection;
+// this mainly gives the race detector something to chew on.
+func TestSession_ConcurrentKeepAliveAndRemove(t *testing.T) {
+	sm := newBareSessionManager()
+	defer func() { assert.NoError(t, sm.Close()) }()
+
+	const sessions = 32
+	for i := 0; i < sessions; i++ {
+		newTestSession(sm, SessionId(i), time.Duration(i)*time.Millisecond)
+	}
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for i := 0; i < sessions; i++ {
+			_ = sm.KeepAlive(int64(i))
+		}
+	})
+	wg.Go(func() {
+		for i := 0; i < sessions; i += 2 {
+			sm.Lock()
+			sm.removeSession(SessionId(i))
+			sm.Unlock()
+		}
+	})
+	wg.Go(func() {
+		for i := 0; i < 10; i++ {
+			collected, _ := sm.collectDueSessions()
+			sm.requeueRefreshed(collected)
+		}
+	})
+	wg.Wait()
 }


### PR DESCRIPTION
### Motivation

Holding a live session costs the data server ~15–20 KB of RAM: every session runs its own goroutine (`waitForHeartbeats`) parked on a dedicated `time.Timer` and heartbeat channel, plus a per-session context/cancel, latch, `slog` logger and pprof label map. The benchmark session-capacity experiment showed a 3-node cluster of 2 vCPU / 4 GiB pods is healthy at 100k cluster-wide sessions but gets OOMKilled during the ramp to 200k (#1235).

### Changes

Sessions become passive ~100-byte records; expiry is driven by a shared scheduler:

- **One scheduler goroutine per session manager** (per shard leader) sleeps until the earliest deadline in a min-heap of sessions (`sessionHeap`, ordered by `heapDeadline`) and expires everything that is due.
- **Keep-alives are lock-free**: a heartbeat atomically stores `now+timeout` into the session's deadline under the existing read lock and never touches the heap. When a queued entry with a stale deadline reaches the top of the heap, the scheduler lazily re-queues it at its current deadline — one heap operation per session per timeout period, independent of heartbeat rate.
- **Mass expiry batches session deletes** (128 per write) instead of issuing one replication round-trip per session; each delete still cascades to the session's ephemeral keys and shadows through the storage update callback.
- **Deadlines are on a monotonic per-manager clock** (`time.Since(epoch)`), immune to wall-clock jumps, like the per-session timers they replace.
- Creating a session with a deadline earlier than every queued one nudges the scheduler (buffered wake channel) so it re-arms its timer.

Existing semantics are preserved:

- `CloseSession`/expiry races stay harmless: deletes are idempotent, and `removeSession` (now also heap-aware) still decrements the active-sessions counter exactly once.
- A failed expiry delete is logged and the session is still removed, leaving the record to be recovered by the next term's `Initialize`, as before.
- `Close` waits for the scheduler outside the manager lock — the same deadlock-avoidance contract the old per-session latch had.
- A session that heartbeats after being popped but before its delete is issued (e.g. queued behind an expiry storm) is rescued and re-queued instead of dropped.

### Results

New `BenchmarkSessionFootprint` holding 100k live sessions (`-benchtime=100000x`, M1 Max):

| | before | after |
|---|---|---|
| heap / session | 2,052 B | 97 B |
| goroutine stack / session | 4,097 B | ~1 B |
| **total / session** | **6,149 B** | **98 B** |
| goroutines / session | 1 | 0 |
| creation time | 4,796 ns | 274 ns |

With GC headroom and runtime overhead on top, this moves the per-node ceiling from ~10^5 towards ~10^7 sessions for the same RAM. Cluster-level validation with the benchmark session suite (200k+ sweep) still pending.

Fixes #1235
