### PR TITLE
fix: quiet failed shell connection health checks

### DIFF
--- a/cmd/client/shell/cmd.go
+++ b/cmd/client/shell/cmd.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/kballard/go-shellquote"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	admincommons "github.com/oxia-db/oxia/cmd/admin/commons"
 	"github.com/oxia-db/oxia/cmd/client/common"
@@ -175,6 +177,18 @@ func (r *repl) clientForCommand() (oxia.SyncClient, error) {
 	return syncClient, nil
 }
 
+func isConnectionFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded:
+		return true
+	default:
+		return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, io.EOF)
+	}
+}
+
 func (r *repl) runBuffered() error {
 	reader := bufio.NewReader(r.in)
 	for {
@@ -242,8 +256,16 @@ func (r *repl) executeLine(line string) error {
 			Out:          r.out,
 			OutputFormat: r.outputFormat,
 		}.Execute(args[1:])
+		if isConnectionFailure(err) && r.admin != nil {
+			_ = r.admin.Close()
+			r.admin = nil
+		}
 	default:
 		err = clientExecutor.Execute(args)
+		if isConnectionFailure(err) && r.client != nil {
+			_ = r.client.Close()
+			r.client = nil
+		}
 	}
 
 	if errors.Is(err, errExit) {

--- a/cmd/client/shell/cmd_test.go
+++ b/cmd/client/shell/cmd_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	admincommons "github.com/oxia-db/oxia/cmd/admin/commons"
 	"github.com/oxia-db/oxia/common/proto"
@@ -113,6 +115,39 @@ func TestShellRejectsClientPrefix(t *testing.T) {
 	assert.Empty(t, stdout)
 	assert.Equal(t, "Error: unknown client command \"client\"\n", stderr)
 	common.MockedClient.AssertExpectations(t)
+}
+
+func TestShellClosesClientAfterConnectionError(t *testing.T) {
+	common.MockedClient = common.NewMockClient()
+	t.Cleanup(func() { common.MockedClient = nil })
+
+	var emptyGetOptions []oxia.GetOption
+	common.MockedClient.On("Get", "k", emptyGetOptions).Return("", []byte(nil), oxia.Version{}, status.Error(codes.Unavailable, "connection refused"))
+	common.MockedClient.On("Close").Return(nil).Once()
+
+	stdout, stderr, err := runShell(t, "get k\n")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "connection refused")
+	common.MockedClient.AssertExpectations(t)
+}
+
+func TestShellClosesAdminClientAfterConnectionError(t *testing.T) {
+	admincommons.MockedAdminClient = admincommons.NewMockAdminClient()
+	t.Cleanup(func() { admincommons.MockedAdminClient = nil })
+
+	admincommons.MockedAdminClient.On("ListNamespaces").Return([]*proto.NamespaceView(nil), status.Error(codes.Unavailable, "connection refused"))
+	admincommons.MockedAdminClient.On("Close").Return(nil).Once()
+
+	stdout, stderr, err := runShell(t, "admin namespace list\n")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "connection refused")
+	admincommons.MockedAdminClient.AssertExpectations(t)
 }
 
 func TestInteractiveShellContinuesAfterCommandError(t *testing.T) {


### PR DESCRIPTION
## Motivation
When an `oxia shell` admin or client command fails to connect, the shell can keep a failed cached client around for later commands. In an interactive terminal that makes the next command reuse stale connection state and can leave background connection handling visible in the prompt.

The shell should surface the command failure and discard the failed cached client so the next command starts from a clean connection.

## Modifications
- Close and clear cached shell admin/client instances after connection-style command failures.
- Inline the close/reset logic at the shell call sites instead of keeping separate helper methods.
- Add shell tests for client/admin connection failures closing the cached clients.

## Testing
- `go test ./cmd/client/shell ./common/rpc`