### PR TITLE
perf: drop the duplicated First() seek in getHigher

### DIFF
--- a/oxiad/dataserver/database/kvstore/kv_pebble.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble.go
@@ -471,16 +471,13 @@ func (p *Pebble) getHigher(key []byte, itOpts IteratorOpts) (returnedKey string,
 		return "", nil, nil, err
 	}
 
-	// The iterator might be positioned exactly on the key. Since we're looking for strict `x > y` comparison,
-	// we will have to skip to the next record
-	it.First()
 	if !it.First() {
 		return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)
 	}
 
-	itKey := it.Key()
-	if bytes.Equal(itKey, key) {
-		// We found the same key, skip it
+	// The lower bound is inclusive, so the iterator may be positioned exactly on
+	// the key. We are looking for a strict `x > y`, so step over it.
+	if bytes.Equal(it.Key(), key) {
 		if !it.Next() {
 			return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)
 		}


### PR DESCRIPTION
### Motivation

`getHigher` positioned the iterator twice in a row:

```go
it.First()
if !it.First() {
```

The second `First()` re-seeks to the same position, so one full seek is wasted on every `HIGHER` (strict `key > x`) lookup.

### Changes

Drop the redundant first call. This is not a correctness change: the strict `x > y` is implemented by the `bytes.Equal`/`Next` below, which steps over the key when the inclusive lower bound lands the iterator on it. The comment moves down to the code it actually describes.

### Verification

- `go test -race` green on `oxiad/dataserver/database/...`.
- `golangci-lint` clean on the CI-pinned v2.6.2.
