### PR TITLE
fix: clamp the separator count in the hierarchical key encoder

### DIFF
--- a/common/compare/encode.go
+++ b/common/compare/encode.go
@@ -60,6 +60,11 @@ const (
 	encodedSeparator      = 0xff
 	internalKeysBitMarker = 1 << 15
 
+	// maxSeparatorCount is the deepest level the 2-byte prefix can record. The
+	// count shares those bytes with the internal-key marker, so it has to stay
+	// below it.
+	maxSeparatorCount = internalKeysBitMarker - 1
+
 	// maxByteValue is the largest byte value; a prefix made only of these has
 	// no successor.
 	maxByteValue = 0xff
@@ -95,6 +100,12 @@ func (encoderHierarchical) Encode(key string) []byte {
 		if l >= 2 && key[l-1] == '/' && key[l-2] == '/' {
 			// Ignore the trailing separator as it doesn't create a new level
 			sepCount--
+		}
+
+		if sepCount > maxSeparatorCount {
+			// Keys deeper than the prefix can count all share the deepest
+			// level, rather than wrapping into the internal-key region
+			sepCount = maxSeparatorCount
 		}
 
 		if strings.HasPrefix(key, constant.InternalKeyPrefix) {

--- a/common/compare/encode_test.go
+++ b/common/compare/encode_test.go
@@ -17,9 +17,12 @@ package compare
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/oxia-db/oxia/common/constant"
 )
 
 func TestEncodeDecode(t *testing.T) {
@@ -109,6 +112,47 @@ func TestEncodeInternalKeys(t *testing.T) {
 			assert.Equal(t, k, encoder.Decode(encoder.Encode(k)))
 		})
 	}
+}
+
+// A key carries its own separator count in the 2-byte prefix, and that count
+// shares the prefix with the internal-key marker. Keys with more separators
+// than the prefix can hold must not reach into the marker, nor wrap around and
+// come back as a different key.
+func TestEncodeDeeplyNestedKeys(t *testing.T) {
+	enc := EncoderHierarchical
+
+	for _, test := range []struct {
+		name     string
+		sepCount int
+	}{
+		{"below the marker", maxSeparatorCount - 1},
+		{"at the marker", internalKeysBitMarker},
+		{"past the marker", internalKeysBitMarker + 1},
+		{"wrapping the prefix", 1 << 16},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// The trailing "a" keeps the last two bytes from being separators,
+			// which would otherwise drop the count by one
+			key := strings.Repeat("/", test.sepCount) + "a"
+
+			encoded := enc.Encode(key)
+			assert.False(t, enc.IsInternalKey(encoded))
+			assert.Equal(t, key, enc.Decode(encoded))
+
+			// and it still sorts before the internal keys
+			assert.Equal(t, -1, bytes.Compare(encoded, enc.Encode("__oxia/xyz")))
+		})
+	}
+}
+
+func TestEncodeDeeplyNestedInternalKeys(t *testing.T) {
+	enc := EncoderHierarchical
+
+	key := constant.InternalKeyPrefix + strings.Repeat("/", 1<<16) + "a"
+	encoded := enc.Encode(key)
+
+	assert.True(t, enc.IsInternalKey(encoded))
+	assert.Equal(t, key, enc.Decode(encoded))
 }
 
 // The buffer passed to Decode is Pebble memory, handed out under an explicit


### PR DESCRIPTION
The hierarchical encoder records a key's nesting depth in a two-byte prefix, and the top bit of that prefix is what marks a key as one of oxia's own `__oxia/` keys. The depth is `strings.Count(key, "/")` over a key that arrives straight from a client Put, and it is narrowed to uint16 with nothing bounding it, so a key carrying 32768 separators sets the internal marker on its own. IsInternalKey then reports true for ordinary user data, and because newIterOptions bounds user iterations at the start of the internal region, that record stays fetchable by Get but stops appearing in List and RangeScan, and it sits above the bounds an ordinary DeleteRange would cover. Past 65535 separators the count wraps to zero, Decode takes its zero-prefix fast path and never restores the 0xff bytes back to '/', so a scan hands back a different key than the one that was written. I noticed it from the comment above InternalKeyRange, which puts the boundary at exactly 32768 separators and then leaves nothing enforcing it. hierarchical is the default sorting and nothing caps key size on the client API, so a 32 KiB key is enough to reach either case. Clamping the count just under the marker leaves every key with fewer separators encoded byte for byte as before, and only keys deeper than the prefix can count end up sharing the deepest level.