### PR TITLE
refactor: extract no-op database callback

### DIFF
--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -1059,26 +1059,6 @@ func (d *db) ReadNextNotifications(ctx context.Context, startOffset int64) ([]*p
 	return d.notificationsTracker.ReadNextNotifications(ctx, startOffset)
 }
 
-type noopCallback struct{}
-
-func (*noopCallback) OnDeleteWithEntry(kvstore.WriteBatch, *Notifications, string, *proto.StorageEntry) error {
-	return nil
-}
-
-func (*noopCallback) OnPut(_ kvstore.WriteBatch, _ *Notifications, _ *proto.PutRequest, _ *proto.StorageEntry) (proto.Status, error) {
-	return proto.Status_OK, nil
-}
-
-func (*noopCallback) OnDelete(_ kvstore.WriteBatch, _ *Notifications, _ string) error {
-	return nil
-}
-
-func (*noopCallback) OnDeleteRange(_ kvstore.WriteBatch, _ *Notifications, _ string, _ string) error {
-	return nil
-}
-
-var NoOpCallback UpdateOperationCallback = &noopCallback{}
-
 func ToDbOption(opt *proto.NewTermOptions) TermOptions {
 	to := TermOptions{NotificationsEnabled: true}
 	if opt != nil {

--- a/oxiad/dataserver/database/noop_callback.go
+++ b/oxiad/dataserver/database/noop_callback.go
@@ -1,0 +1,40 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxiad/dataserver/database/kvstore"
+)
+
+type noopCallback struct{}
+
+func (*noopCallback) OnDeleteWithEntry(kvstore.WriteBatch, *Notifications, string, *proto.StorageEntry) error {
+	return nil
+}
+
+func (*noopCallback) OnPut(_ kvstore.WriteBatch, _ *Notifications, _ *proto.PutRequest, _ *proto.StorageEntry) (proto.Status, error) {
+	return proto.Status_OK, nil
+}
+
+func (*noopCallback) OnDelete(_ kvstore.WriteBatch, _ *Notifications, _ string) error {
+	return nil
+}
+
+func (*noopCallback) OnDeleteRange(_ kvstore.WriteBatch, _ *Notifications, _ string, _ string) error {
+	return nil
+}
+
+var NoOpCallback UpdateOperationCallback = &noopCallback{}


### PR DESCRIPTION
## Motivation

`db.go` currently contains both the database implementation and the no-op update callback. Keeping the callback in its own file makes the callback implementation easier to find and keeps this mechanical cleanup independent from the secondary-index validation work.

## Modifications

- move `noopCallback` and `NoOpCallback` from `db.go` to `noop_callback.go`
- preserve the existing callback behavior and public API

## Testing

- `go test ./oxiad/dataserver/...`
- `make lint`
- `git diff --check`