### PR TITLE
fix: reject sequence key deltas that overflow the counter

### DIFF
--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -48,6 +48,7 @@ var (
 	ErrMissingPartitionKey   = errors.New("oxia: sequential key operation requires partition key")
 	ErrMissingSequenceDeltas = errors.New("oxia: sequential key operation missing some sequence deltas")
 	ErrSequenceDeltaIsZero   = errors.New("oxia: sequential key operation requires first delta do be > 0")
+	ErrSequenceOverflow      = errors.New("oxia: sequential key operation overflows the sequence")
 	ErrNotificationsDisabled = errors.New("oxia: notifications disabled")
 )
 

--- a/oxiad/dataserver/database/db_sequences.go
+++ b/oxiad/dataserver/database/db_sequences.go
@@ -63,6 +63,12 @@ func generateUniqueKeyFromSequences(batch kvstore.WriteBatch, req *proto.PutRequ
 			lastValue = 0
 		}
 
+		if delta > maxSequence-lastValue {
+			// The cumulative value would wrap past uint64: the generated key
+			// would sort below the current tail and could collide with an
+			// earlier entry, so reject the delta instead of overflowing.
+			return "", ErrSequenceOverflow
+		}
 		newKey = fmt.Sprintf("%s-%020d", newKey, lastValue+delta)
 	}
 

--- a/oxiad/dataserver/database/db_test.go
+++ b/oxiad/dataserver/database/db_test.go
@@ -853,6 +853,75 @@ func TestDB_SequentialKeys(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("a-%020d-%020d-%020d", 20, 18, 15), resp.GetPuts()[0].GetKey())
 }
 
+func TestDB_SequentialKeysOverflow(t *testing.T) {
+	factory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	db, err := NewDB(constant.DefaultNamespace, 1, factory, proto.KeySortingType_NATURAL, 0, time.SystemClock)
+	assert.NoError(t, err)
+
+	// A delta that lands exactly on the max sequence value is still fine.
+	resp, err := db.ProcessWrite(&proto.WriteRequest{Puts: []*proto.PutRequest{{
+		Key:              "a",
+		Value:            []byte("0"),
+		PartitionKey:     pb.String("x"),
+		SequenceKeyDelta: []uint64{maxSequence},
+	}}}, 0, 0, NoOpCallback)
+	assert.NoError(t, err)
+	assert.Equal(t, proto.Status_OK, resp.GetPuts()[0].Status)
+	assert.Equal(t, fmt.Sprintf("a-%020d", maxSequence), resp.GetPuts()[0].GetKey())
+
+	// Seed a small sequence, then a huge delta that would wrap uint64 back onto
+	// an earlier key must be rejected instead of silently overwriting it.
+	resp, err = db.ProcessWrite(&proto.WriteRequest{Puts: []*proto.PutRequest{{
+		Key:              "b",
+		Value:            []byte("0"),
+		PartitionKey:     pb.String("x"),
+		SequenceKeyDelta: []uint64{5},
+	}}}, 0, 0, NoOpCallback)
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("b-%020d", 5), resp.GetPuts()[0].GetKey())
+
+	_, err = db.ProcessWrite(&proto.WriteRequest{Puts: []*proto.PutRequest{{
+		Key:              "b",
+		Value:            []byte("0"),
+		PartitionKey:     pb.String("x"),
+		SequenceKeyDelta: []uint64{maxSequence},
+	}}}, 0, 0, NoOpCallback)
+	assert.ErrorIs(t, err, ErrSequenceOverflow)
+
+	// The rejected put left the tail untouched: a normal delta keeps advancing
+	// from 5, so no earlier entry was clobbered.
+	resp, err = db.ProcessWrite(&proto.WriteRequest{Puts: []*proto.PutRequest{{
+		Key:              "b",
+		Value:            []byte("0"),
+		PartitionKey:     pb.String("x"),
+		SequenceKeyDelta: []uint64{3},
+	}}}, 0, 0, NoOpCallback)
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("b-%020d", 8), resp.GetPuts()[0].GetKey())
+
+	// Overflow at a non-leading sequence position is rejected too.
+	resp, err = db.ProcessWrite(&proto.WriteRequest{Puts: []*proto.PutRequest{{
+		Key:              "c",
+		Value:            []byte("0"),
+		PartitionKey:     pb.String("x"),
+		SequenceKeyDelta: []uint64{2, 4},
+	}}}, 0, 0, NoOpCallback)
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("c-%020d-%020d", 2, 4), resp.GetPuts()[0].GetKey())
+
+	_, err = db.ProcessWrite(&proto.WriteRequest{Puts: []*proto.PutRequest{{
+		Key:              "c",
+		Value:            []byte("0"),
+		PartitionKey:     pb.String("x"),
+		SequenceKeyDelta: []uint64{1, maxSequence},
+	}}}, 0, 0, NoOpCallback)
+	assert.ErrorIs(t, err, ErrSequenceOverflow)
+
+	assert.NoError(t, db.Close())
+	assert.NoError(t, factory.Close())
+}
+
 func rangeScanIteratorToSlice(it RangeScanIterator, err error) []string {
 	assert.NoError(nil, err)
 	var keys []string


### PR DESCRIPTION
Oxia builds a sequential key by adding the client-supplied delta to the current tail value for each position in the sequence. generateUniqueKeyFromSequences does that as lastValue+delta in uint64 with no bound, and SequenceKeyDelta arrives straight from the client PutRequest, so a delta large enough to carry the sum past 2^64 wraps around. The generated key then formats to a value below the current tail instead of above it, which breaks the ordering the sequence is supposed to guarantee, and it can land exactly on a key that already lives in the sequence. The sequential-put path skips the expected-version check, so applyPut treats that colliding key as new: the prior record's value is overwritten, its ModificationsCount resets to zero and its creation timestamp is replaced, so an earlier entry is destroyed with nothing to signal it. I ran into this while tracing how the tail is looked up and saw that nothing caps the delta anywhere on the way in. Checking whether the delta would carry lastValue past the max before formatting closes it: the overflowing put returns an error and every in-range delta still encodes exactly as before. I kept the guard inside generateUniqueKeyFromSequences so callers do not have to pre-validate, and it runs at each position rather than only the first.
