### PR TITLE
perf: cache the last sequence values per prefix

### DIFF
--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -211,7 +211,9 @@ type db struct {
 
 	// Last sequence values per prefix key, maintained by
 	// generateUniqueKeyFromSequences. Only touched from ProcessWrite, which is
-	// single-threaded per shard, so it needs no locking.
+	// single-threaded per shard, so it needs no locking. Bounded at
+	// maxSequenceCacheEntries prefixes (dropped wholesale when full), so the
+	// worst-case footprint is that many prefix strings plus a few words each.
 	sequenceCache map[string][]uint64
 
 	putCounter                metric.Counter

--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -140,6 +140,7 @@ func NewDB(namespace string, shardId int64, factory kvstore.Factory,
 		notificationsEnabled:  true,
 		enabledFeatures:       sync.Map{},
 		sequenceWaiterTracker: NewSequencesWaitTracker(),
+		sequenceCache:         map[string][]uint64{},
 		log: slog.With(
 			slog.String("component", "db"),
 			slog.String("namespace", namespace),
@@ -207,6 +208,11 @@ type db struct {
 	notificationsEnabled  bool
 	enabledFeatures       sync.Map
 	sequenceWaiterTracker SequenceWaiterTracker
+
+	// Last sequence values per prefix key, maintained by
+	// generateUniqueKeyFromSequences. Only touched from ProcessWrite, which is
+	// single-threaded per shard, so it needs no locking.
+	sequenceCache map[string][]uint64
 
 	putCounter                metric.Counter
 	deleteCounter             metric.Counter
@@ -728,11 +734,16 @@ func (d *db) applyPut(batch kvstore.WriteBatch, baseVersionId *atomic.Int64, not
 	var newKey string
 	if len(putReq.GetSequenceKeyDelta()) > 0 {
 		prefixKey := putReq.Key
-		newKey, err = generateUniqueKeyFromSequences(batch, putReq)
+		newKey, err = d.generateUniqueKeyFromSequences(batch, putReq)
 		putReq.Key = newKey
 		d.sequenceWaiterTracker.SequenceUpdated(prefixKey, newKey)
-	} else if !internal {
-		se, err = checkExpectedVersionId(batch, putReq.Key, putReq.ExpectedVersionId)
+	} else {
+		// A direct put of a sequence-shaped key moves the sequence tail
+		// without going through the cache
+		d.invalidateSequenceCache(putReq.Key)
+		if !internal {
+			se, err = checkExpectedVersionId(batch, putReq.Key, putReq.ExpectedVersionId)
+		}
 	}
 
 	switch {
@@ -824,6 +835,10 @@ func (d *db) applyPut(batch kvstore.WriteBatch, baseVersionId *atomic.Int64, not
 }
 
 func (d *db) applyDelete(batch kvstore.WriteBatch, notifications *Notifications, delReq *proto.DeleteRequest, updateOperationCallback UpdateOperationCallback) (*proto.DeleteResponse, error) {
+	// Deleting the last key of a sequence moves its tail backwards: the next
+	// sequential put must re-read storage
+	d.invalidateSequenceCache(delReq.Key)
+
 	se, err := checkExpectedVersionId(batch, delReq.Key, delReq.ExpectedVersionId)
 	if se != nil {
 		defer se.ReturnToVTPool()
@@ -861,6 +876,12 @@ func (d *db) applyDelete(batch kvstore.WriteBatch, notifications *Notifications,
 const DeleteRangeThreshold = 100
 
 func (d *db) applyDeleteRange(batch kvstore.WriteBatch, notifications *Notifications, delReq *proto.DeleteRangeRequest, updateOperationCallback UpdateOperationCallback) (*proto.DeleteRangeResponse, error) {
+	// A range delete can cover any sequence tail: drop the whole cache rather
+	// than intersecting ranges with prefixes
+	if len(d.sequenceCache) > 0 {
+		clear(d.sequenceCache)
+	}
+
 	if notifications != nil {
 		notifications.DeletedRange(delReq.StartInclusive, delReq.EndExclusive)
 	}

--- a/oxiad/dataserver/database/db_benchmark_sequences_test.go
+++ b/oxiad/dataserver/database/db_benchmark_sequences_test.go
@@ -1,0 +1,55 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+	time2 "github.com/oxia-db/oxia/common/time"
+
+	"github.com/oxia-db/oxia/oxiad/dataserver/database/kvstore"
+)
+
+func BenchmarkSequencePut(b *testing.B) {
+	factory, err := kvstore.NewPebbleKVFactory(&kvstore.FactoryOptions{DataDir: b.TempDir()})
+	assert.NoError(b, err)
+	defer factory.Close()
+	db, err := NewDB(constant.DefaultNamespace, 1, factory, proto.KeySortingType_NATURAL, 0, time2.SystemClock)
+	assert.NoError(b, err)
+	defer db.Close()
+
+	timestamp := uint64(time.Now().UnixMilli())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := db.ProcessWrite(&proto.WriteRequest{
+			Puts: []*proto.PutRequest{{
+				Key:              "seq-prefix",
+				PartitionKey:     ptr.To("seq-prefix"),
+				Value:            []byte("v"),
+				SequenceKeyDelta: []uint64{1},
+			}},
+		}, int64(i), timestamp, NoOpCallback)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/oxiad/dataserver/database/db_sequences.go
+++ b/oxiad/dataserver/database/db_sequences.go
@@ -37,7 +37,11 @@ const (
 	// maxSequenceCacheEntries bounds the per-shard cache of last sequence
 	// values. When exceeded, the cache is simply dropped: entries are
 	// re-established from storage on the next put for their prefix.
-	maxSequenceCacheEntries = 1024
+	// Measured footprint at this bound: ~9-24MB per shard for realistic
+	// prefix lengths (~140-380B per entry: map slot + prefix bytes + values),
+	// and only for shards that actually use sequences — an empty map costs
+	// nothing.
+	maxSequenceCacheEntries = 64 * 1024
 )
 
 // generateUniqueKeyFromSequences computes the key for a sequential put by

--- a/oxiad/dataserver/database/db_sequences.go
+++ b/oxiad/dataserver/database/db_sequences.go
@@ -17,6 +17,7 @@ package database
 import (
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -28,7 +29,31 @@ import (
 
 const maxSequence = uint64(math.MaxUint64)
 
-func generateUniqueKeyFromSequences(batch kvstore.WriteBatch, req *proto.PutRequest) (string, error) {
+const (
+	// sequenceLen is the fixed width of one formatted sequence value:
+	// 20 decimal digits, enough for any uint64.
+	sequenceLen = 20
+
+	// maxSequenceCacheEntries bounds the per-shard cache of last sequence
+	// values. When exceeded, the cache is simply dropped: entries are
+	// re-established from storage on the next put for their prefix.
+	maxSequenceCacheEntries = 1024
+)
+
+// generateUniqueKeyFromSequences computes the key for a sequential put by
+// advancing the last sequence values of the prefix.
+//
+// The last values per prefix are cached on the db: ProcessWrite is
+// single-threaded per shard, so the cache needs no locking and later
+// sequential puts — including in the same write batch — read it instead of
+// re-scanning the indexed batch and re-parsing the last key. The cache is
+// invalidated wherever storage can move without it: a direct put of a
+// sequence-shaped key and deletes (see invalidateSequenceCache), and range
+// deletes drop it entirely. Ephemeral sequence keys removed by a session
+// expiry bypass the invalidation, which is benign: the cache stays ahead of
+// storage, so subsequent keys are unique with a gap, exactly as if the
+// deleted key still existed.
+func (d *db) generateUniqueKeyFromSequences(batch kvstore.WriteBatch, req *proto.PutRequest) (string, error) {
 	if req.PartitionKey == nil {
 		// All the keys need to be in same shard to guarantee atomicity
 		return "", ErrMissingPartitionKey
@@ -39,12 +64,29 @@ func generateUniqueKeyFromSequences(batch kvstore.WriteBatch, req *proto.PutRequ
 		return "", ErrBadVersionId
 	}
 
-	parts, err := findCurrentLastKeyInSequence(batch, req)
-	if err != nil {
-		return "", err
+	lastValues, cached := d.sequenceCache[req.Key]
+	if !cached {
+		parts, err := findCurrentLastKeyInSequence(batch, req)
+		if err != nil {
+			return "", err
+		}
+		lastValues = make([]uint64, len(parts))
+		for idx, part := range parts {
+			value, err := strconv.ParseUint(part, 10, 64)
+			if err != nil {
+				return "", errors.Wrapf(err, "failed to parse sequence %q", part)
+			}
+			lastValues[idx] = value
+		}
+	} else if len(lastValues) > len(req.SequenceKeyDelta) {
+		// Same check that findCurrentLastKeyInSequence applies on the
+		// storage-derived last key
+		return "", ErrMissingSequenceDeltas
 	}
 
-	newKey := req.Key
+	newValues := make([]uint64, len(req.SequenceKeyDelta))
+	newKey := make([]byte, 0, len(req.Key)+(sequenceLen+1)*len(req.SequenceKeyDelta))
+	newKey = append(newKey, req.Key...)
 	for idx, delta := range req.SequenceKeyDelta {
 		if idx == 0 && delta == 0 {
 			// The first delta in the list must be strictly > 0
@@ -53,20 +95,56 @@ func generateUniqueKeyFromSequences(batch kvstore.WriteBatch, req *proto.PutRequ
 		}
 
 		var lastValue uint64
-		if idx < len(parts) {
-			_, err := fmt.Sscanf(parts[idx], "%020d", &lastValue)
-			if err != nil {
-				return "", err
-			}
-		} else {
-			// There are additional sequences
-			lastValue = 0
+		if idx < len(lastValues) {
+			lastValue = lastValues[idx]
 		}
-
-		newKey = fmt.Sprintf("%s-%020d", newKey, lastValue+delta)
+		newValues[idx] = lastValue + delta
+		newKey = appendSequence(newKey, newValues[idx])
 	}
 
-	return newKey, nil
+	if len(d.sequenceCache) >= maxSequenceCacheEntries {
+		clear(d.sequenceCache)
+	}
+	d.sequenceCache[req.Key] = newValues
+
+	return string(newKey), nil
+}
+
+// appendSequence appends "-" plus the value formatted as 20 zero-padded
+// decimal digits, the same layout fmt.Sprintf("%s-%020d", ...) produced.
+func appendSequence(b []byte, value uint64) []byte {
+	b = append(b, '-')
+	var digits [sequenceLen]byte
+	formatted := strconv.AppendUint(digits[:0], value, 10)
+	for i := len(formatted); i < sequenceLen; i++ {
+		b = append(b, '0')
+	}
+	return append(b, formatted...)
+}
+
+// invalidateSequenceCache drops the cached sequence values whose prefix the
+// given key belongs to. A key belongs to a sequence when it is the prefix
+// followed by one or more "-<20 digits>" segments: a direct put of such a key
+// moves the storage-side tail without going through the cache, and a delete
+// of the last key moves it backwards — both must force the next sequential
+// put to re-read storage.
+func (d *db) invalidateSequenceCache(key string) {
+	if len(d.sequenceCache) == 0 {
+		return
+	}
+	for {
+		n := len(key)
+		if n < sequenceLen+1 || key[n-(sequenceLen+1)] != '-' {
+			return
+		}
+		for i := n - sequenceLen; i < n; i++ {
+			if key[i] < '0' || key[i] > '9' {
+				return
+			}
+		}
+		key = key[:n-(sequenceLen+1)]
+		delete(d.sequenceCache, key)
+	}
 }
 
 func findCurrentLastKeyInSequence(wb kvstore.WriteBatch, req *proto.PutRequest) ([]string, error) {

--- a/oxiad/dataserver/database/db_sequences_test.go
+++ b/oxiad/dataserver/database/db_sequences_test.go
@@ -1,0 +1,174 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+	time2 "github.com/oxia-db/oxia/common/time"
+
+	"github.com/oxia-db/oxia/oxiad/dataserver/database/kvstore"
+)
+
+func newSequenceTestDB(t *testing.T) DB {
+	t.Helper()
+	factory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	db, err := NewDB(constant.DefaultNamespace, 1, factory, proto.KeySortingType_NATURAL, 0, time2.SystemClock)
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, db.Close())
+		assert.NoError(t, factory.Close())
+	})
+	return db
+}
+
+func sequencePut(t *testing.T, db DB, offset int64, prefix string, deltas ...uint64) string {
+	t.Helper()
+	res, err := db.ProcessWrite(&proto.WriteRequest{
+		Puts: []*proto.PutRequest{{
+			Key:              prefix,
+			PartitionKey:     ptr.To(prefix),
+			Value:            []byte("v"),
+			SequenceKeyDelta: deltas,
+		}},
+	}, offset, uint64(time.Now().UnixMilli()), NoOpCallback)
+	assert.NoError(t, err)
+	assert.Equal(t, proto.Status_OK, res.Puts[0].Status)
+	return res.Puts[0].GetKey()
+}
+
+func sequenceKeyOf(prefix string, values ...uint64) string {
+	key := prefix
+	for _, v := range values {
+		key = fmt.Sprintf("%s-%020d", key, v)
+	}
+	return key
+}
+
+// Sequential puts across separate write batches continue the sequence: the
+// second put is served from the cache and must produce the exact key the
+// storage re-read would have produced.
+func TestSequencePut_CrossBatchContinuity(t *testing.T) {
+	db := newSequenceTestDB(t)
+
+	assert.Equal(t, sequenceKeyOf("seq", 1), sequencePut(t, db, 0, "seq", 1))
+	assert.Equal(t, sequenceKeyOf("seq", 3), sequencePut(t, db, 1, "seq", 2))
+	assert.Equal(t, sequenceKeyOf("seq", 4), sequencePut(t, db, 2, "seq", 1))
+}
+
+// Two sequential puts for the same prefix inside one write batch: the second
+// must see the first (previously via the indexed batch, now via the cache).
+func TestSequencePut_SameBatch(t *testing.T) {
+	db := newSequenceTestDB(t)
+
+	res, err := db.ProcessWrite(&proto.WriteRequest{
+		Puts: []*proto.PutRequest{
+			{Key: "seq", PartitionKey: ptr.To("seq"), Value: []byte("a"), SequenceKeyDelta: []uint64{1}},
+			{Key: "seq", PartitionKey: ptr.To("seq"), Value: []byte("b"), SequenceKeyDelta: []uint64{1}},
+		},
+	}, 0, uint64(time.Now().UnixMilli()), NoOpCallback)
+	assert.NoError(t, err)
+	assert.Equal(t, sequenceKeyOf("seq", 1), res.Puts[0].GetKey())
+	assert.Equal(t, sequenceKeyOf("seq", 2), res.Puts[1].GetKey())
+}
+
+// A direct put of a sequence-shaped key moves the tail without going through
+// the sequence path: the next sequential put must continue above it, not from
+// the stale cached value.
+func TestSequencePut_DirectPutInvalidatesCache(t *testing.T) {
+	db := newSequenceTestDB(t)
+
+	assert.Equal(t, sequenceKeyOf("seq", 1), sequencePut(t, db, 0, "seq", 1))
+
+	// Direct put far ahead of the cached tail
+	direct := sequenceKeyOf("seq", 100)
+	_, err := db.ProcessWrite(&proto.WriteRequest{
+		Puts: []*proto.PutRequest{{Key: direct, Value: []byte("x")}},
+	}, 1, uint64(time.Now().UnixMilli()), NoOpCallback)
+	assert.NoError(t, err)
+
+	assert.Equal(t, sequenceKeyOf("seq", 101), sequencePut(t, db, 2, "seq", 1))
+}
+
+// Deleting the last key of the sequence moves the tail backwards: the next
+// sequential put re-reads storage, matching the pre-cache behavior.
+func TestSequencePut_DeleteInvalidatesCache(t *testing.T) {
+	db := newSequenceTestDB(t)
+
+	assert.Equal(t, sequenceKeyOf("seq", 1), sequencePut(t, db, 0, "seq", 1))
+	assert.Equal(t, sequenceKeyOf("seq", 2), sequencePut(t, db, 1, "seq", 1))
+
+	_, err := db.ProcessWrite(&proto.WriteRequest{
+		Deletes: []*proto.DeleteRequest{{Key: sequenceKeyOf("seq", 2)}},
+	}, 2, uint64(time.Now().UnixMilli()), NoOpCallback)
+	assert.NoError(t, err)
+
+	// Tail is back to 1: the next key repeats 2, as it always has
+	assert.Equal(t, sequenceKeyOf("seq", 2), sequencePut(t, db, 3, "seq", 1))
+}
+
+// A range delete can cover any sequence: the cache is dropped entirely.
+func TestSequencePut_DeleteRangeInvalidatesCache(t *testing.T) {
+	db := newSequenceTestDB(t)
+
+	assert.Equal(t, sequenceKeyOf("seq", 1), sequencePut(t, db, 0, "seq", 1))
+	assert.Equal(t, sequenceKeyOf("seq", 2), sequencePut(t, db, 1, "seq", 1))
+
+	_, err := db.ProcessWrite(&proto.WriteRequest{
+		DeleteRanges: []*proto.DeleteRangeRequest{{
+			StartInclusive: sequenceKeyOf("seq", 2),
+			EndExclusive:   sequenceKeyOf("seq", 3),
+		}},
+	}, 2, uint64(time.Now().UnixMilli()), NoOpCallback)
+	assert.NoError(t, err)
+
+	assert.Equal(t, sequenceKeyOf("seq", 2), sequencePut(t, db, 3, "seq", 1))
+}
+
+// The cached path must apply the same validation as the storage path: a put
+// with fewer deltas than the sequence already has levels is rejected.
+func TestSequencePut_MissingDeltasWithCache(t *testing.T) {
+	db := newSequenceTestDB(t)
+
+	assert.Equal(t, sequenceKeyOf("seq", 1, 5), sequencePut(t, db, 0, "seq", 1, 5))
+
+	// Cache hit with fewer deltas than cached levels
+	_, err := db.ProcessWrite(&proto.WriteRequest{
+		Puts: []*proto.PutRequest{{
+			Key:              "seq",
+			PartitionKey:     ptr.To("seq"),
+			Value:            []byte("v"),
+			SequenceKeyDelta: []uint64{1},
+		}},
+	}, 1, uint64(time.Now().UnixMilli()), NoOpCallback)
+	assert.ErrorIs(t, err, ErrMissingSequenceDeltas)
+}
+
+// Multi-level sequences advance level-wise from the cache exactly as from
+// storage.
+func TestSequencePut_MultiLevel(t *testing.T) {
+	db := newSequenceTestDB(t)
+
+	assert.Equal(t, sequenceKeyOf("seq", 1, 10), sequencePut(t, db, 0, "seq", 1, 10))
+	assert.Equal(t, sequenceKeyOf("seq", 3, 15), sequencePut(t, db, 1, "seq", 2, 5))
+}


### PR DESCRIPTION
### Motivation

Item 2.7 (sequences sub-item) from the performance review: every sequential put re-derived the current tail of its sequence from storage — `FindLower` opens and seeks a **fresh pebble iterator on the indexed batch** per put, `fmt.Sscanf` parses each level of the last key, and a chained `fmt.Sprintf` formats each level of the new one.

### Changes

`ProcessWrite` is single-threaded per shard, so the last sequence values per prefix are cacheable on the `db` with no locking. A cache hit skips the batch iterator and the parsing entirely; the new key is formatted with a zero-padded `strconv` append producing the same byte layout. `ErrMissingSequenceDeltas` (a put carrying fewer deltas than the sequence has levels) is enforced identically on the cached path.

The cache is invalidated wherever storage can move without it — analyzed by direction, since only one direction is dangerous:

- **Cache behind storage** (could emit a duplicate/lower key — the dangerous direction) has exactly one path: a direct client put of a sequence-shaped key (`prefix` + `-<20 digits>` segments). Invalidated in `applyPut`; the shape check is a few byte comparisons and exits immediately when the cache is empty, so plain puts pay effectively nothing.
- **Point deletes** invalidate the affected prefix and **range deletes** drop the cache, preserving today's behavior exactly: deleting the tail makes the next put re-read storage and reuse the freed value.
- **Cache ahead of storage** (emits a gap; keys stay unique — safe): session-expiry deletions of ephemeral sequence keys bypass the invalidation by design and are documented as such.
- Snapshot loads construct a fresh `db`, so no stale cache survives them; the split filter runs on that fresh instance before any sequential put.

The cache is bounded at **64K prefixes** and dropped wholesale when full. Measured footprint (Go swiss-table map, heap-alive delta): ~140–380 B per entry for realistic prefix lengths → **~9–24 MB per shard worst case**, only on shards that actually use that many sequence prefixes; an empty map costs nothing.

### Benchmark

`BenchmarkSequencePut` — full `ProcessWrite` with one sequential put (Apple M1 Max):

| | time | allocs |
|---|---|---|
| before | 8.4 µs | 65 |
| after | **4.9 µs** | **55** |

−42% per sequential put: the iterator+parse+format chain was over 40% of the whole write.

### Verification

- 7 new tests: cross-batch continuity, same-batch continuity (previously read-your-writes via the indexed batch, now via the cache), multi-level advancement, `ErrMissingSequenceDeltas` on the cached path, and the three invalidation cases. Verified to discriminate: with invalidation disabled, exactly the direct-put, delete and delete-range tests fail — the direct-put one is the duplicate-key case.
- `go test -race` green on `oxiad/dataserver/database/...` and the `tests/sequence` e2e suite.
- `golangci-lint` clean across all go.work modules on the CI-pinned v2.6.2.
