### PR TITLE
ci: publish nightly channel images

### DIFF
--- a/.github/workflows/ci-nightly-images.yaml
+++ b/.github/workflows/ci-nightly-images.yaml
@@ -1,0 +1,128 @@
+# Copyright 2023-2025 The Oxia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Nightly Images
+
+on:
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+# Override these defaults with repository variables when a channel moves to a
+# new release line or branch.
+env:
+  NIGHTLY_STABLE_REF: ${{ vars.NIGHTLY_STABLE_REF || 'v0.16.8' }}
+  NIGHTLY_BETA_REF: ${{ vars.NIGHTLY_BETA_REF || 'v0.17.1' }}
+  NIGHTLY_ALPHA_REF: ${{ vars.NIGHTLY_ALPHA_REF || 'main' }}
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.channel }} image
+    runs-on: cncf-ubuntu-8-32-x86
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        channel:
+          - stable
+          - beta
+          - alpha
+    steps:
+      - name: Resolve channel
+        id: channel
+        env:
+          CHANNEL: ${{ matrix.channel }}
+        run: |
+          case "${CHANNEL}" in
+            stable)
+              SOURCE_REF="${NIGHTLY_STABLE_REF}"
+              ;;
+            beta)
+              SOURCE_REF="${NIGHTLY_BETA_REF}"
+              ;;
+            alpha)
+              SOURCE_REF="${NIGHTLY_ALPHA_REF}"
+              ;;
+            *)
+              echo "Unsupported nightly channel: ${CHANNEL}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "source-ref=${SOURCE_REF}" >> "${GITHUB_OUTPUT}"
+          echo "image-tag=nightly-${CHANNEL}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check out ${{ steps.channel.outputs.source-ref }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.channel.outputs.source-ref }}
+          fetch-depth: 1
+
+      - name: Resolve source revision
+        id: source
+        run: echo "revision=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+            network=host
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            oxia/oxia:${{ steps.channel.outputs.image-tag }}
+            ${{ matrix.channel == 'alpha' && 'oxia/oxia:main' || '' }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/oxia-db/oxia
+            org.opencontainers.image.revision=${{ steps.source.outputs.revision }}
+            org.opencontainers.image.version=${{ steps.channel.outputs.source-ref }}
+          cache-from: type=gha,scope=nightly-${{ matrix.channel }}
+          cache-to: type=gha,mode=max,scope=nightly-${{ matrix.channel }}
+          # Always rebuild the runtime stage so `apk upgrade` picks up the
+          # latest Alpine security patches instead of a cached layer.
+          no-cache-filters: runtime
+
+      - name: Summarize image
+        env:
+          CHANNEL: ${{ matrix.channel }}
+          IMAGE_TAG: ${{ steps.channel.outputs.image-tag }}
+          SOURCE_REF: ${{ steps.channel.outputs.source-ref }}
+          SOURCE_REVISION: ${{ steps.source.outputs.revision }}
+        run: |
+          {
+            echo "### ${CHANNEL^} nightly image"
+            echo
+            echo "- Image: \`oxia/oxia:${IMAGE_TAG}\`"
+            echo "- Source: \`${SOURCE_REF}\` (\`${SOURCE_REVISION}\`)"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -19,10 +19,6 @@ on:
     tags:
       - 'v*'
   
-  # Publish nightly builds
-  schedule:
-    - cron: '0 0 * * *' # run at midnight UTC
-
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Motivation

Correctness and stability testing needs freshly rebuilt Oxia images for the supported stable, beta, and alpha channels without republishing or mutating official release tags.

## Modifications

- add a daily multi-architecture nightly image workflow for stable (`v0.16.8`), beta (`v0.17.1`), and alpha (`main`) sources
- publish `oxia/oxia:nightly-stable`, `oxia/oxia:nightly-beta`, and `oxia/oxia:nightly-alpha`, while retaining `oxia/oxia:main` as the alpha compatibility alias
- allow source refs to be changed through `NIGHTLY_STABLE_REF`, `NIGHTLY_BETA_REF`, and `NIGHTLY_ALPHA_REF` repository variables
- move scheduled image publication out of the release workflow so tagged/manual releases remain independent

## Testing

- `actionlint -ignore 'label "cncf-ubuntu-8-32-x86" is unknown' .github/workflows/ci-nightly-images.yaml`
- `make license-check`
- verified `v0.16.8` and `v0.17.1` are published, non-prerelease GitHub releases
