### PR TITLE
fix: preserve partition key in delete requests

### DIFF
--- a/common/proto/client.pb.go
+++ b/common/proto/client.pb.go
@@ -1075,8 +1075,11 @@ type DeleteRequest struct {
 	// An optional expected version_id. The delete will fail if the server's current version_id
 	// does not match
 	ExpectedVersionId *int64 `protobuf:"varint,2,opt,name=expected_version_id,json=expectedVersionId,proto3,oneof" json:"expected_version_id,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// If a partition key is present, it supersedes the regular record key in determining the routing
+	// of the delete to a particular shard.
+	PartitionKey  *string `protobuf:"bytes,3,opt,name=partition_key,json=partitionKey,proto3,oneof" json:"partition_key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DeleteRequest) Reset() {
@@ -1121,6 +1124,13 @@ func (x *DeleteRequest) GetExpectedVersionId() int64 {
 		return *x.ExpectedVersionId
 	}
 	return 0
+}
+
+func (x *DeleteRequest) GetPartitionKey() string {
+	if x != nil && x.PartitionKey != nil {
+		return *x.PartitionKey
+	}
+	return ""
 }
 
 // *
@@ -2466,11 +2476,13 @@ const file_client_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x01(\x0e2\x18.io.oxia.proto.v1.StatusR\x06status\x123\n" +
 	"\aversion\x18\x02 \x01(\v2\x19.io.oxia.proto.v1.VersionR\aversion\x12\x15\n" +
 	"\x03key\x18\x03 \x01(\tH\x00R\x03key\x88\x01\x01B\x06\n" +
-	"\x04_key\"n\n" +
+	"\x04_key\"\xaa\x01\n" +
 	"\rDeleteRequest\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x123\n" +
-	"\x13expected_version_id\x18\x02 \x01(\x03H\x00R\x11expectedVersionId\x88\x01\x01B\x16\n" +
-	"\x14_expected_version_id\"B\n" +
+	"\x13expected_version_id\x18\x02 \x01(\x03H\x00R\x11expectedVersionId\x88\x01\x01\x12(\n" +
+	"\rpartition_key\x18\x03 \x01(\tH\x01R\fpartitionKey\x88\x01\x01B\x16\n" +
+	"\x14_expected_version_idB\x10\n" +
+	"\x0e_partition_key\"B\n" +
 	"\x0eDeleteResponse\x120\n" +
 	"\x06status\x18\x01 \x01(\x0e2\x18.io.oxia.proto.v1.StatusR\x06status\"\xe1\x01\n" +
 	"\n" +

--- a/common/proto/client.pb.go
+++ b/common/proto/client.pb.go
@@ -1077,6 +1077,7 @@ type DeleteRequest struct {
 	ExpectedVersionId *int64 `protobuf:"varint,2,opt,name=expected_version_id,json=expectedVersionId,proto3,oneof" json:"expected_version_id,omitempty"`
 	// If a partition key is present, it supersedes the regular record key in determining the routing
 	// of the delete to a particular shard.
+	// An explicitly present empty string is a valid partition key and is hashed normally.
 	PartitionKey  *string `protobuf:"bytes,3,opt,name=partition_key,json=partitionKey,proto3,oneof" json:"partition_key,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/common/proto/client.proto
+++ b/common/proto/client.proto
@@ -297,6 +297,7 @@ message DeleteRequest {
   optional int64 expected_version_id = 2;
   // If a partition key is present, it supersedes the regular record key in determining the routing
   // of the delete to a particular shard.
+  // An explicitly present empty string is a valid partition key and is hashed normally.
   optional string partition_key = 3;
 }
 

--- a/common/proto/client.proto
+++ b/common/proto/client.proto
@@ -295,6 +295,9 @@ message DeleteRequest {
   // An optional expected version_id. The delete will fail if the server's current version_id
   // does not match
   optional int64 expected_version_id = 2;
+  // If a partition key is present, it supersedes the regular record key in determining the routing
+  // of the delete to a particular shard.
+  optional string partition_key = 3;
 }
 
 /**

--- a/common/proto/client_vtproto.pb.go
+++ b/common/proto/client_vtproto.pb.go
@@ -376,6 +376,10 @@ func (m *DeleteRequest) CloneVT() *DeleteRequest {
 		tmpVal := *rhs
 		r.ExpectedVersionId = &tmpVal
 	}
+	if rhs := m.PartitionKey; rhs != nil {
+		tmpVal := *rhs
+		r.PartitionKey = &tmpVal
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1361,6 +1365,9 @@ func (this *DeleteRequest) EqualVT(that *DeleteRequest) bool {
 		return false
 	}
 	if p, q := this.ExpectedVersionId, that.ExpectedVersionId; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
+		return false
+	}
+	if p, q := this.PartitionKey, that.PartitionKey; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -2672,6 +2679,13 @@ func (m *DeleteRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.PartitionKey != nil {
+		i -= len(*m.PartitionKey)
+		copy(dAtA[i:], *m.PartitionKey)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.PartitionKey)))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if m.ExpectedVersionId != nil {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.ExpectedVersionId))
@@ -4069,6 +4083,10 @@ func (m *DeleteRequest) SizeVT() (n int) {
 	}
 	if m.ExpectedVersionId != nil {
 		n += 1 + protohelpers.SizeOfVarint(uint64(*m.ExpectedVersionId))
+	}
+	if m.PartitionKey != nil {
+		l = len(*m.PartitionKey)
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -6320,6 +6338,39 @@ func (m *DeleteRequest) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.ExpectedVersionId = &v
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PartitionKey", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(dAtA[iNdEx:postIndex])
+			m.PartitionKey = &s
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10664,6 +10715,43 @@ func (m *DeleteRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 			}
 			m.ExpectedVersionId = &v
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PartitionKey", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			s := stringValue
+			m.PartitionKey = &s
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/oxia/async_client_impl.go
+++ b/oxia/async_client_impl.go
@@ -123,7 +123,7 @@ func (c *clientImpl) rerouteWrites(puts []model.PutCall, deletes []model.DeleteC
 		c.writeBatchManager.Get(shardId).Add(put)
 	}
 	for _, del := range deletes {
-		shardId := c.shardManager.Get(del.Key)
+		shardId := c.shardManager.Get(del.PartitionKeyOrKey())
 		c.writeBatchManager.Get(shardId).Add(del)
 	}
 	for _, dr := range deleteRanges {
@@ -212,6 +212,7 @@ func (c *clientImpl) Delete(key string, options ...DeleteOption) <-chan error {
 	c.writeBatchManager.Get(shardId).Add(model.DeleteCall{
 		Key:               key,
 		ExpectedVersionId: opts.expectedVersion,
+		PartitionKey:      opts.partitionKey,
 		Callback:          callback,
 	})
 	return ch

--- a/oxia/internal/model/model.go
+++ b/oxia/internal/model/model.go
@@ -33,6 +33,7 @@ type PutCall struct {
 type DeleteCall struct {
 	Key               string
 	ExpectedVersionId *int64
+	PartitionKey      *string
 	Callback          func(*proto.DeleteResponse, error)
 }
 
@@ -59,6 +60,15 @@ func (r PutCall) PartitionKeyOrKey() string {
 	return r.Key
 }
 
+// PartitionKeyOrKey returns the partition key if set, otherwise the record key.
+// Used for shard routing when re-routing operations after a shard split.
+func (r DeleteCall) PartitionKeyOrKey() string {
+	if r.PartitionKey != nil {
+		return *r.PartitionKey
+	}
+	return r.Key
+}
+
 func (r PutCall) ToProto() *proto.PutRequest {
 	return &proto.PutRequest{
 		Key:               r.Key,
@@ -76,6 +86,7 @@ func (r DeleteCall) ToProto() *proto.DeleteRequest {
 	return &proto.DeleteRequest{
 		Key:               r.Key,
 		ExpectedVersionId: r.ExpectedVersionId,
+		PartitionKey:      r.PartitionKey,
 	}
 }
 

--- a/oxia/internal/model/model_test.go
+++ b/oxia/internal/model/model_test.go
@@ -28,7 +28,9 @@ func TestDeleteCallPartitionKey(t *testing.T) {
 	}
 
 	assert.Equal(t, partitionKey, call.PartitionKeyOrKey())
-	assert.Equal(t, &partitionKey, call.ToProto().PartitionKey)
+	req := call.ToProto()
+	assert.NotNil(t, req.PartitionKey)
+	assert.Equal(t, partitionKey, req.GetPartitionKey())
 }
 
 func TestDeleteCallPartitionKeyOrKeyFallback(t *testing.T) {
@@ -46,5 +48,7 @@ func TestDeleteCallEmptyPartitionKey(t *testing.T) {
 	}
 
 	assert.Equal(t, partitionKey, call.PartitionKeyOrKey())
-	assert.Equal(t, &partitionKey, call.ToProto().PartitionKey)
+	req := call.ToProto()
+	assert.NotNil(t, req.PartitionKey)
+	assert.Equal(t, partitionKey, req.GetPartitionKey())
 }

--- a/oxia/internal/model/model_test.go
+++ b/oxia/internal/model/model_test.go
@@ -1,0 +1,39 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteCallPartitionKey(t *testing.T) {
+	partitionKey := "partition-key"
+	call := DeleteCall{
+		Key:          "key",
+		PartitionKey: &partitionKey,
+	}
+
+	assert.Equal(t, partitionKey, call.PartitionKeyOrKey())
+	assert.Equal(t, &partitionKey, call.ToProto().PartitionKey)
+}
+
+func TestDeleteCallPartitionKeyOrKeyFallback(t *testing.T) {
+	call := DeleteCall{Key: "key"}
+
+	assert.Equal(t, "key", call.PartitionKeyOrKey())
+	assert.Nil(t, call.ToProto().PartitionKey)
+}

--- a/oxia/internal/model/model_test.go
+++ b/oxia/internal/model/model_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,4 +36,15 @@ func TestDeleteCallPartitionKeyOrKeyFallback(t *testing.T) {
 
 	assert.Equal(t, "key", call.PartitionKeyOrKey())
 	assert.Nil(t, call.ToProto().PartitionKey)
+}
+
+func TestDeleteCallEmptyPartitionKey(t *testing.T) {
+	partitionKey := ""
+	call := DeleteCall{
+		Key:          "key",
+		PartitionKey: &partitionKey,
+	}
+
+	assert.Equal(t, partitionKey, call.PartitionKeyOrKey())
+	assert.Equal(t, &partitionKey, call.ToProto().PartitionKey)
 }

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -333,18 +333,18 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 
 	var deletes []*proto.DeleteRequest
 	for _, d := range req.Deletes {
-		if d.PartitionKey == nil || *d.PartitionKey == "" {
+		if d.PartitionKey == nil {
 			// For backward compatibility, a missing partition key cannot be
 			// treated like it is for puts. Older clients used the partition key
 			// to route a delete but did not serialize it into DeleteRequest, so
 			// nil does not prove that the delete was routed by its record key.
-			// An empty partition key follows the existing put/snapshot behavior
-			// and is also treated as unspecified. Keep either form in both
-			// children to avoid resurrecting deleted records.
+			// Keep it in both children to avoid resurrecting deleted records.
 			deletes = append(deletes, d)
 			continue
 		}
 
+		// An explicitly empty partition key is still present: existing clients
+		// accept it and route the request using hash("").
 		if isHashInRange(hash.Xxh332(*d.PartitionKey), hashRange) {
 			deletes = append(deletes, d)
 		}

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -296,7 +296,7 @@ func isUserKeyInRange(key string, value []byte, hashRange *proto.HashRange) bool
 	}
 
 	var h uint32
-	if se.PartitionKey != nil && *se.PartitionKey != "" {
+	if se.PartitionKey != nil {
 		h = hash.Xxh332(*se.PartitionKey)
 	} else {
 		h = hash.Xxh332(key)
@@ -321,7 +321,7 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 	var puts []*proto.PutRequest
 	for _, p := range req.Puts {
 		var h uint32
-		if p.PartitionKey != nil && *p.PartitionKey != "" {
+		if p.PartitionKey != nil {
 			h = hash.Xxh332(*p.PartitionKey)
 		} else {
 			h = hash.Xxh332(p.Key)

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -296,7 +296,7 @@ func isUserKeyInRange(key string, value []byte, hashRange *proto.HashRange) bool
 	}
 
 	var h uint32
-	if se.PartitionKey != nil {
+	if se.PartitionKey != nil && *se.PartitionKey != "" {
 		h = hash.Xxh332(*se.PartitionKey)
 	} else {
 		h = hash.Xxh332(key)
@@ -321,7 +321,7 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 	var puts []*proto.PutRequest
 	for _, p := range req.Puts {
 		var h uint32
-		if p.PartitionKey != nil {
+		if p.PartitionKey != nil && *p.PartitionKey != "" {
 			h = hash.Xxh332(*p.PartitionKey)
 		} else {
 			h = hash.Xxh332(p.Key)
@@ -333,12 +333,14 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 
 	var deletes []*proto.DeleteRequest
 	for _, d := range req.Deletes {
-		if d.PartitionKey == nil {
+		if d.PartitionKey == nil || *d.PartitionKey == "" {
 			// For backward compatibility, a missing partition key cannot be
 			// treated like it is for puts. Older clients used the partition key
 			// to route a delete but did not serialize it into DeleteRequest, so
 			// nil does not prove that the delete was routed by its record key.
-			// Keep it in both children to avoid resurrecting deleted records.
+			// An empty partition key follows the existing put/snapshot behavior
+			// and is also treated as unspecified. Keep either form in both
+			// children to avoid resurrecting deleted records.
 			deletes = append(deletes, d)
 			continue
 		}

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -331,14 +331,20 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 		}
 	}
 
-	// A DeleteRequest carries no partition key, so it can only be hashed by its
-	// key. But a partition-keyed record is placed by hash(partition key) (see
-	// the puts above), so filtering deletes by the key hash drops them from the
-	// child that actually holds the record and resurrects data that was already
-	// deleted. Deleting a key a child does not hold is a no-op, so keep every
-	// delete, the same as the delete ranges below.
-	deletes := make([]*proto.DeleteRequest, 0, len(req.Deletes))
-	deletes = append(deletes, req.Deletes...)
+	var deletes []*proto.DeleteRequest
+	for _, d := range req.Deletes {
+		if d.PartitionKey == nil || *d.PartitionKey == "" {
+			// Deletes written by older clients do not carry their partition key.
+			// Keep them in both children because filtering by the record key could
+			// resurrect a partition-keyed record.
+			deletes = append(deletes, d)
+			continue
+		}
+
+		if isHashInRange(hash.Xxh332(*d.PartitionKey), hashRange) {
+			deletes = append(deletes, d)
+		}
+	}
 
 	deleteRanges := make([]*proto.DeleteRangeRequest, 0, len(req.DeleteRanges))
 	deleteRanges = append(deleteRanges, req.DeleteRanges...)

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -296,7 +296,7 @@ func isUserKeyInRange(key string, value []byte, hashRange *proto.HashRange) bool
 	}
 
 	var h uint32
-	if se.PartitionKey != nil {
+	if se.PartitionKey != nil && *se.PartitionKey != "" {
 		h = hash.Xxh332(*se.PartitionKey)
 	} else {
 		h = hash.Xxh332(key)
@@ -321,7 +321,7 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 	var puts []*proto.PutRequest
 	for _, p := range req.Puts {
 		var h uint32
-		if p.PartitionKey != nil {
+		if p.PartitionKey != nil && *p.PartitionKey != "" {
 			h = hash.Xxh332(*p.PartitionKey)
 		} else {
 			h = hash.Xxh332(p.Key)
@@ -333,18 +333,18 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 
 	var deletes []*proto.DeleteRequest
 	for _, d := range req.Deletes {
-		if d.PartitionKey == nil {
+		if d.PartitionKey == nil || *d.PartitionKey == "" {
 			// For backward compatibility, a missing partition key cannot be
 			// treated like it is for puts. Older clients used the partition key
 			// to route a delete but did not serialize it into DeleteRequest, so
 			// nil does not prove that the delete was routed by its record key.
-			// Keep it in both children to avoid resurrecting deleted records.
+			// An empty partition key follows the existing put/snapshot behavior
+			// and is also treated as unspecified. Keep either form in both
+			// children to avoid resurrecting deleted records.
 			deletes = append(deletes, d)
 			continue
 		}
 
-		// An explicitly empty partition key is still present: existing clients
-		// accept it and route the request using hash("").
 		if isHashInRange(hash.Xxh332(*d.PartitionKey), hashRange) {
 			deletes = append(deletes, d)
 		}

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -333,7 +333,7 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 
 	var deletes []*proto.DeleteRequest
 	for _, d := range req.Deletes {
-		if d.PartitionKey == nil || *d.PartitionKey == "" {
+		if d.PartitionKey == nil {
 			// Deletes written by older clients do not carry their partition key.
 			// Keep them in both children because filtering by the record key could
 			// resurrect a partition-keyed record.

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -334,9 +334,11 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 	var deletes []*proto.DeleteRequest
 	for _, d := range req.Deletes {
 		if d.PartitionKey == nil {
-			// Deletes written by older clients do not carry their partition key.
-			// Keep them in both children because filtering by the record key could
-			// resurrect a partition-keyed record.
+			// For backward compatibility, a missing partition key cannot be
+			// treated like it is for puts. Older clients used the partition key
+			// to route a delete but did not serialize it into DeleteRequest, so
+			// nil does not prove that the delete was routed by its record key.
+			// Keep it in both children to avoid resurrecting deleted records.
 			deletes = append(deletes, d)
 			continue
 		}

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -296,7 +296,7 @@ func isUserKeyInRange(key string, value []byte, hashRange *proto.HashRange) bool
 	}
 
 	var h uint32
-	if se.PartitionKey != nil && *se.PartitionKey != "" {
+	if se.PartitionKey != nil {
 		h = hash.Xxh332(*se.PartitionKey)
 	} else {
 		h = hash.Xxh332(key)
@@ -321,7 +321,7 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 	var puts []*proto.PutRequest
 	for _, p := range req.Puts {
 		var h uint32
-		if p.PartitionKey != nil && *p.PartitionKey != "" {
+		if p.PartitionKey != nil {
 			h = hash.Xxh332(*p.PartitionKey)
 		} else {
 			h = hash.Xxh332(p.Key)
@@ -333,18 +333,18 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 
 	var deletes []*proto.DeleteRequest
 	for _, d := range req.Deletes {
-		if d.PartitionKey == nil || *d.PartitionKey == "" {
+		if d.PartitionKey == nil {
 			// For backward compatibility, a missing partition key cannot be
 			// treated like it is for puts. Older clients used the partition key
 			// to route a delete but did not serialize it into DeleteRequest, so
 			// nil does not prove that the delete was routed by its record key.
-			// An empty partition key follows the existing put/snapshot behavior
-			// and is also treated as unspecified. Keep either form in both
-			// children to avoid resurrecting deleted records.
+			// Keep it in both children to avoid resurrecting deleted records.
 			deletes = append(deletes, d)
 			continue
 		}
 
+		// An explicitly empty partition key is still present: existing clients
+		// accept it and route the request using hash("").
 		if isHashInRange(hash.Xxh332(*d.PartitionKey), hashRange) {
 			deletes = append(deletes, d)
 		}

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -165,31 +165,6 @@ func TestFilterDBForSplit_PartitionKey(t *testing.T) {
 	assert.True(t, keyExists(t, kv, "some-key"), "key with left partition_key should survive")
 }
 
-func TestFilterDBForSplit_EmptyPartitionKey(t *testing.T) {
-	kv := newTestKV(t)
-	emptyPartitionKey := ""
-	emptyPartitionKeyHash := hash.Xxh332(emptyPartitionKey)
-	matchingRange := &proto.HashRange{
-		Min: emptyPartitionKeyHash,
-		Max: emptyPartitionKeyHash,
-	}
-
-	var key string
-	for i := 0; i < 1000; i++ {
-		candidate := fmt.Sprintf("empty-pk-key-%d", i)
-		if hash.Xxh332(candidate) != emptyPartitionKeyHash {
-			key = candidate
-			break
-		}
-	}
-	assert.NotEmpty(t, key)
-
-	putStorageEntry(t, kv, key, &emptyPartitionKey)
-
-	assert.NoError(t, FilterDBForSplit(kv, matchingRange))
-	assert.True(t, keyExists(t, kv, key), "explicit empty partition key should determine placement")
-}
-
 func TestFilterDBForSplit_MetadataKeys(t *testing.T) {
 	kv := newTestKV(t)
 
@@ -470,50 +445,20 @@ func TestFilterWriteRequestForSplit_DeletesWithPartitionKey(t *testing.T) {
 
 func TestFilterWriteRequestForSplit_DeleteWithEmptyPartitionKey(t *testing.T) {
 	emptyPartitionKey := ""
-	emptyPartitionKeyHash := hash.Xxh332(emptyPartitionKey)
-	matchingRange := &proto.HashRange{
-		Min: emptyPartitionKeyHash,
-		Max: emptyPartitionKeyHash,
-	}
+	leftRange, rightRange := splitRanges()
 	req := &proto.WriteRequest{
 		Deletes: []*proto.DeleteRequest{
 			{Key: "key", PartitionKey: &emptyPartitionKey},
 		},
 	}
 
-	filtered := FilterWriteRequestForSplit(req, matchingRange)
-	assert.NotNil(t, filtered)
-	assert.Len(t, filtered.Deletes, 1)
+	leftFiltered := FilterWriteRequestForSplit(req, leftRange)
+	assert.NotNil(t, leftFiltered)
+	assert.Len(t, leftFiltered.Deletes, 1)
 
-	nonMatchingRange := &proto.HashRange{
-		Min: emptyPartitionKeyHash ^ 1,
-		Max: emptyPartitionKeyHash ^ 1,
-	}
-	assert.Nil(t, FilterWriteRequestForSplit(req, nonMatchingRange))
-}
-
-func TestFilterWriteRequestForSplit_PutWithEmptyPartitionKey(t *testing.T) {
-	emptyPartitionKey := ""
-	emptyPartitionKeyHash := hash.Xxh332(emptyPartitionKey)
-	matchingRange := &proto.HashRange{
-		Min: emptyPartitionKeyHash,
-		Max: emptyPartitionKeyHash,
-	}
-	req := &proto.WriteRequest{
-		Puts: []*proto.PutRequest{
-			{Key: "key", PartitionKey: &emptyPartitionKey},
-		},
-	}
-
-	filtered := FilterWriteRequestForSplit(req, matchingRange)
-	assert.NotNil(t, filtered)
-	assert.Len(t, filtered.Puts, 1)
-
-	nonMatchingRange := &proto.HashRange{
-		Min: emptyPartitionKeyHash ^ 1,
-		Max: emptyPartitionKeyHash ^ 1,
-	}
-	assert.Nil(t, FilterWriteRequestForSplit(req, nonMatchingRange))
+	rightFiltered := FilterWriteRequestForSplit(req, rightRange)
+	assert.NotNil(t, rightFiltered)
+	assert.Len(t, rightFiltered.Deletes, 1)
 }
 
 func TestFilterWriteRequestForSplit_DeleteKeptForPartitionKeyedRecord(t *testing.T) {

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -165,6 +165,31 @@ func TestFilterDBForSplit_PartitionKey(t *testing.T) {
 	assert.True(t, keyExists(t, kv, "some-key"), "key with left partition_key should survive")
 }
 
+func TestFilterDBForSplit_EmptyPartitionKey(t *testing.T) {
+	kv := newTestKV(t)
+	emptyPartitionKey := ""
+	emptyPartitionKeyHash := hash.Xxh332(emptyPartitionKey)
+	matchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash,
+		Max: emptyPartitionKeyHash,
+	}
+
+	var key string
+	for i := 0; i < 1000; i++ {
+		candidate := fmt.Sprintf("empty-pk-key-%d", i)
+		if hash.Xxh332(candidate) != emptyPartitionKeyHash {
+			key = candidate
+			break
+		}
+	}
+	assert.NotEmpty(t, key)
+
+	putStorageEntry(t, kv, key, &emptyPartitionKey)
+
+	assert.NoError(t, FilterDBForSplit(kv, matchingRange))
+	assert.True(t, keyExists(t, kv, key), "explicit empty partition key should determine placement")
+}
+
 func TestFilterDBForSplit_MetadataKeys(t *testing.T) {
 	kv := newTestKV(t)
 
@@ -445,20 +470,50 @@ func TestFilterWriteRequestForSplit_DeletesWithPartitionKey(t *testing.T) {
 
 func TestFilterWriteRequestForSplit_DeleteWithEmptyPartitionKey(t *testing.T) {
 	emptyPartitionKey := ""
-	leftRange, rightRange := splitRanges()
+	emptyPartitionKeyHash := hash.Xxh332(emptyPartitionKey)
+	matchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash,
+		Max: emptyPartitionKeyHash,
+	}
 	req := &proto.WriteRequest{
 		Deletes: []*proto.DeleteRequest{
 			{Key: "key", PartitionKey: &emptyPartitionKey},
 		},
 	}
 
-	leftFiltered := FilterWriteRequestForSplit(req, leftRange)
-	assert.NotNil(t, leftFiltered)
-	assert.Len(t, leftFiltered.Deletes, 1)
+	filtered := FilterWriteRequestForSplit(req, matchingRange)
+	assert.NotNil(t, filtered)
+	assert.Len(t, filtered.Deletes, 1)
 
-	rightFiltered := FilterWriteRequestForSplit(req, rightRange)
-	assert.NotNil(t, rightFiltered)
-	assert.Len(t, rightFiltered.Deletes, 1)
+	nonMatchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash ^ 1,
+		Max: emptyPartitionKeyHash ^ 1,
+	}
+	assert.Nil(t, FilterWriteRequestForSplit(req, nonMatchingRange))
+}
+
+func TestFilterWriteRequestForSplit_PutWithEmptyPartitionKey(t *testing.T) {
+	emptyPartitionKey := ""
+	emptyPartitionKeyHash := hash.Xxh332(emptyPartitionKey)
+	matchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash,
+		Max: emptyPartitionKeyHash,
+	}
+	req := &proto.WriteRequest{
+		Puts: []*proto.PutRequest{
+			{Key: "key", PartitionKey: &emptyPartitionKey},
+		},
+	}
+
+	filtered := FilterWriteRequestForSplit(req, matchingRange)
+	assert.NotNil(t, filtered)
+	assert.Len(t, filtered.Puts, 1)
+
+	nonMatchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash ^ 1,
+		Max: emptyPartitionKeyHash ^ 1,
+	}
+	assert.Nil(t, FilterWriteRequestForSplit(req, nonMatchingRange))
 }
 
 func TestFilterWriteRequestForSplit_DeleteKeptForPartitionKeyedRecord(t *testing.T) {

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -340,7 +340,6 @@ func TestFilterWriteRequestForSplit_Puts(t *testing.T) {
 			break
 		}
 	}
-
 	req := &proto.WriteRequest{
 		Puts: []*proto.PutRequest{
 			{Key: leftKey, Value: []byte("v1")},
@@ -428,6 +427,8 @@ func TestFilterWriteRequestForSplit_DeletesWithPartitionKey(t *testing.T) {
 			break
 		}
 	}
+	assert.NotEmpty(t, leftPK)
+	assert.NotEmpty(t, rightPK)
 
 	req := &proto.WriteRequest{
 		Deletes: []*proto.DeleteRequest{
@@ -440,6 +441,30 @@ func TestFilterWriteRequestForSplit_DeletesWithPartitionKey(t *testing.T) {
 	assert.NotNil(t, filtered)
 	assert.Len(t, filtered.Deletes, 1)
 	assert.Equal(t, "left", filtered.Deletes[0].Key)
+}
+
+func TestFilterWriteRequestForSplit_DeleteWithEmptyPartitionKey(t *testing.T) {
+	emptyPartitionKey := ""
+	emptyPartitionKeyHash := hash.Xxh332(emptyPartitionKey)
+	matchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash,
+		Max: emptyPartitionKeyHash,
+	}
+	req := &proto.WriteRequest{
+		Deletes: []*proto.DeleteRequest{
+			{Key: "key", PartitionKey: &emptyPartitionKey},
+		},
+	}
+
+	filtered := FilterWriteRequestForSplit(req, matchingRange)
+	assert.NotNil(t, filtered)
+	assert.Len(t, filtered.Deletes, 1)
+
+	nonMatchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash + 1,
+		Max: emptyPartitionKeyHash + 1,
+	}
+	assert.Nil(t, FilterWriteRequestForSplit(req, nonMatchingRange))
 }
 
 func TestFilterWriteRequestForSplit_DeleteKeptForPartitionKeyedRecord(t *testing.T) {

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -412,6 +412,36 @@ func TestFilterWriteRequestForSplit_Deletes(t *testing.T) {
 	assert.Equal(t, rightKey, filtered.Deletes[1].Key)
 }
 
+func TestFilterWriteRequestForSplit_DeletesWithPartitionKey(t *testing.T) {
+	leftRange, _ := splitRanges()
+
+	var leftPK, rightPK string
+	for i := 0; i < 1000; i++ {
+		pk := fmt.Sprintf("delete-pk-%d", i)
+		if leftPK == "" && isHashInRange(hash.Xxh332(pk), leftRange) {
+			leftPK = pk
+		}
+		if rightPK == "" && !isHashInRange(hash.Xxh332(pk), leftRange) {
+			rightPK = pk
+		}
+		if leftPK != "" && rightPK != "" {
+			break
+		}
+	}
+
+	req := &proto.WriteRequest{
+		Deletes: []*proto.DeleteRequest{
+			{Key: "left", PartitionKey: &leftPK},
+			{Key: "right", PartitionKey: &rightPK},
+		},
+	}
+
+	filtered := FilterWriteRequestForSplit(req, leftRange)
+	assert.NotNil(t, filtered)
+	assert.Len(t, filtered.Deletes, 1)
+	assert.Equal(t, "left", filtered.Deletes[0].Key)
+}
+
 func TestFilterWriteRequestForSplit_DeleteKeptForPartitionKeyedRecord(t *testing.T) {
 	leftRange, _ := splitRanges()
 
@@ -446,7 +476,7 @@ func TestFilterWriteRequestForSplit_DeleteKeptForPartitionKeyedRecord(t *testing
 			{Key: outsideKey, Value: []byte("v"), PartitionKey: &leftPK},
 		},
 		Deletes: []*proto.DeleteRequest{
-			{Key: outsideKey},
+			{Key: outsideKey, PartitionKey: &leftPK},
 		},
 	}
 

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -445,20 +445,26 @@ func TestFilterWriteRequestForSplit_DeletesWithPartitionKey(t *testing.T) {
 
 func TestFilterWriteRequestForSplit_DeleteWithEmptyPartitionKey(t *testing.T) {
 	emptyPartitionKey := ""
-	leftRange, rightRange := splitRanges()
+	emptyPartitionKeyHash := hash.Xxh332(emptyPartitionKey)
+	matchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash,
+		Max: emptyPartitionKeyHash,
+	}
 	req := &proto.WriteRequest{
 		Deletes: []*proto.DeleteRequest{
 			{Key: "key", PartitionKey: &emptyPartitionKey},
 		},
 	}
 
-	leftFiltered := FilterWriteRequestForSplit(req, leftRange)
-	assert.NotNil(t, leftFiltered)
-	assert.Len(t, leftFiltered.Deletes, 1)
+	filtered := FilterWriteRequestForSplit(req, matchingRange)
+	assert.NotNil(t, filtered)
+	assert.Len(t, filtered.Deletes, 1)
 
-	rightFiltered := FilterWriteRequestForSplit(req, rightRange)
-	assert.NotNil(t, rightFiltered)
-	assert.Len(t, rightFiltered.Deletes, 1)
+	nonMatchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash ^ 1,
+		Max: emptyPartitionKeyHash ^ 1,
+	}
+	assert.Nil(t, FilterWriteRequestForSplit(req, nonMatchingRange))
 }
 
 func TestFilterWriteRequestForSplit_DeleteKeptForPartitionKeyedRecord(t *testing.T) {

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -165,6 +165,31 @@ func TestFilterDBForSplit_PartitionKey(t *testing.T) {
 	assert.True(t, keyExists(t, kv, "some-key"), "key with left partition_key should survive")
 }
 
+func TestFilterDBForSplit_EmptyPartitionKey(t *testing.T) {
+	kv := newTestKV(t)
+	emptyPartitionKey := ""
+	emptyPartitionKeyHash := hash.Xxh332(emptyPartitionKey)
+	matchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash,
+		Max: emptyPartitionKeyHash,
+	}
+
+	var key string
+	for i := 0; i < 1000; i++ {
+		candidate := fmt.Sprintf("empty-pk-key-%d", i)
+		if hash.Xxh332(candidate) != emptyPartitionKeyHash {
+			key = candidate
+			break
+		}
+	}
+	assert.NotEmpty(t, key)
+
+	putStorageEntry(t, kv, key, &emptyPartitionKey)
+
+	assert.NoError(t, FilterDBForSplit(kv, matchingRange))
+	assert.True(t, keyExists(t, kv, key), "explicit empty partition key should determine placement")
+}
+
 func TestFilterDBForSplit_MetadataKeys(t *testing.T) {
 	kv := newTestKV(t)
 
@@ -461,8 +486,32 @@ func TestFilterWriteRequestForSplit_DeleteWithEmptyPartitionKey(t *testing.T) {
 	assert.Len(t, filtered.Deletes, 1)
 
 	nonMatchingRange := &proto.HashRange{
-		Min: emptyPartitionKeyHash + 1,
-		Max: emptyPartitionKeyHash + 1,
+		Min: emptyPartitionKeyHash ^ 1,
+		Max: emptyPartitionKeyHash ^ 1,
+	}
+	assert.Nil(t, FilterWriteRequestForSplit(req, nonMatchingRange))
+}
+
+func TestFilterWriteRequestForSplit_PutWithEmptyPartitionKey(t *testing.T) {
+	emptyPartitionKey := ""
+	emptyPartitionKeyHash := hash.Xxh332(emptyPartitionKey)
+	matchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash,
+		Max: emptyPartitionKeyHash,
+	}
+	req := &proto.WriteRequest{
+		Puts: []*proto.PutRequest{
+			{Key: "key", PartitionKey: &emptyPartitionKey},
+		},
+	}
+
+	filtered := FilterWriteRequestForSplit(req, matchingRange)
+	assert.NotNil(t, filtered)
+	assert.Len(t, filtered.Puts, 1)
+
+	nonMatchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash ^ 1,
+		Max: emptyPartitionKeyHash ^ 1,
 	}
 	assert.Nil(t, FilterWriteRequestForSplit(req, nonMatchingRange))
 }


### PR DESCRIPTION
## Motivation
Delete operations can use a partition key for initial shard routing, but the Go client currently discards it before building `DeleteRequest`. As a result, the routing decision is not preserved in the WAL, and delete retries and shard-split replay cannot recover the original placement precisely.

Depends on #1255, which aligns snapshot and put replay for explicitly empty partition keys. Merge #1255 first so puts, stored records, and deletes use the same empty-key contract.

## Modifications
- add optional `partition_key` to `DeleteRequest` and document that an explicitly empty value is valid
- retain the partition key in Go client delete calls, protobuf serialization, and shard-split rerouting
- filter split-replayed deletes by partition key when present, including an explicitly empty value
- retain the #1253 fallback of replaying legacy deletes without a partition key in both children
- add model and split-filter coverage for partition-key, explicit-empty, and legacy behavior

## Testing
- `(cd common && go test ./proto/...)`
- `go test ./oxia/internal/model ./oxiad/dataserver/database ./oxiad/dataserver/controller/statemachine`
- all packages in the `common`, `oxia`, `oxiad`, and `cmd` modules passed during the initial change
- `tests/assignments`, `tests/balancer`, `tests/client`, and `tests/control` passed during the initial change