### PR TITLE
fix: move shard split ownership into shard controller

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -497,8 +497,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 h1:DHa2U07rk8syqvCge0QIGMCE1WxGj9njT44GH7zNJLQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
@@ -698,8 +696,6 @@ go.opentelemetry.io/contrib/detectors/gcp v1.39.0 h1:kWRNZMsfBHZ+uHjiH4y7Etn2FK2
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0/go.mod h1:t/OGqzHBa5v6RHZwrDBJ2OirWc+4q/w2fTbLZwAKjTk=
 go.opentelemetry.io/contrib/detectors/gcp v1.42.0 h1:kpt2PEJuOuqYkPcktfJqWWDjTEd/FNgrxcniL7kQrXQ=
 go.opentelemetry.io/contrib/detectors/gcp v1.42.0/go.mod h1:W9zQ439utxymRrXsUOzZbFX4JhLxXU4+ZnCt8GG7yA8=
-go.opentelemetry.io/contrib/detectors/gcp v1.43.0 h1:62yY3dT7/ShwOxzA0RsKRgshBmfElKI4d/Myu2OxDFU=
-go.opentelemetry.io/contrib/detectors/gcp v1.43.0/go.mod h1:RyaZMFY7yi1kAs45S6mbFGz8O8rqB0dTY14uzvG4LCs=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
@@ -764,8 +760,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217/go.mod h1:+rXWjjaukWZun3mLfjmVnQi18E1AsFbDN9QdJ5YXLto=
 google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 h1:tu/dtnW1o3wfaxCOjSLn5IRX4YDcJrtlpzYkhHhGaC4=
 google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171/go.mod h1:M5krXqk4GhBKvB596udGL3UyjL4I1+cTbK0orROM9ng=
-google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=
-google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478/go.mod h1:C6ADNqOxbgdUUeRTU+LCHDPB9ttAMCTff6auwCVa4uc=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=

--- a/go.work.sum
+++ b/go.work.sum
@@ -497,6 +497,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 h1:DHa2U07rk8syqvCge0QIGMCE1WxGj9njT44GH7zNJLQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
@@ -696,6 +698,8 @@ go.opentelemetry.io/contrib/detectors/gcp v1.39.0 h1:kWRNZMsfBHZ+uHjiH4y7Etn2FK2
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0/go.mod h1:t/OGqzHBa5v6RHZwrDBJ2OirWc+4q/w2fTbLZwAKjTk=
 go.opentelemetry.io/contrib/detectors/gcp v1.42.0 h1:kpt2PEJuOuqYkPcktfJqWWDjTEd/FNgrxcniL7kQrXQ=
 go.opentelemetry.io/contrib/detectors/gcp v1.42.0/go.mod h1:W9zQ439utxymRrXsUOzZbFX4JhLxXU4+ZnCt8GG7yA8=
+go.opentelemetry.io/contrib/detectors/gcp v1.43.0 h1:62yY3dT7/ShwOxzA0RsKRgshBmfElKI4d/Myu2OxDFU=
+go.opentelemetry.io/contrib/detectors/gcp v1.43.0/go.mod h1:RyaZMFY7yi1kAs45S6mbFGz8O8rqB0dTY14uzvG4LCs=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
@@ -760,6 +764,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217/go.mod h1:+rXWjjaukWZun3mLfjmVnQi18E1AsFbDN9QdJ5YXLto=
 google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 h1:tu/dtnW1o3wfaxCOjSLn5IRX4YDcJrtlpzYkhHhGaC4=
 google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171/go.mod h1:M5krXqk4GhBKvB596udGL3UyjL4I1+cTbK0orROM9ng=
+google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=
+google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478/go.mod h1:C6ADNqOxbgdUUeRTU+LCHDPB9ttAMCTff6auwCVa4uc=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=

