### PR TITLE
perf: seek past the internal-key region instead of stepping through it

### DIFF
--- a/common/compare/encode.go
+++ b/common/compare/encode.go
@@ -30,11 +30,39 @@ type Encoder interface {
 	Decode(encodedKey []byte) string
 
 	IsInternalKey(encodedKey []byte) bool
+
+	// InternalKeyRange returns the encoded half-open range [start, end) that
+	// contains every internal key. The region is always contiguous, so an
+	// iterator can seek past it in one jump instead of stepping through it.
+	//
+	// end is nil when the region runs to the end of the keyspace — no user key
+	// can sort after it — which lets the region be pruned with an upper bound
+	// instead. That is the case for the hierarchical encoder, but NOT for the
+	// natural one, where a user key is stored raw and can therefore sort after
+	// the internal keys.
+	InternalKeyRange() (start []byte, end []byte)
+}
+
+// keyRegionSuccessor returns the smallest key that sorts after every key with
+// the given prefix, or nil when no such key exists (an all-0xff prefix).
+func keyRegionSuccessor(prefix []byte) []byte {
+	end := bytes.Clone(prefix)
+	for i := len(end) - 1; i >= 0; i-- {
+		if end[i] != maxByteValue {
+			end[i]++
+			return end[:i+1]
+		}
+	}
+	return nil
 }
 
 const (
 	encodedSeparator      = 0xff
 	internalKeysBitMarker = 1 << 15
+
+	// maxByteValue is the largest byte value; a prefix made only of these has
+	// no successor.
+	maxByteValue = 0xff
 )
 
 var (
@@ -105,6 +133,14 @@ func (encoderHierarchical) IsInternalKey(encodedKey []byte) bool {
 	return encodedKey[0]&(1<<7) != 0
 }
 
+// InternalKeyRange: the internal-key marker is the top bit of the 2-byte
+// prefix, so every internal key sorts after every regular one (a regular key
+// would need 32768 separators to reach that region) — the region runs to the
+// end of the keyspace.
+func (encoderHierarchical) InternalKeyRange() (start []byte, end []byte) {
+	return []byte{internalKeysBitMarker >> 8}, nil
+}
+
 // EncoderHierarchical ensure that we can sort keys from same level together
 // and thus we can easily return the children of a given path
 // The encoding is done by prepending 2 bytes with the count of
@@ -162,6 +198,16 @@ func (encoderNatural) Decode(encoded []byte) string {
 func (encoderNatural) IsInternalKey(encodedKey []byte) bool {
 	return bytes.HasPrefix(encodedKey, encodedInternalKeyPrefixBytes)
 }
+
+// InternalKeyRange: internal keys are the "\xff\xffoxia/" prefix region. A
+// regular key is stored raw, so one whose bytes sort after that prefix (e.g.
+// "\xff\xffz") lives *after* the internal keys — the region has a real upper
+// end and cannot be pruned away with an upper bound.
+func (encoderNatural) InternalKeyRange() (start []byte, end []byte) {
+	return encodedInternalKeyPrefixBytes, encodedInternalKeyPrefixSuccessor
+}
+
+var encodedInternalKeyPrefixSuccessor = keyRegionSuccessor(encodedInternalKeyPrefixBytes)
 
 var EncoderNatural Encoder = &encoderNatural{}
 

--- a/common/compare/encode.go
+++ b/common/compare/encode.go
@@ -138,8 +138,13 @@ func (encoderHierarchical) IsInternalKey(encodedKey []byte) bool {
 // would need 32768 separators to reach that region) — the region runs to the
 // end of the keyspace.
 func (encoderHierarchical) InternalKeyRange() (start []byte, end []byte) {
-	return []byte{internalKeysBitMarker >> 8}, nil
+	return hierarchicalInternalKeyStart, nil
 }
+
+// The bounds returned by InternalKeyRange are constant and read-only, so build
+// them once. Callers use them as pebble iterator bounds and seek keys, never
+// mutating them (same contract as encodedInternalKeyPrefixBytes).
+var hierarchicalInternalKeyStart = []byte{internalKeysBitMarker >> 8}
 
 // EncoderHierarchical ensure that we can sort keys from same level together
 // and thus we can easily return the children of a given path

--- a/oxiad/dataserver/database/kvstore/kv_pebble.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble.go
@@ -430,14 +430,13 @@ func (p *Pebble) getFloor(key []byte, itOpts IteratorOpts) (returnedKey string, 
 }
 
 func (p *Pebble) getCeiling(key []byte, itOpts IteratorOpts) (returnedKey string, value []byte, closer io.Closer, err error) {
-	opts := newIterOptions(p.keyEncoder, itOpts)
-	opts.LowerBound = key
-	it, err := p.db.NewIter(opts)
+	it, err := p.db.NewIter(newIterOptions(p.keyEncoder, itOpts, key, nil))
 	if err != nil {
 		return "", nil, nil, err
 	}
+	skipper := newInternalRegionSkipper(p.keyEncoder, itOpts)
 
-	if !it.First() {
+	if !it.First() || !skipper.forward(it) {
 		return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)
 	}
 
@@ -447,14 +446,15 @@ func (p *Pebble) getCeiling(key []byte, itOpts IteratorOpts) (returnedKey string
 }
 
 func (p *Pebble) getLower(key []byte, itOpts IteratorOpts) (returnedKey string, value []byte, closer io.Closer, err error) {
-	opts := newIterOptions(p.keyEncoder, itOpts)
-	opts.UpperBound = key
-	it, err := p.db.NewIter(opts)
+	it, err := p.db.NewIter(newIterOptions(p.keyEncoder, itOpts, nil, key))
 	if err != nil {
 		return "", nil, nil, err
 	}
+	skipper := newInternalRegionSkipper(p.keyEncoder, itOpts)
 
-	if !it.Last() {
+	// Backwards, the internal region is just as costly to step through: a floor
+	// probe above it would walk the whole backlog in reverse.
+	if !it.Last() || !skipper.backward(it) {
 		return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)
 	}
 
@@ -464,21 +464,20 @@ func (p *Pebble) getLower(key []byte, itOpts IteratorOpts) (returnedKey string, 
 }
 
 func (p *Pebble) getHigher(key []byte, itOpts IteratorOpts) (returnedKey string, value []byte, closer io.Closer, err error) {
-	opts := newIterOptions(p.keyEncoder, itOpts)
-	opts.LowerBound = key
-	it, err := p.db.NewIter(opts)
+	it, err := p.db.NewIter(newIterOptions(p.keyEncoder, itOpts, key, nil))
 	if err != nil {
 		return "", nil, nil, err
 	}
+	skipper := newInternalRegionSkipper(p.keyEncoder, itOpts)
 
-	if !it.First() {
+	if !it.First() || !skipper.forward(it) {
 		return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)
 	}
 
-	// The lower bound is inclusive, so the iterator may be positioned exactly on
-	// the key. We are looking for a strict `x > y`, so step over it.
+	// The lower bound is inclusive, so the iterator may be sitting exactly on
+	// the key. We want a strict `x > y`, so step over it.
 	if bytes.Equal(it.Key(), key) {
-		if !it.Next() {
+		if !it.Next() || !skipper.forward(it) {
 			return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)
 		}
 	}
@@ -521,62 +520,52 @@ func (p *Pebble) KeyRangeScan(lowerBound, upperBound string, opts IteratorOpts) 
 }
 
 func (p *Pebble) KeyIterator(itOpts IteratorOpts) (KeyIterator, error) {
-	opts := &pebble.IterOptions{}
-	if !itOpts.IncludeInternalKeys {
-		opts.SkipPoint = func(encodedKey []byte) bool {
-			return p.keyEncoder.IsInternalKey(encodedKey)
-		}
-	}
-	pbit, err := p.db.NewIter(opts)
+	pbit, err := p.db.NewIter(newIterOptions(p.keyEncoder, itOpts, nil, nil))
 	if err != nil {
 		return nil, err
 	}
 
-	return &PebbleIterator{p, pbit}, nil
+	return &PebbleIterator{p, pbit, newInternalRegionSkipper(p.keyEncoder, itOpts)}, nil
 }
 
 func (p *Pebble) KeyRangeScanReverse(lowerBound, upperBound string, itOpts IteratorOpts) (ReverseKeyIterator, error) {
-	opts := &pebble.IterOptions{}
-	if !itOpts.IncludeInternalKeys {
-		opts.SkipPoint = func(encodedKey []byte) bool {
-			return p.keyEncoder.IsInternalKey(encodedKey)
-		}
-	}
+	var lb, ub []byte
 	if lowerBound != "" {
-		opts.LowerBound = p.keyEncoder.Encode(lowerBound)
+		lb = p.keyEncoder.Encode(lowerBound)
 	}
 	if upperBound != "" {
-		opts.UpperBound = p.keyEncoder.Encode(upperBound)
+		ub = p.keyEncoder.Encode(upperBound)
 	}
-	pbit, err := p.db.NewIter(opts)
+	pbit, err := p.db.NewIter(newIterOptions(p.keyEncoder, itOpts, lb, ub))
 	if err != nil {
 		return nil, err
 	}
-	pbit.Last()
-	return &PebbleReverseIterator{p, pbit}, nil
+	skipper := newInternalRegionSkipper(p.keyEncoder, itOpts)
+	if pbit.Last() {
+		skipper.backward(pbit)
+	}
+	return &PebbleReverseIterator{p, pbit, skipper}, nil
 }
 
 func (p *Pebble) RangeScan(lowerBound, upperBound string, itOpts IteratorOpts) (KeyValueIterator, error) {
-	opts := &pebble.IterOptions{}
-	if !itOpts.IncludeInternalKeys {
-		opts.SkipPoint = func(encodedKey []byte) bool {
-			return p.keyEncoder.IsInternalKey(encodedKey)
-		}
-	}
+	var lb, ub []byte
 	if lowerBound != "" {
-		opts.LowerBound = p.keyEncoder.Encode(lowerBound)
+		lb = p.keyEncoder.Encode(lowerBound)
 	}
 	if upperBound != "" {
-		opts.UpperBound = p.keyEncoder.Encode(upperBound)
+		ub = p.keyEncoder.Encode(upperBound)
 	}
 
-	pbit, err := p.db.NewIter(opts)
+	pbit, err := p.db.NewIter(newIterOptions(p.keyEncoder, itOpts, lb, ub))
 	if err != nil {
 		return nil, err
 	}
 
-	pbit.First()
-	return &PebbleIterator{p, pbit}, nil
+	skipper := newInternalRegionSkipper(p.keyEncoder, itOpts)
+	if pbit.First() {
+		skipper.forward(pbit)
+	}
+	return &PebbleIterator{p, pbit, skipper}, nil
 }
 
 func (p *Pebble) Snapshot() (Snapshot, error) {
@@ -620,7 +609,7 @@ func (b *PebbleBatch) RangeScan(lowerBound, upperBound string) (KeyValueIterator
 		return nil, err
 	}
 	pbit.SeekGE(lb)
-	return &PebbleIterator{b.p, pbit}, nil
+	return &PebbleIterator{b.p, pbit, internalRegionSkipper{}}, nil
 }
 
 func (b *PebbleBatch) Close() error {
@@ -714,8 +703,9 @@ func (b *PebbleBatch) Commit() error {
 // Iterator wrapper methods
 
 type PebbleIterator struct {
-	p  *Pebble
-	pi *pebble.Iterator
+	p       *Pebble
+	pi      *pebble.Iterator
+	skipper internalRegionSkipper
 }
 
 func (p *PebbleIterator) Close() error {
@@ -731,19 +721,19 @@ func (p *PebbleIterator) Key() string {
 }
 
 func (p *PebbleIterator) Next() bool {
-	return p.pi.Next()
+	return p.pi.Next() && p.skipper.forward(p.pi)
 }
 
 func (p *PebbleIterator) Prev() bool {
-	return p.pi.Prev()
+	return p.pi.Prev() && p.skipper.backward(p.pi)
 }
 
 func (p *PebbleIterator) SeekGE(key string) bool {
-	return p.pi.SeekGE(p.p.keyEncoder.Encode(key))
+	return p.pi.SeekGE(p.p.keyEncoder.Encode(key)) && p.skipper.forward(p.pi)
 }
 
 func (p *PebbleIterator) SeekLT(key string) bool {
-	return p.pi.SeekLT(p.p.keyEncoder.Encode(key))
+	return p.pi.SeekLT(p.p.keyEncoder.Encode(key)) && p.skipper.backward(p.pi)
 }
 
 func (p *PebbleIterator) Value() ([]byte, error) {
@@ -757,8 +747,9 @@ func (p *PebbleIterator) Value() ([]byte, error) {
 // Iterator wrapper methods
 
 type PebbleReverseIterator struct {
-	p  *Pebble
-	pi *pebble.Iterator
+	p       *Pebble
+	pi      *pebble.Iterator
+	skipper internalRegionSkipper
 }
 
 func (p *PebbleReverseIterator) Close() error {
@@ -774,7 +765,7 @@ func (p *PebbleReverseIterator) Key() string {
 }
 
 func (p *PebbleReverseIterator) Prev() bool {
-	return p.pi.Prev()
+	return p.pi.Prev() && p.skipper.backward(p.pi)
 }
 
 func (p *PebbleReverseIterator) Value() ([]byte, error) {
@@ -855,12 +846,70 @@ func (sl *pebbleSnapshotLoader) Complete() {
 	sl.complete = true
 }
 
-func newIterOptions(keyEncoder compare.Encoder, itOpts IteratorOpts) *pebble.IterOptions {
-	opts := &pebble.IterOptions{}
-	if !itOpts.IncludeInternalKeys {
-		opts.SkipPoint = func(encodedKey []byte) bool {
-			return keyEncoder.IsInternalKey(encodedKey)
+// newIterOptions builds the Pebble iterator options for a scan that may have to
+// exclude the internal-key region.
+//
+// It deliberately does not use pebble's SkipPoint. SkipPoint is a *filter*: the
+// iterator still steps through — and loads the blocks of — every internal key it
+// passes, so a ceiling/higher lookup past the last user key, or a scan with no
+// upper bound, walks the entire live notification backlog before returning. It
+// also hides those keys from us, so we could not detect the region to seek past
+// it. Instead: when the internal region runs to the end of the keyspace it is
+// pruned outright with an upper bound, and otherwise internalRegionSkipper
+// jumps over it with a single seek.
+func newIterOptions(enc compare.Encoder, itOpts IteratorOpts, lowerBound, upperBound []byte) *pebble.IterOptions {
+	opts := &pebble.IterOptions{LowerBound: lowerBound, UpperBound: upperBound}
+	if itOpts.IncludeInternalKeys {
+		return opts
+	}
+	if start, end := enc.InternalKeyRange(); end == nil {
+		// No user key can sort after the internal keys: bound them away.
+		if opts.UpperBound == nil || bytes.Compare(start, opts.UpperBound) < 0 {
+			opts.UpperBound = start
 		}
 	}
 	return opts
+}
+
+// internalRegionSkipper keeps an iterator out of the contiguous internal-key
+// region, jumping over it in a single seek rather than stepping through it.
+//
+// It is a no-op when internal keys are wanted, and when newIterOptions already
+// pruned the region with an upper bound (hierarchical). It carries its weight
+// for the natural encoder, where a user key is stored raw and can sort *after*
+// the internal keys, so the region cannot be bounded away.
+type internalRegionSkipper struct {
+	enc        compare.Encoder
+	start, end []byte
+}
+
+func newInternalRegionSkipper(enc compare.Encoder, itOpts IteratorOpts) internalRegionSkipper {
+	if itOpts.IncludeInternalKeys {
+		return internalRegionSkipper{}
+	}
+	start, end := enc.InternalKeyRange()
+	if end == nil {
+		// Already pruned by the upper bound in newIterOptions.
+		return internalRegionSkipper{}
+	}
+	return internalRegionSkipper{enc: enc, start: start, end: end}
+}
+
+// forward moves the iterator past the internal region when it is positioned
+// inside it, and reports whether it is still valid. A single seek suffices: the
+// region is contiguous, so nothing at or after end is an internal key.
+func (s internalRegionSkipper) forward(it *pebble.Iterator) bool {
+	if s.end == nil || !it.Valid() || !s.enc.IsInternalKey(it.Key()) {
+		return it.Valid()
+	}
+	return it.SeekGE(s.end)
+}
+
+// backward moves the iterator before the internal region when it is positioned
+// inside it, and reports whether it is still valid.
+func (s internalRegionSkipper) backward(it *pebble.Iterator) bool {
+	if s.end == nil || !it.Valid() || !s.enc.IsInternalKey(it.Key()) {
+		return it.Valid()
+	}
+	return it.SeekLT(s.start)
 }

--- a/oxiad/dataserver/database/kvstore/kv_pebble.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble.go
@@ -471,16 +471,13 @@ func (p *Pebble) getHigher(key []byte, itOpts IteratorOpts) (returnedKey string,
 		return "", nil, nil, err
 	}
 
-	// The iterator might be positioned exactly on the key. Since we're looking for strict `x > y` comparison,
-	// we will have to skip to the next record
-	it.First()
 	if !it.First() {
 		return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)
 	}
 
-	itKey := it.Key()
-	if bytes.Equal(itKey, key) {
-		// We found the same key, skip it
+	// The lower bound is inclusive, so the iterator may be positioned exactly on
+	// the key. We are looking for a strict `x > y`, so step over it.
+	if bytes.Equal(it.Key(), key) {
 		if !it.Next() {
 			return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)
 		}

--- a/oxiad/dataserver/database/kvstore/kv_pebble_internal_keys_test.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble_internal_keys_test.go
@@ -1,0 +1,204 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvstore
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+// Under natural sorting a regular key is stored raw, so a key whose bytes sort
+// after the encoded internal prefix ("\xff\xffoxia/") lives *after* the whole
+// internal-key region. Pruning the region with an upper bound would silently
+// hide it — these keys are the reason the region has to be seeked over instead.
+const (
+	keyAfterInternalRegion  = "\xff\xffz"
+	keyBeforeInternalRegion = "\xff\xffa"
+)
+
+func putAll(t *testing.T, kv KV, keys ...string) {
+	t.Helper()
+	wb := kv.NewWriteBatch()
+	for _, k := range keys {
+		assert.NoError(t, wb.Put(k, []byte("v-"+k)))
+	}
+	assert.NoError(t, wb.Commit())
+	assert.NoError(t, wb.Close())
+}
+
+// getKey returns the key found, closing the value reader. It never dereferences
+// a nil closer, so a lookup that unexpectedly misses fails the assertion instead
+// of panicking.
+func getKey(t *testing.T, kv KV, key string, cmp ComparisonType, opts IteratorOpts) (string, error) {
+	t.Helper()
+	found, _, closer, err := kv.Get(key, cmp, opts)
+	if err != nil {
+		return "", err
+	}
+	assert.NoError(t, closer.Close())
+	return found, nil
+}
+
+func scanAllKeys(t *testing.T, kv KV, opts IteratorOpts) []string {
+	t.Helper()
+	it, err := kv.RangeScan("", "", opts)
+	assert.NoError(t, err)
+	defer it.Close()
+
+	var keys []string
+	for ; it.Valid(); it.Next() {
+		keys = append(keys, it.Key())
+	}
+	return keys
+}
+
+// A scan that excludes internal keys must still return the regular keys that
+// sort after them. This is the case an upper-bound prune would break.
+func TestPebbleScanSkipsInternalRegionButKeepsKeysAfterIt(t *testing.T) {
+	for _, sorting := range []proto.KeySortingType{proto.KeySortingType_NATURAL, proto.KeySortingType_HIERARCHICAL} {
+		t.Run(sorting.String(), func(t *testing.T) {
+			factory, err := NewPebbleKVFactory(NewFactoryOptionsForTest(t))
+			assert.NoError(t, err)
+			kv, err := factory.NewKV(constant.DefaultNamespace, 1, sorting)
+			assert.NoError(t, err)
+
+			putAll(t, kv, "a", "b",
+				"__oxia/notifications/0001", "__oxia/notifications/0002", "__oxia/session/0001")
+
+			expected := []string{"a", "b"}
+			if sorting == proto.KeySortingType_NATURAL {
+				// Only the natural encoding can place regular keys around the
+				// internal region; hierarchical sorts internal keys strictly last.
+				putAll(t, kv, keyBeforeInternalRegion, keyAfterInternalRegion)
+				expected = []string{"a", "b", keyBeforeInternalRegion, keyAfterInternalRegion}
+			}
+
+			assert.Equal(t, expected, scanAllKeys(t, kv, NoInternalKeys))
+
+			// With internal keys included, everything shows up.
+			all := scanAllKeys(t, kv, ShowInternalKeys)
+			assert.Contains(t, all, "__oxia/notifications/0001")
+			assert.Contains(t, all, "__oxia/session/0001")
+			for _, k := range expected {
+				assert.Contains(t, all, k)
+			}
+
+			assert.NoError(t, kv.Close())
+			assert.NoError(t, factory.Close())
+		})
+	}
+}
+
+// The point lookups must seek over the internal region in both directions and
+// still see the regular keys on the far side of it.
+func TestPebbleGetAcrossInternalRegionNatural(t *testing.T) {
+	factory, err := NewPebbleKVFactory(NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	kv, err := factory.NewKV(constant.DefaultNamespace, 1, proto.KeySortingType_NATURAL)
+	assert.NoError(t, err)
+
+	putAll(t, kv, "a", "__oxia/notifications/0001", "__oxia/notifications/0002", keyAfterInternalRegion)
+
+	// CEILING from past the last "normal" key must jump the internal region and
+	// land on the regular key beyond it — not on an internal key, and not
+	// NOT_FOUND (which is what bounding the region away would give).
+	found, err := getKey(t, kv, "b", ComparisonCeiling, NoInternalKeys)
+	assert.NoError(t, err)
+	assert.Equal(t, keyAfterInternalRegion, found)
+
+	// HIGHER, same jump.
+	found, err = getKey(t, kv, "a", ComparisonHigher, NoInternalKeys)
+	assert.NoError(t, err)
+	assert.Equal(t, keyAfterInternalRegion, found)
+
+	// FLOOR/LOWER from above the region must step back over it to the regular
+	// key before it, rather than returning an internal key.
+	found, err = getKey(t, kv, keyAfterInternalRegion, ComparisonLower, NoInternalKeys)
+	assert.NoError(t, err)
+	assert.Equal(t, "a", found)
+
+	found, err = getKey(t, kv, "\xff\xffy", ComparisonFloor, NoInternalKeys)
+	assert.NoError(t, err)
+	assert.Equal(t, "a", found)
+
+	// And with internal keys allowed, the ceiling is the internal key itself.
+	found, err = getKey(t, kv, "b", ComparisonCeiling, ShowInternalKeys)
+	assert.NoError(t, err)
+	assert.Equal(t, "__oxia/notifications/0001", found)
+
+	assert.NoError(t, kv.Close())
+	assert.NoError(t, factory.Close())
+}
+
+// With hierarchical sorting the internal keys are last, so a ceiling past the
+// user keys is genuinely NOT_FOUND — and must not walk the region to find that out.
+func TestPebbleGetPastInternalRegionHierarchical(t *testing.T) {
+	factory, err := NewPebbleKVFactory(NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	kv, err := factory.NewKV(constant.DefaultNamespace, 1, proto.KeySortingType_HIERARCHICAL)
+	assert.NoError(t, err)
+
+	putAll(t, kv, "a", "__oxia/notifications/0001", "__oxia/notifications/0002")
+
+	_, _, _, err = kv.Get("b", ComparisonCeiling, NoInternalKeys)
+	assert.ErrorIs(t, err, ErrKeyNotFound)
+
+	found, err := getKey(t, kv, "b", ComparisonCeiling, ShowInternalKeys)
+	assert.NoError(t, err)
+	assert.Equal(t, "__oxia/notifications/0001", found)
+
+	assert.NoError(t, kv.Close())
+	assert.NoError(t, factory.Close())
+}
+
+// A ceiling lookup past the last user key used to step through the entire
+// internal-key backlog (pebble's SkipPoint is a filter, not a seek). The cost
+// must now be flat in the size of that backlog.
+func BenchmarkPebbleGetCeilingPastUserKeys(b *testing.B) {
+	for _, backlog := range []int{100, 10_000, 100_000} {
+		b.Run(fmt.Sprintf("backlog-%d", backlog), func(b *testing.B) {
+			factory, err := NewPebbleKVFactory(&FactoryOptions{DataDir: b.TempDir()})
+			assert.NoError(b, err)
+			defer factory.Close()
+			kv, err := factory.NewKV(constant.DefaultNamespace, 1, proto.KeySortingType_NATURAL)
+			assert.NoError(b, err)
+			defer kv.Close()
+
+			wb := kv.NewWriteBatch()
+			assert.NoError(b, wb.Put("a", []byte("v")))
+			for i := 0; i < backlog; i++ {
+				assert.NoError(b, wb.Put(fmt.Sprintf("__oxia/notifications/%016x", i), []byte("n")))
+			}
+			assert.NoError(b, wb.Commit())
+			assert.NoError(b, wb.Close())
+			assert.NoError(b, kv.Flush())
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _, _, err := kv.Get("b", ComparisonCeiling, NoInternalKeys)
+				if err != nil && !errors.Is(err, ErrKeyNotFound) {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

Item 2.2 from the performance review. Floor/ceiling gets and unbounded scans that exclude internal keys used pebble's `SkipPoint`. `SkipPoint` is a **filter, not a seek**: the iterator still steps through — and loads the blocks of — every internal key it passes. A `CEILING`/`HIGHER` get past the last user key, or a scan with no upper bound, therefore walks the **entire live notification backlog** before returning. With 100k notifications retained a single client `Get` took **3 ms**, and the cost grows without bound with the retention window.

### The subtlety (why the obvious fix is wrong)

The internal keys are contiguous, so the tempting fix is to clamp the iterator's `UpperBound` to the start of the internal region. That is **unsafe for natural sorting**: a regular key is stored raw, so one whose bytes sort after the encoded internal prefix `"\xff\xffoxia/"` — e.g. `"\xff\xffz"` — lives *after* the internal keys. Bounding the region away would silently hide those keys. Hierarchical sorting is different: the marker bit puts internal keys strictly last, so a bound *is* safe there.

### Changes

`Encoder` gains `InternalKeyRange() (start, end []byte)`, returning the contiguous internal-key region as a half-open range:

- **hierarchical** → `end == nil` (region runs to the end of the keyspace): pruned outright with an `UpperBound`, so pebble never visits it.
- **natural** → real `end`: the region is **seeked over** in a single jump (it is contiguous, so nothing at/after `end` is internal), in **both directions** — the reverse paths had the same walk, a floor probe above the region stepped *backwards* through the whole backlog.

`SkipPoint` is removed on these paths. Besides causing the walk, it hides the internal keys from the wrapper, so we could not detect the region in order to seek past it — the two approaches are mutually exclusive. The skipper is applied at every positioning op (the four point lookups plus `Next`/`Prev`/`SeekGE`/`SeekLT` in both iterator wrappers) so no internal key can leak. `InternalKeyRange` is allocation-free for both encoders (constant, read-only bounds shared as package vars).

### Benchmark

`BenchmarkPebbleGetCeilingPastUserKeys` — ceiling lookup past the last user key, N internal keys retained:

| backlog | before (SkipPoint) | after (seek) |
|---|---|---|
| 100 | 4.1 µs | 1.23 µs |
| 10,000 | 295 µs | 1.26 µs |
| 100,000 | **3.05 ms** | **1.27 µs** |

O(N) → O(1).

### Verification

- `TestPebbleScanSkipsInternalRegionButKeepsKeysAfterIt` and `TestPebbleGetAcrossInternalRegionNatural` plant a regular key **after** the internal region under natural sorting and assert scans/gets in both directions still return it. Verified to discriminate: they fail against an upper-bound prune (`end == nil` for natural) — exactly the mistake the naive fix would make.
- `TestPebbleGetPastInternalRegionHierarchical` pins that hierarchical ceilings past the user keys are genuinely `NOT_FOUND` without walking the region.
- `go test -race` green on `oxiad/dataserver/...` and `common/compare`; `golangci-lint` clean across all go.work modules on the CI-pinned v2.6.2 (the change spans `common/` and `oxiad/`).

---

Stacked on #1242 (drops a redundant seek in `getHigher`, which this PR also rewrites); please merge that first. Until it does, its one commit shows in this PR's diff.
