### PR TITLE
fix: reject WAL record sizes that overflow the codec bounds check

### DIFF
--- a/oxiad/dataserver/wal/codec/v1.go
+++ b/oxiad/dataserver/wal/codec/v1.go
@@ -89,7 +89,7 @@ func (v *V1) ReadHeaderWithValidation(buf []byte, startFileOffset uint32) (paylo
 	headerEndOffset := uint64(startFileOffset) + uint64(v.HeaderSize)
 	if headerEndOffset > bufSize {
 		return payloadSize, previousCrc, payloadCrc, errors.Wrapf(ErrOffsetOutOfBounds,
-			"expected payload size: %d. actual buf size: %d ", headerEndOffset, bufSize)
+			"expected header end offset: %d. actual buf size: %d ", headerEndOffset, bufSize)
 	}
 
 	payloadSize = ReadInt(buf, startFileOffset)
@@ -102,7 +102,8 @@ func (v *V1) ReadHeaderWithValidation(buf []byte, startFileOffset uint32) (paylo
 	actualBufSize := bufSize - uint64(startFileOffset)
 	if expectSize > actualBufSize {
 		return payloadSize, previousCrc, payloadCrc,
-			errors.Wrapf(ErrOffsetOutOfBounds, "expected payload size: %d. actual buf size: %d ", expectSize, bufSize)
+			errors.Wrapf(ErrOffsetOutOfBounds,
+				"expected record size: %d. actual remaining buf size: %d ", expectSize, actualBufSize)
 	}
 	return payloadSize, previousCrc, payloadCrc, nil
 }