--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -48,7 +48,10 @@ type Metadata interface {
 	CreateNamespaceStatus(name string, status *commonproto.NamespaceStatus) bool
 	ListNamespaceStatus() map[string]commonobject.Borrowed[*commonproto.NamespaceStatus]
 	GetNamespaceStatus(namespace string) (commonobject.Borrowed[*commonproto.NamespaceStatus], bool)
-	UpdateNamespaceStatus(name string, status *commonproto.NamespaceStatus)
+	// UpdateNamespaceStatus applies update to the latest namespace status while
+	// holding the metadata write lock. The callback must not call Metadata methods
+	// and returns whether it changed the status.
+	UpdateNamespaceStatus(name string, update func(*commonproto.NamespaceStatus) bool) bool
 	DeleteNamespaceStatus(name string) commonobject.Borrowed[*commonproto.NamespaceStatus]
 
 	GetShardStatus(namespace string, shard int64) (commonobject.Borrowed[*commonproto.ShardMetadata], bool)
@@ -272,16 +275,21 @@ func (m *coordinatorMetadata) GetNamespaceStatus(namespace string) (commonobject
 	return commonobject.Borrow(namespaceStatus), true
 }
 
-func (m *coordinatorMetadata) UpdateNamespaceStatus(name string, namespaceStatus *commonproto.NamespaceStatus) {
+func (m *coordinatorMetadata) UpdateNamespaceStatus(
+	name string,
+	update func(*commonproto.NamespaceStatus) bool,
+) bool {
 	namespaceExists := true
+	updated := false
 	_ = backoff.RetryNotify(func() error {
 		return m.computeStatus(func(clusterStatus *commonproto.ClusterStatus, _ metadatacommon.Version) (*commonproto.ClusterStatus, bool) {
-			if _, exists := clusterStatus.Namespaces[name]; !exists {
+			namespaceStatus, exists := clusterStatus.Namespaces[name]
+			if !exists {
 				namespaceExists = false
 				return clusterStatus, false
 			}
-			clusterStatus.Namespaces[name] = namespaceStatus
-			return clusterStatus, true
+			updated = update(namespaceStatus)
+			return clusterStatus, updated
 		})
 	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
 		m.logger.Warn(
@@ -293,6 +301,7 @@ func (m *coordinatorMetadata) UpdateNamespaceStatus(name string, namespaceStatus
 	if !namespaceExists {
 		m.logger.Warn("failed to update namespace status: namespace does not exist", slog.String("namespace", name))
 	}
+	return updated
 }
 
 func (m *coordinatorMetadata) DeleteNamespaceStatus(name string) commonobject.Borrowed[*commonproto.NamespaceStatus] {

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -119,13 +119,17 @@ func (m *mockNamespaceMetadata) CreateNamespaceStatus(
 	return true
 }
 
-func (m *mockNamespaceMetadata) UpdateNamespaceStatus(name string, status *proto.NamespaceStatus) {
+func (m *mockNamespaceMetadata) UpdateNamespaceStatus(
+	name string,
+	update func(*proto.NamespaceStatus) bool,
+) bool {
 	cloned := gproto.Clone(m.status).(*proto.ClusterStatus)
-	if _, exists := cloned.Namespaces[name]; !exists {
-		return
+	status, exists := cloned.Namespaces[name]
+	if !exists || !update(status) {
+		return false
 	}
-	cloned.Namespaces[name] = gproto.Clone(status).(*proto.NamespaceStatus)
 	m.status = cloned
+	return true
 }
 
 func (m *mockNamespaceMetadata) ListNamespaceStatus() map[string]commonobject.Borrowed[*proto.NamespaceStatus] {

--- a/oxiad/coordinator/runtime/action/action.go
+++ b/oxiad/coordinator/runtime/action/action.go
@@ -19,6 +19,7 @@ type Type string
 const (
 	SwapNode Type = "swap-node"
 	Election Type = "election"
+	Split    Type = "split"
 )
 
 type Action interface {

--- a/oxiad/coordinator/runtime/action/split.go
+++ b/oxiad/coordinator/runtime/action/split.go
@@ -1,0 +1,69 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type SplitResult struct {
+	LeftChild  int64
+	RightChild int64
+}
+
+type SplitAction struct {
+	Shard      int64
+	SplitPoint *uint32
+
+	finished atomic.Bool
+	result   SplitResult
+	err      error
+	waiter   sync.WaitGroup
+}
+
+func NewSplitAction(shard int64, splitPoint *uint32) *SplitAction {
+	a := &SplitAction{
+		Shard:      shard,
+		SplitPoint: splitPoint,
+	}
+	a.waiter.Add(1)
+	return a
+}
+
+func (a *SplitAction) Done(result any) {
+	if !a.finished.CompareAndSwap(false, true) {
+		return
+	}
+	a.result = result.(SplitResult) //nolint:revive
+	a.waiter.Done()
+}
+
+func (a *SplitAction) Error(err error) {
+	if !a.finished.CompareAndSwap(false, true) {
+		return
+	}
+	a.err = err
+	a.waiter.Done()
+}
+
+func (a *SplitAction) Wait() (SplitResult, error) {
+	a.waiter.Wait()
+	return a.result, a.err
+}
+
+func (*SplitAction) Type() Type {
+	return Split
+}

--- a/oxiad/coordinator/runtime/autosplit/monitor_test.go
+++ b/oxiad/coordinator/runtime/autosplit/monitor_test.go
@@ -558,10 +558,9 @@ func TestMonitor_LeaderChangeResetsThroughput(t *testing.T) {
 
 	// Leader moves to B, whose cumulative counters are much higher. Age the
 	// sample so elapsed > 0.
-	metadata.UpdateNamespaceStatus("default", &proto.NamespaceStatus{
-		Shards: map[int64]*proto.ShardMetadata{
-			0: steadyShard(leaderB, 0, 4294967295),
-		},
+	metadata.UpdateNamespaceStatus("default", func(status *proto.NamespaceStatus) bool {
+		status.Shards[0] = steadyShard(leaderB, 0, 4294967295)
+		return true
 	})
 	m.mu.Lock()
 	m.trackers[shardKey{namespace: "default", shardId: 0}].lastSampleTime = time.Now().Add(-time.Second)

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 	"github.com/stretchr/testify/assert"
+	gproto "google.golang.org/protobuf/proto"
 
 	commonobject "github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/proto"
@@ -74,7 +75,18 @@ func (*mockMetadata) CreateNamespaceStatus(string, *proto.NamespaceStatus) bool 
 	return false
 }
 
-func (*mockMetadata) UpdateNamespaceStatus(string, *proto.NamespaceStatus) {}
+func (m *mockMetadata) UpdateNamespaceStatus(
+	namespace string,
+	update func(*proto.NamespaceStatus) bool,
+) bool {
+	cloned := gproto.Clone(m.status).(*proto.ClusterStatus)
+	status, exists := cloned.Namespaces[namespace]
+	if !exists || !update(status) {
+		return false
+	}
+	m.status = cloned
+	return true
+}
 
 func (m *mockMetadata) ListNamespaceStatus() map[string]commonobject.Borrowed[*proto.NamespaceStatus] {
 	statuses := make(map[string]commonobject.Borrowed[*proto.NamespaceStatus], len(m.status.GetNamespaces()))

--- a/oxiad/coordinator/runtime/balancer/state/grouping_test.go
+++ b/oxiad/coordinator/runtime/balancer/state/grouping_test.go
@@ -42,7 +42,7 @@ func TestGroupingShardsIncludesNonSteadyShards(t *testing.T) {
 				2: {Status: proto.ShardStatusElection, Ensemble: ensemble},
 				// Being deleted: must not be counted
 				3: {Status: proto.ShardStatusDeleting, Leader: server("server1"), Ensemble: ensemble},
-				// Mid-split: managed by the split controller, must not be counted
+				// Mid-split: managed by the parent shard controller, must not be counted
 				4: {Status: proto.ShardStatusSteadyState, Leader: server("server1"), Ensemble: ensemble,
 					Split: &proto.SplitMetadata{ChildShardIds: []int64{5, 6}}},
 			},

--- a/oxiad/coordinator/runtime/controller/interfaces.go
+++ b/oxiad/coordinator/runtime/controller/interfaces.go
@@ -30,6 +30,8 @@ type ShardEventListener interface {
 }
 
 type ShardSplitEventListener interface {
+	SplitStarted(namespace string, parentShard int64, leftChild int64, rightChild int64)
+
 	SplitComplete(parentShard int64, leftChild int64, rightChild int64)
 
 	SplitAborted(parentShard int64, leftChild int64, rightChild int64)

--- a/oxiad/coordinator/runtime/controller/shard/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller.go
@@ -85,6 +85,11 @@ func NoOpSupportedFeaturesSupplier(dataServers []*proto.DataServerIdentity) map[
 	return features
 }
 
+type splitMetadataUpdate struct {
+	update func()
+	done   chan struct{}
+}
+
 type controller struct {
 	namespace       string
 	shard           int64
@@ -100,6 +105,7 @@ type controller struct {
 
 	electionOp          chan *action.ElectionAction
 	splitOp             chan *action.SplitAction
+	splitMetadataOp     chan splitMetadataUpdate
 	deleteOp            chan any
 	dataServerFailureOp chan *proto.DataServerIdentity
 	changeEnsembleOp    chan *action.ChangeEnsembleAction
@@ -113,8 +119,9 @@ type controller struct {
 	periodicTasksInterval time.Duration
 	logger                *slog.Logger
 
-	currentElection  *Election
-	currentSplitting *Splitting
+	currentElection            *Election
+	currentSplitting           *Splitting
+	executeSplitMetadataUpdate func(func())
 
 	leaderElectionLatency metric.LatencyHistogram
 	newTermQuorumLatency  metric.LatencyHistogram
@@ -162,6 +169,7 @@ func NewController(
 		leaderSelector:                      leaderselector.NewSelector(),
 		electionOp:                          make(chan *action.ElectionAction, chanBufferSize),
 		splitOp:                             make(chan *action.SplitAction, chanBufferSize),
+		splitMetadataOp:                     make(chan splitMetadataUpdate, chanBufferSize),
 		deleteOp:                            make(chan any, chanBufferSize),
 		dataServerFailureOp:                 make(chan *proto.DataServerIdentity, chanBufferSize),
 		changeEnsembleOp:                    make(chan *action.ChangeEnsembleAction, chanBufferSize),
@@ -193,6 +201,7 @@ func NewController(
 		})
 
 	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
+	s.executeSplitMetadataUpdate = s.enqueueSplitMetadataUpdate
 
 	s.logger.Info("Started shard controller", slog.Any("shard-metadata", shardMetadata))
 
@@ -249,6 +258,23 @@ func (s *controller) Split(splitAction *action.SplitAction) (action.SplitResult,
 	return splitAction.Wait()
 }
 
+func (s *controller) enqueueSplitMetadataUpdate(update func()) {
+	op := splitMetadataUpdate{
+		update: update,
+		done:   make(chan struct{}),
+	}
+	select {
+	case <-s.ctx.Done():
+		return
+	case s.splitMetadataOp <- op:
+	}
+
+	select {
+	case <-s.ctx.Done():
+	case <-op.done:
+	}
+}
+
 func (s *controller) newSplitting() *Splitting {
 	return NewSplitting(
 		s.ctx,
@@ -257,6 +283,7 @@ func (s *controller) newSplitting() *Splitting {
 		s.shard,
 		s.metadataStore,
 		s.rpc,
+		s.executeSplitMetadataUpdate,
 		s.splittingConfig,
 	)
 }
@@ -337,6 +364,9 @@ func (s *controller) run() {
 			periodicTasksTimer.Reset(s.periodicTasksInterval)
 		case electionAction := <-s.electionOp:
 			electionAction.Done(s.onElectLeader(nil).GetNameOrDefault())
+		case op := <-s.splitMetadataOp:
+			op.update()
+			close(op.done)
 		case splitAction := <-s.splitOp:
 			splitting := s.newSplitting()
 			leftChild, rightChild, err := splitting.Initialize(splitAction.SplitPoint)
@@ -654,6 +684,8 @@ func (s *controller) Close() error {
 				electionAction.Done("")
 			case splitAction := <-s.splitOp:
 				splitAction.Error(constant.ErrResourceUnavailable)
+			case op := <-s.splitMetadataOp:
+				close(op.done)
 			case <-s.deleteOp:
 			case <-s.dataServerFailureOp:
 			case op := <-s.changeEnsembleOp:

--- a/oxiad/coordinator/runtime/controller/shard/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller.go
@@ -70,6 +70,8 @@ type Controller interface {
 
 	Election(electionAction *action.ElectionAction) string
 
+	Split(splitAction *action.SplitAction) (action.SplitResult, error)
+
 	ChangeEnsemble(changeEnsembleAction *action.ChangeEnsembleAction)
 }
 
@@ -94,8 +96,10 @@ type controller struct {
 	eventListener                       controllerapi.ShardEventListener
 	metadataStore                       coordmetadata.Metadata
 	dataServerSupportedFeaturesSupplier DataServerSupportedFeaturesSupplier
+	splittingConfig                     SplitterConfig
 
 	electionOp          chan *action.ElectionAction
+	splitOp             chan *action.SplitAction
 	deleteOp            chan any
 	dataServerFailureOp chan *proto.DataServerIdentity
 	changeEnsembleOp    chan *action.ChangeEnsembleAction
@@ -109,7 +113,8 @@ type controller struct {
 	periodicTasksInterval time.Duration
 	logger                *slog.Logger
 
-	currentElection *Election
+	currentElection  *Election
+	currentSplitting *Splitting
 
 	leaderElectionLatency metric.LatencyHistogram
 	newTermQuorumLatency  metric.LatencyHistogram
@@ -141,6 +146,7 @@ func NewController(
 	metadataStore coordmetadata.Metadata,
 	dataServerSupportedFeaturesSupplier DataServerSupportedFeaturesSupplier,
 	eventListener controllerapi.ShardEventListener,
+	splitterConfig SplitterConfig,
 	rpcProvider rpc.Provider,
 	periodTasksInterval time.Duration) Controller {
 	labels := metric.LabelsForShard(namespace, shard)
@@ -152,8 +158,10 @@ func NewController(
 		metadataStore:                       metadataStore,
 		dataServerSupportedFeaturesSupplier: dataServerSupportedFeaturesSupplier,
 		eventListener:                       eventListener,
+		splittingConfig:                     splitterConfig,
 		leaderSelector:                      leaderselector.NewSelector(),
 		electionOp:                          make(chan *action.ElectionAction, chanBufferSize),
+		splitOp:                             make(chan *action.SplitAction, chanBufferSize),
 		deleteOp:                            make(chan any, chanBufferSize),
 		dataServerFailureOp:                 make(chan *proto.DataServerIdentity, chanBufferSize),
 		changeEnsembleOp:                    make(chan *action.ChangeEnsembleAction, chanBufferSize),
@@ -175,7 +183,6 @@ func NewController(
 		becomeLeaderLatency: metric.NewLatencyHistogram("oxia_coordinator_become_leader_latency",
 			"The time it takes for the new elected leader to start", labels),
 	}
-
 	s.termGauge = metric.NewGauge("oxia_coordinator_term",
 		"The term of the shard", "count", labels, func() int64 {
 			borrowedMeta, exists := s.metadataStore.GetShardStatus(s.namespace, s.shard)
@@ -225,6 +232,48 @@ func (s *controller) Election(electionAction *action.ElectionAction) string {
 	return clonedAction.NewLeader
 }
 
+func (s *controller) Split(splitAction *action.SplitAction) (action.SplitResult, error) {
+	s.terminationMu.RLock()
+	if s.terminating.Load() {
+		s.terminationMu.RUnlock()
+		splitAction.Error(constant.ErrResourceUnavailable)
+		return splitAction.Wait()
+	}
+	if !channel.PushNoBlock(s.splitOp, splitAction) {
+		s.terminationMu.RUnlock()
+		splitAction.Error(constant.ErrResourceUnavailable)
+		s.logger.Debug("Discarding shard split because queue is full")
+		return splitAction.Wait()
+	}
+	s.terminationMu.RUnlock()
+	return splitAction.Wait()
+}
+
+func (s *controller) newSplitting() *Splitting {
+	return NewSplitting(
+		s.ctx,
+		s.logger,
+		s.namespace,
+		s.shard,
+		s.metadataStore,
+		s.rpc,
+		s.splittingConfig,
+	)
+}
+
+func (s *controller) replaceCurrentSplitting(splitting *Splitting) {
+	if s.currentSplitting != nil {
+		s.currentSplitting.Stop()
+	}
+	s.currentSplitting = splitting
+}
+
+func (s *controller) startSplitting() {
+	splitting := s.newSplitting()
+	s.replaceCurrentSplitting(splitting)
+	splitting.Start()
+}
+
 func (s *controller) run() {
 	borrowedMeta, exists := s.metadataStore.GetShardStatus(s.namespace, s.shard)
 	initShardMeta := common.Must(borrowedMeta, exists,
@@ -236,10 +285,10 @@ func (s *controller) run() {
 	case initShardMeta.GetStatusOrDefault() == proto.ShardStatusDeleting:
 		s.DeleteShard()
 	case initShardMeta.Split != nil && len(initShardMeta.Split.ChildShardIds) == 0:
-		// Child shard during a split: the SplitController manages its lifecycle.
+		// Child shard during a split: the parent shard controller manages its lifecycle.
 		// Wait until the split is complete (Split metadata cleared) before
 		// entering the normal event loop, to prevent the load balancer from
-		// triggering elections that would interfere with the split controller.
+		// triggering elections that would interfere with the split state machine.
 		s.logger.Info("Child shard during split, waiting for split to complete")
 		s.waitForSplitComplete()
 	case initShardMeta.Leader == nil || initShardMeta.GetStatusOrDefault() != proto.ShardStatusSteadyState:
@@ -258,6 +307,10 @@ func (s *controller) run() {
 	}
 
 	s.logger.Info("Shard is ready", slog.Any("leader", initShardMeta.Leader))
+	if initShardMeta.Split != nil && len(initShardMeta.Split.ChildShardIds) == 2 {
+		s.logger.Info("Resuming in-progress shard split")
+		s.startSplitting()
+	}
 
 	// All the shard controllers start together at coordinator startup: spread
 	// the first periodic tick over the interval so the periodic tasks don't
@@ -284,14 +337,28 @@ func (s *controller) run() {
 			periodicTasksTimer.Reset(s.periodicTasksInterval)
 		case electionAction := <-s.electionOp:
 			electionAction.Done(s.onElectLeader(nil).GetNameOrDefault())
+		case splitAction := <-s.splitOp:
+			splitting := s.newSplitting()
+			leftChild, rightChild, err := splitting.Initialize(splitAction.SplitPoint)
+			if err != nil {
+				splitting.Stop()
+				splitAction.Error(err)
+				continue
+			}
+			s.replaceCurrentSplitting(splitting)
+			splitting.Start()
+			splitAction.Done(action.SplitResult{
+				LeftChild:  leftChild,
+				RightChild: rightChild,
+			})
 		}
 	}
 }
 
 // waitForSplitComplete blocks until the Split metadata is cleared from this
-// shard in the status resource, indicating the split controller has finished
+// shard in the status resource, indicating the parent controller has finished
 // and the shard can operate normally. This prevents the load balancer from
-// triggering elections that would interfere with the split controller.
+// triggering elections that would interfere with the split state machine.
 func (s *controller) waitForSplitComplete() {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
@@ -566,6 +633,10 @@ func (s *controller) deleteShardWithRetries() {
 func (s *controller) Close() error {
 	s.closeOnce.Do(func() {
 		s.ctxCancel()
+		if s.currentSplitting != nil {
+			s.currentSplitting.Stop()
+			s.currentSplitting = nil
+		}
 		// Cancel first so any sender blocked while holding terminationMu.RLock can
 		// release it before Close waits for the enqueue barrier.
 		s.terminationMu.Lock()
@@ -581,6 +652,8 @@ func (s *controller) Close() error {
 			select {
 			case electionAction := <-s.electionOp:
 				electionAction.Done("")
+			case splitAction := <-s.splitOp:
+				splitAction.Error(constant.ErrResourceUnavailable)
 			case <-s.deleteOp:
 			case <-s.dataServerFailureOp:
 			case op := <-s.changeEnsembleOp:

--- a/oxiad/coordinator/runtime/controller/shard/shard_controller_split.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller_split.go
@@ -47,10 +47,11 @@ type Splitting struct {
 	started   atomic.Bool
 
 	// borrowed resources
-	metadataStore coordmetadata.Metadata
-	rpc           rpc.Provider
-	eventListener controllerapi.ShardSplitEventListener
-	splitter      *Splitter
+	metadataStore         coordmetadata.Metadata
+	rpc                   rpc.Provider
+	eventListener         controllerapi.ShardSplitEventListener
+	splitter              *Splitter
+	executeMetadataUpdate func(func())
 
 	// owned state
 	namespace  string
@@ -67,6 +68,7 @@ func NewSplitting(
 	shard int64,
 	metadataStore coordmetadata.Metadata,
 	rpcProvider rpc.Provider,
+	executeMetadataUpdate func(func()),
 	config SplitterConfig,
 ) *Splitting {
 	timeout := config.SplitTimeout
@@ -75,15 +77,16 @@ func NewSplitting(
 	}
 	ctx, cancel := context.WithTimeout(parentCtx, timeout)
 	return &Splitting{
-		logger:        logger,
-		ctx:           ctx,
-		ctxCancel:     cancel,
-		metadataStore: metadataStore,
-		rpc:           rpcProvider,
-		eventListener: config.EventListener,
-		splitter:      NewSplitter(namespace, shard, metadataStore, config),
-		namespace:     namespace,
-		shard:         shard,
+		logger:                logger,
+		ctx:                   ctx,
+		ctxCancel:             cancel,
+		metadataStore:         metadataStore,
+		rpc:                   rpcProvider,
+		eventListener:         config.EventListener,
+		splitter:              NewSplitter(namespace, shard, metadataStore, config),
+		executeMetadataUpdate: executeMetadataUpdate,
+		namespace:             namespace,
+		shard:                 shard,
 	}
 }
 
@@ -132,10 +135,6 @@ func (s *Splitting) Stop() {
 		slog.Int64("left-child", s.leftChild),
 		slog.Int64("right-child", s.rightChild),
 	)
-}
-
-func (s *Splitting) executeMetadataUpdate(update func()) {
-	update()
 }
 
 func (s *Splitting) runSplitStateMachine() {
@@ -216,26 +215,18 @@ func (s *Splitting) currentPhase() (proto.SplitPhase, bool) {
 // updatePhase atomically updates the split phase on both parent and children.
 func (s *Splitting) updatePhase(newPhase proto.SplitPhase) {
 	s.executeMetadataUpdate(func() {
-		currentNS, exists := s.metadataStore.GetNamespaceStatus(s.namespace)
-		if !exists {
-			s.logger.Warn("namespace status not found while updating split phase",
-				slog.String("namespace", s.namespace),
-				slog.String("phase", newPhase.String()))
-			return
-		}
-		ns := gproto.Clone(currentNS.UnsafeBorrow()).(*proto.NamespaceStatus) //nolint:revive
-		changed := false
-		for _, shardId := range []int64{s.shard, s.leftChild, s.rightChild} {
-			meta, exists := ns.Shards[shardId]
-			if !exists || meta.Split == nil {
-				continue
+		s.metadataStore.UpdateNamespaceStatus(s.namespace, func(ns *proto.NamespaceStatus) bool {
+			changed := false
+			for _, shardId := range []int64{s.shard, s.leftChild, s.rightChild} {
+				meta, exists := ns.Shards[shardId]
+				if !exists || meta.Split == nil {
+					continue
+				}
+				meta.Split.Phase = newPhase
+				changed = true
 			}
-			meta.Split.Phase = newPhase
-			changed = true
-		}
-		if changed {
-			s.metadataStore.UpdateNamespaceStatus(s.namespace, ns)
-		}
+			return changed
+		})
 	})
 }
 

--- a/oxiad/coordinator/runtime/controller/shard/shard_controller_split.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller_split.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -33,107 +34,115 @@ import (
 	controllerapi "github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
 )
 
-// SplitController drives the shard split state machine through 4 phases
-// (Bootstrap → CatchUp → Cutover → Cleanup). It runs alongside the parent's
-// Controller.
-type SplitController struct {
-	namespace     string
-	parentShardId int64
-	leftChildId   int64
-	rightChildId  int64
-	splitPoint    uint32
+const DefaultSplitTimeout = 5 * time.Minute
 
-	metadata      coordmetadata.Metadata
-	rpcProvider   rpc.Provider
-	eventListener controllerapi.ShardSplitEventListener
-
-	// ensembleSelector selects server ensembles for new shards.
-	ensembleSelector func(namespace string) ([]*proto.DataServerIdentity, error)
-
+// Splitting owns the complete lifecycle and mutable state of one shard split.
+// Like Election, it borrows the controller's external resources while keeping
+// operation-specific state and goroutines out of the controller itself.
+type Splitting struct {
+	logger    *slog.Logger
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 	wg        sync.WaitGroup
-	logger    *slog.Logger
+	started   atomic.Bool
+
+	// borrowed resources
+	metadataStore coordmetadata.Metadata
+	rpc           rpc.Provider
+	eventListener controllerapi.ShardSplitEventListener
+	splitter      *Splitter
+
+	// owned state
+	namespace  string
+	shard      int64
+	leftChild  int64
+	rightChild int64
+	splitPoint uint32
 }
 
-const DefaultSplitTimeout = 5 * time.Minute
-
-// SplitControllerConfig holds the configuration needed to create a SplitController.
-type SplitControllerConfig struct {
-	Namespace        string
-	ParentShardId    int64
-	Metadata         coordmetadata.Metadata
-	RpcProvider      rpc.Provider
-	EventListener    controllerapi.ShardSplitEventListener
-	EnsembleSelector func(namespace string) ([]*proto.DataServerIdentity, error)
-
-	// SplitTimeout is the maximum duration for the entire split operation.
-	// If the split does not complete within this time, it is aborted.
-	// Zero means use DefaultSplitTimeout.
-	SplitTimeout time.Duration
+func NewSplitting(
+	parentCtx context.Context,
+	logger *slog.Logger,
+	namespace string,
+	shard int64,
+	metadataStore coordmetadata.Metadata,
+	rpcProvider rpc.Provider,
+	config SplitterConfig,
+) *Splitting {
+	timeout := config.SplitTimeout
+	if timeout == 0 {
+		timeout = DefaultSplitTimeout
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
+	return &Splitting{
+		logger:        logger,
+		ctx:           ctx,
+		ctxCancel:     cancel,
+		metadataStore: metadataStore,
+		rpc:           rpcProvider,
+		eventListener: config.EventListener,
+		splitter:      NewSplitter(namespace, shard, metadataStore, config),
+		namespace:     namespace,
+		shard:         shard,
+	}
 }
 
-// NewSplitController creates a new SplitController and starts it running
-// in the background. It will pick up from whatever phase is persisted in
-// the cluster status.
-func NewSplitController(cfg SplitControllerConfig) *SplitController {
-	sc := &SplitController{
-		namespace:        cfg.Namespace,
-		parentShardId:    cfg.ParentShardId,
-		metadata:         cfg.Metadata,
-		rpcProvider:      cfg.RpcProvider,
-		eventListener:    cfg.EventListener,
-		ensembleSelector: cfg.EnsembleSelector,
-		logger: slog.With(
-			slog.String("component", "shard-split-controller"),
-			slog.String("namespace", cfg.Namespace),
-			slog.Int64("parent-shard", cfg.ParentShardId),
-		),
+// Initialize validates and persists a new split.
+func (s *Splitting) Initialize(splitPoint *uint32) (leftChild int64, rightChild int64, err error) {
+	return s.splitter.Split(splitPoint)
+}
+
+// Start resumes the split from its persisted phase. RPC work and split metadata
+// mutations run asynchronously in the split state machine goroutine.
+func (s *Splitting) Start() {
+	if !s.started.CompareAndSwap(false, true) {
+		panic("bug! the splitting has been started")
 	}
 
-	splitTimeout := cfg.SplitTimeout
-	if splitTimeout == 0 {
-		splitTimeout = DefaultSplitTimeout
-	}
-	sc.ctx, sc.ctxCancel = context.WithTimeout(context.Background(), splitTimeout)
-
-	// Load the current split metadata from cluster status
-	parentMeta, exists := sc.metadata.GetShardStatus(sc.namespace, sc.parentShardId)
-	if !exists || parentMeta.UnsafeBorrow().Split == nil {
-		sc.logger.Error("Parent shard or split metadata not found")
-		return sc
+	parentMeta, exists := s.metadataStore.GetShardStatus(s.namespace, s.shard)
+	if !exists || parentMeta.UnsafeBorrow().Split == nil ||
+		len(parentMeta.UnsafeBorrow().Split.ChildShardIds) != 2 {
+		return
 	}
 
 	split := parentMeta.UnsafeBorrow().Split
-	sc.leftChildId = split.ChildShardIds[0]
-	sc.rightChildId = split.ChildShardIds[1]
-	sc.splitPoint = split.SplitPoint
+	s.leftChild = split.ChildShardIds[0]
+	s.rightChild = split.ChildShardIds[1]
+	s.splitPoint = split.SplitPoint
 
-	sc.wg.Go(func() {
+	s.wg.Go(func() {
+		defer s.ctxCancel()
 		process.DoWithLabels(
-			sc.ctx,
+			s.ctx,
 			map[string]string{
-				"oxia":      "shard-split-controller",
-				"namespace": sc.namespace,
-				"parent":    fmt.Sprintf("%d", sc.parentShardId),
+				"oxia":      "shard-controller-split",
+				"namespace": s.namespace,
+				"parent":    fmt.Sprintf("%d", s.shard),
 			},
-			sc.run,
+			s.runSplitStateMachine,
 		)
 	})
-
-	return sc
 }
 
-func (sc *SplitController) Close() {
-	sc.ctxCancel()
-	sc.wg.Wait()
+func (s *Splitting) Stop() {
+	s.ctxCancel()
+	s.wg.Wait()
+	s.logger.Info(
+		"Stopped shard splitting",
+		slog.Int64("left-child", s.leftChild),
+		slog.Int64("right-child", s.rightChild),
+	)
 }
 
-func (sc *SplitController) run() {
+func (s *Splitting) executeMetadataUpdate(update func()) {
+	update()
+}
+
+func (s *Splitting) runSplitStateMachine() {
 	_ = backoff.RetryNotify(func() error {
-		return sc.driveStateMachine()
-	}, oxiatime.NewBackOff(sc.ctx), func(err error, duration time.Duration) {
-		sc.logger.Warn(
+		return s.driveStateMachine()
+	}, oxiatime.NewBackOff(s.ctx), func(err error, duration time.Duration) {
+		s.logger.Warn(
 			"Split state machine step failed, retrying",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
@@ -142,20 +151,20 @@ func (sc *SplitController) run() {
 
 	// If we exited due to timeout/cancellation and the split isn't done,
 	// abort and clean up.
-	if sc.ctx.Err() != nil {
-		phase, exists := sc.currentPhase()
+	if s.ctx.Err() != nil {
+		phase, exists := s.currentPhase()
 		if !exists {
 			return
 		}
 		switch phase {
 		case proto.SplitPhaseBootstrap, proto.SplitPhaseCatchUp:
-			sc.abort()
+			s.abort()
 		case proto.SplitPhaseCutover:
 			// Cutover is abortable only before the parent is fenced. After the
 			// fence (the point of no return) it is forward-only and is resumed
 			// from the persisted phase, so we must not roll it back here.
-			if !sc.parentFenced() {
-				sc.abort()
+			if !s.parentFenced() {
+				s.abort()
 			}
 		default:
 			// No cleanup needed for any other phase.
@@ -163,30 +172,30 @@ func (sc *SplitController) run() {
 	}
 }
 
-func (sc *SplitController) driveStateMachine() error {
+func (s *Splitting) driveStateMachine() error {
 	for {
-		if err := sc.ctx.Err(); err != nil {
+		if err := s.ctx.Err(); err != nil {
 			return backoff.Permanent(err)
 		}
 
-		phase, exists := sc.currentPhase()
+		phase, exists := s.currentPhase()
 		if !exists {
 			// Split is done or metadata was cleaned up
 			return nil
 		}
 
-		sc.logger.Info("Running split phase", slog.String("phase", phase.String()))
+		s.logger.Info("Running split phase", slog.String("phase", phase.String()))
 
 		var err error
 		switch phase {
 		case proto.SplitPhaseBootstrap:
-			err = sc.runBootstrap()
+			err = s.runBootstrap()
 		case proto.SplitPhaseCatchUp:
-			err = sc.runCatchUp()
+			err = s.runCatchUp()
 		case proto.SplitPhaseCutover:
-			err = sc.runCutover()
+			err = s.runCutover()
 		default:
-			sc.logger.Error("Unknown split phase", slog.Any("phase", phase))
+			s.logger.Error("Unknown split phase", slog.Any("phase", phase))
 			return nil
 		}
 
@@ -196,8 +205,8 @@ func (sc *SplitController) driveStateMachine() error {
 	}
 }
 
-func (sc *SplitController) currentPhase() (proto.SplitPhase, bool) {
-	parentMeta, exists := sc.metadata.GetShardStatus(sc.namespace, sc.parentShardId)
+func (s *Splitting) currentPhase() (proto.SplitPhase, bool) {
+	parentMeta, exists := s.metadataStore.GetShardStatus(s.namespace, s.shard)
 	if !exists || parentMeta.UnsafeBorrow().Split == nil {
 		return proto.SplitPhaseBootstrap, false
 	}
@@ -205,36 +214,38 @@ func (sc *SplitController) currentPhase() (proto.SplitPhase, bool) {
 }
 
 // updatePhase atomically updates the split phase on both parent and children.
-func (sc *SplitController) updatePhase(newPhase proto.SplitPhase) {
-	currentNS, exists := sc.metadata.GetNamespaceStatus(sc.namespace)
-	if !exists {
-		sc.logger.Warn("namespace status not found while updating split phase",
-			slog.String("namespace", sc.namespace),
-			slog.String("phase", newPhase.String()))
-		return
-	}
-	ns := gproto.Clone(currentNS.UnsafeBorrow()).(*proto.NamespaceStatus) //nolint:revive
-	changed := false
-	for _, shardId := range []int64{sc.parentShardId, sc.leftChildId, sc.rightChildId} {
-		meta, exists := ns.Shards[shardId]
-		if !exists || meta.Split == nil {
-			continue
+func (s *Splitting) updatePhase(newPhase proto.SplitPhase) {
+	s.executeMetadataUpdate(func() {
+		currentNS, exists := s.metadataStore.GetNamespaceStatus(s.namespace)
+		if !exists {
+			s.logger.Warn("namespace status not found while updating split phase",
+				slog.String("namespace", s.namespace),
+				slog.String("phase", newPhase.String()))
+			return
 		}
-		meta.Split.Phase = newPhase
-		changed = true
-	}
-	if changed {
-		sc.metadata.UpdateNamespaceStatus(sc.namespace, ns)
-	}
+		ns := gproto.Clone(currentNS.UnsafeBorrow()).(*proto.NamespaceStatus) //nolint:revive
+		changed := false
+		for _, shardId := range []int64{s.shard, s.leftChild, s.rightChild} {
+			meta, exists := ns.Shards[shardId]
+			if !exists || meta.Split == nil {
+				continue
+			}
+			meta.Split.Phase = newPhase
+			changed = true
+		}
+		if changed {
+			s.metadataStore.UpdateNamespaceStatus(s.namespace, ns)
+		}
+	})
 }
 
 // runBootstrap validates preconditions, fences child ensemble members, elects
 // child leaders (so they start replicating to their followers immediately),
 // and adds children as observer followers on the parent leader.
-func (sc *SplitController) runBootstrap() error {
-	sc.logger.Info("Phase Bootstrap: fencing children and adding as observers")
+func (s *Splitting) runBootstrap() error {
+	s.logger.Info("Phase Bootstrap: fencing children and adding as observers")
 
-	parentMeta := sc.loadParentMeta()
+	parentMeta := s.loadParentMeta()
 	if parentMeta == nil || parentMeta.Leader == nil {
 		return errors.New("parent shard has no leader")
 	}
@@ -245,8 +256,8 @@ func (sc *SplitController) runBootstrap() error {
 	parentTerm := parentMeta.Term
 
 	// Step 1: Fence and elect each child leader (if not already done).
-	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		if err := sc.fenceAndElectChild(childId, parentTerm); err != nil {
+	for _, childId := range []int64{s.leftChild, s.rightChild} {
+		if err := s.fenceAndElectChild(childId, parentTerm); err != nil {
 			return err
 		}
 	}
@@ -255,8 +266,8 @@ func (sc *SplitController) runBootstrap() error {
 	// using the same parent term the children were fenced with. If the
 	// parent had a new election in the meantime, AddFollower fails with
 	// an invalid-term error and Bootstrap is retried from scratch.
-	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		if err := sc.addChildObserver(childId, parentLeader, parentTerm); err != nil {
+	for _, childId := range []int64{s.leftChild, s.rightChild} {
+		if err := s.addChildObserver(childId, parentLeader, parentTerm); err != nil {
 			return err
 		}
 	}
@@ -265,18 +276,18 @@ func (sc *SplitController) runBootstrap() error {
 	// CatchUp can detect if a parent or child leader election invalidated
 	// the observer cursors.
 	childLeaders := make(map[int64]string)
-	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		childMeta := sc.loadShardMeta(childId)
+	for _, childId := range []int64{s.leftChild, s.rightChild} {
+		childMeta := s.loadShardMeta(childId)
 		if childMeta != nil && childMeta.Leader != nil {
 			childLeaders[childId] = childMeta.Leader.GetInternal()
 		}
 	}
-	sc.updateParentMeta(func(meta *proto.ShardMetadata) {
+	s.updateParentMeta(func(meta *proto.ShardMetadata) {
 		meta.Split.ParentTermAtBootstrap = parentTerm
 		meta.Split.ChildLeadersAtBootstrap = childLeaders
 	})
 
-	sc.updatePhase(proto.SplitPhaseCatchUp)
+	s.updatePhase(proto.SplitPhaseCatchUp)
 	return nil
 }
 
@@ -287,14 +298,14 @@ func (sc *SplitController) runBootstrap() error {
 // cursor's term matches the child's term (see shardsDirector.GetOrCreateFollower).
 // Skipped if the child already has a leader at that term (from a previous
 // Bootstrap run).
-func (sc *SplitController) fenceAndElectChild(childId int64, parentTerm int64) error {
-	childMeta := sc.loadShardMeta(childId)
+func (s *Splitting) fenceAndElectChild(childId int64, parentTerm int64) error {
+	childMeta := s.loadShardMeta(childId)
 	if childMeta == nil {
 		return errors.Errorf("child shard %d not found", childId)
 	}
 
 	if childMeta.Leader != nil && childMeta.Term == parentTerm {
-		sc.logger.Info("Child already has leader, skipping fence/elect",
+		s.logger.Info("Child already has leader, skipping fence/elect",
 			slog.Int64("child-shard", childId),
 			slog.Any("leader", childMeta.Leader),
 		)
@@ -302,14 +313,14 @@ func (sc *SplitController) fenceAndElectChild(childId int64, parentTerm int64) e
 	}
 
 	childTerm := parentTerm
-	headEntries, err := sc.fenceEnsemble(childId, childTerm, childMeta.Ensemble, namespaceTermOptions(sc.metadata, sc.namespace))
+	headEntries, err := s.fenceEnsemble(childId, childTerm, childMeta.Ensemble, namespaceTermOptions(s.metadataStore, s.namespace))
 	if err != nil {
 		return errors.Wrapf(err, "failed to fence child shard %d", childId)
 	}
 
-	childLeader := sc.pickLeader(headEntries)
+	childLeader := s.pickLeader(headEntries)
 
-	sc.updateChildMeta(childId, func(meta *proto.ShardMetadata) {
+	s.updateChildMeta(childId, func(meta *proto.ShardMetadata) {
 		meta.Term = childTerm
 		meta.Leader = childLeader
 		meta.Status = proto.ShardStatusSteadyState
@@ -324,8 +335,8 @@ func (sc *SplitController) fenceAndElectChild(childId int64, parentTerm int64) e
 		}
 	}
 
-	_, err = sc.rpcProvider.BecomeLeader(sc.ctx, childLeader, &proto.BecomeLeaderRequest{
-		Namespace:         sc.namespace,
+	_, err = s.rpc.BecomeLeader(s.ctx, childLeader, &proto.BecomeLeaderRequest{
+		Namespace:         s.namespace,
 		Shard:             childId,
 		Term:              childTerm,
 		ReplicationFactor: uint32(len(childMeta.Ensemble)),
@@ -335,7 +346,7 @@ func (sc *SplitController) fenceAndElectChild(childId int64, parentTerm int64) e
 		return errors.Wrapf(err, "BecomeLeader failed for child %d", childId)
 	}
 
-	sc.logger.Info("Child leader elected",
+	s.logger.Info("Child leader elected",
 		slog.Int64("child-shard", childId),
 		slog.Any("child-leader", childLeader),
 		slog.Int64("term", childTerm),
@@ -345,16 +356,16 @@ func (sc *SplitController) fenceAndElectChild(childId int64, parentTerm int64) e
 
 // addChildObserver adds a child's leader as an observer follower on the parent
 // leader so the parent streams snapshots and WAL entries to it.
-func (sc *SplitController) addChildObserver(childId int64, parentLeader *proto.DataServerIdentity, parentTerm int64) error {
-	childMeta := sc.loadShardMeta(childId)
+func (s *Splitting) addChildObserver(childId int64, parentLeader *proto.DataServerIdentity, parentTerm int64) error {
+	childMeta := s.loadShardMeta(childId)
 	if childMeta == nil || childMeta.Leader == nil {
 		return errors.Errorf("child shard %d has no leader", childId)
 	}
 	childLeader := childMeta.Leader
 
-	_, err := sc.rpcProvider.AddFollower(sc.ctx, parentLeader, &proto.AddFollowerRequest{
-		Namespace:    sc.namespace,
-		Shard:        sc.parentShardId,
+	_, err := s.rpc.AddFollower(s.ctx, parentLeader, &proto.AddFollowerRequest{
+		Namespace:    s.namespace,
+		Shard:        s.shard,
 		Term:         parentTerm,
 		FollowerName: childLeader.GetInternal(),
 		FollowerHeadEntryId: &proto.EntryId{
@@ -372,7 +383,7 @@ func (sc *SplitController) addChildObserver(childId int64, parentLeader *proto.D
 		return errors.Wrapf(err, "failed to add child %d as observer on parent", childId)
 	}
 
-	sc.logger.Info("Added child as observer on parent",
+	s.logger.Info("Added child as observer on parent",
 		slog.Int64("child-shard", childId),
 		slog.Any("child-leader", childLeader),
 	)
@@ -392,27 +403,27 @@ const CatchUpRoundTimeout = 10 * time.Second
 // We check commitOffset (not headOffset) because the children were elected
 // leader during Bootstrap and are actively replicating to their followers.
 // commitOffset advancing means a quorum of child followers have the data.
-func (sc *SplitController) runCatchUp() error {
-	sc.logger.Info("Phase CatchUp: monitoring observer progress")
+func (s *Splitting) runCatchUp() error {
+	s.logger.Info("Phase CatchUp: monitoring observer progress")
 
 	for {
-		if err := sc.ctx.Err(); err != nil {
+		if err := s.ctx.Err(); err != nil {
 			return backoff.Permanent(err)
 		}
 
-		if fallback, err := sc.checkObserverCursorsStale(); err != nil {
+		if fallback, err := s.checkObserverCursorsStale(); err != nil {
 			return err
 		} else if fallback {
 			return nil
 		}
 
-		caughtUp, err := sc.runCatchUpRound()
+		caughtUp, err := s.runCatchUpRound()
 		if err != nil {
 			return err
 		}
 		if caughtUp {
-			sc.logger.Info("All children caught up")
-			sc.updatePhase(proto.SplitPhaseCutover)
+			s.logger.Info("All children caught up")
+			s.updatePhase(proto.SplitPhaseCutover)
 			return nil
 		}
 	}
@@ -421,8 +432,8 @@ func (sc *SplitController) runCatchUp() error {
 // checkObserverCursorsStale detects if a parent or child leader election has
 // invalidated the observer cursors set up during Bootstrap. Returns
 // (true, nil) if the phase was reset to Bootstrap and the caller should return.
-func (sc *SplitController) checkObserverCursorsStale() (bool, error) {
-	parentMeta := sc.loadParentMeta()
+func (s *Splitting) checkObserverCursorsStale() (bool, error) {
+	parentMeta := s.loadParentMeta()
 	if parentMeta == nil || parentMeta.Split == nil {
 		return false, errors.New("parent or split metadata missing")
 	}
@@ -430,18 +441,18 @@ func (sc *SplitController) checkObserverCursorsStale() (bool, error) {
 	// Parent leader election: observer cursors are closed when the old leader
 	// is fenced, so they need to be re-added on the new leader.
 	if parentMeta.Split.ParentTermAtBootstrap > 0 && parentMeta.Term != parentMeta.Split.ParentTermAtBootstrap {
-		sc.logger.Warn("Parent term changed since bootstrap, resetting to Bootstrap",
+		s.logger.Warn("Parent term changed since bootstrap, resetting to Bootstrap",
 			slog.Int64("bootstrap-term", parentMeta.Split.ParentTermAtBootstrap),
 			slog.Int64("current-term", parentMeta.Term),
 		)
-		sc.updatePhase(proto.SplitPhaseBootstrap)
+		s.updatePhase(proto.SplitPhaseBootstrap)
 		return true, nil
 	}
 
 	// Child leader election: the observer cursor targets the old (dead) leader.
 	// Remove the stale cursor and fall back to Bootstrap to re-add.
-	if sc.removeStaleChildObservers(parentMeta) {
-		sc.updatePhase(proto.SplitPhaseBootstrap)
+	if s.removeStaleChildObservers(parentMeta) {
+		s.updatePhase(proto.SplitPhaseBootstrap)
 		return true, nil
 	}
 
@@ -450,12 +461,12 @@ func (sc *SplitController) checkObserverCursorsStale() (bool, error) {
 
 // removeStaleChildObservers checks if any child leader changed since Bootstrap.
 // If so, removes the stale observer cursor from the parent and returns true.
-func (sc *SplitController) removeStaleChildObservers(parentMeta *proto.ShardMetadata) bool {
+func (s *Splitting) removeStaleChildObservers(parentMeta *proto.ShardMetadata) bool {
 	if parentMeta.Split.ChildLeadersAtBootstrap == nil || parentMeta.Leader == nil {
 		return false
 	}
-	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		childMeta := sc.loadShardMeta(childId)
+	for _, childId := range []int64{s.leftChild, s.rightChild} {
+		childMeta := s.loadShardMeta(childId)
 		if childMeta == nil || childMeta.Leader == nil {
 			continue
 		}
@@ -464,14 +475,14 @@ func (sc *SplitController) removeStaleChildObservers(parentMeta *proto.ShardMeta
 			continue
 		}
 
-		sc.logger.Warn("Child leader changed since bootstrap, removing stale observer and resetting to Bootstrap",
+		s.logger.Warn("Child leader changed since bootstrap, removing stale observer and resetting to Bootstrap",
 			slog.Int64("child-shard", childId),
 			slog.String("old-leader", bootstrapLeader),
 			slog.String("new-leader", childMeta.Leader.GetInternal()),
 		)
-		_, _ = sc.rpcProvider.RemoveObserver(sc.ctx, parentMeta.Leader, &proto.RemoveObserverRequest{
-			Namespace:    sc.namespace,
-			Shard:        sc.parentShardId,
+		_, _ = s.rpc.RemoveObserver(s.ctx, parentMeta.Leader, &proto.RemoveObserverRequest{
+			Namespace:    s.namespace,
+			Shard:        s.shard,
 			Term:         parentMeta.Term,
 			FollowerName: bootstrapLeader,
 			TargetShard:  childId,
@@ -484,31 +495,31 @@ func (sc *SplitController) removeStaleChildObservers(parentMeta *proto.ShardMeta
 // runCatchUpRound snapshots the parent's commitOffset and waits up to
 // CatchUpRoundTimeout for both children to reach it. Returns true if all
 // children caught up, false if the round timed out (caller should retry).
-func (sc *SplitController) runCatchUpRound() (bool, error) {
-	parentMeta := sc.loadParentMeta()
+func (s *Splitting) runCatchUpRound() (bool, error) {
+	parentMeta := s.loadParentMeta()
 	if parentMeta == nil || parentMeta.Leader == nil {
 		return false, errors.New("parent has no leader")
 	}
 
-	parentStatus, err := sc.rpcProvider.GetStatus(sc.ctx, parentMeta.Leader, &proto.GetStatusRequest{
-		Shard: sc.parentShardId,
+	parentStatus, err := s.rpc.GetStatus(s.ctx, parentMeta.Leader, &proto.GetStatusRequest{
+		Shard: s.shard,
 	})
 	if err != nil {
 		return false, err
 	}
 	target := parentStatus.CommitOffset
 
-	sc.logger.Info("CatchUp round: waiting for children to reach target",
+	s.logger.Info("CatchUp round: waiting for children to reach target",
 		slog.Int64("target-commit-offset", target),
 	)
 
-	roundCtx, roundCancel := context.WithTimeout(sc.ctx, CatchUpRoundTimeout)
+	roundCtx, roundCancel := context.WithTimeout(s.ctx, CatchUpRoundTimeout)
 	defer roundCancel()
 
-	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		if err := sc.waitForChildCommitOffset(roundCtx, childId, target); err != nil {
+	for _, childId := range []int64{s.leftChild, s.rightChild} {
+		if err := s.waitForChildCommitOffset(roundCtx, childId, target); err != nil {
 			if roundCtx.Err() != nil {
-				sc.logger.Info("CatchUp round timed out, retrying",
+				s.logger.Info("CatchUp round timed out, retrying",
 					slog.Int64("child-shard", childId),
 					slog.Int64("target", target),
 				)
@@ -531,20 +542,20 @@ func (sc *SplitController) runCatchUpRound() (bool, error) {
 // Freezing before fencing closes the gap where fencing the parent destroys the
 // observer cursors that feed the children: by the time we fence, the children
 // already hold everything up to the parent's final offset.
-func (sc *SplitController) runCutover() error {
-	sc.logger.Info("Phase Cutover: freezing parent, draining tail, then fencing")
+func (s *Splitting) runCutover() error {
+	s.logger.Info("Phase Cutover: freezing parent, draining tail, then fencing")
 
 	// If a parent or child leader election invalidated the observer cursors
 	// since bootstrap, rebuild them before cutover. Unfreeze the parent first
 	// in case an earlier cutover attempt had frozen it.
-	if fallback, err := sc.checkObserverCursorsStale(); err != nil {
+	if fallback, err := s.checkObserverCursorsStale(); err != nil {
 		return err
 	} else if fallback {
-		sc.unfreezeParentBestEffort()
+		s.unfreezeParentBestEffort()
 		return nil
 	}
 
-	parentMeta := sc.loadParentMeta()
+	parentMeta := s.loadParentMeta()
 	if parentMeta == nil || parentMeta.Leader == nil {
 		return errors.New("parent shard has no leader")
 	}
@@ -554,9 +565,9 @@ func (sc *SplitController) runCutover() error {
 	// Step 1: Freeze the parent. It stops accepting new writes but is NOT
 	// fenced, so its observer cursors keep streaming. The head offset stops
 	// advancing at the returned value — the final offset for the cutover.
-	freezeResp, err := sc.rpcProvider.FreezeShard(sc.ctx, parentLeader, &proto.FreezeShardRequest{
-		Namespace: sc.namespace,
-		Shard:     sc.parentShardId,
+	freezeResp, err := s.rpc.FreezeShard(s.ctx, parentLeader, &proto.FreezeShardRequest{
+		Namespace: s.namespace,
+		Shard:     s.shard,
 		Term:      parentTerm,
 		Frozen:    true,
 	})
@@ -565,7 +576,7 @@ func (sc *SplitController) runCutover() error {
 	}
 	parentFinalOffset := freezeResp.HeadOffset
 
-	sc.logger.Info("Parent frozen",
+	s.logger.Info("Parent frozen",
 		slog.Int64("term", parentTerm),
 		slog.Int64("final-offset", parentFinalOffset),
 	)
@@ -579,16 +590,16 @@ func (sc *SplitController) runCutover() error {
 	// Re-check observer staleness each round so a parent/child election during
 	// the wait falls back to Bootstrap instead of hanging.
 	for {
-		if err := sc.ctx.Err(); err != nil {
+		if err := s.ctx.Err(); err != nil {
 			return backoff.Permanent(err)
 		}
-		if fallback, err := sc.checkObserverCursorsStale(); err != nil {
+		if fallback, err := s.checkObserverCursorsStale(); err != nil {
 			return err
 		} else if fallback {
-			sc.unfreezeParentBestEffort()
+			s.unfreezeParentBestEffort()
 			return nil
 		}
-		caughtUp, err := sc.cutoverCatchUpRound(parentFinalOffset)
+		caughtUp, err := s.cutoverCatchUpRound(parentFinalOffset)
 		if err != nil {
 			return err
 		}
@@ -597,7 +608,7 @@ func (sc *SplitController) runCutover() error {
 		}
 	}
 
-	sc.logger.Info("Children received parent tail, fencing parent",
+	s.logger.Info("Children received parent tail, fencing parent",
 		slog.Int64("final-offset", parentFinalOffset),
 	)
 
@@ -607,47 +618,47 @@ func (sc *SplitController) runCutover() error {
 	newParentTerm := parentTerm + 1
 	// Parent is being torn down (Deleting) after this fence, so its term
 	// options are irrelevant — pass nil.
-	if _, err := sc.fenceEnsemble(sc.parentShardId, newParentTerm, parentMeta.Ensemble, nil); err != nil {
+	if _, err := s.fenceEnsemble(s.shard, newParentTerm, parentMeta.Ensemble, nil); err != nil {
 		return errors.Wrap(err, "failed to fence parent during cutover")
 	}
 
-	sc.updateParentMeta(func(meta *proto.ShardMetadata) {
+	s.updateParentMeta(func(meta *proto.ShardMetadata) {
 		meta.Term = newParentTerm
 		meta.Leader = nil
 		meta.Status = proto.ShardStatusElection
 	})
 
-	sc.logger.Info("Parent fenced", slog.Int64("new-term", newParentTerm))
+	s.logger.Info("Parent fenced", slog.Int64("new-term", newParentTerm))
 
 	// Step 4: Re-elect child leaders in a clean term (independent of parent).
-	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		if err := sc.reelectChild(childId); err != nil {
+	for _, childId := range []int64{s.leftChild, s.rightChild} {
+		if err := s.reelectChild(childId); err != nil {
 			return errors.Wrapf(err, "failed to re-elect child %d leader", childId)
 		}
 	}
 
 	// Step 5: Clear split metadata from children and mark parent for deletion.
 	// Children are now independent shards.
-	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		sc.updateChildMeta(childId, func(meta *proto.ShardMetadata) {
+	for _, childId := range []int64{s.leftChild, s.rightChild} {
+		s.updateChildMeta(childId, func(meta *proto.ShardMetadata) {
 			meta.Split = nil
 		})
 	}
 
-	sc.updateParentMeta(func(meta *proto.ShardMetadata) {
+	s.updateParentMeta(func(meta *proto.ShardMetadata) {
 		meta.Status = proto.ShardStatusDeleting
 	})
 
-	// Clear split metadata from parent — the split controller's job is done.
+	// Clear split metadata from parent — the split state machine is done.
 	// The parent shard controller handles the actual deletion.
-	sc.updateParentMeta(func(meta *proto.ShardMetadata) {
+	s.updateParentMeta(func(meta *proto.ShardMetadata) {
 		meta.Split = nil
 	})
 
 	// Step 6: Notify the coordinator. This triggers the parent shard
 	// controller's DeleteShard (which retries indefinitely with backoff)
 	// and recomputes shard assignments so clients discover the children.
-	sc.eventListener.SplitComplete(sc.parentShardId, sc.leftChildId, sc.rightChildId)
+	s.eventListener.SplitComplete(s.shard, s.leftChild, s.rightChild)
 
 	return nil
 }
@@ -656,14 +667,14 @@ func (sc *SplitController) runCutover() error {
 // RECEIVE every entry up to the parent's frozen head (head offset, not commit —
 // see runCutover). Returns true if both reached it, false if the round timed
 // out (the caller retries). Because the parent is frozen, the target is fixed.
-func (sc *SplitController) cutoverCatchUpRound(target int64) (bool, error) {
-	roundCtx, roundCancel := context.WithTimeout(sc.ctx, CatchUpRoundTimeout)
+func (s *Splitting) cutoverCatchUpRound(target int64) (bool, error) {
+	roundCtx, roundCancel := context.WithTimeout(s.ctx, CatchUpRoundTimeout)
 	defer roundCancel()
 
-	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		if err := sc.waitForChildHeadOffset(roundCtx, childId, target); err != nil {
+	for _, childId := range []int64{s.leftChild, s.rightChild} {
+		if err := s.waitForChildHeadOffset(roundCtx, childId, target); err != nil {
 			if roundCtx.Err() != nil {
-				sc.logger.Info("Cutover round timed out, retrying",
+				s.logger.Info("Cutover round timed out, retrying",
 					slog.Int64("child-shard", childId),
 					slog.Int64("target", target),
 				)
@@ -679,20 +690,20 @@ func (sc *SplitController) cutoverCatchUpRound(target int64) (bool, error) {
 // leader, so it resumes serving writes. Used when cutover falls back to
 // Bootstrap or aborts before fencing. Best-effort: a new parent term clears the
 // freeze on its own, and after fencing the parent is gone anyway.
-func (sc *SplitController) unfreezeParentBestEffort() {
-	parentMeta := sc.loadParentMeta()
+func (s *Splitting) unfreezeParentBestEffort() {
+	parentMeta := s.loadParentMeta()
 	if parentMeta == nil || parentMeta.Leader == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if _, err := sc.rpcProvider.FreezeShard(ctx, parentMeta.Leader, &proto.FreezeShardRequest{
-		Namespace: sc.namespace,
-		Shard:     sc.parentShardId,
+	if _, err := s.rpc.FreezeShard(ctx, parentMeta.Leader, &proto.FreezeShardRequest{
+		Namespace: s.namespace,
+		Shard:     s.shard,
 		Term:      parentMeta.Term,
 		Frozen:    false,
 	}); err != nil {
-		sc.logger.Warn("Failed to unfreeze parent (best-effort)", slog.Any("error", err))
+		s.logger.Warn("Failed to unfreeze parent (best-effort)", slog.Any("error", err))
 	}
 }
 
@@ -700,8 +711,8 @@ func (sc *SplitController) unfreezeParentBestEffort() {
 // cutover — the point of no return — detected by its term having advanced past
 // the term recorded at bootstrap. Used to decide whether a timed-out cutover is
 // still safe to abort (pre-fence) or must be resumed forward (post-fence).
-func (sc *SplitController) parentFenced() bool {
-	parentMeta := sc.loadParentMeta()
+func (s *Splitting) parentFenced() bool {
+	parentMeta := s.loadParentMeta()
 	if parentMeta == nil || parentMeta.Split == nil {
 		// Split metadata cleared => cutover already finished.
 		return true
@@ -713,32 +724,32 @@ func (sc *SplitController) parentFenced() bool {
 // It unfreezes the parent (if cutover had frozen it), removes observer cursors
 // from the parent, deletes child shards from status, clears the parent's split
 // metadata, and notifies the coordinator.
-func (sc *SplitController) abort() {
-	sc.logger.Warn("Aborting split due to timeout or cancellation")
+func (s *Splitting) abort() {
+	s.logger.Warn("Aborting split due to timeout or cancellation")
 
 	// Use a fresh context since the split context is cancelled.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	parentMeta := sc.loadParentMeta()
+	parentMeta := s.loadParentMeta()
 
 	// Remove observer cursors from parent leader (best-effort).
 	// Only needed if we reached Bootstrap (observers were added).
 	if parentMeta != nil && parentMeta.Split != nil && parentMeta.Leader != nil {
 		phase := parentMeta.Split.GetPhaseOrDefault()
 		if phase == proto.SplitPhaseBootstrap || phase == proto.SplitPhaseCatchUp || phase == proto.SplitPhaseCutover {
-			for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-				childMeta := sc.loadShardMeta(childId)
+			for _, childId := range []int64{s.leftChild, s.rightChild} {
+				childMeta := s.loadShardMeta(childId)
 				if childMeta != nil && childMeta.Leader != nil {
-					_, err := sc.rpcProvider.RemoveObserver(ctx, parentMeta.Leader, &proto.RemoveObserverRequest{
-						Namespace:    sc.namespace,
-						Shard:        sc.parentShardId,
+					_, err := s.rpc.RemoveObserver(ctx, parentMeta.Leader, &proto.RemoveObserverRequest{
+						Namespace:    s.namespace,
+						Shard:        s.shard,
 						Term:         parentMeta.Term,
 						FollowerName: childMeta.Leader.GetInternal(),
 						TargetShard:  childId,
 					})
 					if err != nil {
-						sc.logger.Warn("Failed to remove observer during abort",
+						s.logger.Warn("Failed to remove observer during abort",
 							slog.Int64("child-shard", childId),
 							slog.Any("error", err),
 						)
@@ -750,64 +761,68 @@ func (sc *SplitController) abort() {
 
 	// Lift any write-freeze placed on the parent during cutover so it resumes
 	// serving (best-effort; a new term would clear it anyway).
-	sc.unfreezeParentBestEffort()
+	s.unfreezeParentBestEffort()
 
 	// Delete child shards from status.
-	for _, childId := range []int64{sc.leftChildId, sc.rightChildId} {
-		sc.metadata.DeleteShardStatus(sc.namespace, childId)
-	}
+	s.executeMetadataUpdate(func() {
+		for _, childId := range []int64{s.leftChild, s.rightChild} {
+			s.metadataStore.DeleteShardStatus(s.namespace, childId)
+		}
+	})
 
 	// Clear parent split metadata.
-	sc.updateParentMeta(func(meta *proto.ShardMetadata) {
+	s.updateParentMeta(func(meta *proto.ShardMetadata) {
 		meta.Split = nil
 	})
 
-	sc.logger.Info("Split aborted, parent restored")
+	s.logger.Info("Split aborted, parent restored")
 
 	// Notify coordinator to clean up child controllers and recompute assignments.
-	sc.eventListener.SplitAborted(sc.parentShardId, sc.leftChildId, sc.rightChildId)
+	s.eventListener.SplitAborted(s.shard, s.leftChild, s.rightChild)
 }
 
 // --- Helper methods ---
 
-func (sc *SplitController) loadParentMeta() *proto.ShardMetadata {
-	return sc.loadShardMeta(sc.parentShardId)
+func (s *Splitting) loadParentMeta() *proto.ShardMetadata {
+	return s.loadShardMeta(s.shard)
 }
 
-func (sc *SplitController) loadShardMeta(shardId int64) *proto.ShardMetadata {
-	meta, exists := sc.metadata.GetShardStatus(sc.namespace, shardId)
+func (s *Splitting) loadShardMeta(shardId int64) *proto.ShardMetadata {
+	meta, exists := s.metadataStore.GetShardStatus(s.namespace, shardId)
 	if !exists {
 		return nil
 	}
 	return gproto.Clone(meta.UnsafeBorrow()).(*proto.ShardMetadata) //nolint:revive
 }
 
-func (sc *SplitController) updateParentMeta(fn func(meta *proto.ShardMetadata)) {
-	sc.updateShardMeta(sc.parentShardId, fn)
+func (s *Splitting) updateParentMeta(fn func(meta *proto.ShardMetadata)) {
+	s.updateShardMeta(s.shard, fn)
 }
 
-func (sc *SplitController) updateChildMeta(childId int64, fn func(meta *proto.ShardMetadata)) {
-	sc.updateShardMeta(childId, fn)
+func (s *Splitting) updateChildMeta(childId int64, fn func(meta *proto.ShardMetadata)) {
+	s.updateShardMeta(childId, fn)
 }
 
-func (sc *SplitController) updateShardMeta(shardId int64, fn func(meta *proto.ShardMetadata)) {
-	ns, exists := sc.metadata.GetNamespaceStatus(sc.namespace)
-	if !exists {
-		sc.logger.Warn("namespace status not found while updating shard metadata",
-			slog.String("namespace", sc.namespace),
-			slog.Int64("shard", shardId))
-		return
-	}
-	meta, exists := ns.UnsafeBorrow().Shards[shardId]
-	if !exists {
-		sc.logger.Warn("shard metadata not found while updating shard metadata",
-			slog.String("namespace", sc.namespace),
-			slog.Int64("shard", shardId))
-		return
-	}
-	cloned := gproto.Clone(meta).(*proto.ShardMetadata) //nolint:revive
-	fn(cloned)
-	sc.metadata.UpdateShardStatus(sc.namespace, shardId, cloned)
+func (s *Splitting) updateShardMeta(shardId int64, fn func(meta *proto.ShardMetadata)) {
+	s.executeMetadataUpdate(func() {
+		ns, exists := s.metadataStore.GetNamespaceStatus(s.namespace)
+		if !exists {
+			s.logger.Warn("namespace status not found while updating shard metadata",
+				slog.String("namespace", s.namespace),
+				slog.Int64("shard", shardId))
+			return
+		}
+		meta, exists := ns.UnsafeBorrow().Shards[shardId]
+		if !exists {
+			s.logger.Warn("shard metadata not found while updating shard metadata",
+				slog.String("namespace", s.namespace),
+				slog.Int64("shard", shardId))
+			return
+		}
+		cloned := gproto.Clone(meta).(*proto.ShardMetadata) //nolint:revive
+		fn(cloned)
+		s.metadataStore.UpdateShardStatus(s.namespace, shardId, cloned)
+	})
 }
 
 // fenceEnsemble sends NewTerm to all ensemble members and returns the
@@ -815,7 +830,7 @@ func (sc *SplitController) updateShardMeta(shardId int64, fn func(meta *proto.Sh
 // namespace's term settings (notifications + key sorting) so a freshly fenced
 // child inherits them; pass nil when fencing a shard that is being torn down
 // (e.g. the parent during cutover), where the settings are irrelevant.
-func (sc *SplitController) fenceEnsemble(
+func (s *Splitting) fenceEnsemble(
 	shardId int64,
 	term int64,
 	ensemble []*proto.DataServerIdentity,
@@ -833,8 +848,8 @@ func (sc *SplitController) fenceEnsemble(
 	for _, server := range ensemble {
 		pinnedServer := server
 		wg.Go(func() {
-			res, err := sc.rpcProvider.NewTerm(sc.ctx, pinnedServer, &proto.NewTermRequest{
-				Namespace: sc.namespace,
+			res, err := s.rpc.NewTerm(s.ctx, pinnedServer, &proto.NewTermRequest{
+				Namespace: s.namespace,
 				Shard:     shardId,
 				Term:      term,
 				Options:   options,
@@ -856,7 +871,7 @@ func (sc *SplitController) fenceEnsemble(
 	var lastErr error
 	for r := range ch {
 		if r.err != nil {
-			sc.logger.Warn("NewTerm failed for server",
+			s.logger.Warn("NewTerm failed for server",
 				slog.Int64("shard", shardId),
 				slog.Any("server", r.server),
 				slog.Any("error", r.err),
@@ -879,7 +894,7 @@ func (sc *SplitController) fenceEnsemble(
 
 // pickLeader chooses the server with the highest term/offset from the
 // fencing results.
-func (*SplitController) pickLeader(entries map[*proto.DataServerIdentity]*proto.EntryId) *proto.DataServerIdentity {
+func (*Splitting) pickLeader(entries map[*proto.DataServerIdentity]*proto.EntryId) *proto.DataServerIdentity {
 	var best *proto.DataServerIdentity
 	var bestEntry *proto.EntryId
 
@@ -898,14 +913,14 @@ func (*SplitController) pickLeader(entries map[*proto.DataServerIdentity]*proto.
 // waitForChildCommitOffset polls until the child's commitOffset reaches the
 // target. Uses the provided context for timeout control (the round-based
 // CatchUp algorithm passes a round-scoped context).
-func (sc *SplitController) waitForChildCommitOffset(ctx context.Context, childId int64, targetOffset int64) error {
+func (s *Splitting) waitForChildCommitOffset(ctx context.Context, childId int64, targetOffset int64) error {
 	return backoff.RetryNotify(func() error {
-		childMeta := sc.loadShardMeta(childId)
+		childMeta := s.loadShardMeta(childId)
 		if childMeta == nil || childMeta.Leader == nil {
 			return errors.Errorf("child shard %d has no leader", childId)
 		}
 
-		resp, err := sc.rpcProvider.GetStatus(ctx, childMeta.Leader, &proto.GetStatusRequest{
+		resp, err := s.rpc.GetStatus(ctx, childMeta.Leader, &proto.GetStatusRequest{
 			Shard: childId,
 		})
 		if err != nil {
@@ -913,7 +928,7 @@ func (sc *SplitController) waitForChildCommitOffset(ctx context.Context, childId
 		}
 
 		if resp.CommitOffset >= targetOffset {
-			sc.logger.Info("Child reached target commit offset",
+			s.logger.Info("Child reached target commit offset",
 				slog.Int64("child-shard", childId),
 				slog.Int64("target", targetOffset),
 				slog.Int64("commit-offset", resp.CommitOffset),
@@ -923,7 +938,7 @@ func (sc *SplitController) waitForChildCommitOffset(ctx context.Context, childId
 
 		return errors.Errorf("child %d commit offset %d, target %d", childId, resp.CommitOffset, targetOffset)
 	}, oxiatime.NewBackOff(ctx), func(err error, duration time.Duration) {
-		sc.logger.Debug("Waiting for child commit offset",
+		s.logger.Debug("Waiting for child commit offset",
 			slog.Int64("child-shard", childId),
 			slog.Int64("target-offset", targetOffset),
 			slog.Any("error", err),
@@ -936,14 +951,14 @@ func (sc *SplitController) waitForChildCommitOffset(ctx context.Context, childId
 // i.e. the child has received (in its WAL) every entry up to that offset. Used
 // during cutover, where a child observer-follower has the entries but its commit
 // is capped at the parent's advertised commit (see runCutover).
-func (sc *SplitController) waitForChildHeadOffset(ctx context.Context, childId int64, targetOffset int64) error {
+func (s *Splitting) waitForChildHeadOffset(ctx context.Context, childId int64, targetOffset int64) error {
 	return backoff.RetryNotify(func() error {
-		childMeta := sc.loadShardMeta(childId)
+		childMeta := s.loadShardMeta(childId)
 		if childMeta == nil || childMeta.Leader == nil {
 			return errors.Errorf("child shard %d has no leader", childId)
 		}
 
-		resp, err := sc.rpcProvider.GetStatus(ctx, childMeta.Leader, &proto.GetStatusRequest{
+		resp, err := s.rpc.GetStatus(ctx, childMeta.Leader, &proto.GetStatusRequest{
 			Shard: childId,
 		})
 		if err != nil {
@@ -951,7 +966,7 @@ func (sc *SplitController) waitForChildHeadOffset(ctx context.Context, childId i
 		}
 
 		if resp.HeadOffset >= targetOffset {
-			sc.logger.Info("Child received entries up to target head offset",
+			s.logger.Info("Child received entries up to target head offset",
 				slog.Int64("child-shard", childId),
 				slog.Int64("target", targetOffset),
 				slog.Int64("head-offset", resp.HeadOffset),
@@ -961,7 +976,7 @@ func (sc *SplitController) waitForChildHeadOffset(ctx context.Context, childId i
 
 		return errors.Errorf("child %d head offset %d, target %d", childId, resp.HeadOffset, targetOffset)
 	}, oxiatime.NewBackOff(ctx), func(err error, duration time.Duration) {
-		sc.logger.Debug("Waiting for child head offset",
+		s.logger.Debug("Waiting for child head offset",
 			slog.Int64("child-shard", childId),
 			slog.Int64("target-offset", targetOffset),
 			slog.Any("error", err),
@@ -972,8 +987,8 @@ func (sc *SplitController) waitForChildHeadOffset(ctx context.Context, childId i
 
 // reelectChild fences the child ensemble with a new term and re-elects the
 // same leader. This establishes a clean term independent of the parent.
-func (sc *SplitController) reelectChild(childId int64) error {
-	childMeta := sc.loadShardMeta(childId)
+func (s *Splitting) reelectChild(childId int64) error {
+	childMeta := s.loadShardMeta(childId)
 	if childMeta == nil {
 		return errors.Errorf("child shard %d not found", childId)
 	}
@@ -982,7 +997,7 @@ func (sc *SplitController) reelectChild(childId int64) error {
 	}
 
 	newTerm := childMeta.Term + 1
-	headEntries, err := sc.fenceEnsemble(childId, newTerm, childMeta.Ensemble, namespaceTermOptions(sc.metadata, sc.namespace))
+	headEntries, err := s.fenceEnsemble(childId, newTerm, childMeta.Ensemble, namespaceTermOptions(s.metadataStore, s.namespace))
 	if err != nil {
 		return err
 	}
@@ -998,8 +1013,8 @@ func (sc *SplitController) reelectChild(childId int64) error {
 		}
 	}
 
-	_, err = sc.rpcProvider.BecomeLeader(sc.ctx, newLeader, &proto.BecomeLeaderRequest{
-		Namespace:         sc.namespace,
+	_, err = s.rpc.BecomeLeader(s.ctx, newLeader, &proto.BecomeLeaderRequest{
+		Namespace:         s.namespace,
 		Shard:             childId,
 		Term:              newTerm,
 		ReplicationFactor: uint32(len(childMeta.Ensemble)),
@@ -1010,13 +1025,13 @@ func (sc *SplitController) reelectChild(childId int64) error {
 	}
 
 	// Update child metadata
-	sc.updateChildMeta(childId, func(meta *proto.ShardMetadata) {
+	s.updateChildMeta(childId, func(meta *proto.ShardMetadata) {
 		meta.Term = newTerm
 		meta.Leader = newLeader
 		meta.Status = proto.ShardStatusSteadyState
 	})
 
-	sc.logger.Info("Child re-elected in clean term",
+	s.logger.Info("Child re-elected in clean term",
 		slog.Int64("child-shard", childId),
 		slog.Any("leader", newLeader),
 		slog.Int64("term", newTerm),

--- a/oxiad/coordinator/runtime/controller/shard/shard_controller_split_test.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller_split_test.go
@@ -15,7 +15,9 @@
 package shard
 
 import (
+	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,6 +33,7 @@ import (
 	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 	coordoption "github.com/oxia-db/oxia/oxiad/coordinator/option"
+	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller/mockutils"
 
 	"github.com/oxia-db/oxia/common/constant"
@@ -39,6 +42,7 @@ import (
 )
 
 type mockShardSplitEventListener struct {
+	starts      chan splitEvent
 	completions chan splitEvent
 	aborts      chan splitEvent
 }
@@ -51,9 +55,14 @@ type splitEvent struct {
 
 func newMockShardSplitEventListener() *mockShardSplitEventListener {
 	return &mockShardSplitEventListener{
+		starts:      make(chan splitEvent, 10),
 		completions: make(chan splitEvent, 10),
 		aborts:      make(chan splitEvent, 10),
 	}
+}
+
+func (m *mockShardSplitEventListener) SplitStarted(_ string, parentShard int64, leftChild int64, rightChild int64) {
+	m.starts <- splitEvent{parentShard, leftChild, rightChild}
 }
 
 func (m *mockShardSplitEventListener) SplitComplete(parentShard int64, leftChild int64, rightChild int64) {
@@ -62,6 +71,41 @@ func (m *mockShardSplitEventListener) SplitComplete(parentShard int64, leftChild
 
 func (m *mockShardSplitEventListener) SplitAborted(parentShard int64, leftChild int64, rightChild int64) {
 	m.aborts <- splitEvent{parentShard, leftChild, rightChild}
+}
+
+type splitTestControllerConfig struct {
+	Namespace     string
+	ParentShardId int64
+	Metadata      coordmetadata.Metadata
+	RpcProvider   rpc.Provider
+	EventListener *mockShardSplitEventListener
+	SplitTimeout  time.Duration
+}
+
+type splitTestController struct {
+	*controller
+}
+
+func newSplitTestController(cfg splitTestControllerConfig) *splitTestController {
+	ctx, cancel := context.WithCancel(context.Background())
+	sc := &controller{
+		namespace:       cfg.Namespace,
+		shard:           cfg.ParentShardId,
+		metadataStore:   cfg.Metadata,
+		rpc:             cfg.RpcProvider,
+		splittingConfig: SplitterConfig{EventListener: cfg.EventListener, SplitTimeout: cfg.SplitTimeout},
+		ctx:             ctx,
+		ctxCancel:       cancel,
+		logger:          slog.Default(),
+	}
+	sc.startSplitting()
+	return &splitTestController{controller: sc}
+}
+
+func (sc *splitTestController) Close() {
+	sc.ctxCancel()
+	sc.currentSplitting.Stop()
+	sc.wg.Wait()
 }
 
 var (
@@ -266,14 +310,14 @@ func queueCutoverResponses(rpcMock *mockutils.RpcProvider) {
 }
 
 // queueCleanupResponses queues all responses needed for the cleanup phase.
-func TestSplitController_FullLifecycle(t *testing.T) {
+func TestShardControllerSplit_FullLifecycle(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseBootstrap)
 
 	queueBootstrapResponses(rpcMock)
 	queueCatchUpResponses(rpcMock)
 	queueCutoverResponses(rpcMock)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -310,21 +354,21 @@ func TestSplitController_FullLifecycle(t *testing.T) {
 	assert.Nil(t, rightMeta.Split, "right child split metadata should be cleared")
 }
 
-// TestSplitController_ChildrenFencedAtParentTerm verifies that child shards
+// TestShardControllerSplit_ChildrenFencedAtParentTerm verifies that child shards
 // are fenced and elected at the parent's current term during Bootstrap. The
 // observer cursor that streams parent data to a child runs at the parent's
 // term, and the data server converts the child leader into an observer
 // follower only when the cursor's term matches the child's term: any other
 // term leaves the observer cursor retrying forever and the split stuck in
 // CatchUp.
-func TestSplitController_ChildrenFencedAtParentTerm(t *testing.T) {
+func TestShardControllerSplit_ChildrenFencedAtParentTerm(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseBootstrap)
 
 	queueBootstrapResponses(rpcMock)
 	queueCatchUpResponses(rpcMock)
 	queueCutoverResponses(rpcMock)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -383,13 +427,13 @@ func drainNewTermRequests(node *mockutils.PerNodeChannels) []*proto.NewTermReque
 	}
 }
 
-// TestSplitController_ChildrenInheritNamespaceTermOptions verifies that child
+// TestShardControllerSplit_ChildrenInheritNamespaceTermOptions verifies that child
 // shards are fenced with the namespace's term options rather than the
 // ToDbOption(nil) defaults. A namespace with notifications disabled (and a
 // non-default key sorting) must not have those settings silently reset on its
 // post-split children — every NewTerm sent to a child ensemble member, both at
 // Bootstrap and at the Cutover re-election, must carry the namespace options.
-func TestSplitController_ChildrenInheritNamespaceTermOptions(t *testing.T) {
+func TestShardControllerSplit_ChildrenInheritNamespaceTermOptions(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseBootstrap,
 		func(ns *proto.Namespace) {
 			ns.NotificationsEnabled = gproto.Bool(false)
@@ -400,7 +444,7 @@ func TestSplitController_ChildrenInheritNamespaceTermOptions(t *testing.T) {
 	queueCatchUpResponses(rpcMock)
 	queueCutoverResponses(rpcMock)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -432,14 +476,14 @@ func TestSplitController_ChildrenInheritNamespaceTermOptions(t *testing.T) {
 	}
 }
 
-func TestSplitController_ResumeFromBootstrap(t *testing.T) {
+func TestShardControllerSplit_ResumeFromBootstrap(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseBootstrap)
 
 	queueBootstrapResponses(rpcMock)
 	queueCatchUpResponses(rpcMock)
 	queueCutoverResponses(rpcMock)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -458,7 +502,7 @@ func TestSplitController_ResumeFromBootstrap(t *testing.T) {
 	}
 }
 
-func TestSplitController_ResumeFromCatchUp(t *testing.T) {
+func TestShardControllerSplit_ResumeFromCatchUp(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// For CatchUp, we need child leaders to already be set (they were set during bootstrap)
@@ -479,7 +523,7 @@ func TestSplitController_ResumeFromCatchUp(t *testing.T) {
 	queueCatchUpResponses(rpcMock)
 	queueCutoverResponses(rpcMock)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -496,14 +540,14 @@ func TestSplitController_ResumeFromCatchUp(t *testing.T) {
 	}
 }
 
-func TestSplitController_PhaseTransitions(t *testing.T) {
+func TestShardControllerSplit_PhaseTransitions(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseBootstrap)
 
 	queueBootstrapResponses(rpcMock)
 	queueCatchUpResponses(rpcMock)
 	queueCutoverResponses(rpcMock)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -536,11 +580,11 @@ func TestSplitController_PhaseTransitions(t *testing.T) {
 
 // --- Abort / Timeout Tests ---
 
-func TestSplitController_TimeoutDuringBootstrap(t *testing.T) {
+func TestShardControllerSplit_TimeoutDuringBootstrap(t *testing.T) {
 	// Don't queue any RPC responses -- bootstrap will hang on fenceEnsemble.
 	_, statusRes, listener := setupSplitTest(t, proto.SplitPhaseBootstrap)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -575,7 +619,7 @@ func TestSplitController_TimeoutDuringBootstrap(t *testing.T) {
 	assert.False(t, rightExists, "right child should be deleted")
 }
 
-func TestSplitController_TimeoutDuringCatchUp(t *testing.T) {
+func TestShardControllerSplit_TimeoutDuringCatchUp(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders (as if Bootstrap completed) and ParentTermAtBootstrap
@@ -605,7 +649,7 @@ func TestSplitController_TimeoutDuringCatchUp(t *testing.T) {
 
 	// Don't queue CatchUp responses -- it will hang and timeout
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -637,7 +681,7 @@ func TestSplitController_TimeoutDuringCatchUp(t *testing.T) {
 
 // --- Parent Leader Election Tests ---
 
-func TestSplitController_ParentTermChangeDuringCatchUp(t *testing.T) {
+func TestShardControllerSplit_ParentTermChangeDuringCatchUp(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders and ParentTermAtBootstrap = 5
@@ -690,7 +734,7 @@ func TestSplitController_ParentTermChangeDuringCatchUp(t *testing.T) {
 
 	queueCutoverResponses(rpcMock)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -711,7 +755,7 @@ func TestSplitController_ParentTermChangeDuringCatchUp(t *testing.T) {
 
 // --- Child Failure Tests ---
 
-func TestSplitController_ChildFencingPartialSuccess(t *testing.T) {
+func TestShardControllerSplit_ChildFencingPartialSuccess(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseBootstrap)
 
 	// Left child: only 2/3 respond (quorum OK)
@@ -736,7 +780,7 @@ func TestSplitController_ChildFencingPartialSuccess(t *testing.T) {
 	queueCatchUpResponses(rpcMock)
 	queueCutoverResponses(rpcMock)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -754,7 +798,7 @@ func TestSplitController_ChildFencingPartialSuccess(t *testing.T) {
 	}
 }
 
-func TestSplitController_ParentFencingPartialFailure(t *testing.T) {
+func TestShardControllerSplit_ParentFencingPartialFailure(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseBootstrap)
 
 	queueBootstrapResponses(rpcMock)
@@ -779,7 +823,7 @@ func TestSplitController_ParentFencingPartialFailure(t *testing.T) {
 	rpcMock.GetNode(ls1).BecomeLeaderResponse(nil)
 	rpcMock.GetNode(rs1).BecomeLeaderResponse(nil)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -797,7 +841,7 @@ func TestSplitController_ParentFencingPartialFailure(t *testing.T) {
 	}
 }
 
-func TestSplitController_ChildQuorumCommitRetry(t *testing.T) {
+func TestShardControllerSplit_ChildQuorumCommitRetry(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseBootstrap)
 
 	queueBootstrapResponses(rpcMock)
@@ -827,7 +871,7 @@ func TestSplitController_ChildQuorumCommitRetry(t *testing.T) {
 	rpcMock.GetNode(ls1).BecomeLeaderResponse(nil)
 	rpcMock.GetNode(rs1).BecomeLeaderResponse(nil)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -845,7 +889,7 @@ func TestSplitController_ChildQuorumCommitRetry(t *testing.T) {
 	}
 }
 
-func TestSplitController_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
+func TestShardControllerSplit_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders (as if Bootstrap completed) and ParentTermAtBootstrap
@@ -877,7 +921,7 @@ func TestSplitController_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
 	rpcMock.GetNode(ps1).GetStatusResponse(5, proto.ServingStatus_LEADER, 100, 100) // parent OK
 	rpcMock.GetNode(ls1).EnqueueGetStatusError(errors.New("connection refused"))    // child-L dead
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -911,7 +955,7 @@ func TestSplitController_ChildLeaderDiesTimesOutAndAborts(t *testing.T) {
 	assert.False(t, rightExists)
 }
 
-func TestSplitController_ChildFollowersDeadCommitStalls(t *testing.T) {
+func TestShardControllerSplit_ChildFollowersDeadCommitStalls(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders (as if Bootstrap completed) and ParentTermAtBootstrap
@@ -949,7 +993,7 @@ func TestSplitController_ChildFollowersDeadCommitStalls(t *testing.T) {
 		rpcMock.GetNode(rs1).GetStatusResponse(1, proto.ServingStatus_LEADER, 100, -1)
 	}
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -983,7 +1027,7 @@ func TestSplitController_ChildFollowersDeadCommitStalls(t *testing.T) {
 	assert.False(t, rightExists)
 }
 
-func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
+func TestShardControllerSplit_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseCatchUp)
 
 	// Set child leaders and ParentTermAtBootstrap as if Bootstrap completed.
@@ -1057,7 +1101,7 @@ func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 	rpcMock.GetNode(ls2).BecomeLeaderResponse(nil)
 	rpcMock.GetNode(rs1).BecomeLeaderResponse(nil)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,
@@ -1092,7 +1136,7 @@ func TestSplitController_ChildLeaderChangeDuringCatchUp(t *testing.T) {
 	assert.NotNil(t, rm.Leader)
 }
 
-func TestSplitController_ChildEnsembleMemberDiesDuringBootstrap(t *testing.T) {
+func TestShardControllerSplit_ChildEnsembleMemberDiesDuringBootstrap(t *testing.T) {
 	rpcMock, statusRes, listener := setupSplitTest(t, proto.SplitPhaseBootstrap)
 
 	// Left child: 2/3 respond, 1 dead — quorum still met.
@@ -1117,7 +1161,7 @@ func TestSplitController_ChildEnsembleMemberDiesDuringBootstrap(t *testing.T) {
 	queueCatchUpResponses(rpcMock)
 	queueCutoverResponses(rpcMock)
 
-	sc := NewSplitController(SplitControllerConfig{
+	sc := newSplitTestController(splitTestControllerConfig{
 		Namespace:     constant.DefaultNamespace,
 		ParentShardId: 0,
 		Metadata:      statusRes,

--- a/oxiad/coordinator/runtime/controller/shard/shard_controller_split_test.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller_split_test.go
@@ -89,14 +89,15 @@ type splitTestController struct {
 func newSplitTestController(cfg splitTestControllerConfig) *splitTestController {
 	ctx, cancel := context.WithCancel(context.Background())
 	sc := &controller{
-		namespace:       cfg.Namespace,
-		shard:           cfg.ParentShardId,
-		metadataStore:   cfg.Metadata,
-		rpc:             cfg.RpcProvider,
-		splittingConfig: SplitterConfig{EventListener: cfg.EventListener, SplitTimeout: cfg.SplitTimeout},
-		ctx:             ctx,
-		ctxCancel:       cancel,
-		logger:          slog.Default(),
+		namespace:                  cfg.Namespace,
+		shard:                      cfg.ParentShardId,
+		metadataStore:              cfg.Metadata,
+		rpc:                        cfg.RpcProvider,
+		splittingConfig:            SplitterConfig{EventListener: cfg.EventListener, SplitTimeout: cfg.SplitTimeout},
+		executeSplitMetadataUpdate: func(update func()) { update() },
+		ctx:                        ctx,
+		ctxCancel:                  cancel,
+		logger:                     slog.Default(),
 	}
 	sc.startSplitting()
 	return &splitTestController{controller: sc}

--- a/oxiad/coordinator/runtime/controller/shard/shard_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller_test.go
@@ -123,6 +123,7 @@ func newTestController( //nolint:revive // Test helper mirrors NewController and
 		metadata,
 		dataServerSupportedFeaturesSupplier,
 		nil,
+		SplitterConfig{},
 		rpcProvider,
 		periodicTasksInterval,
 	)

--- a/oxiad/coordinator/runtime/controller/shard/shard_splitter.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_splitter.go
@@ -1,0 +1,206 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shard
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/pkg/errors"
+	gproto "google.golang.org/protobuf/proto"
+
+	commonobject "github.com/oxia-db/oxia/common/object"
+	"github.com/oxia-db/oxia/common/proto"
+	coordmetadata "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	controllerapi "github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller"
+)
+
+type SplitEnsembleSelector func(
+	namespace string,
+	shard int64,
+	editingStatus map[string]commonobject.Borrowed[*proto.NamespaceStatus],
+) ([]*proto.DataServerIdentity, error)
+
+type SplitterConfig struct {
+	EnsembleSelector SplitEnsembleSelector
+	EventListener    controllerapi.ShardSplitEventListener
+	SplitTimeout     time.Duration
+}
+
+// Splitter validates and persists the initial metadata for a shard split.
+// Split is called only from the parent shard controller's event-loop thread,
+// serializing it with elections, ensemble changes, and deletion.
+type Splitter struct {
+	namespace        string
+	parentShardID    int64
+	metadata         coordmetadata.Metadata
+	ensembleSelector SplitEnsembleSelector
+	eventListener    controllerapi.ShardSplitEventListener
+	logger           *slog.Logger
+}
+
+func NewSplitter(
+	namespace string,
+	parentShardID int64,
+	metadata coordmetadata.Metadata,
+	config SplitterConfig,
+) *Splitter {
+	return &Splitter{
+		namespace:        namespace,
+		parentShardID:    parentShardID,
+		metadata:         metadata,
+		ensembleSelector: config.EnsembleSelector,
+		eventListener:    config.EventListener,
+		logger: slog.With(
+			slog.String("component", "shard-splitter"),
+			slog.String("namespace", namespace),
+			slog.Int64("parent-shard", parentShardID),
+		),
+	}
+}
+
+func cloneNamespaceStatuses(
+	namespaces map[string]commonobject.Borrowed[*proto.NamespaceStatus],
+) map[string]commonobject.Borrowed[*proto.NamespaceStatus] {
+	statuses := make(map[string]commonobject.Borrowed[*proto.NamespaceStatus], len(namespaces))
+	for namespace, status := range namespaces {
+		statuses[namespace] = commonobject.Borrow(
+			gproto.Clone(status.UnsafeBorrow()).(*proto.NamespaceStatus), //nolint:revive
+		)
+	}
+	return statuses
+}
+
+func (s *Splitter) Split(splitPoint *uint32) (leftChildID int64, rightChildID int64, err error) {
+	if s.ensembleSelector == nil || s.eventListener == nil {
+		return 0, 0, errors.New("shard splitting is not configured")
+	}
+
+	status := cloneNamespaceStatuses(s.metadata.ListNamespaceStatus())
+	borrowedNS, exists := status[s.namespace]
+	if !exists {
+		return 0, 0, errors.Errorf("namespace %q not found", s.namespace)
+	}
+	ns := borrowedNS.UnsafeBorrow()
+
+	parentMeta, exists := ns.Shards[s.parentShardID]
+	if !exists {
+		return 0, 0, errors.Errorf("shard %d not found in namespace %q", s.parentShardID, s.namespace)
+	}
+	if parentMeta.GetStatusOrDefault() != proto.ShardStatusSteadyState {
+		return 0, 0, errors.Errorf(
+			"shard %d is not in steady state (status=%s)",
+			s.parentShardID,
+			parentMeta.GetStatus(),
+		)
+	}
+	if parentMeta.Split != nil {
+		return 0, 0, errors.Errorf("shard %d already has an active split", s.parentShardID)
+	}
+	if len(parentMeta.PendingDeleteShardNodes) > 0 {
+		return 0, 0, errors.Errorf("shard %d has pending ensemble changes", s.parentShardID)
+	}
+	if parentMeta.GetInt32HashRange().GetMax()-parentMeta.GetInt32HashRange().GetMin() < 1 {
+		return 0, 0, errors.Errorf("shard %d hash range is too small to split", s.parentShardID)
+	}
+
+	sp := parentMeta.GetInt32HashRange().GetMin() +
+		(parentMeta.GetInt32HashRange().GetMax()-parentMeta.GetInt32HashRange().GetMin())/2
+	if splitPoint != nil {
+		sp = *splitPoint
+		if sp < parentMeta.GetInt32HashRange().GetMin() || sp >= parentMeta.GetInt32HashRange().GetMax() {
+			return 0, 0, errors.Errorf(
+				"split point %d is outside shard's hash range [%d, %d]",
+				sp,
+				parentMeta.GetInt32HashRange().GetMin(),
+				parentMeta.GetInt32HashRange().GetMax(),
+			)
+		}
+	}
+
+	leftChildID = s.metadata.ReserveShardIDs(2)
+	rightChildID = leftChildID + 1
+
+	leftEnsemble, err := s.ensembleSelector(s.namespace, leftChildID, status)
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "failed to select ensemble for left child")
+	}
+
+	ns.Shards[leftChildID] = &proto.ShardMetadata{
+		Status:   proto.ShardStatusSteadyState,
+		Ensemble: leftEnsemble,
+		Int32HashRange: &proto.HashRange{
+			Min: parentMeta.GetInt32HashRange().GetMin(),
+			Max: sp,
+		},
+	}
+	rightEnsemble, err := s.ensembleSelector(s.namespace, rightChildID, status)
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "failed to select ensemble for right child")
+	}
+
+	parentMeta.Split = &proto.SplitMetadata{
+		Phase:         proto.SplitPhaseBootstrap,
+		ChildShardIds: []int64{leftChildID, rightChildID},
+		SplitPoint:    sp,
+	}
+	ns.Shards[leftChildID] = childShardMetadata(
+		s.parentShardID,
+		parentMeta.GetInt32HashRange().GetMin(),
+		sp,
+		sp,
+		leftEnsemble,
+	)
+	ns.Shards[rightChildID] = childShardMetadata(
+		s.parentShardID,
+		sp+1,
+		parentMeta.GetInt32HashRange().GetMax(),
+		sp,
+		rightEnsemble,
+	)
+
+	s.metadata.UpdateNamespaceStatus(s.namespace, ns)
+	s.logger.Info(
+		"Split initiated",
+		slog.Int64("left-child", leftChildID),
+		slog.Int64("right-child", rightChildID),
+		slog.Uint64("split-point", uint64(sp)),
+	)
+	s.eventListener.SplitStarted(s.namespace, s.parentShardID, leftChildID, rightChildID)
+	return leftChildID, rightChildID, nil
+}
+
+func childShardMetadata(
+	parentShardID int64,
+	minHash uint32,
+	maxHash uint32,
+	splitPoint uint32,
+	ensemble []*proto.DataServerIdentity,
+) *proto.ShardMetadata {
+	return &proto.ShardMetadata{
+		Status:   proto.ShardStatusSteadyState,
+		Term:     0,
+		Ensemble: ensemble,
+		Int32HashRange: &proto.HashRange{
+			Min: minHash,
+			Max: maxHash,
+		},
+		Split: &proto.SplitMetadata{
+			Phase:         proto.SplitPhaseBootstrap,
+			ParentShardId: parentShardID,
+			SplitPoint:    splitPoint,
+		},
+	}
+}

--- a/oxiad/coordinator/runtime/controller/shard/shard_splitter.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_splitter.go
@@ -151,19 +151,19 @@ func (s *Splitter) Split(splitPoint *uint32) (leftChildID int64, rightChildID in
 		return 0, 0, errors.Wrap(err, "failed to select ensemble for right child")
 	}
 
-	parentMeta.Split = &proto.SplitMetadata{
+	splitMetadata := &proto.SplitMetadata{
 		Phase:         proto.SplitPhaseBootstrap,
 		ChildShardIds: []int64{leftChildID, rightChildID},
 		SplitPoint:    sp,
 	}
-	ns.Shards[leftChildID] = childShardMetadata(
+	leftChildMetadata := childShardMetadata(
 		s.parentShardID,
 		parentMeta.GetInt32HashRange().GetMin(),
 		sp,
 		sp,
 		leftEnsemble,
 	)
-	ns.Shards[rightChildID] = childShardMetadata(
+	rightChildMetadata := childShardMetadata(
 		s.parentShardID,
 		sp+1,
 		parentMeta.GetInt32HashRange().GetMax(),
@@ -171,7 +171,24 @@ func (s *Splitter) Split(splitPoint *uint32) (leftChildID int64, rightChildID in
 		rightEnsemble,
 	)
 
-	s.metadata.UpdateNamespaceStatus(s.namespace, ns)
+	parentExists := true
+	updated := s.metadata.UpdateNamespaceStatus(s.namespace, func(current *proto.NamespaceStatus) bool {
+		currentParent, exists := current.Shards[s.parentShardID]
+		if !exists {
+			parentExists = false
+			return false
+		}
+		currentParent.Split = splitMetadata
+		current.Shards[leftChildID] = leftChildMetadata
+		current.Shards[rightChildID] = rightChildMetadata
+		return true
+	})
+	if !updated {
+		if !parentExists {
+			return 0, 0, errors.Errorf("shard %d not found in namespace %q", s.parentShardID, s.namespace)
+		}
+		return 0, 0, errors.Errorf("namespace %q not found", s.namespace)
+	}
 	s.logger.Info(
 		"Split initiated",
 		slog.Int64("left-child", leftChildID),

--- a/oxiad/coordinator/runtime/controller/shard/shard_splitter_test.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_splitter_test.go
@@ -41,7 +41,7 @@ func splitParentMetadata() *proto.ShardMetadata {
 	}
 }
 
-func TestSplitterPersistsChildrenBeforeSelectingSecondEnsemble(t *testing.T) {
+func TestSplitterMergesChildrenIntoLatestNamespaceStatus(t *testing.T) {
 	metadata := newTestMetadata(
 		t,
 		memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled, ""),
@@ -56,6 +56,12 @@ func TestSplitterPersistsChildrenBeforeSelectingSecondEnsemble(t *testing.T) {
 		namespaceConfig,
 		splitParentMetadata(),
 	)
+	unrelatedShardID := metadata.ReserveShardIDs(1)
+	metadata.UpdateShardStatus(constant.DefaultNamespace, unrelatedShardID, &proto.ShardMetadata{
+		Status:         proto.ShardStatusSteadyState,
+		Term:           1,
+		Int32HashRange: &proto.HashRange{Min: 100, Max: 199},
+	})
 
 	listener := newMockShardSplitEventListener()
 	selectorCalls := 0
@@ -66,7 +72,10 @@ func TestSplitterPersistsChildrenBeforeSelectingSecondEnsemble(t *testing.T) {
 	) ([]*proto.DataServerIdentity, error) {
 		selectorCalls++
 		if selectorCalls == 2 {
-			assert.Len(t, status[namespace].UnsafeBorrow().Shards, 2, "left child must affect right-child placement")
+			assert.Len(t, status[namespace].UnsafeBorrow().Shards, 3, "left child must affect right-child placement")
+			unrelated := requireShardMetadata(t, metadata, constant.DefaultNamespace, unrelatedShardID)
+			unrelated.Term = 2
+			metadata.UpdateShardStatus(constant.DefaultNamespace, unrelatedShardID, unrelated)
 			return []*proto.DataServerIdentity{rs1, rs2, rs3}, nil
 		}
 		return []*proto.DataServerIdentity{ls1, ls2, ls3}, nil
@@ -98,6 +107,7 @@ func TestSplitterPersistsChildrenBeforeSelectingSecondEnsemble(t *testing.T) {
 	right := requireShardMetadata(t, metadata, constant.DefaultNamespace, rightChild)
 	assert.Equal(t, &proto.HashRange{Min: 50, Max: 99}, right.Int32HashRange)
 	assert.Equal(t, []*proto.DataServerIdentity{rs1, rs2, rs3}, right.Ensemble)
+	assert.Equal(t, int64(2), requireShardMetadata(t, metadata, constant.DefaultNamespace, unrelatedShardID).Term)
 
 	select {
 	case event := <-listener.starts:
@@ -180,4 +190,85 @@ func TestControllerSerializesSplitActionsOnEventLoop(t *testing.T) {
 	close(releaseSelector)
 	require.NoError(t, <-firstDone)
 	assert.ErrorContains(t, <-secondDone, "already has an active split")
+}
+
+func TestControllerSerializesSplitMetadataUpdatesOnEventLoop(t *testing.T) {
+	metadata := newTestMetadata(
+		t,
+		memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled, ""),
+		nil,
+	)
+	parentShardID := metadata.ReserveShardIDs(1)
+	parent := splitParentMetadata()
+	parent.Ensemble = nil
+	storeTestShardMetadata(
+		t,
+		metadata,
+		constant.DefaultNamespace,
+		parentShardID,
+		namespaceConfig,
+		parent,
+	)
+
+	shardController := NewController(
+		constant.DefaultNamespace,
+		parentShardID,
+		namespaceConfig,
+		parent,
+		metadata,
+		NoOpSupportedFeaturesSupplier,
+		nil,
+		SplitterConfig{},
+		mockutils.NewRpcProvider(),
+		time.Hour,
+	).(*controller)
+	t.Cleanup(func() { assert.NoError(t, shardController.Close()) })
+	splitting := shardController.newSplitting()
+	t.Cleanup(splitting.Stop)
+
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseFirst:
+		default:
+			close(releaseFirst)
+		}
+	})
+	firstDone := make(chan struct{})
+	go func() {
+		splitting.executeMetadataUpdate(func() {
+			close(firstEntered)
+			<-releaseFirst
+		})
+		close(firstDone)
+	}()
+	<-firstEntered
+
+	secondEntered := make(chan struct{})
+	secondDone := make(chan struct{})
+	go func() {
+		splitting.executeMetadataUpdate(func() {
+			close(secondEntered)
+		})
+		close(secondDone)
+	}()
+
+	select {
+	case <-secondEntered:
+		t.Fatal("second metadata update bypassed the shard controller event loop")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("first metadata update did not complete")
+	}
+	select {
+	case <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatal("second metadata update did not complete")
+	}
 }

--- a/oxiad/coordinator/runtime/controller/shard/shard_splitter_test.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_splitter_test.go
@@ -1,0 +1,183 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shard
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/common/constant"
+	commonobject "github.com/oxia-db/oxia/common/object"
+	"github.com/oxia-db/oxia/common/proto"
+	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	metadatacodec "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common/codec"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
+	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/action"
+	"github.com/oxia-db/oxia/oxiad/coordinator/runtime/controller/mockutils"
+)
+
+func splitParentMetadata() *proto.ShardMetadata {
+	return &proto.ShardMetadata{
+		Status:         proto.ShardStatusSteadyState,
+		Term:           1,
+		Leader:         ps1,
+		Ensemble:       []*proto.DataServerIdentity{ps1, ps2, ps3},
+		Int32HashRange: &proto.HashRange{Min: 0, Max: 99},
+	}
+}
+
+func TestSplitterPersistsChildrenBeforeSelectingSecondEnsemble(t *testing.T) {
+	metadata := newTestMetadata(
+		t,
+		memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled, ""),
+		nil,
+	)
+	parentShardID := metadata.ReserveShardIDs(1)
+	storeTestShardMetadata(
+		t,
+		metadata,
+		constant.DefaultNamespace,
+		parentShardID,
+		namespaceConfig,
+		splitParentMetadata(),
+	)
+
+	listener := newMockShardSplitEventListener()
+	selectorCalls := 0
+	selector := func(
+		namespace string,
+		_ int64,
+		status map[string]commonobject.Borrowed[*proto.NamespaceStatus],
+	) ([]*proto.DataServerIdentity, error) {
+		selectorCalls++
+		if selectorCalls == 2 {
+			assert.Len(t, status[namespace].UnsafeBorrow().Shards, 2, "left child must affect right-child placement")
+			return []*proto.DataServerIdentity{rs1, rs2, rs3}, nil
+		}
+		return []*proto.DataServerIdentity{ls1, ls2, ls3}, nil
+	}
+
+	splitter := NewSplitter(
+		constant.DefaultNamespace,
+		parentShardID,
+		metadata,
+		SplitterConfig{
+			EnsembleSelector: selector,
+			EventListener:    listener,
+		},
+	)
+	leftChild, rightChild, err := splitter.Split(nil)
+	require.NoError(t, err)
+	assert.Equal(t, leftChild+1, rightChild)
+	assert.Equal(t, 2, selectorCalls)
+
+	parent := requireShardMetadata(t, metadata, constant.DefaultNamespace, parentShardID)
+	require.NotNil(t, parent.Split)
+	assert.Equal(t, []int64{leftChild, rightChild}, parent.Split.ChildShardIds)
+	assert.Equal(t, uint32(49), parent.Split.SplitPoint)
+
+	left := requireShardMetadata(t, metadata, constant.DefaultNamespace, leftChild)
+	assert.Equal(t, &proto.HashRange{Min: 0, Max: 49}, left.Int32HashRange)
+	assert.Equal(t, []*proto.DataServerIdentity{ls1, ls2, ls3}, left.Ensemble)
+
+	right := requireShardMetadata(t, metadata, constant.DefaultNamespace, rightChild)
+	assert.Equal(t, &proto.HashRange{Min: 50, Max: 99}, right.Int32HashRange)
+	assert.Equal(t, []*proto.DataServerIdentity{rs1, rs2, rs3}, right.Ensemble)
+
+	select {
+	case event := <-listener.starts:
+		assert.Equal(t, splitEvent{parentShardID, leftChild, rightChild}, event)
+	default:
+		t.Fatal("expected split-started event")
+	}
+}
+
+func TestControllerSerializesSplitActionsOnEventLoop(t *testing.T) {
+	metadata := newTestMetadata(
+		t,
+		memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled, ""),
+		nil,
+	)
+	parentShardID := metadata.ReserveShardIDs(1)
+	parent := splitParentMetadata()
+	parent.Ensemble = nil
+	storeTestShardMetadata(
+		t,
+		metadata,
+		constant.DefaultNamespace,
+		parentShardID,
+		namespaceConfig,
+		parent,
+	)
+
+	selectorEntered := make(chan struct{})
+	releaseSelector := make(chan struct{})
+	selectorCalls := 0
+	selector := func(
+		_ string,
+		_ int64,
+		_ map[string]commonobject.Borrowed[*proto.NamespaceStatus],
+	) ([]*proto.DataServerIdentity, error) {
+		selectorCalls++
+		if selectorCalls == 1 {
+			close(selectorEntered)
+			<-releaseSelector
+		}
+		return []*proto.DataServerIdentity{ls1, ls2, ls3}, nil
+	}
+	listener := newMockShardSplitEventListener()
+	shardController := NewController(
+		constant.DefaultNamespace,
+		parentShardID,
+		namespaceConfig,
+		parent,
+		metadata,
+		NoOpSupportedFeaturesSupplier,
+		nil,
+		SplitterConfig{
+			EnsembleSelector: selector,
+			EventListener:    listener,
+		},
+		mockutils.NewRpcProvider(),
+		time.Hour,
+	).(*controller)
+	t.Cleanup(func() { assert.NoError(t, shardController.Close()) })
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := shardController.Split(action.NewSplitAction(parentShardID, nil))
+		firstDone <- err
+	}()
+	<-selectorEntered
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := shardController.Split(action.NewSplitAction(parentShardID, nil))
+		secondDone <- err
+	}()
+
+	select {
+	case err := <-secondDone:
+		t.Fatalf("second split bypassed the event loop: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseSelector)
+	require.NoError(t, <-firstDone)
+	assert.ErrorContains(t, <-secondDone, "already has an active split")
+}

--- a/oxiad/coordinator/runtime/runtime.go
+++ b/oxiad/coordinator/runtime/runtime.go
@@ -25,7 +25,6 @@ import (
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
-	pb "google.golang.org/protobuf/proto"
 
 	"github.com/oxia-db/oxia/common/constant"
 	commonobject "github.com/oxia-db/oxia/common/object"
@@ -75,7 +74,6 @@ type runtime struct {
 	metadata coordmetadata.Metadata
 
 	shardControllers      map[int64]shardcontroller.Controller
-	splitControllers      map[int64]*shardcontroller.SplitController // keyed by parent shard ID
 	dataServerControllers map[string]dataservercontroller.Controller
 	// Draining nodes are nodes that were removed from the
 	// nodes list. We keep sending them assignments updates
@@ -266,7 +264,10 @@ func (c *runtime) CreateNamespace(name string, namespaceConfig *proto.Namespace)
 	for shard, shardMetadata := range namespaceStatus.GetShards() {
 		c.shardControllers[shard] = shardcontroller.NewController(name, shard, namespaceConfig,
 			shardMetadata, c.metadata, c.findDataServerFeatures,
-			c, c.rpc, shardcontroller.DefaultPeriodicTasksInterval)
+			c, shardcontroller.SplitterConfig{
+				EnsembleSelector: c.selectSplitEnsemble,
+				EventListener:    c,
+			}, c.rpc, shardcontroller.DefaultPeriodicTasksInterval)
 		slog.Info("Added new shard", slog.Int64("shard", shard),
 			slog.String("namespace", name), slog.Any("shard-metadata", shardMetadata))
 	}
@@ -333,14 +334,6 @@ func dataServersToCandidatesAndMetadata(dataServers map[string]commonobject.Borr
 	return candidates, metadata
 }
 
-func cloneNamespaceStatuses(namespaces map[string]commonobject.Borrowed[*proto.NamespaceStatus]) map[string]commonobject.Borrowed[*proto.NamespaceStatus] {
-	statuses := make(map[string]commonobject.Borrowed[*proto.NamespaceStatus], len(namespaces))
-	for namespace, status := range namespaces {
-		statuses[namespace] = commonobject.Borrow(pb.Clone(status.UnsafeBorrow()).(*proto.NamespaceStatus))
-	}
-	return statuses
-}
-
 // selectNewEnsemble select a new server ensemble based on namespace policy and current cluster status.
 // It uses the ensemble selector to choose appropriate servers and returns the selected server metadata or an error.
 func (c *runtime) selectNewEnsemble(namespace string, shard int64, ns *proto.Namespace, editingStatus map[string]commonobject.Borrowed[*proto.NamespaceStatus]) ([]*proto.DataServerIdentity, error) {
@@ -378,6 +371,14 @@ func (c *runtime) selectNewEnsemble(namespace string, shard int64, ns *proto.Nam
 	return esm, nil
 }
 
+func (c *runtime) selectSplitEnsemble(
+	namespace string,
+	shard int64,
+	editingStatus map[string]commonobject.Borrowed[*proto.NamespaceStatus],
+) ([]*proto.DataServerIdentity, error) {
+	return c.selectNewEnsemble(namespace, shard, c.namespaceConfigForSplit(namespace), editingStatus)
+}
+
 func (c *runtime) Close() error {
 	c.ctxCancel()
 
@@ -391,7 +392,6 @@ func (c *runtime) Close() error {
 	// because their callbacks acquire it.
 	c.Lock()
 	c.closed = true
-	splitControllers := maps.Clone(c.splitControllers)
 	shardControllers := maps.Clone(c.shardControllers)
 	dataServerControllers := maps.Clone(c.dataServerControllers)
 	drainingNodes := maps.Clone(c.drainingNodes)
@@ -401,9 +401,6 @@ func (c *runtime) Close() error {
 	// worker: the worker blocks on in-flight election actions, which only
 	// complete once the shard controllers' retry loops get canceled
 	var err error
-	for _, sc := range splitControllers {
-		sc.Close()
-	}
 	for _, sc := range shardControllers {
 		err = multierr.Append(err, sc.Close())
 	}
@@ -621,164 +618,71 @@ func dataServersFromStatus(status map[string]commonobject.Borrowed[*proto.Namesp
 	return result
 }
 
-// InitiateSplit validates and initiates a shard split. It creates child shards
-// in the cluster status and starts a SplitController to drive the split.
+// InitiateSplit delegates split initiation to the parent shard controller. The
+// controller executes the action on its event-loop thread, serialized with
+// elections and other shard metadata transitions.
 func (c *runtime) InitiateSplit(namespace string, parentShardId int64, splitPoint *uint32) (leftChild, rightChild int64, err error) {
-	c.Lock()
-	defer c.Unlock()
-
-	status := cloneNamespaceStatuses(c.metadata.ListNamespaceStatus())
-
-	// Validate namespace
-	borrowedNs, exists := status[namespace]
-	if !exists {
-		return 0, 0, errors.Errorf("namespace %q not found", namespace)
+	if _, exists := c.metadata.GetShardStatus(namespace, parentShardId); !exists {
+		return 0, 0, errors.Errorf("shard %d not found in namespace %q", parentShardId, namespace)
 	}
-	ns := borrowedNs.UnsafeBorrow()
 
-	// Validate parent shard
-	parentMeta, exists := ns.Shards[parentShardId]
+	c.RLock()
+	sc, exists := c.shardControllers[parentShardId]
+	c.RUnlock()
 	if !exists {
 		return 0, 0, errors.Errorf("shard %d not found in namespace %q", parentShardId, namespace)
 	}
-	if parentMeta.GetStatusOrDefault() != proto.ShardStatusSteadyState {
-		return 0, 0, errors.Errorf("shard %d is not in steady state (status=%s)", parentShardId, parentMeta.GetStatus())
-	}
-	if parentMeta.Split != nil {
-		return 0, 0, errors.Errorf("shard %d already has an active split", parentShardId)
-	}
-	if len(parentMeta.PendingDeleteShardNodes) > 0 {
-		return 0, 0, errors.Errorf("shard %d has pending ensemble changes", parentShardId)
-	}
-	if parentMeta.GetInt32HashRange().GetMax()-parentMeta.GetInt32HashRange().GetMin() < 1 {
-		return 0, 0, errors.Errorf("shard %d hash range is too small to split", parentShardId)
-	}
 
-	// Compute split point
-	var sp uint32
-	if splitPoint != nil {
-		sp = *splitPoint
-		if sp < parentMeta.GetInt32HashRange().GetMin() || sp >= parentMeta.GetInt32HashRange().GetMax() {
-			return 0, 0, errors.Errorf("split point %d is outside shard's hash range [%d, %d]",
-				sp, parentMeta.GetInt32HashRange().GetMin(), parentMeta.GetInt32HashRange().GetMax())
-		}
-	} else {
-		sp = parentMeta.GetInt32HashRange().GetMin() + (parentMeta.GetInt32HashRange().GetMax()-parentMeta.GetInt32HashRange().GetMin())/2
-	}
-
-	// Allocate child shard IDs
-	leftChildId := c.metadata.ReserveShardIDs(2)
-	rightChildId := leftChildId + 1
-	// Select ensembles for children.
-	// After selecting the left child's ensemble, insert it into the cloned
-	// status so the right child's selection sees the updated load distribution
-	// and picks a different server.
-	nsConfig := c.namespaceConfigForSplit(namespace)
-	leftEnsemble, err := c.selectNewEnsemble(namespace, leftChildId, nsConfig, status)
+	result, err := sc.Split(action.NewSplitAction(parentShardId, splitPoint))
 	if err != nil {
-		return 0, 0, errors.Wrap(err, "failed to select ensemble for left child")
+		return 0, 0, err
 	}
-
-	// Update cloned status with left child placement before selecting right child
-	status[namespace].UnsafeBorrow().Shards[leftChildId] = &proto.ShardMetadata{
-		Status:   proto.ShardStatusSteadyState,
-		Ensemble: leftEnsemble,
-		Int32HashRange: &proto.HashRange{
-			Min: parentMeta.GetInt32HashRange().GetMin(),
-			Max: sp,
-		},
-	}
-	rightEnsemble, err := c.selectNewEnsemble(namespace, rightChildId, nsConfig, status)
-	if err != nil {
-		return 0, 0, errors.Wrap(err, "failed to select ensemble for right child")
-	}
-
-	nsCloned := status[namespace].UnsafeBorrow()
-
-	// Create split metadata for parent
-	parentMetaCloned := nsCloned.Shards[parentShardId]
-	parentMetaCloned.Split = &proto.SplitMetadata{
-		Phase:         proto.SplitPhaseBootstrap,
-		ChildShardIds: []int64{leftChildId, rightChildId},
-		SplitPoint:    sp,
-	}
-
-	// Create left child shard
-	nsCloned.Shards[leftChildId] = &proto.ShardMetadata{
-		Status:   proto.ShardStatusSteadyState,
-		Term:     0,
-		Ensemble: leftEnsemble,
-		Int32HashRange: &proto.HashRange{
-			Min: parentMeta.GetInt32HashRange().GetMin(),
-			Max: sp,
-		},
-		Split: &proto.SplitMetadata{
-			Phase:         proto.SplitPhaseBootstrap,
-			ParentShardId: parentShardId,
-			SplitPoint:    sp,
-		},
-	}
-
-	// Create right child shard
-	nsCloned.Shards[rightChildId] = &proto.ShardMetadata{
-		Status:   proto.ShardStatusSteadyState,
-		Term:     0,
-		Ensemble: rightEnsemble,
-		Int32HashRange: &proto.HashRange{
-			Min: sp + 1,
-			Max: parentMeta.GetInt32HashRange().GetMax(),
-		},
-		Split: &proto.SplitMetadata{
-			Phase:         proto.SplitPhaseBootstrap,
-			ParentShardId: parentShardId,
-			SplitPoint:    sp,
-		},
-	}
-
-	// Persist
-	c.metadata.UpdateNamespaceStatus(namespace, nsCloned)
-
-	c.logger.Info("Split initiated",
-		slog.Int64("parent-shard", parentShardId),
-		slog.Int64("left-child", leftChildId),
-		slog.Int64("right-child", rightChildId),
-		slog.Uint64("split-point", uint64(sp)),
-	)
-
-	// Create shard controllers for children
-	for _, childId := range []int64{leftChildId, rightChildId} {
-		childMeta := nsCloned.Shards[childId]
-		c.shardControllers[childId] = shardcontroller.NewController(namespace, childId, nsConfig,
-			childMeta, c.metadata, c.findDataServerFeatures,
-			c, c.rpc, shardcontroller.DefaultPeriodicTasksInterval)
-	}
-
-	// Start split controller
-	sc := shardcontroller.NewSplitController(shardcontroller.SplitControllerConfig{
-		Namespace:     namespace,
-		ParentShardId: parentShardId,
-		Metadata:      c.metadata,
-		RpcProvider:   c.rpc,
-		EventListener: c,
-		EnsembleSelector: func(ns string) ([]*proto.DataServerIdentity, error) {
-			return c.selectNewEnsemble(ns, 0, c.namespaceConfigForSplit(ns), c.metadata.ListNamespaceStatus())
-		},
-	})
-	c.splitControllers[parentShardId] = sc
-
-	return leftChildId, rightChildId, nil
+	return result.LeftChild, result.RightChild, nil
 }
 
-// SplitComplete is called by the SplitController at the end of the Cutover
+// SplitStarted creates child shard controllers after the parent controller
+// persists the initial split metadata. The parent controller owns and starts
+// the remaining split state machine.
+func (c *runtime) SplitStarted(namespace string, parentShard int64, leftChild int64, rightChild int64) {
+	c.Lock()
+	defer c.Unlock()
+
+	if _, parentExists := c.shardControllers[parentShard]; !parentExists {
+		c.logger.Error("Split parent controller not found", slog.Int64("parent-shard", parentShard))
+		return
+	}
+
+	nsConfig := c.namespaceConfigForSplit(namespace)
+	for _, childID := range []int64{leftChild, rightChild} {
+		childMeta, exists := c.metadata.GetShardStatus(namespace, childID)
+		if !exists {
+			c.logger.Error("Split child metadata not found", slog.Int64("child-shard", childID))
+			continue
+		}
+		c.shardControllers[childID] = shardcontroller.NewController(
+			namespace,
+			childID,
+			nsConfig,
+			childMeta.UnsafeBorrow(),
+			c.metadata,
+			c.findDataServerFeatures,
+			c,
+			shardcontroller.SplitterConfig{
+				EnsembleSelector: c.selectSplitEnsemble,
+				EventListener:    c,
+			},
+			c.rpc,
+			shardcontroller.DefaultPeriodicTasksInterval,
+		)
+	}
+
+}
+
+// SplitComplete is called by the parent shard controller at the end of Cutover
 // phase, after children are re-elected in clean terms and the parent is marked
 // Deleting. The coordinator triggers the parent shard's deletion (which retries
 // indefinitely until all ensemble members have deleted the shard) and recomputes
 // shard assignments so clients discover the children.
-//
-// NOTE: This is called from within the split controller's own goroutine,
-// so we must NOT call sc.Close() on the split controller (that would deadlock
-// on wg.Wait). Instead we just remove it from the map and let the goroutine
-// finish naturally.
 func (c *runtime) SplitComplete(parentShard int64, leftChild int64, rightChild int64) {
 	c.Lock()
 	defer c.Unlock()
@@ -788,10 +692,6 @@ func (c *runtime) SplitComplete(parentShard int64, leftChild int64, rightChild i
 		slog.Int64("left-child", leftChild),
 		slog.Int64("right-child", rightChild),
 	)
-
-	// Remove split controller from map without calling Close (would deadlock).
-	// The goroutine will return naturally after this callback.
-	delete(c.splitControllers, parentShard)
 
 	// Trigger the parent shard controller's deletion. The shard controller
 	// retries DeleteShard RPCs indefinitely with backoff, handles unreachable
@@ -803,8 +703,8 @@ func (c *runtime) SplitComplete(parentShard int64, leftChild int64, rightChild i
 	c.computeNewAssignments()
 }
 
-// SplitAborted is called by the SplitController when a split has been
-// aborted due to timeout or cancellation. The split controller has already
+// SplitAborted is called by the parent shard controller when a split has been
+// aborted due to timeout or cancellation. The shard controller has already
 // cleaned up observer cursors, deleted child shards from status, and
 // cleared the parent's split metadata.
 func (c *runtime) SplitAborted(parentShard int64, leftChild int64, rightChild int64) {
@@ -816,9 +716,6 @@ func (c *runtime) SplitAborted(parentShard int64, leftChild int64, rightChild in
 		slog.Int64("left-child", leftChild),
 		slog.Int64("right-child", rightChild),
 	)
-
-	// Remove split controller from map (goroutine will return after this).
-	delete(c.splitControllers, parentShard)
 
 	// Close child shard controllers.
 	for _, childId := range []int64{leftChild, rightChild} {
@@ -839,41 +736,6 @@ func (c *runtime) namespaceConfigForSplit(namespace string) *proto.Namespace {
 	return borrowedNsConfig.UnsafeBorrow()
 }
 
-// restartInProgressSplits checks the cluster status for any shards that have
-// active SplitMetadata and creates SplitControllers to resume them.
-func (c *runtime) restartInProgressSplits(clusterStatus map[string]commonobject.Borrowed[*proto.NamespaceStatus]) {
-	for ns, borrowedShards := range clusterStatus {
-		shards := borrowedShards.UnsafeBorrow()
-		for shardId, meta := range shards.Shards {
-			if meta.Split == nil {
-				continue
-			}
-			// Only create split controller from the parent shard (has ChildShardIds)
-			if len(meta.Split.ChildShardIds) == 0 {
-				continue
-			}
-
-			c.logger.Info("Resuming in-progress split",
-				slog.String("namespace", ns),
-				slog.Int64("parent-shard", shardId),
-				slog.String("phase", meta.Split.GetPhaseOrDefault().String()),
-			)
-
-			sc := shardcontroller.NewSplitController(shardcontroller.SplitControllerConfig{
-				Namespace:     ns,
-				ParentShardId: shardId,
-				Metadata:      c.metadata,
-				RpcProvider:   c.rpc,
-				EventListener: c,
-				EnsembleSelector: func(namespace string) ([]*proto.DataServerIdentity, error) {
-					return c.selectNewEnsemble(namespace, 0, c.namespaceConfigForSplit(namespace), c.metadata.ListNamespaceStatus())
-				},
-			})
-			c.splitControllers[shardId] = sc
-		}
-	}
-}
-
 func New(
 	metadata coordmetadata.Metadata,
 	rpcProvider rpc.ProviderFactory,
@@ -884,7 +746,6 @@ func New(
 		),
 		ensembleSelector:      ensemble.NewSelector(),
 		shardControllers:      make(map[int64]shardcontroller.Controller),
-		splitControllers:      make(map[int64]*shardcontroller.SplitController),
 		dataServerControllers: make(map[string]dataservercontroller.Controller),
 		drainingNodes:         make(map[string]dataservercontroller.Controller),
 		metadata:              metadata,
@@ -945,12 +806,12 @@ func New(
 			}
 			c.shardControllers[shard] = shardcontroller.NewController(ns, shard, nsConfig,
 				shardMetadata, c.metadata, c.findDataServerFeatures,
-				c, c.rpc, shardcontroller.DefaultPeriodicTasksInterval)
+				c, shardcontroller.SplitterConfig{
+					EnsembleSelector: c.selectSplitEnsemble,
+					EventListener:    c,
+				}, c.rpc, shardcontroller.DefaultPeriodicTasksInterval)
 		}
 	}
-
-	// Restart any in-progress splits from persisted state
-	c.restartInProgressSplits(clusterStatus)
 
 	c.wg.Go(func() {
 		process.DoWithLabels(c.ctx, map[string]string{


### PR DESCRIPTION
## Motivation

Shard splitting currently has two owners: the coordinator runtime creates and tracks a standalone `SplitController`, while the parent shard controller owns elections, ensemble changes, and deletion. We found that the runtime lock does not serialize with the parent controller event loop. Both paths can read, clone, and write the same shard metadata, so a split-phase write can be based on a stale term, leader, or ensemble and overwrite a newer controller transition.

We also found that `Metadata.UpdateNamespaceStatus` replaced an entire namespace with a snapshot captured by its caller. Even though store writes are locked, persisting split metadata could discard a concurrent update to another shard. The standalone controller's `context.Background()` lifecycle and separate runtime map also duplicate shutdown and recovery ownership. The parent shard controller should own the split lifecycle and mediate its metadata mutations.

## Modifications

- add a `SplitAction` queue and serialize split initiation with the parent shard controller event loop
- marshal split metadata mutations through the same event loop as elections, ensemble changes, and deletion
- derive the split lifecycle from the parent controller context and resume persisted split state there
- remove runtime-level `splitControllers` ownership and simplify child-controller lifecycle handling
- change `Metadata.UpdateNamespaceStatus` to mutate the latest namespace snapshot atomically under the metadata write lock
- add regression coverage for event-loop ordering and preservation of concurrent shard metadata updates

## Testing

- `go test ./oxiad/...`
- `go test -race ./oxiad/coordinator/runtime/controller/shard -run 'TestSplitterMergesChildrenIntoLatestNamespaceStatus|TestControllerSerializesSplit' -count=1`