### PR TITLE
fix: enable mutex and block profiling when --profile is set

### DIFF
--- a/common/process/pprof.go
+++ b/common/process/pprof.go
@@ -99,5 +99,17 @@ func RunProfiling() io.Closer {
 			}
 		})
 
-	return s
+	return &profilingServer{s}
+}
+
+// profilingServer scopes the contention-profiling rates to the pprof server
+// lifetime: closing it restores the runtime defaults.
+type profilingServer struct {
+	*http.Server
+}
+
+func (p *profilingServer) Close() error {
+	runtime.SetMutexProfileFraction(0)
+	runtime.SetBlockProfileRate(0)
+	return p.Server.Close()
 }

--- a/common/process/pprof.go
+++ b/common/process/pprof.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec
 	"os"
+	"runtime"
 	"runtime/pprof"
 	"time"
 )
@@ -29,6 +30,16 @@ import (
 var (
 	PprofEnable      bool
 	PprofBindAddress string
+)
+
+const (
+	// mutexProfileFraction samples 1 in N mutex contention events, and
+	// blockProfileRate samples roughly one blocking event per N nanoseconds
+	// spent blocked. Both profiles are disabled by default in the Go runtime,
+	// which would leave /debug/pprof/mutex and /debug/pprof/block always
+	// empty; these sampling rates are cheap enough for a debugging session.
+	mutexProfileFraction = 100
+	blockProfileRate     = 100_000
 )
 
 // DoWithLabels attaches the labels to the current go-routine Pprof context,
@@ -58,6 +69,10 @@ func RunProfiling() io.Closer {
 		// Do not start pprof server
 		return s
 	}
+
+	// Enable sampled contention profiling while the pprof server is on
+	runtime.SetMutexProfileFraction(mutexProfileFraction)
+	runtime.SetBlockProfileRate(blockProfileRate)
 
 	slog.Info(
 		"Starting pprof server",

--- a/common/process/pprof_test.go
+++ b/common/process/pprof_test.go
@@ -31,9 +31,12 @@ func TestRunProfilingEnablesContentionProfiles(t *testing.T) {
 	})
 
 	closer := RunProfiling()
-	defer closer.Close()
 
 	// SetMutexProfileFraction with a negative value only reads the current
 	// setting. There is no equivalent getter for the block profile rate.
 	assert.Equal(t, mutexProfileFraction, runtime.SetMutexProfileFraction(-1))
+
+	// Closing the profiling server restores the runtime defaults
+	assert.NoError(t, closer.Close())
+	assert.Equal(t, 0, runtime.SetMutexProfileFraction(-1))
 }

--- a/common/process/pprof_test.go
+++ b/common/process/pprof_test.go
@@ -1,0 +1,39 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package process
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunProfilingEnablesContentionProfiles(t *testing.T) {
+	PprofEnable = true
+	PprofBindAddress = "127.0.0.1:0"
+	t.Cleanup(func() {
+		PprofEnable = false
+		runtime.SetMutexProfileFraction(0)
+		runtime.SetBlockProfileRate(0)
+	})
+
+	closer := RunProfiling()
+	defer closer.Close()
+
+	// SetMutexProfileFraction with a negative value only reads the current
+	// setting. There is no equivalent getter for the block profile rate.
+	assert.Equal(t, mutexProfileFraction, runtime.SetMutexProfileFraction(-1))
+}


### PR DESCRIPTION
The `--profile` flag exposes `/debug/pprof`, but the Go runtime's mutex and block profiling are off by default, so `/debug/pprof/mutex` and `/debug/pprof/block` were always empty — exactly the profiles needed when investigating a saturated server.

Enable sampled contention profiling when the pprof server is started: `runtime.SetMutexProfileFraction(100)` (1 in 100 contention events) and `runtime.SetBlockProfileRate(100_000)` (~one blocking event per 100µs blocked). Both rates are cheap enough for a debugging session, and nothing changes when `--profile` is not set.

Split out of #1233, where the missing contention profiles were noticed while diagnosing saturation-induced leader elections.