### PR TITLE
fix: synchronize coordinator runtime Close with the ShardDeleted callback

### DIFF
--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"sync"
 
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
@@ -56,6 +57,14 @@ type runtime struct {
 	wg        sync.WaitGroup
 	insID     string
 
+	// closed is set (under the write lock) when Close starts, so that late
+	// shard-controller callbacks become no-ops instead of racing with the
+	// teardown (metadata may be closed right after Close returns).
+	closed bool
+	// callbacksWg tracks in-flight ShardDeleted callbacks: they run on
+	// detached goroutines that no controller's Close waits for.
+	callbacksWg sync.WaitGroup
+
 	metadata coordmetadata.Metadata
 
 	shardControllers      map[int64]shardcontroller.Controller
@@ -83,6 +92,15 @@ func (c *runtime) LeaderElected(int64, *proto.DataServerIdentity, []*proto.DataS
 
 func (c *runtime) ShardDeleted(shard int64) {
 	c.Lock()
+	if c.closed {
+		// Close tears down all the controllers from its own snapshot of the
+		// maps, including this shard's.
+		c.Unlock()
+		return
+	}
+	c.callbacksWg.Add(1)
+	defer c.callbacksWg.Done()
+
 	sc, exists := c.shardControllers[shard]
 	if exists {
 		delete(c.shardControllers, shard)
@@ -360,24 +378,41 @@ func (c *runtime) Close() error {
 		c.autoSplitMonitor.Close()
 	}
 
+	// Snapshot the controller maps under the lock: shard-controller callbacks
+	// (e.g. ShardDeleted, running on a detached goroutine) mutate them
+	// concurrently. The controllers must still be closed outside the lock,
+	// because their callbacks acquire it.
+	c.Lock()
+	c.closed = true
+	splitControllers := maps.Clone(c.splitControllers)
+	shardControllers := maps.Clone(c.shardControllers)
+	dataServerControllers := maps.Clone(c.dataServerControllers)
+	drainingNodes := maps.Clone(c.drainingNodes)
+	c.Unlock()
+
 	// The shard controllers must be closed before waiting for the action
 	// worker: the worker blocks on in-flight election actions, which only
 	// complete once the shard controllers' retry loops get canceled
 	var err error
-	for _, sc := range c.splitControllers {
+	for _, sc := range splitControllers {
 		sc.Close()
 	}
-	for _, sc := range c.shardControllers {
+	for _, sc := range shardControllers {
 		err = multierr.Append(err, sc.Close())
 	}
 
+	// Wait for any in-flight ShardDeleted callback: it may still be closing
+	// the shard controller it removed from the map. Controller Close is
+	// idempotent, so overlapping with the loop above is safe.
+	c.callbacksWg.Wait()
+
 	c.wg.Wait()
 
-	for _, nc := range c.dataServerControllers {
+	for _, nc := range dataServerControllers {
 		err = multierr.Append(err, nc.Close())
 	}
 
-	for _, nc := range c.drainingNodes {
+	for _, nc := range drainingNodes {
 		err = multierr.Append(err, nc.Close())
 	}
 	err = multierr.Append(err, c.rpc.Close())


### PR DESCRIPTION
### Motivation

`TestCoordinator_ShardSplit_ConcurrentSplitRejected` fails deterministically under `-race` on current main (5/5 runs):

```
WARNING: DATA RACE
Read at 0x00c000462c60 by goroutine 30:
  github.com/oxia-db/oxia/oxiad/coordinator/runtime.(*runtime).Close()
      oxiad/coordinator/runtime/runtime.go:370
  github.com/oxia-db/oxia/tests/coordinator.(*splitTestCluster).close()
      tests/coordinator/split_e2e_test.go:525

Previous write at 0x00c000462c60 by goroutine 793:
  runtime.mapassign_fast64ptr()
  github.com/oxia-db/oxia/oxiad/coordinator/runtime.(*runtime).ShardDeleted()
      oxiad/coordinator/runtime/runtime.go:88
  github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller/shard.(*controller).deleteShardWithRetries.func1.1.1()
      oxiad/coordinator/runtime/controller/shard/shard_controller.go:481
```

`runtime.Close()` iterates the four controller maps (`splitControllers`, `shardControllers`, `dataServerControllers`, `drainingNodes`) without holding the runtime lock. Meanwhile the shard-delete retry loop fires the `ShardDeleted` callback on a detached goroutine (`deleteShardWithRetries` spawns it with `context.Background()`, and no controller's `Close` waits for it), which takes the lock and mutates `shardControllers`. After a split completes, the parent shard's deletion makes this overlap with coordinator teardown routine.

`Close` can't simply hold the lock across the teardown: controller callbacks (`ShardDeleted`, `LeaderElected`, `SplitComplete`/`SplitAborted`) acquire the same lock, so waiting for the controllers to close while holding it would deadlock.

### Changes

- `runtime.Close` snapshots the controller maps under the write lock and closes the controllers outside of it.
- A `closed` flag, set under the lock when `Close` starts, turns late `ShardDeleted` callbacks into no-ops. `Close` tears down every controller from its own snapshot, so nothing leaks — and a late callback can no longer touch metadata after `Close` returns.
- A `callbacksWg` tracks in-flight `ShardDeleted` callbacks (the `Add` is gated by `closed` under the lock, keeping the `Add`/`Wait` pairing race-free); `Close` waits for them before returning, so no callback goroutine outlives the runtime. The overlapping controller `Close` calls this allows are safe: the shard controller's `Close` is `sync.Once`-guarded and the data-server controller's is CAS-guarded.

### Verification

- Before: `go test -race -count=1 -run TestCoordinator_ShardSplit_ConcurrentSplitRejected ./tests/coordinator/` failed 5/5 with the race above.
- After: the same command passes 5/5, and both `go test -race ./oxiad/coordinator/...` and the full `go test -race ./tests/coordinator/` suite pass.
