### PR TITLE
fix: use a stable per-run data dir for Maelstrom storage nodes

### DIFF
--- a/oxiad/maelstrom/main.go
+++ b/oxiad/maelstrom/main.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
 
@@ -175,15 +176,16 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		// Any other node will be a storage node
-		dataDir, err := os.MkdirTemp("", "oxia-maelstrom")
-		if err != nil {
-			slog.Error(
-				"failed to create data dir",
-				slog.Any("error", err),
-			)
-			os.Exit(1)
-		}
+		// Any other node will be a storage node.
+		// One subdirectory per Maelstrom run (os.Getppid() is the Maelstrom process
+		// that spawned every node) and per node id: a node restarted by the kill
+		// nemesis reopens its own data, while separate runs don't share state.
+		dataDir := filepath.Join(os.TempDir(), "oxia-maelstrom", strconv.Itoa(os.Getppid()))
+		slog.Info(
+			"Using data dir",
+			slog.String("data-dir", dataDir),
+			slog.String("node-id", thisNode),
+		)
 
 		dataServerOption := option.NewDefaultOptions()
 		dataServerOption.FeatureFlags.AuthorityValidation = new(bool)


### PR DESCRIPTION
### Motivation

Maelstrom now supports a process kill/restart nemesis. Each oxia storage node was creating a fresh random temp dir (`os.MkdirTemp`) on every process start, so a node restarted by the nemesis came back with an empty db/wal instead of reopening its previous data.

### Changes

Key the data dir on the Maelstrom run and the node id received in the `init` message:

```
$TMPDIR/oxia-maelstrom/<maelstrom-pid>/<node-id>/{db,wal}
```

`os.Getppid()` is the Maelstrom process that spawns every node (nodes are exec'ed as direct children of its JVM), so:

- a node restarted by the kill nemesis resolves the same directory and recovers its data;
- separate Maelstrom runs get distinct subdirectories and never share state, with no manual cleanup required;
- everything lives under one predictable root.

### Verification

Two consecutive `maelstrom test -w lin-kv --nemesis kill --nemesis-interval 10 --time-limit 60 --node-count 4` runs with no cleanup in between: every data node reused a single directory across its 2–6 restarts, the two runs used distinct per-run directories, and the linearizability checker passed.

One unrelated issue surfaced during validation (tracked separately): if the first nemesis op kills all data nodes ~1s into bootstrap, the cluster can wedge with the coordinator looping on `FenceNewTerm: timed out` even after all nodes restart.