### PR TITLE
fix: bound secondary-index get to requested index (release-0.16)

### DIFF
--- a/oxiad/dataserver/controller/lead/secondary_indexes.go
+++ b/oxiad/dataserver/controller/lead/secondary_indexes.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
@@ -335,7 +336,8 @@ func secondaryIndexGet(req *proto.GetRequest, db database.DB) (*proto.GetRespons
 //nolint:revive
 func doSecondaryGet(db database.DB, req *proto.GetRequest) (primaryKey string, secondaryKey string, err error) {
 	indexName := *req.SecondaryIndexName
-	searchKey := fmt.Sprintf(secondaryIdxRangePrefixFormat, indexName, req.Key)
+	indexPrefix := fmt.Sprintf(secondaryIdxRangePrefixFormat, indexName, "")
+	searchKey := indexPrefix + req.Key
 	it, err := db.KeyIterator(true)
 	if err != nil {
 		return "", "", err
@@ -348,17 +350,23 @@ func doSecondaryGet(db database.DB, req *proto.GetRequest) (primaryKey string, s
 	} else {
 		// For all the other cases, we set the iterator on >=
 		it.SeekGE(searchKey)
-	}
 
-	if !it.Valid() && (req.ComparisonType == proto.KeyComparisonType_FLOOR ||
-		req.ComparisonType == proto.KeyComparisonType_CEILING) {
-		// There might be more keys in the db. Let's try to compare it
-		// to the highest one
-		it.Prev()
+		if req.ComparisonType == proto.KeyComparisonType_FLOOR &&
+			(!it.Valid() || !strings.HasPrefix(it.Key(), indexPrefix)) {
+			// There is no entry of this index at or after the search key: the
+			// floor candidate, if any, is the last index entry before it.
+			it.SeekLT(searchKey)
+		}
 	}
 
 	for it.Valid() {
 		itKey := it.Key()
+		if !strings.HasPrefix(itKey, indexPrefix) {
+			// We stepped out of the region of the requested index: entries of
+			// other indexes (or other keyspaces) must not be considered.
+			break
+		}
+
 		primaryKey, secondaryKey, err = secondaryIndexPrimaryAndSecondaryKey(itKey)
 		if err != nil && !errors.Is(err, errFailedToParseSecondaryKey) {
 			return "", "", err
@@ -406,9 +414,6 @@ func doSecondaryGet(db database.DB, req *proto.GetRequest) (primaryKey string, s
 		}
 	}
 
-	if !it.Valid() {
-		primaryKey = ""
-	}
-
-	return primaryKey, secondaryKey, err
+	// The walk ran out of entries of the requested index without finding a match
+	return "", "", nil
 }

--- a/oxiad/dataserver/controller/lead/secondary_indexes_test.go
+++ b/oxiad/dataserver/controller/lead/secondary_indexes_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	pb "google.golang.org/protobuf/proto"
 
+	"github.com/oxia-db/oxia/common/channel"
 	"github.com/oxia-db/oxia/oxiad/dataserver/option"
 
 	"github.com/oxia-db/oxia/common/rpc"
@@ -348,6 +349,102 @@ func TestSecondaryIndices_MultipleKeysForSameIdx(t *testing.T) {
 	assert.Contains(t, keys, "/c")
 	assert.Contains(t, keys, "/d")
 	assert.Contains(t, keys, "/e")
+
+	assert.NoError(t, lc.Close())
+	assert.NoError(t, kvFactory.Close())
+	assert.NoError(t, walFactory.Close())
+}
+
+func TestSecondaryIndices_GetBoundedToRequestedIndex(t *testing.T) {
+	var shard int64 = 1
+
+	kvFactory, _ := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	walFactory := newTestWalFactory(t)
+
+	lc, _ := NewLeaderController(&option.StorageOptions{}, constant.DefaultNamespace, shard, rpc.NewMockRpcClient(), walFactory, kvFactory, nil)
+	_, _ = lc.NewTerm(&proto.NewTermRequest{Shard: shard, Term: 1})
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
+		Shard:             shard,
+		Term:              1,
+		ReplicationFactor: 1,
+		FollowerMaps:      nil,
+	})
+
+	// Three indexes whose regions are adjacent in the key space:
+	// "id" < "md5" < "schemaId". The "md5" index only contains "m", so gets
+	// around its edges must not return entries of the neighboring indexes.
+	_, err := lc.WriteBlock(context.Background(), &proto.WriteRequest{
+		Shard: &shard,
+		Puts: []*proto.PutRequest{
+			{Key: "/id-aa", Value: []byte("0"), SecondaryIndexes: []*proto.SecondaryIndex{{IndexName: "id", SecondaryKey: "aa"}}},
+			{Key: "/md5-m", Value: []byte("1"), SecondaryIndexes: []*proto.SecondaryIndex{{IndexName: "md5", SecondaryKey: "m"}}},
+			{Key: "/schema-zz", Value: []byte("2"), SecondaryIndexes: []*proto.SecondaryIndex{{IndexName: "schemaId", SecondaryKey: "zz"}}},
+		},
+	})
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		comparison     proto.KeyComparisonType
+		index          string
+		key            string
+		expectedKey    string // "" means KEY_NOT_FOUND expected
+		expectedSecKey string
+	}{
+		// Same-index matches around the "md5" entry.
+		{"equal-match", proto.KeyComparisonType_EQUAL, "md5", "m", "/md5-m", "m"},
+		{"ceiling-from-below", proto.KeyComparisonType_CEILING, "md5", "b", "/md5-m", "m"},
+		{"higher-from-below", proto.KeyComparisonType_HIGHER, "md5", "b", "/md5-m", "m"},
+		{"floor-from-above", proto.KeyComparisonType_FLOOR, "md5", "x", "/md5-m", "m"},
+		{"lower-from-above", proto.KeyComparisonType_LOWER, "md5", "x", "/md5-m", "m"},
+
+		// Below the lowest "md5" entry: must not return entries of the
+		// preceding "id" index.
+		{"floor-below-all", proto.KeyComparisonType_FLOOR, "md5", "b", "", ""},
+		{"lower-below-all", proto.KeyComparisonType_LOWER, "md5", "b", "", ""},
+		{"equal-of-preceding-index", proto.KeyComparisonType_EQUAL, "md5", "aa", "", ""},
+
+		// Above the highest "md5" entry: must not return entries of the
+		// following "schemaId" index.
+		{"ceiling-above-all", proto.KeyComparisonType_CEILING, "md5", "x", "", ""},
+		{"higher-above-all", proto.KeyComparisonType_HIGHER, "md5", "x", "", ""},
+		{"higher-at-max", proto.KeyComparisonType_HIGHER, "md5", "m", "", ""},
+		{"equal-of-following-index", proto.KeyComparisonType_EQUAL, "md5", "zz", "", ""},
+
+		// Index with no entries at all: the neighboring indexes must stay
+		// invisible.
+		{"floor-missing-index", proto.KeyComparisonType_FLOOR, "missing", "x", "", ""},
+		{"ceiling-missing-index", proto.KeyComparisonType_CEILING, "missing", "b", "", ""},
+		{"lower-missing-index", proto.KeyComparisonType_LOWER, "missing", "x", "", ""},
+		{"higher-missing-index", proto.KeyComparisonType_HIGHER, "missing", "b", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			responses := make(chan *entity.TWithError[*proto.GetResponse], 1)
+			lc.Read(context.Background(), &proto.ReadRequest{
+				Shard: &shard,
+				Gets: []*proto.GetRequest{{
+					Key:                tc.key,
+					ComparisonType:     tc.comparison,
+					SecondaryIndexName: pb.String(tc.index),
+				}},
+			}, concurrent.ReadFromStreamCallback(responses))
+			resps, err := channel.ReadAll[*proto.GetResponse](context.Background(), responses)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(resps))
+
+			res := resps[0]
+			if tc.expectedKey == "" {
+				assert.Equal(t, proto.Status_KEY_NOT_FOUND, res.Status)
+				assert.Nil(t, res.Key)
+			} else {
+				assert.Equal(t, proto.Status_OK, res.Status)
+				assert.Equal(t, tc.expectedKey, *res.Key)
+				assert.Equal(t, tc.expectedSecKey, *res.SecondaryIndexKey)
+			}
+		})
+	}
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, kvFactory.Close())


### PR DESCRIPTION
## Motivation
Secondary-index gets can cross into a neighboring index key region when no matching entry exists in the requested index. This can return a primary key belonging to a different secondary index and can also scan unrelated key regions.

Backports #1248 to `release-0.16`.

## Modifications
- Bound secondary-index iteration to the requested index key prefix.
- Reposition `FLOOR` lookups with `SeekLT` when the initial seek is past the end.
- Return `KEY_NOT_FOUND` for `CEILING` lookups past the end.
- Add regression coverage for all comparison types at index boundaries and for missing indexes.
- Adapt the regression test to the `release-0.16` streaming-read test API.

## Testing
- `go test ./oxiad/dataserver/controller/lead -run '^TestSecondaryIndices_GetBoundedToRequestedIndex$' -count=1`
- `go test ./oxiad/dataserver/controller/lead -count=1`