--- a/oxiad/dataserver/wal/codec/v1.go
+++ b/oxiad/dataserver/wal/codec/v1.go
@@ -85,10 +85,11 @@ func (v *V1) GetRecordSize(buf []byte, startFileOffset uint32) (payloadSize uint
 }
 
 func (v *V1) ReadHeaderWithValidation(buf []byte, startFileOffset uint32) (payloadSize uint32, previousCrc uint32, payloadCrc uint32, err error) {
-	bufSize := uint32(len(buf))
-	if startFileOffset >= bufSize {
+	bufSize := uint64(len(buf))
+	headerEndOffset := uint64(startFileOffset) + uint64(v.HeaderSize)
+	if headerEndOffset > bufSize {
 		return payloadSize, previousCrc, payloadCrc, errors.Wrapf(ErrOffsetOutOfBounds,
-			"expected payload size: %d. actual buf size: %d ", startFileOffset+v1PayloadSizeLen, bufSize)
+			"expected payload size: %d. actual buf size: %d ", headerEndOffset, bufSize)
 	}
 
 	payloadSize = ReadInt(buf, startFileOffset)
@@ -96,9 +97,9 @@ func (v *V1) ReadHeaderWithValidation(buf []byte, startFileOffset uint32) (paylo
 	if payloadSize == 0 {
 		return payloadSize, previousCrc, payloadCrc, errors.Wrapf(ErrEmptyPayload, "unexpected empty payload")
 	}
-	expectSize := payloadSize + v.HeaderSize
+	expectSize := uint64(payloadSize) + uint64(v.HeaderSize)
 	// overflow checking
-	actualBufSize := bufSize - startFileOffset
+	actualBufSize := bufSize - uint64(startFileOffset)
 	if expectSize > actualBufSize {
 		return payloadSize, previousCrc, payloadCrc,
 			errors.Wrapf(ErrOffsetOutOfBounds, "expected payload size: %d. actual buf size: %d ", expectSize, bufSize)

--- a/oxiad/dataserver/wal/codec/v1_test.go
+++ b/oxiad/dataserver/wal/codec/v1_test.go
@@ -16,6 +16,7 @@ package codec
 
 import (
 	"encoding/binary"
+	"math"
 	"os"
 	"path"
 	"testing"
@@ -40,6 +41,44 @@ func TestV1_Codec(t *testing.T) {
 	getPayload, _, _, err := v1.ReadRecordWithValidation(buf, 0)
 	assert.NoError(t, err)
 	assert.EqualValues(t, payload, getPayload)
+}
+
+func TestV1_BreakingPoint_SizeOverflow(t *testing.T) {
+	buf := make([]byte, 100)
+
+	v1.WriteRecord(buf, 0, 0, []byte{1})
+	// a size this close to the uint32 max wraps once the header size is added to it
+	binary.BigEndian.PutUint32(buf, math.MaxUint32)
+
+	_, _, _, err := v1.ReadHeaderWithValidation(buf, 0)
+	assert.ErrorIs(t, err, ErrOffsetOutOfBounds)
+
+	_, err = v1.GetRecordSize(buf, 0)
+	assert.ErrorIs(t, err, ErrOffsetOutOfBounds)
+}
+
+func TestV1_BreakingPoint_PartialHeader(t *testing.T) {
+	buf := make([]byte, 100)
+
+	v1.WriteRecord(buf, 0, 0, []byte{1})
+
+	// an offset with fewer than HeaderSize bytes behind it has no readable header
+	_, _, _, err := v1.ReadHeaderWithValidation(buf, uint32(len(buf))-1)
+	assert.ErrorIs(t, err, ErrOffsetOutOfBounds)
+}
+
+func TestV1_RecoverIndexWithSizeOverflow(t *testing.T) {
+	buf := make([]byte, 100)
+
+	v1.WriteRecord(buf, 0, 0, []byte{1})
+	// HeaderSize + payloadSize wraps to exactly 0, so recovery must not advance by nothing
+	binary.BigEndian.PutUint32(buf, math.MaxUint32-v1.HeaderSize+1)
+
+	index, _, newFileOffset, lastEntryOffset, err := v1.RecoverIndex(buf, 0, 0, nil)
+	assert.NoError(t, err)
+	assert.Empty(t, index)
+	assert.EqualValues(t, 0, newFileOffset)
+	assert.EqualValues(t, -1, lastEntryOffset)
 }
 
 func TestV1_WriteReadIndex(t *testing.T) {

--- a/oxiad/dataserver/wal/codec/v2.go
+++ b/oxiad/dataserver/wal/codec/v2.go
@@ -98,11 +98,12 @@ func (v *V2) ReadRecordWithValidation(buf []byte, startFileOffset uint32) (paylo
 }
 
 func (v *V2) ReadHeaderWithValidation(buf []byte, startFileOffset uint32) (payloadSize uint32, previousCrc uint32, payloadCrc uint32, err error) {
-	bufSize := uint32(len(buf))
-	if startFileOffset >= bufSize {
+	bufSize := uint64(len(buf))
+	headerEndOffset := uint64(startFileOffset) + uint64(v.HeaderSize)
+	if headerEndOffset > bufSize {
 		return payloadSize, previousCrc, payloadCrc,
 			errors.Wrapf(ErrOffsetOutOfBounds, "expected payload size: %d. actual buf size: %d ",
-				startFileOffset+v2PayloadSizeLen, bufSize)
+				headerEndOffset, bufSize)
 	}
 
 	var headerOffset uint32
@@ -114,9 +115,9 @@ func (v *V2) ReadHeaderWithValidation(buf []byte, startFileOffset uint32) (paylo
 		return payloadSize, previousCrc, payloadCrc, errors.Wrapf(ErrEmptyPayload, "unexpected empty payload")
 	}
 
-	expectSize := payloadSize + v.HeaderSize
+	expectSize := uint64(payloadSize) + uint64(v.HeaderSize)
 	// overflow checking
-	actualBufSize := bufSize - startFileOffset
+	actualBufSize := bufSize - uint64(startFileOffset)
 	if expectSize > actualBufSize {
 		return payloadSize, previousCrc, payloadCrc,
 			errors.Wrapf(ErrOffsetOutOfBounds, "expected payload size: %d. actual buf size: %d ", expectSize, bufSize)

--- a/oxiad/dataserver/wal/codec/v2.go
+++ b/oxiad/dataserver/wal/codec/v2.go
@@ -102,7 +102,7 @@ func (v *V2) ReadHeaderWithValidation(buf []byte, startFileOffset uint32) (paylo
 	headerEndOffset := uint64(startFileOffset) + uint64(v.HeaderSize)
 	if headerEndOffset > bufSize {
 		return payloadSize, previousCrc, payloadCrc,
-			errors.Wrapf(ErrOffsetOutOfBounds, "expected payload size: %d. actual buf size: %d ",
+			errors.Wrapf(ErrOffsetOutOfBounds, "expected header end offset: %d. actual buf size: %d ",
 				headerEndOffset, bufSize)
 	}
 
@@ -120,7 +120,8 @@ func (v *V2) ReadHeaderWithValidation(buf []byte, startFileOffset uint32) (paylo
 	actualBufSize := bufSize - uint64(startFileOffset)
 	if expectSize > actualBufSize {
 		return payloadSize, previousCrc, payloadCrc,
-			errors.Wrapf(ErrOffsetOutOfBounds, "expected payload size: %d. actual buf size: %d ", expectSize, bufSize)
+			errors.Wrapf(ErrOffsetOutOfBounds,
+				"expected record size: %d. actual remaining buf size: %d ", expectSize, actualBufSize)
 	}
 
 	previousCrc = ReadInt(buf, startFileOffset+headerOffset)

--- a/oxiad/dataserver/wal/codec/v2_test.go
+++ b/oxiad/dataserver/wal/codec/v2_test.go
@@ -17,6 +17,7 @@ package codec
 import (
 	"bytes"
 	"encoding/binary"
+	"math"
 	"os"
 	"path"
 	"testing"
@@ -196,6 +197,35 @@ func TestV2_BreakingPoint_Size(t *testing.T) {
 
 	_, _, _, err = v2.ReadRecordWithValidation(buf, 0)
 	assert.ErrorIs(t, err, ErrOffsetOutOfBounds)
+}
+
+func TestV2_BreakingPoint_SizeOverflow(t *testing.T) {
+	buf := make([]byte, 100)
+
+	v2.WriteRecord(buf, 0, 0, []byte{1})
+	// a size this close to the uint32 max wraps once the header size is added to it
+	binary.BigEndian.PutUint32(buf, math.MaxUint32)
+
+	_, _, _, err := v2.ReadHeaderWithValidation(buf, 0)
+	assert.ErrorIs(t, err, ErrOffsetOutOfBounds)
+
+	_, _, _, err = v2.ReadRecordWithValidation(buf, 0)
+	assert.ErrorIs(t, err, ErrOffsetOutOfBounds)
+
+	_, err = v2.GetRecordSize(buf, 0)
+	assert.ErrorIs(t, err, ErrOffsetOutOfBounds)
+}
+
+func TestV2_BreakingPoint_PartialHeader(t *testing.T) {
+	buf := make([]byte, 100)
+
+	v2.WriteRecord(buf, 0, 0, []byte{1})
+
+	// an offset with fewer than HeaderSize bytes behind it has no readable header
+	for _, startFileOffset := range []uint32{uint32(len(buf)) - 1, uint32(len(buf)) - v2.HeaderSize + 1} {
+		_, _, _, err := v2.ReadHeaderWithValidation(buf, startFileOffset)
+		assert.ErrorIs(t, err, ErrOffsetOutOfBounds)
+	}
 }
 
 func TestV2_BreakingPoint_PreviousCrc(t *testing.T) {


### PR DESCRIPTION
The WAL codec checks a record's declared payload size against what is left in the segment before it reads the payload, but it adds the header size to that declared size in uint32. A size field within a header's width of the uint32 max wraps to a small number, so the guard that is meant to catch an oversized record passes instead, and V2 then slices the payload with a high bound that has wrapped below the low bound. The size is used to slice before the CRC is checked, so a single flipped byte is enough, and since RecoverIndex runs on every WAL open the panic lands on the startup path with nothing to recover it. The quieter consequences bothered me more than the crash: GetRecordSize hands back a wrapped record size, which makes readWriteSegment.Truncate compute an end offset below the offset the caller declared safe and zero out committed records, and V1's RecoverIndex can advance by exactly zero and spin. I ran into this while extending TestV2_BreakingPoint_Size, which already corrupts the size field but uses 123123, a value too small to wrap. Doing the arithmetic in uint64 and requiring the whole header to be in range before reading it covers both codec versions, and that second part also closes a case where ReadInt read four bytes behind a guard that only required one to be present. I kept it inside ReadHeaderWithValidation because every read path funnels through it.