### PR TITLE
fix: reject gapped appends instead of acking entries the follower does not have

### DIFF
--- a/oxiad/dataserver/controller/follow/follower_controller_test.go
+++ b/oxiad/dataserver/controller/follow/follower_controller_test.go
@@ -1104,6 +1104,53 @@ func TestFollower_DupEntries(t *testing.T) {
 	assert.NoError(t, walFactory.Close())
 }
 
+// A fresh follower (empty wal and db) whose first entries were lost in
+// transit receives its first append at a non-zero offset: the append must be
+// rejected and the stream must fail, so that the leader reconnects and
+// resends from the beginning. Accepting the gap would let the follower ack
+// entries it does not have, and the leader would count those acks towards the
+// commit quorum.
+func TestFollower_RejectGapOnEmptyWal(t *testing.T) {
+	var shardId int64
+	kvFactory, _ := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	walFactory := newTestWalFactory(t)
+
+	fc, _ := NewFollowerController(&option.StorageOptions{}, constant.DefaultNamespace, shardId, walFactory, kvFactory, nil)
+	_, _ = fc.NewTerm(&proto.NewTermRequest{Term: 1})
+
+	stream1 := rpc.NewMockServerReplicateStream()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- fc.AppendEntries(stream1)
+		stream1.Cancel()
+	}()
+
+	// First-ever entry arrives at offset 5: entries 0..4 were lost
+	stream1.AddRequest(createAddRequest(t, 1, 5, map[string]string{"a": "0"}, wal.InvalidOffset))
+	assert.ErrorIs(t, <-errCh, wal.ErrInvalidNextOffset)
+
+	// The leader reconnects and resends from the beginning: the follower
+	// accepts and acks the contiguous entries
+	stream2 := rpc.NewMockServerReplicateStream()
+	go func() {
+		// cancelled due to fc.Close() below
+		assert.ErrorIs(t, fc.AppendEntries(stream2), context.Canceled)
+		stream2.Cancel()
+	}()
+
+	stream2.AddRequest(createAddRequest(t, 1, 0, map[string]string{"a": "0"}, wal.InvalidOffset))
+	r1 := stream2.GetResponse()
+	assert.EqualValues(t, 0, r1.Offset)
+
+	stream2.AddRequest(createAddRequest(t, 1, 1, map[string]string{"a": "1"}, wal.InvalidOffset))
+	r2 := stream2.GetResponse()
+	assert.EqualValues(t, 1, r2.Offset)
+
+	assert.NoError(t, fc.Close())
+	assert.NoError(t, kvFactory.Close())
+	assert.NoError(t, walFactory.Close())
+}
+
 func TestFollowerController_DeleteShard(t *testing.T) {
 	var shardId int64
 	kvFactory, _ := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))

--- a/oxiad/dataserver/controller/follow/log_synchronizer.go
+++ b/oxiad/dataserver/controller/follow/log_synchronizer.go
@@ -185,6 +185,18 @@ func (ls *LogSynchronizer) append0(syncCond chan struct{}, onAppend func(), req 
 		return nil
 	}
 
+	// A gap between the last known offset and the incoming entry means
+	// entries were lost in transit: reject the append and let the leader
+	// re-establish the stream from the last acked position. The WAL
+	// contiguity check cannot catch a gap when the WAL is empty (a follower
+	// bootstrapped from a snapshot legitimately starts at an arbitrary
+	// offset), and accepting it would let the follower ack entries it does
+	// not have.
+	if req.Entry.Offset != lastAppendedOffset+1 {
+		return fmt.Errorf("entry %d can not immediately follow %d: %w",
+			req.Entry.Offset, lastAppendedOffset, wal.ErrInvalidNextOffset)
+	}
+
 	// Append the entry asynchronously, passing the previous CRC from the leader.
 	// When the WAL is empty (e.g. after snapshot install), the CRC seeds the chain
 	// so that the follower's CRC matches the leader's.

--- a/oxiad/dataserver/controller/follow/log_synchronizer_test.go
+++ b/oxiad/dataserver/controller/follow/log_synchronizer_test.go
@@ -117,6 +117,54 @@ func TestLogSynchronizer_DuplicateAckOnlySynced(t *testing.T) {
 	assert.EqualValues(t, 4, w.synced.Load())
 }
 
