### PR TITLE
fix: parse secondary index keys at the last separator

### DIFF
--- a/oxiad/dataserver/controller/lead/secondary_indexes.go
+++ b/oxiad/dataserver/controller/lead/secondary_indexes.go
@@ -146,7 +146,12 @@ const secondaryIdxSeparator = "\x01"
 const secondaryIdxRangePrefixFormat = secondaryIdxKeyPrefix + "/%s/%s"
 const secondaryIdxFormat = secondaryIdxRangePrefixFormat + secondaryIdxSeparator + "%s"
 
-const regex = "^" + secondaryIdxKeyPrefix + "/[^/]+/([^" + secondaryIdxSeparator + "]+)" + secondaryIdxSeparator + "(.+)$"
+// The index name and the secondary key are stored as the client supplied them,
+// so both can be empty and the secondary key can contain the separator. Only
+// the primary key is url-escaped, and that escaping never emits a separator, so
+// the last one is the field boundary.
+const regex = "(?s)^" + secondaryIdxKeyPrefix + "/[^/]*/(.*)" + secondaryIdxSeparator +
+	"([^" + secondaryIdxSeparator + "]*)$"
 
 var secondaryIdxFormatRegex = regexp.MustCompile(regex)
 

--- a/oxiad/dataserver/controller/lead/secondary_indexes_test.go
+++ b/oxiad/dataserver/controller/lead/secondary_indexes_test.go
@@ -16,6 +16,7 @@ package lead
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -426,6 +427,70 @@ func TestSecondaryIndices_GetBoundedToRequestedIndex(t *testing.T) {
 				assert.Equal(t, tc.expectedSecKey, *res.SecondaryIndexKey)
 			}
 		})
