### PR TITLE
fix: emulate gRPC stream semantics in the Maelstrom replicate transport

### DIFF
--- a/oxiad/maelstrom/dispatcher.go
+++ b/oxiad/maelstrom/dispatcher.go
@@ -97,12 +97,23 @@ func (d *dispatcher) onOxiaStreamRequestMessage(msgType MsgType, m any, message 
 		}
 
 	case MsgTypeAppend:
+		// Deliver inline, not on a per-message goroutine: goroutine scheduling
+		// would reorder entries within a stream, which gRPC never does. The
+		// stream delivery never blocks (buffered channel, drops on overflow).
 		msg := m.(*Message[OxiaStreamMessage])
-		go d.grpcProvider.HandleOxiaStreamRequest(msgType, msg, message)
+		d.grpcProvider.HandleOxiaStreamRequest(msgType, msg, message)
 
 	case MsgTypeAck:
 		streamId := m.(*Message[OxiaStreamMessage]).Body.StreamId
-		go d.replicationProvider.HandleAck(streamId, message.(*proto.Ack))
+		d.replicationProvider.HandleAck(streamId, message.(*proto.Ack))
+
+	case MsgTypeStreamError:
+		// A peer declared one of our streams dead. The stream id alone doesn't
+		// say which side of it we hold, so try both: each side ignores unknown
+		// ids.
+		msg := m.(*Message[OxiaStreamMessage])
+		d.replicationProvider.HandleStreamError(msg.Body.StreamId)
+		d.grpcProvider.HandleStreamError(msg.Src, msg.Body.StreamId)
 
 	default:
 		panic(fmt.Sprintf("Unknown message type: %v", msgType))

--- a/oxiad/maelstrom/grpc_provider.go
+++ b/oxiad/maelstrom/grpc_provider.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"sync"
@@ -45,12 +46,18 @@ type maelstromGrpcProvider struct {
 	services map[string]any
 
 	replicateStreams map[string]*maelstromReplicateServerStream
+
+	// Streams that already terminated: late messages for them are dropped
+	// instead of resurrecting the stream mid-sequence. Grows by one small
+	// entry per stream ever created, which is fine for a Maelstrom run.
+	deadStreams map[string]bool
 }
 
 func newMaelstromGrpcProvider() *maelstromGrpcProvider {
 	return &maelstromGrpcProvider{
 		services:         make(map[string]any),
 		replicateStreams: make(map[string]*maelstromReplicateServerStream),
+		deadStreams:      make(map[string]bool),
 	}
 }
 
@@ -127,29 +134,69 @@ func (m *maelstromGrpcProvider) HandleOxiaStreamRequest(msgType MsgType, msg *Me
 		key := fmt.Sprintf("%s-%d", msg.Src, msg.Body.StreamId)
 
 		m.Lock()
+		if m.deadStreams[key] {
+			m.Unlock()
+			// The stream already terminated on this side: remind the peer, in
+			// case the first notification was lost in a partition, so its
+			// cursor stops pushing into the void and reconnects.
+			sendStreamError(msg.Src, msg.Body.StreamId)
+			return
+		}
 		stream, alreadyCreated := m.replicateStreams[key]
 		if !alreadyCreated {
 			stream = newMaelstromReplicateServerStream(msg)
 			m.replicateStreams[key] = stream
 
-			go func() {
-				err := m.getService(oxiaLogReplication).(proto.OxiaLogReplicationServer).Replicate(stream)
-				if err != nil {
-					slog.Warn(
-						"failed to call replicate",
-						slog.Any("error", err),
-					)
-				}
-			}()
+			go m.runReplicateStream(key, stream)
 		}
 		m.Unlock()
 
-		stream.requests <- message.(*proto.Append)
+		stream.deliver(message.(*proto.Append))
 	default:
 		slog.Info(
 			"HandleOxiaStreamRequest with unsupported message",
 			slog.Any("msg-type", msgType),
 		)
+	}
+}
+
+// runReplicateStream runs the Replicate handler for one server-side stream
+// and, when the handler exits (error or graceful close), tears the stream
+// down: late messages are dropped and the peer is told so that its follower
+// cursor can reconnect. gRPC gives all of this for free at the transport
+// level; over Maelstrom's fire-and-forget messages it has to be explicit,
+// otherwise a failed stream leaves the leader pushing entries nobody reads.
+func (m *maelstromGrpcProvider) runReplicateStream(key string, stream *maelstromReplicateServerStream) {
+	err := m.getService(oxiaLogReplication).(proto.OxiaLogReplicationServer).Replicate(stream)
+	if err != nil {
+		slog.Warn(
+			"failed to call replicate",
+			slog.Any("error", err),
+		)
+	}
+
+	m.Lock()
+	delete(m.replicateStreams, key)
+	m.deadStreams[key] = true
+	m.Unlock()
+
+	stream.close()
+	sendStreamError(stream.client, stream.streamId)
+}
+
+// HandleStreamError closes the server side of a replicate stream after the
+// peer (the leader owning the client side) declared it dead.
+func (m *maelstromGrpcProvider) HandleStreamError(src string, streamId int64) {
+	key := fmt.Sprintf("%s-%d", src, streamId)
+
+	m.Lock()
+	stream, ok := m.replicateStreams[key]
+	m.Unlock()
+
+	if ok {
+		// Unblocks the handler's Recv(); runReplicateStream completes the
+		// teardown.
+		stream.close()
 	}
 }
 
