### PR TITLE
fix: reject non-local snapshot chunk names in AddChunk

### DIFF
--- a/oxiad/dataserver/database/kvstore/kv_pebble.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble.go
@@ -819,6 +819,12 @@ func (sl *pebbleSnapshotLoader) AddChunk(fileName string, chunkIndex int32, chun
 		if sl.file != nil {
 			return errors.Errorf("Inconsistent snapshot: previous file not finished")
 		}
+		// fileName arrives from the snapshot sender over the network. Reject any
+		// name that isn't confined to the loader directory so a peer can't use
+		// path components like "../" to write outside of it.
+		if !filepath.IsLocal(fileName) {
+			return errors.Errorf("invalid snapshot chunk file name: %q", fileName)
+		}
 		sl.file, err = os.OpenFile(filepath.Join(sl.dbPath, fileName), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return err

--- a/oxiad/dataserver/database/kvstore/kv_pebble.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble.go
@@ -819,10 +819,11 @@ func (sl *pebbleSnapshotLoader) AddChunk(fileName string, chunkIndex int32, chun
 		if sl.file != nil {
 			return errors.Errorf("Inconsistent snapshot: previous file not finished")
 		}
-		// fileName arrives from the snapshot sender over the network. Reject any
-		// name that isn't confined to the loader directory so a peer can't use
-		// path components like "../" to write outside of it.
-		if !filepath.IsLocal(fileName) {
+		// fileName arrives from the snapshot sender over the network. The sender
+		// only ever emits the base names of the regular files sitting directly in
+		// the checkpoint dir, so require exactly that: no traversal, no absolute
+		// path, no nested path, and not the loader dir itself.
+		if fileName != filepath.Base(fileName) || fileName == "." || !filepath.IsLocal(fileName) {
 			return errors.Errorf("invalid snapshot chunk file name: %q", fileName)
 		}
 		sl.file, err = os.OpenFile(filepath.Join(sl.dbPath, fileName), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)

--- a/oxiad/dataserver/database/kvstore/kv_pebble_test.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble_test.go
@@ -685,6 +685,34 @@ func TestPebbleSnapshot_Loader(t *testing.T) {
 	assert.NoError(t, factory2.Close())
 }
 
+func TestPebbleSnapshotLoader_RejectsPathTraversal(t *testing.T) {
+	dataDir := t.TempDir()
+	factory, err := NewPebbleKVFactory(&FactoryOptions{
+		DataDir:     dataDir,
+		CacheSizeMB: 1,
+	})
+	assert.NoError(t, err)
+
+	loader, err := factory.NewSnapshotLoader(constant.DefaultNamespace, 1)
+	assert.NoError(t, err)
+
+	dbPath := filepath.Join(dataDir, constant.DefaultNamespace, "shard-1")
+	// Point the chunk name above the data dir; the sender only ever emits plain
+	// file names, so a name carrying ".." can only come from a hostile peer.
+	outside := filepath.Join(filepath.Dir(dataDir), "escape-marker.txt")
+	rel, err := filepath.Rel(dbPath, outside)
+	assert.NoError(t, err)
+
+	err = loader.AddChunk(rel, 0, 1, []byte("payload"))
+	assert.Error(t, err)
+
+	_, statErr := os.Stat(outside)
+	assert.True(t, os.IsNotExist(statErr))
+
+	assert.NoError(t, loader.Close())
+	assert.NoError(t, factory.Close())
+}
+
 func TestPebbleRangeScanNoLimits(t *testing.T) {
 	factory, err := NewPebbleKVFactory(NewFactoryOptionsForTest(t))
 	assert.NoError(t, err)

--- a/oxiad/dataserver/database/kvstore/kv_pebble_test.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/common/compare"
 	"github.com/oxia-db/oxia/common/constant"
@@ -691,23 +692,32 @@ func TestPebbleSnapshotLoader_RejectsPathTraversal(t *testing.T) {
 		DataDir:     dataDir,
 		CacheSizeMB: 1,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loader, err := factory.NewSnapshotLoader(constant.DefaultNamespace, 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dbPath := filepath.Join(dataDir, constant.DefaultNamespace, "shard-1")
 	// Point the chunk name above the data dir; the sender only ever emits plain
 	// file names, so a name carrying ".." can only come from a hostile peer.
 	outside := filepath.Join(filepath.Dir(dataDir), "escape-marker.txt")
 	rel, err := filepath.Rel(dbPath, outside)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = loader.AddChunk(rel, 0, 1, []byte("payload"))
 	assert.Error(t, err)
 
 	_, statErr := os.Stat(outside)
 	assert.True(t, os.IsNotExist(statErr))
+
+	// Anything else that isn't a plain file name is rejected too, so a peer can't
+	// reach into a nested path or name the loader dir itself.
+	for _, fileName := range []string{"", ".", "..", "sub/dir/file", "./MANIFEST-000001", outside} {
+		assert.Error(t, loader.AddChunk(fileName, 0, 1, []byte("payload")), "expected %q to be rejected", fileName)
+	}
+
+	// A name the sender actually emits still goes through.
+	assert.NoError(t, loader.AddChunk(markerFileName, 0, 1, []byte("payload")))
 
 	assert.NoError(t, loader.Close())
 	assert.NoError(t, factory.Close())


### PR DESCRIPTION
When a follower installs a snapshot it streams SnapshotChunk messages from the sending peer and writes each one to a file named by the chunk. pebbleSnapshotLoader.AddChunk takes that name straight off the wire and joins it onto the loader directory with filepath.Join before opening the file for writing. Because filepath.Join cleans the result but does not keep it under the base, a name that walks upward with ../ lands outside the snapshot directory, so the sender controls where the bytes go rather than just what they contain. I noticed it while reading the receive path in follower_controller.loadSnapshotChunks, where firstChunk.Name and snapChunk.Name flow into the loader with no validation, and confirmed a chunk named to escape the shard directory gets written above it. The sender only ever emits plain file names from the checkpoint dir, so the fix is to reject anything that is not a local path with filepath.IsLocal before opening it. I kept the check inside AddChunk so every caller of the loader is covered, and added a regression test alongside the existing loader test.