+// A follower with an empty wal (lastAppendedOffset = InvalidOffset) that
+// receives its first append at a non-zero offset must reject it: entries were
+// lost in transit. The wal cannot catch this gap itself (an empty wal accepts
+// any first offset, for the post-snapshot case), and accepting it would let
+// the follower ack entries it does not have — which the leader then counts,
+// cumulatively, towards the commit quorum.
+func TestLogSynchronizer_RejectGapOnEmptyWal(t *testing.T) {
+	w := &stubWal{}
+	w.appended.Store(wal.InvalidOffset)
+	w.synced.Store(wal.InvalidOffset)
+
+	lastAppendedOffset := &atomic.Int64{}
+	lastAppendedOffset.Store(wal.InvalidOffset)
+	advertisedCommitOffset := &atomic.Int64{}
+	advertisedCommitOffset.Store(wal.InvalidOffset)
+
+	stream := rpc.NewMockServerReplicateStream()
+	ls := NewLogSynchronizer(LogSynchronizerParams{
+		Log:                    slog.Default(),
+		Namespace:              "test",
+		ShardId:                0,
+		Term:                   1,
+		Wal:                    w,
+		AdvertisedCommitOffset: advertisedCommitOffset,
+		LastAppendedOffset:     lastAppendedOffset,
+		WriteLatencyHisto: metric.NewLatencyHistogram("oxia_test_reject_gap",
+			"test", map[string]any{}),
+		StateApplierCond: make(chan struct{}, 1),
+		Stream:           stream,
+		OnAppend:         func() {},
+	})
+
+	stream.AddRequest(&proto.Append{
+		Term:                    1,
+		Entry:                   &proto.LogEntry{Term: 1, Offset: 5},
+		CommitOffset:            wal.InvalidOffset,
+		CumulativeAcksSupported: true,
+	})
+
+	assert.ErrorIs(t, ls.Sync(), wal.ErrInvalidNextOffset)
+	assert.NoError(t, ls.Close())
+
+	// Nothing was appended and no ack was sent
+	assert.EqualValues(t, wal.InvalidOffset, w.appended.Load())
+	assert.EqualValues(t, wal.InvalidOffset, lastAppendedOffset.Load())
+	assert.Empty(t, stream.Responses)
+}
+
 // An entry-less Append is a commit-offset advertisement (sent by the leader to
 // an observer parked at the head of the wal): it must take the new commit
 // offset and wake up the applier chain, without appending anything to the wal


### PR DESCRIPTION
### Motivation

In the Maelstrom CI run [29353845606](https://github.com/oxia-db/oxia/actions/runs/29353845606/job/87156449161) (an unrelated PR, #1238), node n4 died on the harness's unimplemented `SendSnapshot`. The panic turned out to be the last link of a chain that starts with a real replication hole:

1. A partition swallowed entries 0..7 streamed to a brand-new follower (n4). When it healed, the first delivered entry was offset 8 — and the follower **accepted it into its empty WAL**. The WAL contiguity check is deliberately skipped when the WAL is empty (a follower bootstrapped from a snapshot legitimately starts at an arbitrary offset), so the gap went undetected.
2. The follower acked its gapped WAL head, and with cumulative acks the leader counted entries 0..8 as replicated: it committed them and acknowledged the writes to clients (quorum = leader + n4).
3. The follower's state applier meanwhile error-looped on `entry not found` forever — nothing was ever applied to its DB.
4. When the leader was later isolated, the coordinator elected n4 on head `{0, 18}` — a head backed by a gapped WAL and an **empty database**. Serving reads would have lost every client-acked write; the new leader also needed to snapshot the other follower (its own WAL starts at 8), which is what hit the `panic("not implemented")` in the Maelstrom harness.

The panic pre-empted an actual linearizability violation. The same acceptance-of-a-gap is reachable in production only if the transport misbehaves or a cursor bug streams from the wrong position — this is defense in depth for the invariant that an ack means "I durably have everything up to here".

### Modification

In the log synchronizer's append path, require every non-duplicate entry to be exactly contiguous with the follower's last appended offset, which is the WAL head — or the DB commit offset when the WAL is empty (as set by `NewFollowerController` and `InstallSnapshot`). All legitimate flows pass:

- fresh follower: expects 0
- post-snapshot: expects `snapshotOffset + 1`
- post-snapshot restart, leader tailing from 0: the 0..S replay is absorbed by the existing duplicate path
- normal reconnect: duplicates re-acked, then `head + 1`

A gap now fails the replicate stream with `ErrInvalidNextOffset`; the leader's cursor backs off and re-establishes the stream from the last acked position, exactly as it already does for the non-empty-WAL gap case.

Tests: a synchronizer-level repro (first append at offset 5 into an empty WAL is rejected, nothing acked) and an end-to-end follower test (gap rejected, then a fresh stream from offset 0 recovers).

Note: #1240 makes the Maelstrom harness propagate these stream failures so the cursor reconnects promptly there too; this PR should merge first, since it alone removes the panic scenario.