@@ -361,9 +408,11 @@ func (m *maelstromGrpcServer) Port() int {
 type maelstromReplicateServerStream struct {
 	BaseStream
 
-	requests chan *proto.Append
-	streamId int64
-	client   string
+	requests  chan *proto.Append
+	done      chan struct{}
+	closeOnce sync.Once
+	streamId  int64
+	client    string
 }
 
 func (m *maelstromReplicateServerStream) SetHeader(metadata.MD) error {
@@ -371,6 +420,12 @@ func (m *maelstromReplicateServerStream) SetHeader(metadata.MD) error {
 }
 
 func (m *maelstromReplicateServerStream) Send(response *proto.Ack) error {
+	select {
+	case <-m.done:
+		return errors.New("replicate stream is closed")
+	default:
+	}
+
 	b, _ := json.Marshal(&Message[OxiaStreamMessage]{
 		Src:  thisNode,
 		Dest: m.client,
@@ -389,7 +444,32 @@ func (m *maelstromReplicateServerStream) Send(response *proto.Ack) error {
 }
 
 func (m *maelstromReplicateServerStream) Recv() (*proto.Append, error) {
-	return <-m.requests, nil
+	select {
+	case req := <-m.requests:
+		return req, nil
+	case <-m.done:
+		return nil, io.EOF
+	}
+}
+
+// deliver hands an entry to the Replicate handler without ever blocking the
+// dispatcher: entries for a dead stream are dropped, and a stream whose
+// handler stopped draining is closed rather than piling up goroutines.
+func (m *maelstromReplicateServerStream) deliver(req *proto.Append) {
+	select {
+	case m.requests <- req:
+	case <-m.done:
+	default:
+		slog.Warn(
+			"Replicate stream buffer overflow, closing stream",
+			slog.Int64("stream-id", m.streamId),
+		)
+		m.close()
+	}
+}
+
+func (m *maelstromReplicateServerStream) close() {
+	m.closeOnce.Do(func() { close(m.done) })
 }
 
 func (m *maelstromReplicateServerStream) Context() context.Context {
@@ -404,6 +484,7 @@ func newMaelstromReplicateServerStream(msg *Message[OxiaStreamMessage]) *maelstr
 	return &maelstromReplicateServerStream{
 		client:   msg.Src,
 		streamId: msg.Body.StreamId,
-		requests: make(chan *proto.Append),
+		requests: make(chan *proto.Append, 1024),
+		done:     make(chan struct{}),
 	}
 }

--- a/oxiad/maelstrom/grpc_provider.go
+++ b/oxiad/maelstrom/grpc_provider.go
@@ -444,6 +444,16 @@ func (m *maelstromReplicateServerStream) Send(response *proto.Ack) error {
 }
 
 func (m *maelstromReplicateServerStream) Recv() (*proto.Append, error) {
+	// Check the reset first: a plain select picks randomly among ready cases,
+	// which would keep draining buffered entries after a close. A stream
+	// reset discards what is still buffered, like a transport-level reset
+	// does, so once close is observed no entry is ever delivered.
+	select {
+	case <-m.done:
+		return nil, io.EOF
+	default:
+	}
+
 	select {
 	case req := <-m.requests:
 		return req, nil
@@ -453,9 +463,17 @@ func (m *maelstromReplicateServerStream) Recv() (*proto.Append, error) {
 }
 
 // deliver hands an entry to the Replicate handler without ever blocking the
-// dispatcher: entries for a dead stream are dropped, and a stream whose
-// handler stopped draining is closed rather than piling up goroutines.
+// dispatcher: entries for a dead stream are dropped (best effort here — an
+// entry racing with a concurrent close may still be buffered, but Recv never
+// delivers past the close), and a stream whose handler stopped draining is
+// closed rather than piling up goroutines.
 func (m *maelstromReplicateServerStream) deliver(req *proto.Append) {
+	select {
+	case <-m.done:
+		return
+	default:
+	}
+
 	select {
 	case m.requests <- req:
 	case <-m.done:

--- a/oxiad/maelstrom/messages.go
+++ b/oxiad/maelstrom/messages.go
@@ -52,6 +52,7 @@ const (
 	MsgTypeBecomeLeaderResponse MsgType = "leader-resp"
 	MsgTypeAppend               MsgType = "add-entry"
 	MsgTypeAck                  MsgType = "ack"
+	MsgTypeStreamError          MsgType = "stream-error"
 	MsgTypeAddFollowerRequest   MsgType = "add-follower-req"
 	MsgTypeAddFollowerResponse  MsgType = "add-follower-resp"
 	MsgTypeGetStatusRequest     MsgType = "get-status"
@@ -88,6 +89,7 @@ var (
 	oxiaStreamRequests = map[MsgType]bool{
 		MsgTypeAppend:                   true,
 		MsgTypeAck:                      true,
+		MsgTypeStreamError:              true,
 		MsgTypeShardAssignmentsResponse: true,
 	}
 )
@@ -183,6 +185,29 @@ func sendError(msgId int64, dest string, err error) {
 	sendErrorWithCode(msgId, dest, 1000, err.Error())
 }
 
+// sendStreamError notifies the peer that a replicate stream is dead, so it
+// can tear down its own end instead of staying parked on it forever. It plays
+// the role of the transport-level stream reset that gRPC provides and the
+// Maelstrom fire-and-forget messages don't.
+func sendStreamError(dest string, streamId int64) {
+	b, err := json.Marshal(&Message[OxiaStreamMessage]{
+		Src:  thisNode,
+		Dest: dest,
+		Body: OxiaStreamMessage{
+			BaseMessageBody: BaseMessageBody{
+				Type:  MsgTypeStreamError,
+				MsgId: msgIdGenerator.Add(1),
+			},
+			StreamId: streamId,
+		},
+	})
+	if err != nil {
+		panic("failed to serialize json")
+	}
+
+	fmt.Fprintln(os.Stdout, string(b))
+}
+
 func sendErrorWithCode(msgId int64, dest string, code int, text string) {
 	b, err := json.Marshal(&Message[ErrorResponse]{
 		Src:  thisNode,
@@ -217,7 +242,8 @@ var jsonMsgMapping = map[MsgType]any{
 	MsgTypeHealthCheck:   &Message[OxiaMessage]{},
 	MsgTypeHealthCheckOk: &Message[OxiaMessage]{},
 
-	MsgTypeAppend: &Message[OxiaStreamMessage]{},
+	MsgTypeAppend:      &Message[OxiaStreamMessage]{},
+	MsgTypeStreamError: &Message[OxiaStreamMessage]{},
 }
 
 var protoMsgMapping = map[MsgType]pb.Message{

--- a/oxiad/maelstrom/replication_rpc_provider.go
+++ b/oxiad/maelstrom/replication_rpc_provider.go
@@ -22,7 +22,9 @@ import (
 	"os"
 	"sync"
 
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/proto"
 )
@@ -53,17 +55,36 @@ func (r *maelstromReplicationRpcProvider) GetReplicateStream(ctx context.Context
 		shard:     shard,
 		streamId:  msgIdGenerator.Add(1),
 		md:        make(metadata.MD),
-		responses: make(chan *proto.Ack),
+		responses: make(chan *proto.Ack, 1024),
+		failed:    make(chan error, 1),
 	}
 
 	r.Lock()
-	defer r.Unlock()
 	r.replicateStreams[s.streamId] = s
+	r.Unlock()
+
+	// When the follower cursor tears the stream down, tell the follower: its
+	// Replicate handler would otherwise stay parked on the stream forever
+	// (there is no transport to break), which in turn blocks the follower's
+	// NewTerm while it waits for the log synchronizer to close.
+	context.AfterFunc(ctx, func() {
+		r.removeStream(s.streamId)
+		sendStreamError(follower, s.streamId)
+	})
+
 	return s, nil
 }
 
+func (r *maelstromReplicationRpcProvider) removeStream(streamId int64) {
+	r.Lock()
+	defer r.Unlock()
+	delete(r.replicateStreams, streamId)
+}
+
 func (r *maelstromReplicationRpcProvider) HandleAck(streamId int64, res *proto.Ack) {
+	r.Lock()
 	s, ok := r.replicateStreams[streamId]
+	r.Unlock()
 	if !ok {
 		slog.Warn(
 			"Stream not found",
@@ -72,7 +93,34 @@ func (r *maelstromReplicationRpcProvider) HandleAck(streamId int64, res *proto.A
 		return
 	}
 
-	s.responses <- res
+	// Never block the dispatcher: acks are cumulative, so one dropped on
+	// overflow is covered by the next.
+	select {
+	case s.responses <- res:
+	default:
+		slog.Warn(
+			"Dropping ack on stream buffer overflow",
+			slog.Int64("stream-id", streamId),
+		)
+	}
+}
+
+// HandleStreamError fails the client side of a replicate stream after the
+// follower declared it dead: the cursor's Recv() returns an error and the
+// cursor reconnects from the last acked offset with a fresh stream.
+func (r *maelstromReplicationRpcProvider) HandleStreamError(streamId int64) {
+	r.Lock()
+	s, ok := r.replicateStreams[streamId]
+	delete(r.replicateStreams, streamId)
+	r.Unlock()
+	if !ok {
+		return
+	}
+
+	select {
+	case s.failed <- status.Error(codes.Unavailable, "replicate stream reset by peer"):
+	default:
+	}
 }
 
 func (r *maelstromReplicationRpcProvider) Truncate(follower string, req *proto.TruncateRequest) (*proto.TruncateResponse, error) {
@@ -97,6 +145,7 @@ type maelstromReplicateClient struct {
 	streamId  int64
 	md        metadata.MD
 	responses chan *proto.Ack
+	failed    chan error
 }
 
 func (m *maelstromReplicateClient) Send(request *proto.Append) error {
@@ -124,6 +173,8 @@ func (m *maelstromReplicateClient) Recv() (*proto.Ack, error) {
 	select {
 	case r := <-m.responses:
 		return r, nil
+	case err := <-m.failed:
+		return nil, err
 	case <-m.ctx.Done():
 		return nil, m.ctx.Err()
 	}


### PR DESCRIPTION
### Motivation

The Maelstrom harness models a replicate stream as fire-and-forget messages: `Send()` never fails, entries can be dropped (partitions) or reordered (network latency — and the dispatcher's per-message goroutines, even with no nemesis at all), and when one side of a stream dies the other side is never told. The replication protocol is built on gRPC's opposite contract: in-order reliable delivery, or a stream that visibly breaks for both ends.

That mismatch produced every failure mode in CI run [29353845606](https://github.com/oxia-db/oxia/actions/runs/29353845606/job/87156449161):

- a partition swallowed the first entries to a brand-new follower and the entry delivered after healing created a silent gap (addressed on the server side by #1239);
- when a follower correctly rejected a gapped append (`"5 can not immediately follow 1"` — from reordering alone, no partition active), its Replicate handler exited but the leader cursor was never notified: it stayed wedged pushing entries nobody read. The term-0 leader spent its last 13 seconds with **both** follower cursors silently dead, and every entry delivered to a dead stream leaked a goroutine blocked on the stream channel.

### Modification

- **New `stream-error` message**, playing the role of gRPC's transport-level stream reset:
  - sent by the follower when its Replicate handler exits, so the leader cursor's `Recv()` fails and the existing backoff reconnects from the last acked offset with a fresh stream;
  - sent by the leader (via `context.AfterFunc` on the stream context) when the cursor tears the stream down, so the follower's handler unblocks from `Recv()` — otherwise a later `NewTerm` hangs in `logSynchronizer.Close()` while holding the controller lock.
- **Terminated streams are tombstoned**: late entries are dropped (and re-trigger the notification, in case the first one was lost in a partition) instead of resurrecting the stream mid-sequence or piling up blocked goroutines.
- **Appends and acks are delivered inline** from the stdin loop, in receipt order, through buffered channels that never block the dispatcher (drop-on-overflow; acks are cumulative so a dropped one is covered by the next). The previous per-message goroutines could reorder entries within a stream.
- `HandleAck` reads the streams map under the lock (was a data race).

`SendSnapshot` deliberately keeps its `panic("not implemented")`: with this PR and #1239 the snapshot path is unreachable in Maelstrom (no WAL trimming within a 60s run), and the panic is the canary if that assumption ever breaks.

### Verification

Local 60s `lin-kv` runs with the CI parameters (`--concurrency 2n --latency 10 --latency-dist uniform`), 4 runs across `--nemesis partition` and `--nemesis partition,kill`: all pass the linearizability checker, zero panics, with tens of gap-reject/reconnect cycles per run each recovering in ~100ms (previously a wedge until the next election).