### PR TITLE
perf: commit the split filter in bounded chunks

### DIFF
--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -170,7 +170,7 @@ func rotateSplitBatchIfFull(kv kvstore.KV, batch kvstore.WriteBatch, chunks *int
 	if err := batch.Close(); err != nil {
 		return batch, errors.Wrap(err, "failed to close split filter chunk")
 	}
-	*chunks++
+	(*chunks)++
 	return kv.NewWriteBatch(), nil
 }
 

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -111,31 +111,19 @@ func FilterDBForSplit(kv kvstore.KV, hashRange *proto.HashRange) error {
 				keptKeys++
 			}
 		} else {
-			// User data key
-			value, err := it.Value()
+			deleted, err := filterUserKey(it, batch, key, hashRange)
 			if err != nil {
-				return errors.Wrapf(err, "failed to read value for key %q", key)
+				return err
 			}
-
-			if !isUserKeyInRange(key, value, hashRange) {
-				if err := batch.Delete(key); err != nil {
-					return err
-				}
+			if deleted {
 				deletedKeys++
 			} else {
 				keptKeys++
 			}
 		}
 
-		if batch.Count() >= splitFilterMaxBatchCount || batch.Size() >= splitFilterMaxBatchBytes {
-			if err := batch.Commit(); err != nil {
-				return errors.Wrap(err, "failed to commit split filter chunk")
-			}
-			if err := batch.Close(); err != nil {
-				return errors.Wrap(err, "failed to close split filter chunk")
-			}
-			batch = kv.NewWriteBatch()
-			chunks++
+		if batch, err = rotateSplitBatchIfFull(kv, batch, &chunks); err != nil {
+			return err
 		}
 
 		it.Next()
@@ -151,6 +139,39 @@ func FilterDBForSplit(kv kvstore.KV, hashRange *proto.HashRange) error {
 	)
 
 	return batch.Commit()
+}
+
+// filterUserKey deletes the user key when it falls outside the child's hash
+// range, reporting whether it did.
+func filterUserKey(it kvstore.KeyValueIterator, batch kvstore.WriteBatch, key string, hashRange *proto.HashRange) (bool, error) {
+	value, err := it.Value()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to read value for key %q", key)
+	}
+
+	if isUserKeyInRange(key, value, hashRange) {
+		return false, nil
+	}
+	if err := batch.Delete(key); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// rotateSplitBatchIfFull commits and closes the batch once it reaches the
+// chunk thresholds, returning a fresh batch to continue with.
+func rotateSplitBatchIfFull(kv kvstore.KV, batch kvstore.WriteBatch, chunks *int64) (kvstore.WriteBatch, error) {
+	if batch.Count() < splitFilterMaxBatchCount && batch.Size() < splitFilterMaxBatchBytes {
+		return batch, nil
+	}
+	if err := batch.Commit(); err != nil {
+		return batch, errors.Wrap(err, "failed to commit split filter chunk")
+	}
+	if err := batch.Close(); err != nil {
+		return batch, errors.Wrap(err, "failed to close split filter chunk")
+	}
+	*chunks++
+	return kv.NewWriteBatch(), nil
 }
 
 type splitAction int

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -34,6 +34,22 @@ const (
 	idxKeyPrefix     = constant.InternalKeyPrefix + "idx"
 	idxSeparator     = "\x01"
 	sessionKeyLength = len(sessionKeyPrefix) + 1 + 16 // __oxia/session/ + 16 hex digits
+
+	// Filtering deletes about half the shard: accumulated in a single indexed
+	// batch, that grows to GB scale (batch arena plus the batch skiplist).
+	// Committing in bounded chunks keeps the memory flat. This is safe here:
+	// nothing reads through the batch (every classification reads the
+	// iterator, which keeps the consistent view it was created with across
+	// commits), the child is not serving yet so there are no concurrent
+	// writers, and the filter is idempotent — on a failed snapshot load it
+	// either re-runs or the snapshot is re-sent wholesale.
+)
+
+// Vars, not consts, so tests can shrink them to exercise the chunk rotation
+// with small datasets.
+var (
+	splitFilterMaxBatchCount = 100_000
+	splitFilterMaxBatchBytes = 8 * 1024 * 1024
 )
 
 var secondaryIdxRegex = regexp.MustCompile(
@@ -59,7 +75,9 @@ func FilterDBForSplit(kv kvstore.KV, hashRange *proto.HashRange) error {
 	)
 
 	batch := kv.NewWriteBatch()
-	defer batch.Close()
+	// Closes whichever batch is current when returning; rotated chunks are
+	// closed at rotation
+	defer func() { _ = batch.Close() }()
 
 	it, err := kv.RangeScan("", "", kvstore.ShowInternalKeys)
 	if err != nil {
@@ -68,6 +86,7 @@ func FilterDBForSplit(kv kvstore.KV, hashRange *proto.HashRange) error {
 	defer it.Close()
 
 	var deletedKeys, keptKeys, filteredNotifications, deletedNotifications int64
+	chunks := int64(1)
 
 	for it.Valid() {
 		key := it.Key()
@@ -108,6 +127,17 @@ func FilterDBForSplit(kv kvstore.KV, hashRange *proto.HashRange) error {
 			}
 		}
 
+		if batch.Count() >= splitFilterMaxBatchCount || batch.Size() >= splitFilterMaxBatchBytes {
+			if err := batch.Commit(); err != nil {
+				return errors.Wrap(err, "failed to commit split filter chunk")
+			}
+			if err := batch.Close(); err != nil {
+				return errors.Wrap(err, "failed to close split filter chunk")
+			}
+			batch = kv.NewWriteBatch()
+			chunks++
+		}
+
 		it.Next()
 	}
 
@@ -117,6 +147,7 @@ func FilterDBForSplit(kv kvstore.KV, hashRange *proto.HashRange) error {
 		slog.Int64("kept-keys", keptKeys),
 		slog.Int64("filtered-notifications", filteredNotifications),
 		slog.Int64("deleted-notifications", deletedNotifications),
+		slog.Int64("chunks", chunks),
 	)
 
 	return batch.Commit()

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -461,20 +461,27 @@ func TestFilterDBForSplit_ChunkedCommits(t *testing.T) {
 		inRange[k] = h >= leftRange.Min && h <= leftRange.Max
 	}
 
-	// A couple of notification batches spanning both sides, and one fully
-	// out-of-range (must be deleted)
-	putNotificationBatch(t, kv, 0, map[string]*proto.Notification{
-		"chunked-key-0000": {Type: proto.NotificationType_KEY_CREATED},
-		"chunked-key-0001": {Type: proto.NotificationType_KEY_CREATED},
-	})
-	var outOfRangeKey string
+	// Pick one key from each side of the range, so the mixed notification
+	// batch below is filtered — not kept whole, not deleted whole — by
+	// construction rather than by luck of the hardcoded hashes
+	var inRangeKey, outOfRangeKey string
 	for k, in := range inRange {
-		if !in {
+		if in && inRangeKey == "" {
+			inRangeKey = k
+		}
+		if !in && outOfRangeKey == "" {
 			outOfRangeKey = k
-			break
 		}
 	}
+	assert.NotEmpty(t, inRangeKey)
 	assert.NotEmpty(t, outOfRangeKey)
+
+	// One mixed batch (must be filtered down to the in-range entry) and one
+	// fully out-of-range batch (must be deleted)
+	putNotificationBatch(t, kv, 0, map[string]*proto.Notification{
+		inRangeKey:    {Type: proto.NotificationType_KEY_CREATED},
+		outOfRangeKey: {Type: proto.NotificationType_KEY_CREATED},
+	})
 	putNotificationBatch(t, kv, 1, map[string]*proto.Notification{
 		outOfRangeKey: {Type: proto.NotificationType_KEY_CREATED},
 	})
@@ -492,11 +499,10 @@ func TestFilterDBForSplit_ChunkedCommits(t *testing.T) {
 	assert.Greater(t, deleted, 3*splitFilterMaxBatchCount)
 
 	// The out-of-range-only notification batch is gone; the mixed one is
-	// filtered down to its in-range entries
+	// filtered down to exactly its in-range entry
 	assert.Nil(t, readNotificationBatch(t, kv, 1))
 	nb := readNotificationBatch(t, kv, 0)
 	assert.NotNil(t, nb)
-	for _, entry := range nb.Notifications {
-		assert.True(t, inRange[entry.GetKey()])
-	}
+	assert.Equal(t, 1, len(nb.Notifications))
+	assert.Equal(t, inRangeKey, nb.Notifications[0].GetKey())
 }

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -436,3 +436,67 @@ func TestFilterWriteRequestForSplit_Nil(t *testing.T) {
 	leftRange, _ := splitRanges()
 	assert.Nil(t, FilterWriteRequestForSplit(nil, leftRange))
 }
+
+// The filter commits in bounded chunks so half-shard deletions do not
+// accumulate into one GB-scale indexed batch. With the thresholds shrunk,
+// the rotation runs many times mid-iteration: every key must still end up on
+// the right side, which also pins that the range-scan iterator keeps its
+// consistent view across the interleaved commits.
+func TestFilterDBForSplit_ChunkedCommits(t *testing.T) {
+	oldCount, oldBytes := splitFilterMaxBatchCount, splitFilterMaxBatchBytes
+	splitFilterMaxBatchCount, splitFilterMaxBatchBytes = 7, 1<<20
+	defer func() {
+		splitFilterMaxBatchCount, splitFilterMaxBatchBytes = oldCount, oldBytes
+	}()
+
+	kv := newTestKV(t)
+	leftRange, _ := splitRanges()
+
+	const numKeys = 200
+	inRange := map[string]bool{}
+	for i := 0; i < numKeys; i++ {
+		k := fmt.Sprintf("chunked-key-%04d", i)
+		putStorageEntry(t, kv, k, nil)
+		h := hash.Xxh332(k)
+		inRange[k] = h >= leftRange.Min && h <= leftRange.Max
+	}
+
+	// A couple of notification batches spanning both sides, and one fully
+	// out-of-range (must be deleted)
+	putNotificationBatch(t, kv, 0, map[string]*proto.Notification{
+		"chunked-key-0000": {Type: proto.NotificationType_KEY_CREATED},
+		"chunked-key-0001": {Type: proto.NotificationType_KEY_CREATED},
+	})
+	var outOfRangeKey string
+	for k, in := range inRange {
+		if !in {
+			outOfRangeKey = k
+			break
+		}
+	}
+	assert.NotEmpty(t, outOfRangeKey)
+	putNotificationBatch(t, kv, 1, map[string]*proto.Notification{
+		outOfRangeKey: {Type: proto.NotificationType_KEY_CREATED},
+	})
+
+	assert.NoError(t, FilterDBForSplit(kv, leftRange))
+
+	deleted := 0
+	for k, in := range inRange {
+		assert.Equal(t, in, keyExists(t, kv, k), "key %s (in-range=%v)", k, in)
+		if !in {
+			deleted++
+		}
+	}
+	// Sanity: the dataset actually forced multiple chunk rotations
+	assert.Greater(t, deleted, 3*splitFilterMaxBatchCount)
+
+	// The out-of-range-only notification batch is gone; the mixed one is
+	// filtered down to its in-range entries
+	assert.Nil(t, readNotificationBatch(t, kv, 1))
+	nb := readNotificationBatch(t, kv, 0)
+	assert.NotNil(t, nb)
+	for _, entry := range nb.Notifications {
+		assert.True(t, inRange[entry.GetKey()])
+	}
+}


### PR DESCRIPTION
### Motivation

Item 2.7 (split-filter sub-item) from the performance review: filtering a child shard after a split deletes roughly half the keys, and all of it accumulated in a **single indexed batch** — batch arena plus the indexed-batch skiplist grow to GB scale on large shards, held in memory until the one final commit.

### Changes

`FilterDBForSplit` now commits in bounded chunks — **100k ops or 8 MB, whichever comes first** — keeping memory flat regardless of shard size. The completion log gains a `chunks` count.

Why chunking is safe here, on every axis:

- **No read-your-writes**: every classification decision (user keys, notification rewrites, session shadows, secondary indexes) reads the range-scan **iterator**, never the batch — and the Pebble iterator keeps the consistent view it was created with across the interleaved commits.
- **No concurrent writers**: the only caller is the follower controller's snapshot-load path, before the child acks the snapshot — the shard is not serving yet.
- **Atomicity is not load-bearing**: the filter is idempotent (deterministic classification; deleting absent keys is a no-op; the notification rewrite is deterministic), so on a failed load the snapshot is either re-sent wholesale or the filter re-runs and converges to the same state.

`DeleteRange` — the review's alternative suggestion — does not apply: the out-of-range keys are hash-scattered across the keyspace, not contiguous.

The chunk thresholds are unexported vars (not consts) only so the test can shrink them; nothing mutates them at runtime. A second commit extracts the rotation and the user-key branch into helpers — the inline block pushed `FilterDBForSplit` to cognitive complexity 33 against the pinned linter's max of 25.

### Verification

- New `TestFilterDBForSplit_ChunkedCommits`: thresholds shrunk to force ~14 rotations across 200 keys plus notification batches; asserts every key lands on the correct side of the hash range (which also pins that the iterator survives the interleaved commits) and that notification filtering is unaffected. Verified to discriminate: against a rotation that drops its chunk (Close without Commit), it fails 91 assertions.
- All existing `TestFilterDBForSplit_*` tests pass unchanged (single-chunk path intact).
- `go test -race` green on `oxiad/dataserver/database/...`, the follower controller package, and the split e2e suite (`tests/coordinator -run Split`).
- `golangci-lint` clean across all go.work modules on the CI-pinned v2.6.2.
