### PR TITLE
fix: delay connection health ping

### DIFF
--- a/common/rpc/connection.go
+++ b/common/rpc/connection.go
@@ -170,6 +170,12 @@ func (c *connection) healthCheckLoop() {
 
 	consecutiveFailures := 0
 	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
 		ctx, cancel := context.WithTimeout(c.ctx, c.healthPingTimeout)
 		response, err := c.healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: ""})
 		cancel()
@@ -205,12 +211,6 @@ func (c *connection) healthCheckLoop() {
 		if shouldDisconnect && c.disconnected.CompareAndSwap(false, true) {
 			c.notifyDisconnect()
 			return
-		}
-
-		select {
-		case <-c.ctx.Done():
-			return
-		case <-ticker.C:
 		}
 	}
 }


### PR DESCRIPTION
## Motivation
The RPC connection health loop currently sends its first health check immediately after a client connection is created. For short-lived clients, such as failed `oxia shell` commands, that background ping can race with the command failure and print a `Connection health ping failed` warning into the terminal prompt.

Delaying the first health ping until the configured health interval keeps the health checker behavior for long-lived connections while avoiding immediate log noise for short-lived failed connections.

## Modifications
- Move the health-loop ticker wait to the start of `healthCheckLoop`.
- Leave the existing health failure threshold and connection removal behavior unchanged.

## Testing
- `go test ./common/rpc`
- `go build -o bin/oxia ./cmd`
- `printf 'admin namespace list\n' | ./bin/oxia shell --admin-address 127.0.0.1:1`