+	}
+
+	assert.NoError(t, lc.Close())
+	assert.NoError(t, kvFactory.Close())
+	assert.NoError(t, walFactory.Close())
+}
+
+func TestSecondaryIndices_SecondaryKeyWithSeparator(t *testing.T) {
+	var shard int64 = 1
+
+	kvFactory, _ := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	walFactory := newTestWalFactory(t)
+
+	lc, _ := NewLeaderController(&option.StorageOptions{}, constant.DefaultNamespace, shard, rpc.NewMockRpcClient(), walFactory, kvFactory, nil)
+	_, _ = lc.NewTerm(&proto.NewTermRequest{Shard: shard, Term: 1})
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
+		Shard:             shard,
+		Term:              1,
+		ReplicationFactor: 1,
+		FollowerMaps:      nil,
+	})
+
+	// The secondary key is stored as the client supplied it, so it can be empty
+	// or carry the byte that separates it from the primary key. Neither may
+	// change which record an index entry points back to.
+	sneaky := "k1" + secondaryIdxSeparator + url.PathEscape("/not-a-real-key")
+	_, err := lc.WriteBlock(context.Background(), &proto.WriteRequest{
+		Shard: &shard,
+		Puts: []*proto.PutRequest{
+			{Key: "/a", Value: []byte("0"), SecondaryIndexes: []*proto.SecondaryIndex{
+				{IndexName: "my-idx", SecondaryKey: sneaky}}},
+			{Key: "/b", Value: []byte("1"), SecondaryIndexes: []*proto.SecondaryIndex{
+				{IndexName: "my-idx", SecondaryKey: ""}}},
+		},
+	})
+	assert.NoError(t, err)
+
+	keys, err := lc.ListBlock(context.Background(), &proto.ListRequest{
+		Shard:              &shard,
+		StartInclusive:     "",
+		EndExclusive:       "\xff",
+		SecondaryIndexName: pb.String("my-idx"),
+	})
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"/a", "/b"}, keys)
+
+	// The same keys have to come back through a get on the index.
+	for _, tc := range []struct{ secondaryKey, expectedKey string }{
+		{sneaky, "/a"},
+		{"", "/b"},
+	} {
+		resps, err := readAll(context.Background(), lc, &proto.ReadRequest{
+			Shard: &shard,
+			Gets: []*proto.GetRequest{{
+				Key:                tc.secondaryKey,
+				ComparisonType:     proto.KeyComparisonType_EQUAL,
+				SecondaryIndexName: pb.String("my-idx"),
+			}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(resps))
+		assert.Equal(t, proto.Status_OK, resps[0].Status)
+		assert.Equal(t, tc.expectedKey, *resps[0].Key)
+		assert.Equal(t, tc.secondaryKey, *resps[0].SecondaryIndexKey)
 	}
 
 	assert.NoError(t, lc.Close())

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -52,8 +52,11 @@ var (
 	splitFilterMaxBatchBytes = 8 * 1024 * 1024
 )
 
+// Anchored on the last separator, like the index writer's own parser: the index
+// name and the secondary key are stored as the client supplied them, while the
+// url-escaped primary key never contains a separator.
 var secondaryIdxRegex = regexp.MustCompile(
-	"^" + idxKeyPrefix + "/[^/]+/([^" + idxSeparator + "]+)" + idxSeparator + "(.+)$",
+	"(?s)^" + idxKeyPrefix + "/[^/]*/(.*)" + idxSeparator + "([^" + idxSeparator + "]*)$",
 )
 
 // FilterDBForSplit removes keys that do not belong to the specified hash range.

--- a/oxiad/dataserver/database/split_filter_test.go
+++ b/oxiad/dataserver/database/split_filter_test.go
@@ -348,6 +348,50 @@ func TestFilterDBForSplit_SecondaryIndexKeys(t *testing.T) {
 	assert.False(t, keyExists(t, kv, rightIdxKey))
 }
 
+func TestFilterDBForSplit_SecondaryIndexKeysWithSeparator(t *testing.T) {
+	kv := newTestKV(t)
+
+	leftRange, _ := splitRanges()
+
+	// Find primary keys for each side
+	var leftPrimaryKey, rightPrimaryKey string
+	for i := 0; i < 1000; i++ {
+		k := fmt.Sprintf("pri-%d", i)
+		h := hash.Xxh332(k)
+		if leftPrimaryKey == "" && isHashInRange(h, leftRange) {
+			leftPrimaryKey = k
+		}
+		if rightPrimaryKey == "" && !isHashInRange(h, leftRange) {
+			rightPrimaryKey = k
+		}
+		if leftPrimaryKey != "" && rightPrimaryKey != "" {
+			break
+		}
+	}
+
+	// The secondary key is stored as the client supplied it, so it may be empty
+	// or contain the separator. The primary key still decides the side.
+	idxKey := func(secondary, primary string) string {
+		return fmt.Sprintf("%s/myidx/%s%s%s", idxKeyPrefix, secondary, idxSeparator, url.PathEscape(primary))
+	}
+	sneaky := "sec" + idxSeparator + url.PathEscape(rightPrimaryKey)
+
+	leftSneaky := idxKey(sneaky, leftPrimaryKey)
+	rightSneaky := idxKey(sneaky, rightPrimaryKey)
+	leftEmpty := idxKey("", leftPrimaryKey)
+	rightEmpty := idxKey("", rightPrimaryKey)
+	for _, k := range []string{leftSneaky, rightSneaky, leftEmpty, rightEmpty} {
+		putRawKey(t, kv, k, []byte{})
+	}
+
+	assert.NoError(t, FilterDBForSplit(kv, leftRange))
+
+	assert.True(t, keyExists(t, kv, leftSneaky))
+	assert.False(t, keyExists(t, kv, rightSneaky))
+	assert.True(t, keyExists(t, kv, leftEmpty))
+	assert.False(t, keyExists(t, kv, rightEmpty))
+}
+
 func TestFilterWriteRequestForSplit_Puts(t *testing.T) {
 	leftRange, _ := splitRanges()
 


### PR DESCRIPTION
A secondary index entry is stored under `__oxia/idx/{name}/{secondary}\x01{primary}`, where the index name and the secondary key go in exactly as the client sent them and only the primary key is url-escaped. Both parsers of that format split on the first `\x01`, so a record whose secondary key happens to contain that byte gets everything after the first one handed back as its primary key, and a List or RangeScan on the index reports a key that was never written while the range iterator issues a Get for it. An empty secondary key fares worse, since the pattern requires at least one character there and fails to match at all, and the list iterator turns that parse failure into the panic commented as unreachable because we control the key format. The same mis-parse reaches the split filter, which hashes the recovered primary key to pick which child keeps an entry, so after a shard split index entries settle on the wrong side and no later delete can clean them up, since deletes rebuild the key from the record's own side. I ran into this while checking what validates `SecondaryIndex.index_name` and `secondary_key` on the way in, and nothing does. Because `url.PathEscape` never emits a `\x01` for any input, the last separator is by construction the real field boundary, so anchoring both parsers there leaves every well formed key parsing exactly as it did before and asks nothing of what is already on disk.
