### PR TITLE
refactor: add atomic shard split metadata update

### DIFF
--- a/oxiad/coordinator/metadata/metadata.go
+++ b/oxiad/coordinator/metadata/metadata.go
@@ -54,6 +54,12 @@ type Metadata interface {
 	GetShardStatus(namespace string, shard int64) (commonobject.Borrowed[*commonproto.ShardMetadata], bool)
 	UpdateShardStatus(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata)
 	DeleteShardStatus(namespace string, shard int64)
+	UpdateSplitShardStatus(
+		namespace string,
+		shard int64,
+		split *commonproto.SplitMetadata,
+		children map[int64]*commonproto.ShardMetadata,
+	) error
 
 	GetConfig() commonobject.Borrowed[*commonproto.ClusterConfiguration]
 	SubscribeConfig() *commonwatch.Receiver[provider.Versioned[*commonproto.ClusterConfiguration]]
@@ -334,6 +340,93 @@ func (m *coordinatorMetadata) GetShardStatus(namespace string, shard int64) (com
 		return commonobject.Borrowed[*commonproto.ShardMetadata]{}, false
 	}
 	return commonobject.Borrow(shardStatus), true
+}
+
+func (m *coordinatorMetadata) UpdateSplitShardStatus( //nolint:revive // Keep validation and the atomic transition colocated.
+	namespace string,
+	shard int64,
+	split *commonproto.SplitMetadata,
+	children map[int64]*commonproto.ShardMetadata,
+) error {
+	if split == nil {
+		return errors.New("split metadata is required")
+	}
+
+	expectedChildren := make(map[int64]struct{}, len(split.ChildShardIds))
+	for _, childShard := range split.ChildShardIds {
+		expectedChildren[childShard] = struct{}{}
+	}
+	if len(expectedChildren) != 2 || len(children) != 2 {
+		return errors.New("a shard split requires two distinct children")
+	}
+
+	clonedSplit := gproto.Clone(split).(*commonproto.SplitMetadata) //nolint:revive
+	clonedChildren := make(map[int64]*commonproto.ShardMetadata, len(children))
+	for childShard, childMetadata := range children {
+		if _, expected := expectedChildren[childShard]; !expected {
+			return fmt.Errorf("shard %d is not listed in the split metadata", childShard)
+		}
+		if childMetadata == nil {
+			return fmt.Errorf("metadata for child shard %d is required", childShard)
+		}
+		clonedChildren[childShard] = gproto.Clone(childMetadata).(*commonproto.ShardMetadata) //nolint:revive
+	}
+
+	var updateErr error
+	err := backoff.RetryNotify(func() error {
+		updateErr = nil
+		return m.computeStatus(func(clusterStatus *commonproto.ClusterStatus, _ metadatacommon.Version) (*commonproto.ClusterStatus, bool) {
+			namespaceStatus, exists := clusterStatus.Namespaces[namespace]
+			if !exists {
+				updateErr = fmt.Errorf("namespace %q not found", namespace)
+				return clusterStatus, false
+			}
+
+			parentMetadata, exists := namespaceStatus.Shards[shard]
+			if !exists {
+				updateErr = fmt.Errorf("parent shard %d not found in namespace %q", shard, namespace)
+				return clusterStatus, false
+			}
+			if parentMetadata.Split != nil {
+				if !gproto.Equal(parentMetadata.Split, clonedSplit) {
+					updateErr = fmt.Errorf("shard %d already has an active split", shard)
+					return clusterStatus, false
+				}
+				for childShard, childMetadata := range clonedChildren {
+					persistedChild, exists := namespaceStatus.Shards[childShard]
+					if !exists || !gproto.Equal(persistedChild, childMetadata) {
+						updateErr = fmt.Errorf("persisted metadata for child shard %d does not match the split", childShard)
+						return clusterStatus, false
+					}
+				}
+				return clusterStatus, false
+			}
+			for childShard := range clonedChildren {
+				if _, exists := namespaceStatus.Shards[childShard]; exists {
+					updateErr = fmt.Errorf("child shard %d already exists in namespace %q", childShard, namespace)
+					return clusterStatus, false
+				}
+			}
+
+			parentMetadata.Split = gproto.Clone(clonedSplit).(*commonproto.SplitMetadata) //nolint:revive
+			for childShard, childMetadata := range clonedChildren {
+				namespaceStatus.Shards[childShard] = gproto.Clone(childMetadata).(*commonproto.ShardMetadata) //nolint:revive
+			}
+			return clusterStatus, true
+		})
+	}, oxiatime.NewBackOff(m.ctx), func(err error, duration time.Duration) {
+		m.logger.Warn(
+			"failed to create shard split",
+			slog.Any("error", err),
+			slog.String("namespace", namespace),
+			slog.Int64("parent-shard", shard),
+			slog.Duration("retry-after", duration),
+		)
+	})
+	if err != nil {
+		return err
+	}
+	return updateErr
 }
 
 func (m *coordinatorMetadata) UpdateShardStatus(namespace string, shard int64, shardMetadata *commonproto.ShardMetadata) {

--- a/oxiad/coordinator/metadata/metadata_split_test.go
+++ b/oxiad/coordinator/metadata/metadata_split_test.go
@@ -1,0 +1,219 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	gproto "google.golang.org/protobuf/proto"
+
+	commonproto "github.com/oxia-db/oxia/common/proto"
+	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	metadatacodec "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common/codec"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider"
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
+)
+
+const (
+	splitTestNamespace = "default"
+	splitTestParent    = int64(1)
+	splitTestLeft      = int64(2)
+	splitTestRight     = int64(3)
+)
+
+func TestUpdateSplitShardStatusMergesLatestMetadataAndClonesInputs(t *testing.T) {
+	metadata := newSplitMetadataTestStore(t)
+	latestParent := splitTestParentMetadata()
+	latestParent.Term = 8
+	latestParent.Leader = &commonproto.DataServerIdentity{Internal: "new-leader:8191"}
+	metadata.UpdateShardStatus(splitTestNamespace, splitTestParent, latestParent)
+
+	unrelated := &commonproto.ShardMetadata{Status: commonproto.ShardStatusSteadyState, Term: 12}
+	metadata.UpdateShardStatus(splitTestNamespace, 9, unrelated)
+	split, children := splitTestMetadata()
+	expectedSplit := gproto.Clone(split).(*commonproto.SplitMetadata)
+	expectedLeft := gproto.Clone(children[splitTestLeft]).(*commonproto.ShardMetadata)
+	expectedRight := gproto.Clone(children[splitTestRight]).(*commonproto.ShardMetadata)
+
+	require.NoError(t, metadata.UpdateSplitShardStatus(splitTestNamespace, splitTestParent, split, children))
+
+	split.SplitPoint = 99
+	children[splitTestLeft].Term = 99
+	delete(children, splitTestRight)
+
+	status := requireSplitNamespaceStatus(t, metadata)
+	require.Len(t, status.Shards, 4)
+	require.Equal(t, int64(8), status.Shards[splitTestParent].Term)
+	require.Equal(t, "new-leader:8191", status.Shards[splitTestParent].GetLeader().GetInternal())
+	require.True(t, gproto.Equal(expectedSplit, status.Shards[splitTestParent].Split))
+	require.True(t, gproto.Equal(expectedLeft, status.Shards[splitTestLeft]))
+	require.True(t, gproto.Equal(expectedRight, status.Shards[splitTestRight]))
+	require.True(t, gproto.Equal(unrelated, status.Shards[9]))
+}
+
+func TestUpdateSplitShardStatusIsIdempotent(t *testing.T) {
+	metadata := newSplitMetadataTestStore(t)
+	split, children := splitTestMetadata()
+	require.NoError(t, metadata.UpdateSplitShardStatus(splitTestNamespace, splitTestParent, split, children))
+	first := requireSplitNamespaceStatus(t, metadata)
+
+	require.NoError(t, metadata.UpdateSplitShardStatus(splitTestNamespace, splitTestParent, split, children))
+	require.True(t, gproto.Equal(first, requireSplitNamespaceStatus(t, metadata)))
+}
+
+func TestUpdateSplitShardStatusRejectsConflicts(t *testing.T) {
+	t.Run("active split", func(t *testing.T) {
+		metadata := newSplitMetadataTestStore(t)
+		split, children := splitTestMetadata()
+		require.NoError(t, metadata.UpdateSplitShardStatus(splitTestNamespace, splitTestParent, split, children))
+		split.SplitPoint++
+
+		err := metadata.UpdateSplitShardStatus(splitTestNamespace, splitTestParent, split, children)
+		require.ErrorContains(t, err, "already has an active split")
+	})
+
+	t.Run("existing child", func(t *testing.T) {
+		metadata := newSplitMetadataTestStore(t)
+		metadata.UpdateShardStatus(splitTestNamespace, splitTestLeft, &commonproto.ShardMetadata{Term: 1})
+		split, children := splitTestMetadata()
+
+		err := metadata.UpdateSplitShardStatus(splitTestNamespace, splitTestParent, split, children)
+		require.ErrorContains(t, err, "child shard 2 already exists")
+	})
+
+	t.Run("changed persisted child", func(t *testing.T) {
+		metadata := newSplitMetadataTestStore(t)
+		split, children := splitTestMetadata()
+		require.NoError(t, metadata.UpdateSplitShardStatus(splitTestNamespace, splitTestParent, split, children))
+		changedChild := gproto.Clone(children[splitTestLeft]).(*commonproto.ShardMetadata)
+		changedChild.Term++
+		metadata.UpdateShardStatus(splitTestNamespace, splitTestLeft, changedChild)
+
+		err := metadata.UpdateSplitShardStatus(splitTestNamespace, splitTestParent, split, children)
+		require.ErrorContains(t, err, "does not match the split")
+	})
+}
+
+func TestUpdateSplitShardStatusValidatesInput(t *testing.T) {
+	metadata := newSplitMetadataTestStore(t)
+	split, children := splitTestMetadata()
+
+	tests := []struct {
+		name     string
+		split    *commonproto.SplitMetadata
+		children map[int64]*commonproto.ShardMetadata
+		error    string
+	}{
+		{name: "missing split", children: children, error: "split metadata is required"},
+		{
+			name:     "duplicate child IDs",
+			split:    &commonproto.SplitMetadata{ChildShardIds: []int64{splitTestLeft, splitTestLeft}},
+			children: children,
+			error:    "requires two distinct children",
+		},
+		{
+			name:     "missing child",
+			split:    split,
+			children: map[int64]*commonproto.ShardMetadata{splitTestLeft: children[splitTestLeft]},
+			error:    "requires two distinct children",
+		},
+		{
+			name:  "unexpected child",
+			split: split,
+			children: map[int64]*commonproto.ShardMetadata{
+				splitTestLeft: children[splitTestLeft],
+				4:             children[splitTestRight],
+			},
+			error: "shard 4 is not listed",
+		},
+		{
+			name:  "missing child metadata",
+			split: split,
+			children: map[int64]*commonproto.ShardMetadata{
+				splitTestLeft:  nil,
+				splitTestRight: children[splitTestRight],
+			},
+			error: "metadata for child shard 2 is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := metadata.UpdateSplitShardStatus(splitTestNamespace, splitTestParent, test.split, test.children)
+			require.ErrorContains(t, err, test.error)
+		})
+	}
+}
+
+func newSplitMetadataTestStore(t *testing.T) Metadata {
+	t.Helper()
+
+	statusProvider := memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled, "test")
+	_, err := statusProvider.Store(provider.Versioned[*commonproto.ClusterStatus]{
+		Value: &commonproto.ClusterStatus{
+			Namespaces: map[string]*commonproto.NamespaceStatus{
+				splitTestNamespace: {
+					Shards: map[int64]*commonproto.ShardMetadata{
+						splitTestParent: splitTestParentMetadata(),
+					},
+				},
+			},
+		},
+		Version: metadatacommon.NotExists,
+	})
+	require.NoError(t, err)
+
+	metadata := newMetadata(t.Context(), statusProvider, nil, "test")
+	t.Cleanup(func() { require.NoError(t, metadata.Close()) })
+	return metadata
+}
+
+func splitTestParentMetadata() *commonproto.ShardMetadata {
+	return &commonproto.ShardMetadata{
+		Status:         commonproto.ShardStatusSteadyState,
+		Term:           7,
+		Leader:         &commonproto.DataServerIdentity{Internal: "parent:8191"},
+		Int32HashRange: &commonproto.HashRange{Min: 0, Max: 99},
+	}
+}
+
+func splitTestMetadata() (*commonproto.SplitMetadata, map[int64]*commonproto.ShardMetadata) {
+	split := &commonproto.SplitMetadata{
+		Phase:         commonproto.SplitPhaseBootstrap,
+		ChildShardIds: []int64{splitTestLeft, splitTestRight},
+		SplitPoint:    49,
+	}
+	return split, map[int64]*commonproto.ShardMetadata{
+		splitTestLeft: {
+			Status:         commonproto.ShardStatusSteadyState,
+			Int32HashRange: &commonproto.HashRange{Min: 0, Max: 49},
+			Split:          &commonproto.SplitMetadata{ParentShardId: splitTestParent, SplitPoint: 49},
+		},
+		splitTestRight: {
+			Status:         commonproto.ShardStatusSteadyState,
+			Int32HashRange: &commonproto.HashRange{Min: 50, Max: 99},
+			Split:          &commonproto.SplitMetadata{ParentShardId: splitTestParent, SplitPoint: 49},
+		},
+	}
+}
+
+func requireSplitNamespaceStatus(t *testing.T, metadata Metadata) *commonproto.NamespaceStatus {
+	t.Helper()
+
+	status, exists := metadata.GetNamespaceStatus(splitTestNamespace)
+	require.True(t, exists)
+	return gproto.Clone(status.UnsafeBorrow()).(*commonproto.NamespaceStatus)
+}

