### PR TITLE
fix: preserve empty partition key split routing

### DIFF
--- a/common/proto/client.pb.go
+++ b/common/proto/client.pb.go
@@ -887,6 +887,7 @@ type PutRequest struct {
 	// If a partition key is present, it supersedes the regular record key in determining the routing of
 	// a record to a particular shard. It is passed to the server because it needs to be persisted as
 	// part of the record. We would need the partition_key if we're going to do a split of the shards.
+	// An explicitly present empty string is a valid partition key and is hashed normally.
 	PartitionKey *string `protobuf:"bytes,6,opt,name=partition_key,json=partitionKey,proto3,oneof" json:"partition_key,omitempty"`
 	// If one or more sequence key are specified. The key will get added suffixes
 	// based on adding the delta to the current highest key with the same prefix

--- a/common/proto/client.proto
+++ b/common/proto/client.proto
@@ -258,6 +258,7 @@ message PutRequest {
   // If a partition key is present, it supersedes the regular record key in determining the routing of
   // a record to a particular shard. It is passed to the server because it needs to be persisted as
   // part of the record. We would need the partition_key if we're going to do a split of the shards.
+  // An explicitly present empty string is a valid partition key and is hashed normally.
   optional string partition_key = 6;
 
   // If one or more sequence key are specified. The key will get added suffixes

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -296,7 +296,7 @@ func isUserKeyInRange(key string, value []byte, hashRange *proto.HashRange) bool
 	}
 
 	var h uint32
-	if se.PartitionKey != nil && *se.PartitionKey != "" {
+	if se.PartitionKey != nil {
 		h = hash.Xxh332(*se.PartitionKey)
 	} else {
 		h = hash.Xxh332(key)
@@ -321,7 +321,7 @@ func FilterWriteRequestForSplit(req *proto.WriteRequest, hashRange *proto.HashRa
 	var puts []*proto.PutRequest
 	for _, p := range req.Puts {
 		var h uint32
-		if p.PartitionKey != nil && *p.PartitionKey != "" {
+		if p.PartitionKey != nil {
 			h = hash.Xxh332(*p.PartitionKey)
 		} else {
 			h = hash.Xxh332(p.Key)

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -165,6 +165,31 @@ func TestFilterDBForSplit_PartitionKey(t *testing.T) {
 	assert.True(t, keyExists(t, kv, "some-key"), "key with left partition_key should survive")
 }
 
+func TestFilterDBForSplit_EmptyPartitionKey(t *testing.T) {
+	kv := newTestKV(t)
+	emptyPartitionKey := ""
+	emptyPartitionKeyHash := hash.Xxh332(emptyPartitionKey)
+	matchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash,
+		Max: emptyPartitionKeyHash,
+	}
+
+	var key string
+	for i := 0; i < 1000; i++ {
+		candidate := fmt.Sprintf("empty-pk-key-%d", i)
+		if hash.Xxh332(candidate) != emptyPartitionKeyHash {
+			key = candidate
+			break
+		}
+	}
+	assert.NotEmpty(t, key)
+
+	putStorageEntry(t, kv, key, &emptyPartitionKey)
+
+	assert.NoError(t, FilterDBForSplit(kv, matchingRange))
+	assert.True(t, keyExists(t, kv, key), "explicit empty partition key should determine placement")
+}
+
 func TestFilterDBForSplit_MetadataKeys(t *testing.T) {
 	kv := newTestKV(t)
 
@@ -375,6 +400,30 @@ func TestFilterWriteRequestForSplit_PartitionKey(t *testing.T) {
 	filtered := FilterWriteRequestForSplit(req, leftRange)
 	assert.NotNil(t, filtered)
 	assert.Equal(t, 1, len(filtered.Puts))
+}
+
+func TestFilterWriteRequestForSplit_EmptyPartitionKey(t *testing.T) {
+	emptyPartitionKey := ""
+	emptyPartitionKeyHash := hash.Xxh332(emptyPartitionKey)
+	matchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash,
+		Max: emptyPartitionKeyHash,
+	}
+	req := &proto.WriteRequest{
+		Puts: []*proto.PutRequest{
+			{Key: "key", PartitionKey: &emptyPartitionKey},
+		},
+	}
+
+	filtered := FilterWriteRequestForSplit(req, matchingRange)
+	assert.NotNil(t, filtered)
+	assert.Len(t, filtered.Puts, 1)
+
+	nonMatchingRange := &proto.HashRange{
+		Min: emptyPartitionKeyHash ^ 1,
+		Max: emptyPartitionKeyHash ^ 1,
+	}
+	assert.Nil(t, FilterWriteRequestForSplit(req, nonMatchingRange))
 }
 
 func TestFilterWriteRequestForSplit_Deletes(t *testing.T) {


### PR DESCRIPTION
## Motivation
Existing clients accept an explicitly empty partition key and route it using the hash of the empty string. Snapshot and WAL split filtering instead treated the empty string as absent and used the record key, which could move the record to a different child than subsequent client operations target.

Client behavior:
- [Go accepts any partition-key string](https://github.com/oxia-db/oxia/blob/c60c2909/oxia/options_base.go#L74-L82) and [uses the provided value for put routing](https://github.com/oxia-db/oxia/blob/c60c2909/oxia/async_client_impl.go#L168-L180)
- [Java accepts any partition-key string](https://github.com/oxia-db/oxia-client-java/blob/84ae3afe62ee668e3c163624bc1ca2e408b86ff0/client-api/src/main/java/io/oxia/client/api/options/defs/OptionPartitionKey.java) and [uses the provided value for put routing](https://github.com/oxia-db/oxia-client-java/blob/84ae3afe62ee668e3c163624bc1ca2e408b86ff0/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java#L395-L417)

## Modifications
- treat every present `PutRequest.partition_key`, including an empty string, as the split routing key
- apply the same rule to persisted `StorageEntry.partition_key` during snapshot filtering
- document the empty partition-key contract in `client.proto`
- add snapshot and WAL replay regression coverage

## Testing
- `(cd common && go test ./proto/...)`
- `go test ./oxiad/dataserver/database ./oxiad/dataserver/controller/statemachine`