### PR TITLE
fix: keep deletes when filtering a write request for a shard split

### DIFF
--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -331,13 +331,14 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 		}
 	}
 
-	var deletes []*proto.DeleteRequest
-	for _, d := range req.Deletes {
-		h := hash.Xxh332(d.Key)
-		if isHashInRange(h, hashRange) {
-			deletes = append(deletes, d)
-		}
-	}
+	// A DeleteRequest carries no partition key, so it can only be hashed by its
+	// key. But a partition-keyed record is placed by hash(partition key) (see
+	// the puts above), so filtering deletes by the key hash drops them from the
+	// child that actually holds the record and resurrects data that was already
+	// deleted. Deleting a key a child does not hold is a no-op, so keep every
+	// delete, the same as the delete ranges below.
+	deletes := make([]*proto.DeleteRequest, 0, len(req.Deletes))
+	deletes = append(deletes, req.Deletes...)
 
 	deleteRanges := make([]*proto.DeleteRangeRequest, 0, len(req.DeleteRanges))
 	deleteRanges = append(deleteRanges, req.DeleteRanges...)

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -402,10 +402,59 @@ func TestFilterWriteRequestForSplit_Deletes(t *testing.T) {
 		},
 	}
 
+	// Deletes are kept for every child regardless of the key hash: a delete for
+	// a key the child does not hold is a harmless no-op, and dropping it would
+	// resurrect a partition-keyed record (see the test below).
 	filtered := FilterWriteRequestForSplit(req, leftRange)
 	assert.NotNil(t, filtered)
-	assert.Equal(t, 1, len(filtered.Deletes))
+	assert.Equal(t, 2, len(filtered.Deletes))
 	assert.Equal(t, leftKey, filtered.Deletes[0].Key)
+	assert.Equal(t, rightKey, filtered.Deletes[1].Key)
+}
+
+func TestFilterWriteRequestForSplit_DeleteKeptForPartitionKeyedRecord(t *testing.T) {
+	leftRange, _ := splitRanges()
+
+	// A partition key that places the record in the left child.
+	var leftPK string
+	for i := 0; i < 1000; i++ {
+		pk := fmt.Sprintf("pk-%d", i)
+		if isHashInRange(hash.Xxh332(pk), leftRange) {
+			leftPK = pk
+			break
+		}
+	}
+	assert.NotEmpty(t, leftPK)
+
+	// A key whose own hash falls outside the left child's range.
+	var outsideKey string
+	for i := 0; i < 1000; i++ {
+		k := fmt.Sprintf("outside-%d", i)
+		if !isHashInRange(hash.Xxh332(k), leftRange) {
+			outsideKey = k
+			break
+		}
+	}
+	assert.NotEmpty(t, outsideKey)
+
+	// The record is placed in the left child by its partition key, and the
+	// matching delete lands on the same child. The delete's key hashes outside
+	// the range, so filtering deletes by key hash would drop it and leave the
+	// record behind after the split.
+	req := &proto.WriteRequest{
+		Puts: []*proto.PutRequest{
+			{Key: outsideKey, Value: []byte("v"), PartitionKey: &leftPK},
+		},
+		Deletes: []*proto.DeleteRequest{
+			{Key: outsideKey},
+		},
+	}
+
+	filtered := FilterWriteRequestForSplit(req, leftRange)
+	assert.NotNil(t, filtered)
+	assert.Equal(t, 1, len(filtered.Puts))
+	assert.Equal(t, 1, len(filtered.Deletes))
+	assert.Equal(t, outsideKey, filtered.Deletes[0].Key)
 }
 
 func TestFilterWriteRequestForSplit_AllFiltered(t *testing.T) {


### PR DESCRIPTION
When a shard splits, each child replays the parent's write-ahead log through FilterWriteRequestForSplit, which keeps only the operations that fall in the child's hash range. Puts are placed by the hash of their partition key when one is set, matching how the client routed them, but the delete loop hashes the delete's own key instead. A DeleteRequest carries no partition key, so for any record written with a partition key the delete gets hashed by a value unrelated to where the record actually lives, and it is dropped from the child that holds the record whenever the key hash lands in a different range. The put survives and the delete does not, so a key the client already deleted comes back in that child after the split and stays readable to later gets and scans. I noticed it while comparing the three placement paths: the put loop here and the snapshot-side isUserKeyInRange both honor the partition key, while this delete loop cannot, since the field is not on the message. A delete for a key a child does not hold is a no-op, so the fix keeps every delete instead of filtering it, the same way the delete ranges just below are already passed through. I also updated the existing delete test, which had encoded the old behavior, and added one that reproduces the resurrection with a partition-keyed record.