### PR TITLE
fix: preserve the partition key when rerouting reads

### DIFF
--- a/oxia/async_client_impl.go
+++ b/oxia/async_client_impl.go
@@ -135,7 +135,7 @@ func (c *clientImpl) rerouteWrites(puts []model.PutCall, deletes []model.DeleteC
 
 func (c *clientImpl) rerouteReads(gets []model.GetCall) {
 	for _, get := range gets {
-		shardId := c.shardManager.Get(get.Key)
+		shardId := c.shardManager.Get(get.PartitionKeyOrKey())
 		c.readBatchManager.Get(shardId).Add(get)
 	}
 }
@@ -296,6 +296,7 @@ func (c *clientImpl) doSingleShardGet(key string, opts *getOptions, ch chan GetR
 		ComparisonType:     opts.comparisonType,
 		IncludeValue:       opts.includeValue,
 		SecondaryIndexName: opts.secondaryIndexName,
+		PartitionKey:       opts.partitionKey,
 		Callback: func(response *proto.GetResponse, err error) {
 			ch <- toGetResult(response, key, err)
 			close(ch)

--- a/oxia/internal/model/model.go
+++ b/oxia/internal/model/model.go
@@ -48,7 +48,17 @@ type GetCall struct {
 	ComparisonType     proto.KeyComparisonType
 	IncludeValue       bool
 	SecondaryIndexName *string
+	PartitionKey       *string
 	Callback           func(*proto.GetResponse, error)
+}
+
+// PartitionKeyOrKey returns the partition key if set, otherwise the record key.
+// Used for shard routing when re-routing operations after a shard split.
+func (r GetCall) PartitionKeyOrKey() string {
+	if r.PartitionKey != nil {
+		return *r.PartitionKey
+	}
+	return r.Key
 }
 
 // PartitionKeyOrKey returns the partition key if set, otherwise the record key.

--- a/oxia/internal/model/model_test.go
+++ b/oxia/internal/model/model_test.go
@@ -52,3 +52,29 @@ func TestDeleteCallEmptyPartitionKey(t *testing.T) {
 	assert.NotNil(t, req.PartitionKey)
 	assert.Equal(t, partitionKey, req.GetPartitionKey())
 }
+
+func TestGetCallPartitionKey(t *testing.T) {
+	partitionKey := "partition-key"
+	call := GetCall{
+		Key:          "key",
+		PartitionKey: &partitionKey,
+	}
+
+	assert.Equal(t, partitionKey, call.PartitionKeyOrKey())
+}
+
+func TestGetCallPartitionKeyOrKeyFallback(t *testing.T) {
+	call := GetCall{Key: "key"}
+
+	assert.Equal(t, "key", call.PartitionKeyOrKey())
+}
+
+func TestGetCallEmptyPartitionKey(t *testing.T) {
+	partitionKey := ""
+	call := GetCall{
+		Key:          "key",
+		PartitionKey: &partitionKey,
+	}
+
+	assert.Equal(t, partitionKey, call.PartitionKeyOrKey())
+}


### PR DESCRIPTION
A Get issued with a partition key is routed by hash(partitionKey), which is correct, but the batched GetCall never carries the partition key along. When a shard split retires the parent shard and the queued read batch fails with ErrShardNotFound, rerouteReads re-resolves the shard from get.Key, so the retried get lands on hash(key), usually neither of the two children that now hold the record. The caller then gets KEY_NOT_FOUND for a key that exists, which is indistinguishable from a genuine miss and quietly breaks the co-location that partition keys are meant to guarantee; a ReadModifyUpdate layered on top will rebuild the record from an empty base. I ran into it tracing why partition-keyed reads went missing right after a split, and the write path already avoids this since rerouteWrites routes puts and deletes by PartitionKeyOrKey. This gives GetCall the same PartitionKey field and PartitionKeyOrKey helper, carries the partition key through doSingleShardGet, and routes the read reroute by it. GetRequest has no partition-key field, so the wire format is unchanged and only the client shard selection on retry differs.