### PR TITLE
reject ack offsets past the head in cursorAcker.Ack

### DIFF
--- a/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
+++ b/oxiad/dataserver/controller/lead/quorum_ack_tracker.go
@@ -412,6 +412,16 @@ func (c *cursorAcker) Ack(offset int64) {
 		return
 	}
 
+	// A follower can only ack entries the leader has actually written, so an
+	// offset past the head is a malformed or hostile ack. Acting on it would
+	// run the cumulative loop below up to an arbitrary value while holding the
+	// lock, and would move lastAckedOffset ahead of the head so later acks for
+	// the real entries get skipped. Drop it, the same out-of-range offset that
+	// NewCursorAcker already rejects.
+	if offset > q.headOffset.Load() {
+		return
+	}
+
 	// Entries at or below the commit offset have already reached the quorum
 	start := max(c.lastAckedOffset, q.commitOffset.Load()) + 1
 	for o := start; o <= offset; o++ {

--- a/oxiad/dataserver/controller/lead/quorum_ack_tracker_test.go
+++ b/oxiad/dataserver/controller/lead/quorum_ack_tracker_test.go
@@ -66,6 +66,26 @@ func TestQuorumAckTrackerRF2(t *testing.T) {
 	assert.EqualValues(t, 2, at.CommitOffset())
 }
 
+func TestQuorumAckTrackerAckBeyondHead(t *testing.T) {
+	at := NewQuorumAckTracker(2, 1, wal.InvalidOffset)
+	at.AdvanceHeadOffset(2)
+
+	c1, err := at.NewCursorAcker(wal.InvalidOffset)
+	assert.NoError(t, err)
+
+	// An ack for an offset the leader never wrote must be ignored: it must not
+	// commit the entries that do exist, and it must not push the cursor past
+	// the head.
+	c1.Ack(100)
+	assert.EqualValues(t, 2, at.HeadOffset())
+	assert.Equal(t, wal.InvalidOffset, at.CommitOffset())
+
+	// A later ack for the real head still commits, proving the out-of-range
+	// ack did not poison the cursor's tracked offset.
+	c1.Ack(2)
+	assert.EqualValues(t, 2, at.CommitOffset())
+}
+
 func TestQuorumAckTrackerRF3(t *testing.T) {
 	at := NewQuorumAckTracker(3, 1, wal.InvalidOffset)
 


### PR DESCRIPTION
A leader keeps one cursor per follower and advances the shard commit offset from the acks each follower sends back over the replication stream. receiveAcks in follower_cursor.go hands res.Offset straight to cursorAcker.Ack with no validation, and Ack then walks a cumulative loop from the last acked offset up to that value while holding the quorum tracker lock. The offset is whatever the peer put on the wire, so a follower that answers with an offset past the head makes that loop run up to an arbitrary bound under a lock that every write on the leader also takes, so the shard stops making progress. A smaller over-ack is harmful too, since Ack stores the value in lastAckedOffset and once that sits above the head the cursor skips the real entries when they are finally written and the commit offset quietly stalls. I noticed it while comparing Ack against NewCursorAcker in the same file, which already rejects an ackOffset past the head with ErrInvalidHeadOffset before running the identical loop. This drops any ack above the current head inside Ack to match that existing guard, with a regression test next to the RF2 case.