### PR TITLE
fix: prevent abandoned gets from blocking read batches

### DIFF
--- a/oxia/async_client_impl.go
+++ b/oxia/async_client_impl.go
@@ -275,7 +275,7 @@ func (c *clientImpl) doSingleShardDeleteRange(shardId int64, minKeyInclusive str
 }
 
 func (c *clientImpl) Get(key string, options ...GetOption) <-chan GetResult {
-	ch := make(chan GetResult)
+	ch := make(chan GetResult, 1)
 
 	opts := newGetOptions(options)
 	if opts.partitionKey == nil && //

--- a/oxia/async_client_impl_test.go
+++ b/oxia/async_client_impl_test.go
@@ -15,14 +15,103 @@
 package oxia
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/common/proto"
+	commonbatch "github.com/oxia-db/oxia/oxia/batch"
+	"github.com/oxia-db/oxia/oxia/internal/batch"
+	"github.com/oxia-db/oxia/oxia/internal/model"
 )
+
+type capturingGetBatcher struct {
+	calls chan model.GetCall
+}
+
+func (b *capturingGetBatcher) Add(call any) {
+	b.calls <- call.(model.GetCall)
+}
+
+func (*capturingGetBatcher) Close() error { return nil }
+func (*capturingGetBatcher) Run()         {}
+
+type staticShardManager struct {
+	shards []int64
+}
+
+func (*staticShardManager) Close() error       { return nil }
+func (s *staticShardManager) Get(string) int64 { return s.shards[0] }
+func (s *staticShardManager) GetAll() []int64  { return s.shards }
+func (*staticShardManager) Leader(int64) string {
+	return ""
+}
+func (*staticShardManager) Exists(int64) bool { return true }
+
+func newGetTestClient(shards ...int64) (*clientImpl, *capturingGetBatcher) {
+	b := &capturingGetBatcher{calls: make(chan model.GetCall, len(shards))}
+	return &clientImpl{
+		shardManager: &staticShardManager{shards: shards},
+		readBatchManager: batch.NewManager(context.Background(), func(context.Context, *int64) commonbatch.Batcher {
+			return b
+		}),
+	}, b
+}
+
+func requireGetCallbackDoesNotBlock(t *testing.T, callback func(), resultCh <-chan GetResult) GetResult {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		callback()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return <-resultCh
+	case <-time.After(time.Second):
+		// Consume the result to release the callback before failing the test.
+		<-resultCh
+		<-done
+		t.Fatal("get callback blocked until the result was consumed")
+		return GetResult{}
+	}
+}
+
+func TestGetCallbackDoesNotBlockWhenSingleShardResultIsAbandoned(t *testing.T) {
+	client, batcher := newGetTestClient(1)
+	resultCh := client.Get("key-a")
+	call := <-batcher.calls
+
+	result := requireGetCallbackDoesNotBlock(t, func() {
+		call.Callback(&proto.GetResponse{Status: proto.Status_KEY_NOT_FOUND}, nil)
+	}, resultCh)
+
+	assert.ErrorIs(t, result.Err, ErrKeyNotFound)
+	_, open := <-resultCh
+	assert.False(t, open)
+}
+
+func TestGetCallbackDoesNotBlockWhenMultiShardResultIsAbandoned(t *testing.T) {
+	client, batcher := newGetTestClient(1, 2)
+	resultCh := client.Get("key-a", ComparisonFloor())
+	firstCall := <-batcher.calls
+	secondCall := <-batcher.calls
+
+	firstCall.Callback(&proto.GetResponse{Status: proto.Status_KEY_NOT_FOUND}, nil)
+	result := requireGetCallbackDoesNotBlock(t, func() {
+		secondCall.Callback(&proto.GetResponse{Status: proto.Status_KEY_NOT_FOUND}, nil)
+	}, resultCh)
+
+	assert.ErrorIs(t, result.Err, ErrKeyNotFound)
+	_, open := <-resultCh
+	assert.False(t, open)
+}
 
 // The first shard error terminates the result channel; the responses of the
 // remaining shards — errors included — must be discarded, not panic with a


### PR DESCRIPTION
## Motivation

When a synchronous `Get` returns because its context is canceled, its asynchronous result channel is abandoned. The unbuffered channel can then block the read batch completion callback while publishing the late result, preventing that shard batcher from processing subsequent reads.

Fixes #1221.

## Modifications

- buffer each one-shot `GetResult` channel with capacity one
- add regression coverage for abandoned single-shard and multi-shard get results

## Testing

- `make test`
- `make lint`