### PR TITLE
docs: remove star history tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,6 @@ Please 🌟 star the project if you like it.
 
 Feel free to open an [issue](https://github.com/oxia-db/oxia/issues/new) or start a [discussion](https://github.com/oxia-db/oxia/discussions/new/choose). You can also follow the development [guide]() to contribute and build on it.
 
-<p align="center">
-  <a href="https://star-history.com/#oxia-db/oxia&Date">
-    <img src="https://api.star-history.com/svg?repos=oxia-db/oxia&type=Date" alt="Star History Chart" width="600"/>
-  </a>
-</p>
-
 ### License
 
 Copyright 2023-2026 The Oxia Authors


### PR DESCRIPTION
## Motivation
The README embedded a Star History chart loaded from a third-party tracking service. Removing it avoids relying on external star tracking and keeps the README from encouraging token-dependent tracking setups.

## Modifications
- Removed the Star History chart embed from `README.md`.
- Left the existing project links and contribution text unchanged.

## Testing
- Ran `rg -n "star-history|Star History|api\.star-history\.com|stargazers|stargazers_count"` in the repo; no matches remain.
- Ran `git diff --check`.
- No code tests run; this is a documentation-only change.