--- a/oxiad/coordinator/reconciler/namespace_reconciler_test.go
+++ b/oxiad/coordinator/reconciler/namespace_reconciler_test.go
@@ -183,6 +183,15 @@ func (m *mockNamespaceMetadata) UpdateShardStatus(namespace string, shard int64,
 
 func (*mockNamespaceMetadata) DeleteShardStatus(string, int64) {}
 
+func (*mockNamespaceMetadata) UpdateSplitShardStatus(
+	string,
+	int64,
+	*proto.SplitMetadata,
+	map[int64]*proto.ShardMetadata,
+) error {
+	return nil
+}
+
 func (*mockNamespaceMetadata) CreateNamespace(*proto.Namespace) error {
 	return nil
 }

--- a/oxiad/coordinator/runtime/balancer/scheduler_test.go
+++ b/oxiad/coordinator/runtime/balancer/scheduler_test.go
@@ -118,6 +118,15 @@ func (m *mockMetadata) UpdateShardStatus(namespace string, shard int64, shardMet
 
 func (*mockMetadata) DeleteShardStatus(string, int64) {}
 
+func (*mockMetadata) UpdateSplitShardStatus(
+	string,
+	int64,
+	*proto.SplitMetadata,
+	map[int64]*proto.ShardMetadata,
+) error {
+	return nil
+}
+
 func (*mockMetadata) IsReady(*proto.ClusterConfiguration) bool { return true }
 
 func (*mockMetadata) CreateNamespace(*proto.Namespace) error {


### PR DESCRIPTION
## Motivation

Shard split initialization currently replaces an entire `NamespaceStatus` snapshot. A concurrent parent term, leader, ensemble, or unrelated shard update can therefore be overwritten by stale split preparation state.

Introduce a shard-split-specific metadata transaction before changing runtime ownership. This PR provides the metadata primitive only; runtime integration will follow in the next stacked PR.

## Modifications

- add `UpdateSplitShardStatus(namespace, shard, split, children)`
- update the latest parent split metadata and create both children atomically
- preserve concurrent parent fields and unrelated shard metadata
- validate child metadata, reject conflicts, clone caller inputs, and support idempotent retries
- add focused metadata tests and update `Metadata` interface mocks

## Testing

- `make lint`
- `go test ./oxiad/coordinator/metadata ./oxiad/coordinator/reconciler ./oxiad/coordinator/runtime/balancer/...`
- `git diff --check`