### PR TITLE
refactor: share secondary index key parser

### DIFF
--- a/oxiad/dataserver/controller/lead/secondary_indexes.go
+++ b/oxiad/dataserver/controller/lead/secondary_indexes.go
@@ -17,7 +17,6 @@ package lead
 import (
 	"fmt"
 	"net/url"
-	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -146,39 +145,8 @@ const secondaryIdxSeparator = "\x01"
 const secondaryIdxRangePrefixFormat = secondaryIdxKeyPrefix + "/%s/%s"
 const secondaryIdxFormat = secondaryIdxRangePrefixFormat + secondaryIdxSeparator + "%s"
 
-// The index name and the secondary key are stored as the client supplied them,
-// so both can be empty and the secondary key can contain the separator. Only
-// the primary key is url-escaped, and that escaping never emits a separator, so
-// the last one is the field boundary.
-const regex = "(?s)^" + secondaryIdxKeyPrefix + "/[^/]*/(.*)" + secondaryIdxSeparator +
-	"([^" + secondaryIdxSeparator + "]*)$"
-
-var secondaryIdxFormatRegex = regexp.MustCompile(regex)
-
-var errFailedToParseSecondaryKey = errors.New("oxia db: failed to parse secondary index key")
-
 func secondaryIndexKey(primaryKey string, si *proto.SecondaryIndex) string {
 	return fmt.Sprintf(secondaryIdxFormat, si.IndexName, si.SecondaryKey, url.PathEscape(primaryKey))
-}
-
-func secondaryIndexPrimaryKey(completeKey string) (string, error) {
-	matches := secondaryIdxFormatRegex.FindStringSubmatch(completeKey)
-	if len(matches) != 3 {
-		return "", errFailedToParseSecondaryKey
-	}
-
-	return url.PathUnescape(matches[2])
-}
-
-func secondaryIndexPrimaryAndSecondaryKey(completeKey string) (primaryKey string, secondaryKey string, err error) {
-	matches := secondaryIdxFormatRegex.FindStringSubmatch(completeKey)
-	if len(matches) != 3 {
-		return "", "", errFailedToParseSecondaryKey
-	}
-
-	secondaryKey = matches[1]
-	primaryKey, err = url.PathUnescape(matches[2])
-	return primaryKey, secondaryKey, err
 }
 
 func deleteSecondaryIndexes(batch kvstore.WriteBatch, primaryKey string, existingEntry *proto.StorageEntry) error {
@@ -231,7 +199,7 @@ func (it *secondaryIndexListIterator) Valid() bool {
 
 func (it *secondaryIndexListIterator) Key() string {
 	idxKey := it.it.Key()
-	primaryKey, err := secondaryIndexPrimaryKey(idxKey)
+	primaryKey, _, err := database.ParseSecondaryIndexKey(idxKey)
 	if err != nil {
 		// This should never happen since we control the key format
 		panic(errors.Wrap(err, "Failed to parse secondary index key"))
@@ -317,7 +285,7 @@ func (it *secondaryIndexRangeIterator) Value() (*proto.GetResponse, error) {
 
 func secondaryIndexGet(req *proto.GetRequest, db database.DB) (*proto.GetResponse, error) {
 	primaryKey, secondaryKey, err := doSecondaryGet(db, req)
-	if err != nil && !errors.Is(err, errFailedToParseSecondaryKey) {
+	if err != nil && !errors.Is(err, database.ErrInvalidSecondaryIndexKey) {
 		return nil, err
 	}
 
@@ -372,8 +340,8 @@ func doSecondaryGet(db database.DB, req *proto.GetRequest) (primaryKey string, s
 			break
 		}
 
-		primaryKey, secondaryKey, err = secondaryIndexPrimaryAndSecondaryKey(itKey)
-		if err != nil && !errors.Is(err, errFailedToParseSecondaryKey) {
+		primaryKey, secondaryKey, err = database.ParseSecondaryIndexKey(itKey)
+		if err != nil && !errors.Is(err, database.ErrInvalidSecondaryIndexKey) {
 			return "", "", err
 		}
 

--- a/oxiad/dataserver/database/secondary_index.go
+++ b/oxiad/dataserver/database/secondary_index.go
@@ -1,0 +1,53 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"net/url"
+	"regexp"
+
+	"github.com/pkg/errors"
+
+	"github.com/oxia-db/oxia/common/constant"
+)
+
+const (
+	idxKeyPrefix = constant.InternalKeyPrefix + "idx"
+	idxSeparator = "\x01"
+)
+
+// The index name and the secondary key are stored as the client supplied them,
+// so both can be empty and the secondary key can contain the separator. Only
+// the primary key is URL-escaped, and that escaping never emits a separator, so
+// the last one is the field boundary.
+var secondaryIndexKeyRegex = regexp.MustCompile(
+	"(?s)^" + idxKeyPrefix + "/[^/]*/(.*)" + idxSeparator + "([^" + idxSeparator + "]*)$",
+)
+
+// ErrInvalidSecondaryIndexKey indicates that a key does not use the persisted
+// secondary index key format.
+var ErrInvalidSecondaryIndexKey = errors.New("oxia db: failed to parse secondary index key")
+
+// ParseSecondaryIndexKey extracts the primary and secondary keys from a
+// persisted secondary index entry.
+func ParseSecondaryIndexKey(key string) (primaryKey string, secondaryKey string, err error) {
+	matches := secondaryIndexKeyRegex.FindStringSubmatch(key)
+	if len(matches) != 3 {
+		return "", "", ErrInvalidSecondaryIndexKey
+	}
+
+	primaryKey, err = url.PathUnescape(matches[2])
+	return primaryKey, matches[1], err
+}

--- a/oxiad/dataserver/database/secondary_index_test.go
+++ b/oxiad/dataserver/database/secondary_index_test.go
@@ -1,0 +1,75 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSecondaryIndexKey(t *testing.T) {
+	primaryKey := "/primary\x01key"
+	tests := []struct {
+		name              string
+		indexKey          string
+		expectedPrimary   string
+		expectedSecondary string
+	}{
+		{
+			name:              "standard",
+			indexKey:          idxKeyPrefix + "/index/secondary" + idxSeparator + url.PathEscape(primaryKey),
+			expectedPrimary:   primaryKey,
+			expectedSecondary: "secondary",
+		},
+		{
+			name:              "separator in secondary key",
+			indexKey:          idxKeyPrefix + "/index/first" + idxSeparator + "second" + idxSeparator + url.PathEscape(primaryKey),
+			expectedPrimary:   primaryKey,
+			expectedSecondary: "first" + idxSeparator + "second",
+		},
+		{
+			name:              "empty secondary key",
+			indexKey:          idxKeyPrefix + "/index/" + idxSeparator + url.PathEscape(primaryKey),
+			expectedPrimary:   primaryKey,
+			expectedSecondary: "",
+		},
+		{
+			name:              "newline in secondary key",
+			indexKey:          idxKeyPrefix + "/index/first\nsecond" + idxSeparator + url.PathEscape(primaryKey),
+			expectedPrimary:   primaryKey,
+			expectedSecondary: "first\nsecond",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualPrimary, actualSecondary, err := ParseSecondaryIndexKey(tc.indexKey)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedPrimary, actualPrimary)
+			assert.Equal(t, tc.expectedSecondary, actualSecondary)
+		})
+	}
+}
+
+func TestParseSecondaryIndexKeyRejectsMalformedKey(t *testing.T) {
+	_, _, err := ParseSecondaryIndexKey(idxKeyPrefix + "/index/secondary")
+	assert.ErrorIs(t, err, ErrInvalidSecondaryIndexKey)
+
+	_, _, err = ParseSecondaryIndexKey(idxKeyPrefix + "/index/secondary" + idxSeparator + "%zz")
+	assert.Error(t, err)
+}

--- a/oxiad/dataserver/database/split_filter.go
+++ b/oxiad/dataserver/database/split_filter.go
@@ -17,7 +17,6 @@ package database
 import (
 	"log/slog"
 	"net/url"
-	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -31,8 +30,6 @@ import (
 
 const (
 	sessionKeyPrefix = constant.InternalKeyPrefix + "session"
-	idxKeyPrefix     = constant.InternalKeyPrefix + "idx"
-	idxSeparator     = "\x01"
 	sessionKeyLength = len(sessionKeyPrefix) + 1 + 16 // __oxia/session/ + 16 hex digits
 
 	// Filtering deletes about half the shard: accumulated in a single indexed
@@ -50,13 +47,6 @@ const (
 var (
 	splitFilterMaxBatchCount = 100_000
 	splitFilterMaxBatchBytes = 8 * 1024 * 1024
-)
-
-// Anchored on the last separator, like the index writer's own parser: the index
-// name and the secondary key are stored as the client supplied them, while the
-// url-escaped primary key never contains a separator.
-var secondaryIdxRegex = regexp.MustCompile(
-	"(?s)^" + idxKeyPrefix + "/[^/]*/(.*)" + idxSeparator + "([^" + idxSeparator + "]*)$",
 )
 
 // FilterDBForSplit removes keys that do not belong to the specified hash range.
@@ -320,14 +310,9 @@ func classifySessionShadowKey(key string, hashRange *proto.HashRange) splitActio
 // and checks if it belongs to this child's hash range.
 // Format: __oxia/idx/{name}/{secondary}\x01{url_escaped_primary}.
 func classifySecondaryIndexKey(key string, hashRange *proto.HashRange) splitAction {
-	matches := secondaryIdxRegex.FindStringSubmatch(key)
-	if len(matches) != 3 {
-		// Can't parse: keep to be safe
-		return splitActionKeep
-	}
-
-	primaryKey, err := url.PathUnescape(matches[2])
+	primaryKey, _, err := ParseSecondaryIndexKey(key)
 	if err != nil {
+		// Can't parse: keep to be safe
 		return splitActionKeep
 	}
 


### PR DESCRIPTION
## Motivation

Normal secondary-index reads and shard split filtering independently parse the same persisted key format. PR #1262 had to update both regex copies, demonstrating that the implementations can drift and make two data-server paths interpret the same key differently.

A single parser gives the persisted format one implementation without changing the last-separator behavior introduced by #1262.

Tracks #1265.

## Modifications

- add `database.ParseSecondaryIndexKey` and a shared malformed-key sentinel
- use the parser from index Get, List, and RangeScan paths
- use the same parser when classifying index entries during shard splitting
- remove both duplicated regex implementations
- add focused parser tests for empty, newline, embedded-separator, escaped-primary, and malformed keys

## Testing

- `go test ./oxiad/dataserver/...`
- `golangci-lint run ./oxiad/dataserver/...`