### PR TITLE
fix: bound secondary-index get to the requested index's key region

### DIFF
--- a/oxiad/dataserver/controller/lead/secondary_indexes.go
+++ b/oxiad/dataserver/controller/lead/secondary_indexes.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
@@ -335,7 +336,8 @@ func secondaryIndexGet(req *proto.GetRequest, db database.DB) (*proto.GetRespons
 //nolint:revive
 func doSecondaryGet(db database.DB, req *proto.GetRequest) (primaryKey string, secondaryKey string, err error) {
 	indexName := *req.SecondaryIndexName
-	searchKey := fmt.Sprintf(secondaryIdxRangePrefixFormat, indexName, req.Key)
+	indexPrefix := fmt.Sprintf(secondaryIdxRangePrefixFormat, indexName, "")
+	searchKey := indexPrefix + req.Key
 	it, err := db.KeyIterator(true)
 	if err != nil {
 		return "", "", err
@@ -348,17 +350,23 @@ func doSecondaryGet(db database.DB, req *proto.GetRequest) (primaryKey string, s
 	} else {
 		// For all the other cases, we set the iterator on >=
 		it.SeekGE(searchKey)
-	}
 
-	if !it.Valid() && (req.ComparisonType == proto.KeyComparisonType_FLOOR ||
-		req.ComparisonType == proto.KeyComparisonType_CEILING) {
-		// There might be more keys in the db. Let's try to compare it
-		// to the highest one
-		it.Prev()
+		if req.ComparisonType == proto.KeyComparisonType_FLOOR &&
+			(!it.Valid() || !strings.HasPrefix(it.Key(), indexPrefix)) {
+			// There is no entry of this index at or after the search key: the
+			// floor candidate, if any, is the last index entry before it.
+			it.SeekLT(searchKey)
+		}
 	}
 
 	for it.Valid() {
 		itKey := it.Key()
+		if !strings.HasPrefix(itKey, indexPrefix) {
+			// We stepped out of the region of the requested index: entries of
+			// other indexes (or other keyspaces) must not be considered.
+			break
+		}
+
 		primaryKey, secondaryKey, err = secondaryIndexPrimaryAndSecondaryKey(itKey)
 		if err != nil && !errors.Is(err, errFailedToParseSecondaryKey) {
 			return "", "", err
@@ -406,9 +414,6 @@ func doSecondaryGet(db database.DB, req *proto.GetRequest) (primaryKey string, s
 		}
 	}
 
-	if !it.Valid() {
-		primaryKey = ""
-	}
-
-	return primaryKey, secondaryKey, err
+	// The walk ran out of entries of the requested index without finding a match
+	return "", "", nil
 }

--- a/oxiad/dataserver/controller/lead/secondary_indexes_test.go
+++ b/oxiad/dataserver/controller/lead/secondary_indexes_test.go
@@ -339,6 +339,100 @@ func TestSecondaryIndices_MultipleKeysForSameIdx(t *testing.T) {
 	assert.NoError(t, walFactory.Close())
 }
 
+func TestSecondaryIndices_GetBoundedToRequestedIndex(t *testing.T) {
+	var shard int64 = 1
+
+	kvFactory, _ := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	walFactory := newTestWalFactory(t)
+
+	lc, _ := NewLeaderController(&option.StorageOptions{}, constant.DefaultNamespace, shard, rpc.NewMockRpcClient(), walFactory, kvFactory, nil)
+	_, _ = lc.NewTerm(&proto.NewTermRequest{Shard: shard, Term: 1})
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
+		Shard:             shard,
+		Term:              1,
+		ReplicationFactor: 1,
+		FollowerMaps:      nil,
+	})
+
+	// Three indexes whose regions are adjacent in the key space:
+	// "id" < "md5" < "schemaId". The "md5" index only contains "m", so gets
+	// around its edges must not return entries of the neighboring indexes.
+	_, err := lc.WriteBlock(context.Background(), &proto.WriteRequest{
+		Shard: &shard,
+		Puts: []*proto.PutRequest{
+			{Key: "/id-aa", Value: []byte("0"), SecondaryIndexes: []*proto.SecondaryIndex{{IndexName: "id", SecondaryKey: "aa"}}},
+			{Key: "/md5-m", Value: []byte("1"), SecondaryIndexes: []*proto.SecondaryIndex{{IndexName: "md5", SecondaryKey: "m"}}},
+			{Key: "/schema-zz", Value: []byte("2"), SecondaryIndexes: []*proto.SecondaryIndex{{IndexName: "schemaId", SecondaryKey: "zz"}}},
+		},
+	})
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		comparison     proto.KeyComparisonType
+		index          string
+		key            string
+		expectedKey    string // "" means KEY_NOT_FOUND expected
+		expectedSecKey string
+	}{
+		// Same-index matches around the "md5" entry.
+		{"equal-match", proto.KeyComparisonType_EQUAL, "md5", "m", "/md5-m", "m"},
+		{"ceiling-from-below", proto.KeyComparisonType_CEILING, "md5", "b", "/md5-m", "m"},
+		{"higher-from-below", proto.KeyComparisonType_HIGHER, "md5", "b", "/md5-m", "m"},
+		{"floor-from-above", proto.KeyComparisonType_FLOOR, "md5", "x", "/md5-m", "m"},
+		{"lower-from-above", proto.KeyComparisonType_LOWER, "md5", "x", "/md5-m", "m"},
+
+		// Below the lowest "md5" entry: must not return entries of the
+		// preceding "id" index.
+		{"floor-below-all", proto.KeyComparisonType_FLOOR, "md5", "b", "", ""},
+		{"lower-below-all", proto.KeyComparisonType_LOWER, "md5", "b", "", ""},
+		{"equal-of-preceding-index", proto.KeyComparisonType_EQUAL, "md5", "aa", "", ""},
+
+		// Above the highest "md5" entry: must not return entries of the
+		// following "schemaId" index.
+		{"ceiling-above-all", proto.KeyComparisonType_CEILING, "md5", "x", "", ""},
+		{"higher-above-all", proto.KeyComparisonType_HIGHER, "md5", "x", "", ""},
+		{"higher-at-max", proto.KeyComparisonType_HIGHER, "md5", "m", "", ""},
+		{"equal-of-following-index", proto.KeyComparisonType_EQUAL, "md5", "zz", "", ""},
+
+		// Index with no entries at all: the neighboring indexes must stay
+		// invisible.
+		{"floor-missing-index", proto.KeyComparisonType_FLOOR, "missing", "x", "", ""},
+		{"ceiling-missing-index", proto.KeyComparisonType_CEILING, "missing", "b", "", ""},
+		{"lower-missing-index", proto.KeyComparisonType_LOWER, "missing", "x", "", ""},
+		{"higher-missing-index", proto.KeyComparisonType_HIGHER, "missing", "b", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resps, err := readAll(context.Background(), lc, &proto.ReadRequest{
+				Shard: &shard,
+				Gets: []*proto.GetRequest{{
+					Key:                tc.key,
+					ComparisonType:     tc.comparison,
+					SecondaryIndexName: pb.String(tc.index),
+				}},
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(resps))
+
+			res := resps[0]
+			if tc.expectedKey == "" {
+				assert.Equal(t, proto.Status_KEY_NOT_FOUND, res.Status)
+				assert.Nil(t, res.Key)
+			} else {
+				assert.Equal(t, proto.Status_OK, res.Status)
+				assert.Equal(t, tc.expectedKey, *res.Key)
+				assert.Equal(t, tc.expectedSecKey, *res.SecondaryIndexKey)
+			}
+		})
+	}
+
+	assert.NoError(t, lc.Close())
+	assert.NoError(t, kvFactory.Close())
+	assert.NoError(t, walFactory.Close())
+}
+
 func TestDoSecondaryGet_UnsupportedComparisonType(t *testing.T) {
 	var shard int64 = 1
 


### PR DESCRIPTION
### Motivation

`doSecondaryGet()` iterates an unbounded `KeyIterator` and parses any `__oxia/idx/<anyIndex>/<sec>\x01<pk>` entry it lands on, without verifying that the entry belongs to the requested index. Whenever the requested index has no matching entry in the walk direction, `SeekGE`/`SeekLT`/`Prev`/`Next` cross into a neighboring index's region (or other keyspaces), and the value comparisons can then return a primary key belonging to a *different* secondary index:

- `FLOOR`/`LOWER` below the index's lowest entry walk into the preceding index and can return its records when the foreign secondary key satisfies the comparison.
- `CEILING`/`HIGHER` above the highest entry land in the following index and can return its records.
- `EQUAL` can return a foreign record when the requested index has no entries at/after the key and a neighboring index contains an exact secondary-key match.
- Even when the comparison guards happen to produce `KEY_NOT_FOUND`, the walk can scan unrelated regions entry by entry (other indexes, sessions, ...) before giving up.

This is the residue of the bug partially fixed in #763: that fix added the value-comparison guards but not index-boundary enforcement. Found while investigating a schema-id duplication where a get on one index returned a record indexed under a different index.

### Changes

- Derive the index's key-space prefix (`__oxia/idx/<indexName>/`) and stop the walk as soon as the iterated key leaves it.
- For `FLOOR`, when there is no entry of the index at or after the search key, reposition with `SeekLT(searchKey)` — which lands either inside the index's region or below it, never above — instead of relying on `Prev()` to walk down across foreign keys.
- Drop the `CEILING` past-the-end fallback: if nothing ≥ the search key exists, there is no ceiling candidate by construction, so the answer is `KEY_NOT_FOUND` either way.
- Exiting the walk without a match returns empty explicitly instead of the leftover named return values, which could otherwise leak a stale previously-parsed entry.

### Verification

New `TestSecondaryIndices_GetBoundedToRequestedIndex` sets up three adjacent index regions (`id` < `md5` < `schemaId`) and probes every comparison type at both edges of the middle index, plus an index with no entries at all. Before the fix, 10 of the 16 cases returned a record of a neighboring index; they now assert `KEY_NOT_FOUND`. The same-index cases guard against over-restricting the walk (`floor-from-above` specifically exercises the new `SeekLT` repositioning).