### PR TITLE
perf: decode WAL entries zero-copy in ApplyLogEntry

### DIFF
--- a/oxiad/dataserver/controller/statemachine/state_machine.go
+++ b/oxiad/dataserver/controller/statemachine/state_machine.go
@@ -25,7 +25,21 @@ func ApplyLogEntry(db database.DB, entry *proto.LogEntry, updateOperationCallbac
 	logEntryValue := proto.LogEntryValueFromVTPool()
 	defer logEntryValue.ReturnToVTPool()
 
-	if err := logEntryValue.UnmarshalVT(entry.Value); err != nil {
+	// UnmarshalVTUnsafe aliases every string/bytes field of the decoded tree
+	// into entry.Value instead of copying it. The lifetime contract:
+	//   - entry.Value is a private heap buffer: the WAL reader materializes
+	//     every LogEntry with a copying unmarshal (and the segment codec
+	//     itself copies records out of the mmap), so the buffer is never
+	//     mutated, recycled, or unmapped behind the aliases.
+	//   - Everything ProcessWrite/ProcessControlRequest persists is copied
+	//     (Pebble batch arena, sealed notifications) before returning, and
+	//     nothing retains the aliased strings past the call.
+	//   - The pool only recycles the top-level LogEntryValue: ResetVT nils
+	//     the oneof, so aliased sub-messages are never handed out again.
+	//   - Pooled StorageEntry objects must not keep request-owned buffers on
+	//     pool return (see applyPut), or a later pooled unmarshal would
+	//     append over this entry's payload while parts of it are still live.
+	if err := logEntryValue.UnmarshalVTUnsafe(entry.Value); err != nil {
 		return ApplyResponse{}, err
 	}
 
@@ -64,7 +78,8 @@ func ApplyLogEntryWithSplitFilter(
 	logEntryValue := proto.LogEntryValueFromVTPool()
 	defer logEntryValue.ReturnToVTPool()
 
-	if err := logEntryValue.UnmarshalVT(entry.Value); err != nil {
+	// Zero-copy decode: same lifetime contract as in ApplyLogEntry above.
+	if err := logEntryValue.UnmarshalVTUnsafe(entry.Value); err != nil {
 		return ApplyResponse{}, err
 	}
 

--- a/oxiad/dataserver/controller/statemachine/state_machine_test.go
+++ b/oxiad/dataserver/controller/statemachine/state_machine_test.go
@@ -15,7 +15,11 @@
 package statemachine
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"testing"
+	stdtime "time"
 
 	"github.com/stretchr/testify/assert"
 	pb "google.golang.org/protobuf/proto"
@@ -281,6 +285,105 @@ func TestApplyLogEntry_MultipleEntries(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, proto.Status_OK, getY.Status)
 	assert.Equal(t, []byte("2"), getY.Value)
+}
+
+// TestApplyLogEntry_DeleteRangeDoesNotCorruptAliasedEntry guards the lifetime
+// contract of the zero-copy decode in ApplyLogEntry: applyPut must detach the
+// request-owned buffers from the pooled StorageEntry before returning it, or
+// the pooled Deserialize in applyDeleteRange appends the deleted entry's
+// stored value over the WAL entry payload that the remaining operations of
+// the same entry still alias.
+//
+// The entry holds two puts followed by two delete-ranges, and the first range
+// deletes a key whose stored value is sized to fill the donated capacity
+// exactly: without the detach, that Deserialize overwrites the second
+// delete-range's keys and the captured notification keys in place.
+func TestApplyLogEntry_DeleteRangeDoesNotCorruptAliasedEntry(t *testing.T) {
+	db := newTestDB(t)
+
+	// A few rounds, with distinct keys and offsets: the overwrite needs the
+	// delete-range's pool Get to return the object the last put just
+	// recycled, which holds on the same P absent a badly timed preemption.
+	for i := int64(0); i < 3; i++ {
+		p := fmt.Sprintf("it-%d-", i)
+		v2 := []byte(p + "marker-value-2")
+
+		proposal := NewWriteProposal(2*i+1, &proto.WriteRequest{
+			Puts: []*proto.PutRequest{
+				{Key: p + "put-1", Value: []byte(p + "value-1")},
+				{Key: p + "put-2", Value: v2},
+			},
+			DeleteRanges: []*proto.DeleteRangeRequest{
+				{StartInclusive: p + "range-a", EndExclusive: p + "range-b"},
+				{StartInclusive: p + "range-m", EndExclusive: p + "range-n"},
+			},
+		})
+		entryValue := marshalProposal(t, proposal)
+
+		// The pooled StorageEntry recycled by the last put keeps, as spare
+		// capacity, a slice of the entry payload running from v2 to the end
+		// of the buffer. A stored value of exactly that size makes a pooled
+		// append overwrite everything after v2, delete-range keys included.
+		v2Off := bytes.Index(entryValue, v2)
+		assert.Greater(t, v2Off, 0)
+		storedValue := bytes.Repeat([]byte("Z"), len(entryValue)-v2Off)
+
+		_, err := ApplyLogEntry(db, &proto.LogEntry{
+			Term:   1,
+			Offset: 2 * i,
+			Value: marshalProposal(t, NewWriteProposal(2*i, &proto.WriteRequest{
+				Puts: []*proto.PutRequest{
+					{Key: p + "range-a-key", Value: storedValue},
+					{Key: p + "range-m-key", Value: []byte(p + "m-value")},
+				},
+			})),
+			Timestamp: 1,
+		}, database.NoOpCallback)
+		assert.NoError(t, err)
+
+		_, err = ApplyLogEntry(db, &proto.LogEntry{
+			Term:      1,
+			Offset:    2*i + 1,
+			Value:     entryValue,
+			Timestamp: 2,
+		}, database.NoOpCallback)
+		assert.NoError(t, err)
+
+		// Both ranges must have been deleted under their original keys.
+		for _, key := range []string{p + "range-a-key", p + "range-m-key"} {
+			resp, err := db.Get(&proto.GetRequest{Key: key})
+			assert.NoError(t, err)
+			assert.Equal(t, proto.Status_KEY_NOT_FOUND, resp.Status, key)
+		}
+		for key, expected := range map[string][]byte{
+			p + "put-1": []byte(p + "value-1"),
+			p + "put-2": v2,
+		} {
+			resp, err := db.Get(&proto.GetRequest{Key: key, IncludeValue: true})
+			assert.NoError(t, err)
+			assert.Equal(t, proto.Status_OK, resp.Status, key)
+			assert.Equal(t, expected, resp.Value, key)
+		}
+
+		// The notification batch must carry the original keys, not bytes of
+		// the deleted entry's stored value.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*stdtime.Second)
+		batches, err := db.ReadNextNotifications(ctx, 2*i+1)
+		cancel()
+		assert.NoError(t, err)
+		if assert.NotEmpty(t, batches) {
+			keys := make(map[string]proto.NotificationType)
+			for _, n := range batches[0].Notifications {
+				keys[n.GetKey()] = n.Value.Type
+			}
+			assert.Equal(t, map[string]proto.NotificationType{
+				p + "put-1":   proto.NotificationType_KEY_CREATED,
+				p + "put-2":   proto.NotificationType_KEY_CREATED,
+				p + "range-a": proto.NotificationType_KEY_RANGE_DELETED,
+				p + "range-m": proto.NotificationType_KEY_RANGE_DELETED,
+			}, keys)
+		}
+	}
 }
 
 func TestApplyLogEntry_ControlRequestPersistsCommitOffsetForWalReplay(t *testing.T) {

--- a/oxiad/dataserver/controller/statemachine/state_machine_test.go
+++ b/oxiad/dataserver/controller/statemachine/state_machine_test.go
@@ -301,10 +301,11 @@ func TestApplyLogEntry_MultipleEntries(t *testing.T) {
 func TestApplyLogEntry_DeleteRangeDoesNotCorruptAliasedEntry(t *testing.T) {
 	db := newTestDB(t)
 
-	// A few rounds, with distinct keys and offsets: the overwrite needs the
+	// Several rounds, with distinct keys and offsets: the overwrite needs the
 	// delete-range's pool Get to return the object the last put just
-	// recycled, which holds on the same P absent a badly timed preemption.
-	for i := int64(0); i < 3; i++ {
+	// recycled, which holds on the same P but is not guaranteed by sync.Pool
+	// (preemption or a GC can break the chain in any single round).
+	for i := int64(0); i < 10; i++ {
 		p := fmt.Sprintf("it-%d-", i)
 		v2 := []byte(p + "marker-value-2")
 

--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -744,7 +744,12 @@ func (d *db) applyPut(batch kvstore.WriteBatch, baseVersionId *atomic.Int64, not
 		return nil, errors.Wrap(err, "oxia db: failed to apply batch")
 	}
 
-	// No version conflict
+	// No version conflict.
+	// The closure returns whichever entry is current on exit: se is nil for a
+	// new key and replaced with a pooled entry below, and the callback paths
+	// can return early before that happens.
+	defer func() { se.ReturnToVTPool() }()
+
 	versionId := wal.InvalidOffset
 	if !internal {
 		status, err := updateOperationCallback.OnPut(batch, notifications, putReq, se)
@@ -788,8 +793,6 @@ func (d *db) applyPut(batch kvstore.WriteBatch, baseVersionId *atomic.Int64, not
 	}
 
 	se.SecondaryIndexes = putReq.SecondaryIndexes
-
-	defer se.ReturnToVTPool()
 
 	// Marshal the entry directly into the batch arena: marshal-then-Put would
 	// allocate an intermediate buffer and copy the entry twice

--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -793,7 +793,17 @@ func (d *db) applyPut(batch kvstore.WriteBatch, baseVersionId *atomic.Int64, not
 
 	// Marshal the entry directly into the batch arena: marshal-then-Put would
 	// allocate an intermediate buffer and copy the entry twice
-	if err = batch.PutMarshalable(putReq.Key, se); err != nil {
+	err = batch.PutMarshalable(putReq.Key, se)
+	// The entry borrowed the request's buffers (Value, SecondaryIndexes), and
+	// the marshal above was their last reader. Detach them before the pool
+	// return: ResetVT keeps the Value capacity and the SecondaryIndexes slice
+	// for reuse, and a later Deserialize into this pooled entry appends into
+	// that capacity — the apply path decodes requests with UnmarshalVTUnsafe,
+	// so the borrowed buffer is the WAL entry payload, still aliased by every
+	// other operation of the same entry.
+	se.Value = nil
+	se.SecondaryIndexes = nil
+	if err != nil {
 		return nil, err
 	}
 

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -215,6 +215,9 @@ func (t *wal) readAtIndex(index int64) (entry *proto.LogEntry, previousCrc uint3
 	}
 
 	entry = &proto.LogEntry{}
+	// Keep the copying unmarshal: entry.Value must be a private heap buffer,
+	// because ApplyLogEntry decodes it zero-copy and the aliases must survive
+	// segment unmap/close. (The codec also copies records out of the mmap.)
 	if err = entry.UnmarshalVT(val); err != nil {
 		t.readErrors.Inc()
 		return nil, 0, 0, err


### PR DESCRIPTION
### Motivation

The follower apply path decodes every committed entry through a pooled `LogEntryValue` before `ProcessWrite`. A ser/de benchmark measured the pooled `UnmarshalVT` at ~6.6µs for a 32-put/512B batch vs ~2.5µs with `UnmarshalVTUnsafe` (~2.7x), since the unsafe variant aliases string/bytes fields into the source buffer instead of copying every field.

### Changes

- **`statemachine.ApplyLogEntry` / `ApplyLogEntryWithSplitFilter`** now decode with `UnmarshalVTUnsafe`, with a comment documenting the lifetime contract. The aliasing is safe because `entry.Value` is a private heap buffer — the WAL reader materializes each `LogEntry` with a copying unmarshal, and the segment codec copies records out of the mmap — and every consumer traced through `ProcessWrite`/`ProcessControlRequest` copies what it persists (Pebble batch arena, sealed notifications) and retains nothing past the call. The pool only recycles the top-level `LogEntryValue` (`ResetVT` nils the oneof), so aliased sub-messages are never handed out again.
- **Prerequisite fix in `applyPut`**: it returned its pooled `StorageEntry` with the request's `Value`/`SecondaryIndexes` still attached. `ResetVT` retains bytes capacity across pool cycles, and the copying `Deserialize` in the delete-range paths appends into that retained capacity — under zero-copy decode that borrowed buffer is the WAL entry payload, still aliased by the remaining operations of the same entry (and the pool is process-global, so a concurrent apply on another shard could be corrupted as well). `applyPut` now detaches the borrowed buffers right after `PutMarshalable`, their last reader.
- **Regression test** (`TestApplyLogEntry_DeleteRangeDoesNotCorruptAliasedEntry`): a single entry with puts followed by delete-ranges, where the deleted key's stored value is sized to exactly fill the donated pool capacity. With the detach reverted it fails as predicted: the range-delete notification key turns into the deleted entry's stored bytes and the second range delete skips its key.
- A guard comment in `wal.readAtIndex` marking the copying `LogEntry` unmarshal as load-bearing for the zero-copy apply path.

### Verification

- `make test` (race, all modules incl. `tests/` integration): 90/90 packages ok
- Maelstrom lin-kv, 4 nodes, 60s, `--nemesis kill` (forces WAL replay through the new decode on every restart): `:valid? true`
- Maelstrom lin-kv, 4 nodes, 60s, `--nemesis partition`: `:valid? true`

A possible follow-up: `readAtIndex` could decode the `LogEntry` itself with `UnmarshalVTUnsafe` (the codec already hands it a private copy), eliding one more full-payload copy per WAL read — left out here since it widens the contract to all `Reader` consumers.