### PR TITLE
feat: support embedding oxia as a library (#1132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,27 @@ With Oxia, you get a scalable, robust, and flexible solution for managing metada
 
 <br>
 
+### Embedding Oxia
+
+Besides running as dedicated `oxia server` / `oxia coordinator` processes, Oxia can be embedded as a library inside a Go application, so that each application node hosts an Oxia data server (and, on some nodes, the coordinator) in the same binary:
+
+```go
+import (
+    "github.com/oxia-db/oxia/oxiad/dataserver"
+    "github.com/oxia-db/oxia/oxiad/dataserver/option"
+)
+
+options := option.NewDefaultOptions()
+options.Storage.Database.Dir = "./data/db"
+options.Storage.WAL.Dir = "./data/wal"
+
+server, err := dataserver.New(ctx, options)
+```
+
+These are the same entry points the `oxia` binary itself is built on. See the [`dataserver`](oxiad/dataserver/doc.go) package documentation for embedding a data server or a standalone single-node server, and the [`coordinator`](oxiad/coordinator/doc.go) package documentation for bootstrapping a whole cluster in-process with `coordinator.New`.
+
+<br>
+
 ### Contributing to Oxia
 
 Please 🌟 star the project if you like it. 

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -147,6 +147,6 @@ func exec(cmd *cobra.Command, _ []string) {
 			}
 		}
 
-		return dataserver.New(context.Background(), optionsWatch)
+		return dataserver.NewWithOptionsWatch(context.Background(), optionsWatch)
 	})
 }

--- a/oxiad/coordinator/doc.go
+++ b/oxiad/coordinator/doc.go
@@ -1,0 +1,71 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package coordinator implements the Oxia coordinator: it manages the
+// cluster status, assigns shards to data servers and drives leader
+// elections. It backs the `oxia coordinator` command and can equally be
+// embedded in a Go application together with the dataserver package, running
+// a whole Oxia cluster in-process:
+//
+//	ctx := context.Background()
+//
+//	var identities []*proto.DataServerIdentity
+//	for i := 0; i < 3; i++ {
+//		dsOptions := dsoption.NewDefaultOptions()
+//		dsOptions.Server.Public.BindAddress = "localhost:0"
+//		dsOptions.Server.Internal.BindAddress = "localhost:0"
+//		dsOptions.Storage.Database.Dir = filepath.Join(dataDir, strconv.Itoa(i), "db")
+//		dsOptions.Storage.WAL.Dir = filepath.Join(dataDir, strconv.Itoa(i), "wal")
+//
+//		server, err := dataserver.New(ctx, dsOptions)
+//		if err != nil {
+//			return err
+//		}
+//		defer server.Close()
+//
+//		identities = append(identities, &proto.DataServerIdentity{
+//			Public:   fmt.Sprintf("localhost:%d", server.PublicPort()),
+//			Internal: fmt.Sprintf("localhost:%d", server.InternalPort()),
+//		})
+//	}
+//
+//	options := option.NewDefaultOptions()
+//	options.Server.Public.BindAddress = "localhost:0"
+//	options.Server.Internal.BindAddress = "localhost:0"
+//	options.Metadata.ProviderName = option.ProviderMemory
+//
+//	coord, err := coordinator.New(ctx, options,
+//		coordinator.WithInitialClusterConfiguration(&proto.ClusterConfiguration{
+//			Namespaces: []*proto.Namespace{{
+//				Name:              constant.DefaultNamespace,
+//				ReplicationFactor: 3,
+//				InitialShardCount: 1,
+//			}},
+//			Servers: identities,
+//		}))
+//	if err != nil {
+//		return err
+//	}
+//	defer coord.Close()
+//
+//	client, err := oxia.NewSyncClient(identities[0].Public)
+//
+// The example uses the in-memory metadata provider, which keeps the cluster
+// status inside the coordinator process and is suitable when a single
+// coordinator is embedded. Multi-coordinator topologies should use the file
+// or raft metadata providers instead, and must decide what happens when a
+// coordinator loses the metadata leadership: by default the whole process
+// exits, which embedding applications usually want to override with
+// [WithOnLeadershipLost].
+package coordinator

--- a/oxiad/coordinator/grpc_server.go
+++ b/oxiad/coordinator/grpc_server.go
@@ -54,7 +54,9 @@ type serverOptions struct {
 func newServerOptions(serverOpts []ServerOption) serverOptions {
 	so := serverOptions{onLeadershipLost: onLeadershipLost}
 	for _, opt := range serverOpts {
-		opt(&so)
+		if opt != nil {
+			opt(&so)
+		}
 	}
 	return so
 }
@@ -77,6 +79,11 @@ func (so *serverOptions) seedClusterConfig(metadataFactory *coordmetadata.Factor
 // synchronously; spawn a goroutine instead.
 func WithOnLeadershipLost(handler func()) ServerOption {
 	return func(so *serverOptions) {
+		if handler == nil {
+			// A nil handler would panic at the worst moment; keep the
+			// fail-safe default instead.
+			handler = onLeadershipLost
+		}
 		so.onLeadershipLost = handler
 	}
 }

--- a/oxiad/coordinator/grpc_server.go
+++ b/oxiad/coordinator/grpc_server.go
@@ -16,6 +16,7 @@ package coordinator
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"sync"
@@ -42,6 +43,55 @@ import (
 	commonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
 )
 
+// ServerOption configures optional behavior of the coordinator server.
+type ServerOption func(*serverOptions)
+
+type serverOptions struct {
+	onLeadershipLost     func()
+	initialClusterConfig *proto.ClusterConfiguration
+}
+
+func newServerOptions(serverOpts []ServerOption) serverOptions {
+	so := serverOptions{onLeadershipLost: onLeadershipLost}
+	for _, opt := range serverOpts {
+		opt(&so)
+	}
+	return so
+}
+
+func (so *serverOptions) seedClusterConfig(metadataFactory *coordmetadata.Factory) error {
+	if so.initialClusterConfig == nil {
+		return nil
+	}
+	return metadataFactory.SeedClusterConfig(so.initialClusterConfig)
+}
+
+// WithOnLeadershipLost overrides what happens when this coordinator loses the
+// metadata leadership. The default handler terminates the process, which is
+// the right behavior for a dedicated coordinator process but not when the
+// coordinator is embedded in a larger application.
+//
+// A coordinator that lost the leadership must stop coordinating: the handler
+// is expected to arrange for the server to be closed. It is invoked from an
+// internal goroutine that Close waits on, so the handler must not call Close
+// synchronously; spawn a goroutine instead.
+func WithOnLeadershipLost(handler func()) ServerOption {
+	return func(so *serverOptions) {
+		so.onLeadershipLost = handler
+	}
+}
+
+// WithInitialClusterConfiguration seeds the metadata store with the given
+// cluster configuration when none exists yet. It allows bootstrapping a
+// cluster programmatically, without a cluster configuration file or a
+// separate admin call. If a configuration is already present it is left
+// untouched.
+func WithInitialClusterConfiguration(config *proto.ClusterConfiguration) ServerOption {
+	return func(so *serverOptions) {
+		so.initialClusterConfig = config
+	}
+}
+
 type GrpcServer struct {
 	// concurrent control
 	ctx          context.Context
@@ -60,7 +110,32 @@ type GrpcServer struct {
 	metrics          *metric.PrometheusMetrics
 }
 
-func NewGrpcServer(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options]) (_ *GrpcServer, err error) {
+// New starts a coordinator with the given options. Unset option values are
+// filled with their defaults, and the options are validated before the
+// coordinator starts. If options is nil, the default options are used.
+//
+// The coordinator keeps a reference to options: the caller must not mutate
+// them after this call and should use UpdateOptions instead.
+//
+// With a multi-coordinator metadata provider (file, configmap or raft), this
+// call blocks until the coordinator acquires the metadata leadership.
+func New(parent context.Context, options *option.Options, serverOpts ...ServerOption) (*GrpcServer, error) {
+	if options == nil {
+		options = option.NewDefaultOptions()
+	}
+	options.WithDefault()
+	if err := options.Validate(); err != nil {
+		return nil, err
+	}
+	return NewGrpcServer(parent, commonwatch.New(options), serverOpts...)
+}
+
+// NewGrpcServer starts a coordinator whose options are supplied through a
+// watch, allowing the caller to publish configuration updates at runtime
+// (e.g. from a configuration file watcher). Most callers should use New
+// instead.
+func NewGrpcServer(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options], serverOpts ...ServerOption) (_ *GrpcServer, err error) {
+	so := newServerOptions(serverOpts)
 	options := optionsWatch.Load()
 	slog.Info("Starting Oxia coordinator", slog.Any("options", options))
 
@@ -133,6 +208,9 @@ func NewGrpcServer(parent context.Context, optionsWatch *commonwatch.Watch[*opti
 	if err != nil {
 		return nil, err
 	}
+	if err = so.seedClusterConfig(metadataFactory); err != nil {
+		return nil, err
+	}
 	runtime, err = coordruntime.New(metadata, rpc.NewRpcProviderFactory(controllerTLS)) //nolint:contextcheck
 	if err != nil {
 		return nil, err
@@ -173,7 +251,7 @@ func NewGrpcServer(parent context.Context, optionsWatch *commonwatch.Watch[*opti
 				select {
 				case <-leadershipLost:
 					server.logger.Error("Coordination leadership lost: terminating to avoid a split brain")
-					onLeadershipLost()
+					so.onLeadershipLost()
 				case <-ctx.Done():
 				}
 			})
@@ -183,12 +261,40 @@ func NewGrpcServer(parent context.Context, optionsWatch *commonwatch.Watch[*opti
 	return &server, nil
 }
 
-// onLeadershipLost terminates the process: a coordinator that lost the
-// leadership must stop coordinating immediately, before it can run elections
-// or move ensembles alongside the new leader, and a restart rejoins the
-// election from a clean state. Overridable in tests.
+// onLeadershipLost is the default WithOnLeadershipLost handler. It terminates
+// the process: a coordinator that lost the leadership must stop coordinating
+// immediately, before it can run elections or move ensembles alongside the
+// new leader, and a restart rejoins the election from a clean state.
+// Overridable in tests.
 var onLeadershipLost = func() {
 	os.Exit(1)
+}
+
+// InternalPort returns the port of the internal gRPC server used for
+// coordinator-to-coordinator communication.
+func (s *GrpcServer) InternalPort() int {
+	return s.grpcServer.Port()
+}
+
+// PublicPort returns the port of the public gRPC server exposing the
+// management (admin) API.
+func (s *GrpcServer) PublicPort() int {
+	return s.managementServer.Port()
+}
+
+// UpdateOptions publishes a new configuration to the running coordinator.
+// Only the dynamic settings (currently the log options) take effect at
+// runtime; the remaining settings require a restart.
+func (s *GrpcServer) UpdateOptions(options *option.Options) error {
+	if options == nil {
+		return errors.New("options must not be nil")
+	}
+	options.WithDefault()
+	if err := options.Validate(); err != nil {
+		return err
+	}
+	s.optionsWatch.Publish(options)
+	return nil
 }
 
 func startMetricsServer(metrics commonoption.MetricOptions) (*metric.PrometheusMetrics, error) {

--- a/oxiad/coordinator/grpc_server_test.go
+++ b/oxiad/coordinator/grpc_server_test.go
@@ -38,3 +38,11 @@ func TestServerOptions(t *testing.T) {
 	assert.True(t, called)
 	assert.Same(t, config, so.initialClusterConfig)
 }
+
+// A nil option is ignored and a nil leadership-loss handler keeps the
+// fail-safe default: neither can leave the coordinator with a nil to call.
+func TestServerOptionsNilSafe(t *testing.T) {
+	so := newServerOptions([]ServerOption{nil, WithOnLeadershipLost(nil)})
+	assert.NotNil(t, so.onLeadershipLost)
+	assert.Nil(t, so.initialClusterConfig)
+}

--- a/oxiad/coordinator/grpc_server_test.go
+++ b/oxiad/coordinator/grpc_server_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+func TestServerOptions(t *testing.T) {
+	so := newServerOptions(nil)
+	assert.NotNil(t, so.onLeadershipLost)
+	assert.Nil(t, so.initialClusterConfig)
+
+	config := &proto.ClusterConfiguration{}
+	called := false
+	so = newServerOptions([]ServerOption{
+		WithOnLeadershipLost(func() { called = true }),
+		WithInitialClusterConfiguration(config),
+	})
+
+	so.onLeadershipLost()
+	assert.True(t, called)
+	assert.Same(t, config, so.initialClusterConfig)
+}

--- a/oxiad/coordinator/metadata/factory.go
+++ b/oxiad/coordinator/metadata/factory.go
@@ -110,6 +110,9 @@ func New(ctx context.Context, options *option.Options) (*Factory, error) {
 // It is a no-op when a configuration is already present, and it tolerates
 // losing the seeding race to another coordinator.
 func (f *Factory) SeedClusterConfig(config *commonproto.ClusterConfiguration) error {
+	if config == nil {
+		return errors.New("cluster configuration to seed must not be nil")
+	}
 	f.mu.Lock()
 	configProvider := f.configProvider
 	f.mu.Unlock()

--- a/oxiad/coordinator/metadata/factory.go
+++ b/oxiad/coordinator/metadata/factory.go
@@ -106,6 +106,30 @@ func New(ctx context.Context, options *option.Options) (*Factory, error) {
 	return factory, nil
 }
 
+// SeedClusterConfig stores the given cluster configuration if none exists yet.
+// It is a no-op when a configuration is already present, and it tolerates
+// losing the seeding race to another coordinator.
+func (f *Factory) SeedClusterConfig(config *commonproto.ClusterConfiguration) error {
+	f.mu.Lock()
+	configProvider := f.configProvider
+	f.mu.Unlock()
+
+	if configProvider.Watch().Load().Version != metadatacommon.NotExists {
+		return nil
+	}
+	if _, err := configProvider.Store(provider.Versioned[*commonproto.ClusterConfiguration]{
+		Value:   config,
+		Version: metadatacommon.NotExists,
+	}); err != nil {
+		if errors.Is(err, metadatacommon.ErrBadVersion) {
+			// Another coordinator stored a configuration first.
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 func (f *Factory) CreateMetadata(ctx context.Context) (Metadata, error) {
 	f.mu.Lock()
 	statusProvider := f.statusProvider

--- a/oxiad/coordinator/metadata/factory_test.go
+++ b/oxiad/coordinator/metadata/factory_test.go
@@ -61,6 +61,13 @@ func TestSeedClusterConfig(t *testing.T) {
 	assert.Equal(t, "test-namespace", seeded.Value.Namespaces[0].Name)
 }
 
+func TestSeedClusterConfigRejectsNil(t *testing.T) {
+	factory := newMemoryFactory(t)
+
+	require.Error(t, factory.SeedClusterConfig(nil))
+	assert.Equal(t, metadatacommon.NotExists, factory.configProvider.Watch().Load().Version)
+}
+
 func TestSeedClusterConfigDoesNotOverwrite(t *testing.T) {
 	factory := newMemoryFactory(t)
 

--- a/oxiad/coordinator/metadata/factory_test.go
+++ b/oxiad/coordinator/metadata/factory_test.go
@@ -1,0 +1,82 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonproto "github.com/oxia-db/oxia/common/proto"
+	metadatacommon "github.com/oxia-db/oxia/oxiad/coordinator/metadata/common"
+	"github.com/oxia-db/oxia/oxiad/coordinator/option"
+)
+
+func newMemoryFactory(t *testing.T) *Factory {
+	t.Helper()
+
+	factory, err := New(t.Context(), &option.Options{
+		Metadata: option.MetadataOptions{
+			Name: "coordinator-test",
+			ProviderOptions: option.ProviderOptions{
+				ProviderName: metadatacommon.NameMemory,
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, factory.Close())
+	})
+	return factory
+}
+
+func TestSeedClusterConfig(t *testing.T) {
+	factory := newMemoryFactory(t)
+
+	config := &commonproto.ClusterConfiguration{
+		Namespaces: []*commonproto.Namespace{{
+			Name:              "test-namespace",
+			ReplicationFactor: 1,
+			InitialShardCount: 1,
+		}},
+	}
+	require.NoError(t, factory.SeedClusterConfig(config))
+
+	seeded := factory.configProvider.Watch().Load()
+	assert.NotEqual(t, metadatacommon.NotExists, seeded.Version)
+	require.Len(t, seeded.Value.Namespaces, 1)
+	assert.Equal(t, "test-namespace", seeded.Value.Namespaces[0].Name)
+}
+
+func TestSeedClusterConfigDoesNotOverwrite(t *testing.T) {
+	factory := newMemoryFactory(t)
+
+	first := &commonproto.ClusterConfiguration{
+		Namespaces: []*commonproto.Namespace{{Name: "first"}},
+	}
+	require.NoError(t, factory.SeedClusterConfig(first))
+	version := factory.configProvider.Watch().Load().Version
+
+	second := &commonproto.ClusterConfiguration{
+		Namespaces: []*commonproto.Namespace{{Name: "second"}},
+	}
+	require.NoError(t, factory.SeedClusterConfig(second))
+
+	current := factory.configProvider.Watch().Load()
+	assert.Equal(t, version, current.Version)
+	require.Len(t, current.Value.Namespaces, 1)
+	assert.Equal(t, "first", current.Value.Namespaces[0].Name)
+}

--- a/oxiad/coordinator/option/option.go
+++ b/oxiad/coordinator/option/option.go
@@ -150,6 +150,14 @@ func (co *ControllerOptions) Validate() error {
 	return co.TLS.Validate()
 }
 
+// Valid MetadataOptions.ProviderName values.
+const (
+	ProviderMemory    = metadataconstant.NameMemory
+	ProviderFile      = metadataconstant.NameFile
+	ProviderConfigMap = metadataconstant.NameConfigMap
+	ProviderRaft      = metadataconstant.NameRaft
+)
+
 type ProviderOptions struct {
 	ProviderName string       `yaml:"providerName" json:"providerName" jsonschema:"description=Metadata provider type. Valid values: memory/configmap/file/raft,example=configmap"`
 	Kubernetes   K8sMetadata  `yaml:"kubernetes,omitempty" json:"kubernetes,omitempty" jsonschema:"description=Kubernetes ConfigMap metadata configuration"`

--- a/oxiad/dataserver/doc.go
+++ b/oxiad/dataserver/doc.go
@@ -1,0 +1,37 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dataserver implements the Oxia data server: it serves the shards
+// assigned to it by a coordinator and replicates data to its peers. It backs
+// the `oxia server` command and can equally be embedded in a Go application,
+// so that each application node hosts an Oxia data server in the same binary:
+//
+//	options := option.NewDefaultOptions()
+//	options.Storage.Database.Dir = "./data/db"
+//	options.Storage.WAL.Dir = "./data/wal"
+//
+//	server, err := dataserver.New(ctx, options)
+//	if err != nil {
+//		return err
+//	}
+//	defer server.Close()
+//
+// A data server is passive until a coordinator assigns shards to it; see the
+// coordinator package for how to run a whole Oxia cluster in-process.
+//
+// [NewStandalone] starts a self-contained single-node server instead, with no
+// replication and no coordinator: the embedded equivalent of the
+// `oxia standalone` command, and the simplest option for tests and
+// single-process deployments.
+package dataserver

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -16,6 +16,7 @@ package dataserver
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 
@@ -60,7 +61,28 @@ type Server struct {
 	healthServer commonrpc.HealthServer
 }
 
-func New(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options]) (*Server, error) {
+// New starts a data server with the given options. Unset option values are
+// filled with their defaults, and the options are validated before the server
+// starts. If options is nil, the default options are used.
+//
+// The server keeps a reference to options: the caller must not mutate them
+// after this call and should use UpdateOptions instead.
+func New(parent context.Context, options *option.Options) (*Server, error) {
+	if options == nil {
+		options = option.NewDefaultOptions()
+	}
+	options.WithDefault()
+	if err := options.Validate(); err != nil {
+		return nil, err
+	}
+	return NewWithOptionsWatch(parent, commonwatch.New(options))
+}
+
+// NewWithOptionsWatch starts a data server whose options are supplied through
+// a watch, allowing the caller to publish configuration updates at runtime
+// (e.g. from a configuration file watcher). Most callers should use New
+// instead.
+func NewWithOptionsWatch(parent context.Context, optionsWatch *commonwatch.Watch[*option.Options]) (*Server, error) {
 	options := optionsWatch.Load()
 	manifest, err := manifestpkg.NewManifest(options.Storage.Database.Dir)
 	if err != nil {
@@ -168,6 +190,21 @@ func (s *Server) PublicPort() int {
 
 func (s *Server) InternalPort() int {
 	return s.internalRpcServer.grpcServer.Port()
+}
+
+// UpdateOptions publishes a new configuration to the running server. Only the
+// dynamic settings (currently the log options) take effect at runtime; the
+// remaining settings require a restart.
+func (s *Server) UpdateOptions(options *option.Options) error {
+	if options == nil {
+		return errors.New("options must not be nil")
+	}
+	options.WithDefault()
+	if err := options.Validate(); err != nil {
+		return err
+	}
+	s.optionsWatch.Publish(options)
+	return nil
 }
 
 func (s *Server) backgroundHandleConfChange() {

--- a/oxiad/dataserver/server_test.go
+++ b/oxiad/dataserver/server_test.go
@@ -24,7 +24,6 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/oxia-db/oxia/common/constant"
-	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/option"
 
@@ -39,7 +38,7 @@ func TestNewServer(t *testing.T) {
 	options.Storage.Database.Dir = t.TempDir()
 	options.Storage.WAL.Dir = t.TempDir()
 
-	server, err := New(t.Context(), commonwatch.New(options))
+	server, err := New(t.Context(), options)
 	assert.NoError(t, err)
 
 	url := fmt.Sprintf("http://localhost:%d/metrics", server.metrics.Port())
@@ -66,7 +65,7 @@ func TestNewServerClosableWithHealthWatch(t *testing.T) {
 	options.Storage.Database.Dir = t.TempDir()
 	options.Storage.WAL.Dir = t.TempDir()
 
-	server, err := New(t.Context(), commonwatch.New(options))
+	server, err := New(t.Context(), options)
 	assert.NoError(t, err)
 
 	clientPool := rpc.NewClientPool(nil, nil)
@@ -103,7 +102,7 @@ func TestNewServerAuthorityValidationFeatureFlag(t *testing.T) {
 				options.FeatureFlags.AuthorityValidation = &authorityValidation
 			}
 
-			server, err := New(t.Context(), commonwatch.New(options))
+			server, err := New(t.Context(), options)
 			if !assert.NoError(t, err) {
 				return
 			}

--- a/oxiad/dataserver/standalone.go
+++ b/oxiad/dataserver/standalone.go
@@ -76,7 +76,21 @@ func NewTestConfig(dir string) StandaloneConfig {
 	}
 }
 
+// NewStandalone starts a single-node server with the given configuration,
+// with no replication and no coordinator. Unset data server options are
+// filled with their defaults and validated before the server starts, and
+// NumShards defaults to 1.
+//
+// Use ServiceAddr to obtain the address that Oxia clients should connect to.
 func NewStandalone(config StandaloneConfig) (*Standalone, error) {
+	config.DataServerOptions.WithDefault()
+	if err := config.DataServerOptions.Validate(); err != nil {
+		return nil, err
+	}
+	if config.NumShards == 0 {
+		config.NumShards = 1
+	}
+
 	slog.Info(
 		"Starting Oxia standalone",
 		slog.Any("config", config),

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 
 	"github.com/oxia-db/oxia/common/proto"
@@ -55,7 +54,7 @@ func newServer(t *testing.T) (s *dataserver.Server, addr *proto.DataServerIdenti
 	options.Storage.WAL.Dir = t.TempDir()
 
 	var err error
-	s, err = dataserver.New(t.Context(), commonwatch.New(options))
+	s, err = dataserver.New(t.Context(), options)
 
 	assert.NoError(t, err)
 

--- a/tests/coordinator/split_e2e_test.go
+++ b/tests/coordinator/split_e2e_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/option"
@@ -962,7 +961,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 			dataServerOption.Observability.Metric.Enabled = &constant.FlagFalse
 			dataServerOption.Storage.Database.Dir = t.TempDir()
 			dataServerOption.Storage.WAL.Dir = t.TempDir()
-			s1, err := dataserver.New(t.Context(), commonwatch.New(dataServerOption))
+			s1, err := dataserver.New(t.Context(), dataServerOption)
 			assert.NoError(t, err)
 
 			sa1 := &proto.DataServerIdentity{

--- a/tests/embedded/embedded_test.go
+++ b/tests/embedded/embedded_test.go
@@ -1,0 +1,144 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package embedded verifies that a whole Oxia cluster can be embedded in a
+// single Go process through the public dataserver and coordinator APIs.
+package embedded
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxia"
+	"github.com/oxia-db/oxia/oxiad/coordinator"
+	coordinatoroption "github.com/oxia-db/oxia/oxiad/coordinator/option"
+	"github.com/oxia-db/oxia/oxiad/dataserver"
+	dataserveroption "github.com/oxia-db/oxia/oxiad/dataserver/option"
+)
+
+func newDataServerOptions(t *testing.T) *dataserveroption.Options {
+	t.Helper()
+
+	options := dataserveroption.NewDefaultOptions()
+	options.Server.Public.BindAddress = "localhost:0"
+	options.Server.Internal.BindAddress = "localhost:0"
+	options.Observability.Metric.Enabled = &constant.FlagFalse
+	options.Storage.Database.Dir = t.TempDir()
+	options.Storage.WAL.Dir = t.TempDir()
+	return options
+}
+
+func newDataServer(t *testing.T) (*dataserver.Server, *proto.DataServerIdentity) {
+	t.Helper()
+
+	server, err := dataserver.New(t.Context(), newDataServerOptions(t))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close())
+	})
+
+	return server, &proto.DataServerIdentity{
+		Public:   fmt.Sprintf("localhost:%d", server.PublicPort()),
+		Internal: fmt.Sprintf("localhost:%d", server.InternalPort()),
+	}
+}
+
+func TestEmbeddedCluster(t *testing.T) {
+	_, id1 := newDataServer(t)
+	_, id2 := newDataServer(t)
+	_, id3 := newDataServer(t)
+
+	options := coordinatoroption.NewDefaultOptions()
+	options.Server.Public.BindAddress = "localhost:0"
+	options.Server.Internal.BindAddress = "localhost:0"
+	options.Observability.Metric.Enabled = &constant.FlagFalse
+	options.Metadata.Name = "embedded-coordinator"
+	options.Metadata.ProviderName = coordinatoroption.ProviderMemory
+
+	coord, err := coordinator.New(t.Context(), options,
+		coordinator.WithInitialClusterConfiguration(&proto.ClusterConfiguration{
+			Namespaces: []*proto.Namespace{{
+				Name:              constant.DefaultNamespace,
+				ReplicationFactor: 3,
+				InitialShardCount: 2,
+			}},
+			Servers: []*proto.DataServerIdentity{id1, id2, id3},
+		}))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, coord.Close())
+	})
+	assert.NotZero(t, coord.PublicPort())
+	assert.NotZero(t, coord.InternalPort())
+
+	client, err := oxia.NewSyncClient(id1.Public)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+	})
+
+	ctx := t.Context()
+	for i := range 10 {
+		key := fmt.Sprintf("key-%d", i)
+		_, _, err = client.Put(ctx, key, fmt.Appendf(nil, "value-%d", i))
+		require.NoError(t, err)
+	}
+	for i := range 10 {
+		key := fmt.Sprintf("key-%d", i)
+		_, value, _, err := client.Get(ctx, key)
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("value-%d", i), string(value))
+	}
+}
+
+func TestEmbeddedStandalone(t *testing.T) {
+	config := dataserver.StandaloneConfig{}
+	config.DataServerOptions.Server.Public.BindAddress = "localhost:0"
+	config.DataServerOptions.Server.Internal.BindAddress = "localhost:0"
+	config.DataServerOptions.Observability.Metric.Enabled = &constant.FlagFalse
+	config.DataServerOptions.Storage.Database.Dir = t.TempDir()
+	config.DataServerOptions.Storage.WAL.Dir = t.TempDir()
+
+	server, err := dataserver.NewStandalone(config)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close())
+	})
+
+	client, err := oxia.NewSyncClient(server.ServiceAddr())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+	})
+
+	ctx := t.Context()
+	_, _, err = client.Put(ctx, "key", []byte("value"))
+	require.NoError(t, err)
+
+	_, value, _, err := client.Get(ctx, "key")
+	require.NoError(t, err)
+	assert.Equal(t, "value", string(value))
+}
+
+func TestEmbeddedDataServerUpdateOptions(t *testing.T) {
+	server, _ := newDataServer(t)
+
+	assert.Error(t, server.UpdateOptions(nil))
+	assert.NoError(t, server.UpdateOptions(newDataServerOptions(t)))
+}

--- a/tests/mock/server.go
+++ b/tests/mock/server.go
@@ -20,8 +20,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
-
 	"github.com/oxia-db/oxia/common/constant"
 	commonproto "github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/dataserver/option"
@@ -39,7 +37,7 @@ func NewServerWithOptions(t *testing.T, name string, optionsConsumer func(option
 	dataServerOption.Storage.WAL.Dir = t.TempDir()
 	optionsConsumer(dataServerOption)
 	var err error
-	s, err = dataserver.New(t.Context(), commonwatch.New(dataServerOption))
+	s, err = dataserver.New(t.Context(), dataServerOption)
 
 	assert.NoError(t, err)
 
@@ -69,7 +67,7 @@ func NewServerWithAddress(t *testing.T, name string, publicAddress string, inter
 	dataServerOption.Storage.WAL.Dir = t.TempDir()
 
 	var err error
-	s, err = dataserver.New(t.Context(), commonwatch.New(dataServerOption))
+	s, err = dataserver.New(t.Context(), dataServerOption)
 
 	assert.NoError(t, err)
 

--- a/tests/security/auth/auth_oidc_test.go
+++ b/tests/security/auth/auth_oidc_test.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 
 	"github.com/oxia-db/oxia/common/proto"
-	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/option"
@@ -72,7 +71,7 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 	dataServerOption1.Observability.Metric.Enabled = &constant.FlagFalse
 	dataServerOption1.Storage.Database.Dir = t.TempDir()
 	dataServerOption1.Storage.WAL.Dir = t.TempDir()
-	s1, err := dataserver.New(t.Context(), commonwatch.New(dataServerOption1))
+	s1, err := dataserver.New(t.Context(), dataServerOption1)
 	assert.NoError(t, err)
 	s1Addr := &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s1.PublicPort()),
@@ -86,7 +85,7 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 	dataServerOption2.Storage.Database.Dir = t.TempDir()
 	dataServerOption2.Storage.WAL.Dir = t.TempDir()
 
-	s2, err := dataserver.New(t.Context(), commonwatch.New(dataServerOption2))
+	s2, err := dataserver.New(t.Context(), dataServerOption2)
 	assert.NoError(t, err)
 	s2Addr := &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s2.PublicPort()),
@@ -100,7 +99,7 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 	dataServerOption3.Storage.Database.Dir = t.TempDir()
 	dataServerOption3.Storage.WAL.Dir = t.TempDir()
 
-	s3, err := dataserver.New(t.Context(), commonwatch.New(dataServerOption3))
+	s3, err := dataserver.New(t.Context(), dataServerOption3)
 	assert.NoError(t, err)
 	s3Addr := &proto.DataServerIdentity{
 		Public:   fmt.Sprintf("localhost:%d", s3.PublicPort()),
@@ -259,7 +258,7 @@ func TestOIDCWithPerIssuerConfig(t *testing.T) {
 	dataServerOption1.Observability.Metric.Enabled = &constant.FlagFalse
 	dataServerOption1.Storage.Database.Dir = t.TempDir()
 	dataServerOption1.Storage.WAL.Dir = t.TempDir()
-	s1, err := dataserver.New(t.Context(), commonwatch.New(dataServerOption1))
+	s1, err := dataserver.New(t.Context(), dataServerOption1)
 	assert.NoError(t, err)
 	defer s1.Close()
 
@@ -275,7 +274,7 @@ func TestOIDCWithPerIssuerConfig(t *testing.T) {
 	dataServerOption2.Observability.Metric.Enabled = &constant.FlagFalse
 	dataServerOption2.Storage.Database.Dir = t.TempDir()
 	dataServerOption2.Storage.WAL.Dir = t.TempDir()
-	s2, err := dataserver.New(t.Context(), commonwatch.New(dataServerOption2))
+	s2, err := dataserver.New(t.Context(), dataServerOption2)
 	assert.NoError(t, err)
 	defer s2.Close()
 
@@ -291,7 +290,7 @@ func TestOIDCWithPerIssuerConfig(t *testing.T) {
 	dataServerOption3.Observability.Metric.Enabled = &constant.FlagFalse
 	dataServerOption3.Storage.Database.Dir = t.TempDir()
 	dataServerOption3.Storage.WAL.Dir = t.TempDir()
-	s3, err := dataserver.New(t.Context(), commonwatch.New(dataServerOption3))
+	s3, err := dataserver.New(t.Context(), dataServerOption3)
 	assert.NoError(t, err)
 	defer s3.Close()
 
@@ -413,7 +412,7 @@ func TestOIDCWithStaticKeyFile(t *testing.T) {
 	dataServerOption1.Observability.Metric.Enabled = &constant.FlagFalse
 	dataServerOption1.Storage.Database.Dir = t.TempDir()
 	dataServerOption1.Storage.WAL.Dir = t.TempDir()
-	s1, err := dataserver.New(t.Context(), commonwatch.New(dataServerOption1))
+	s1, err := dataserver.New(t.Context(), dataServerOption1)
 	assert.NoError(t, err)
 	defer s1.Close()
 
@@ -429,7 +428,7 @@ func TestOIDCWithStaticKeyFile(t *testing.T) {
 	dataServerOption2.Observability.Metric.Enabled = &constant.FlagFalse
 	dataServerOption2.Storage.Database.Dir = t.TempDir()
 	dataServerOption2.Storage.WAL.Dir = t.TempDir()
-	s2, err := dataserver.New(t.Context(), commonwatch.New(dataServerOption2))
+	s2, err := dataserver.New(t.Context(), dataServerOption2)
 	assert.NoError(t, err)
 	defer s2.Close()
 
@@ -445,7 +444,7 @@ func TestOIDCWithStaticKeyFile(t *testing.T) {
 	dataServerOption3.Observability.Metric.Enabled = &constant.FlagFalse
 	dataServerOption3.Storage.Database.Dir = t.TempDir()
 	dataServerOption3.Storage.WAL.Dir = t.TempDir()
-	s3, err := dataserver.New(t.Context(), commonwatch.New(dataServerOption3))
+	s3, err := dataserver.New(t.Context(), dataServerOption3)
 	assert.NoError(t, err)
 	defer s3.Close()
 

--- a/tests/security/tls/tls_encryption_test.go
+++ b/tests/security/tls/tls_encryption_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/oxia-db/oxia/common/proto"
-	commonwatch "github.com/oxia-db/oxia/oxiad/common/watch"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata/provider/memory"
 
 	dataserveroption "github.com/oxia-db/oxia/oxiad/dataserver/option"
@@ -101,7 +100,7 @@ func newTLSServerWithInterceptor(t *testing.T, interceptor func(config *dataserv
 
 	interceptor(dataServerOption)
 
-	s, err = dataserver.New(t.Context(), commonwatch.New(dataServerOption))
+	s, err = dataserver.New(t.Context(), dataServerOption)
 
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Closes the "how" half of #1132: make the data server and the coordinator embeddable in a Go application through the same entry points the `oxia` binary uses, so the embedding API cannot drift from the shipped server.

## What changes

- `dataserver.New(ctx, options)` and `coordinator.New(ctx, options, ...ServerOption)` take plain `Options`. Defaults are applied and the options validated before the server starts. The watch-based constructors (`dataserver.NewWithOptionsWatch`, `coordinator.NewGrpcServer`) stay for dynamic reload, and the CLI keeps using them.
- Two coordinator options for embedders:
  - `WithOnLeadershipLost(func())` replaces the default `os.Exit(1)` on metadata-leadership loss, which an embedding process cannot accept.
  - `WithInitialClusterConfiguration(*proto.ClusterConfiguration)` bootstraps the cluster configuration through the new `metadata.Factory.SeedClusterConfig`, which is idempotent and never overwrites an existing configuration.
- `UpdateOptions` on `dataserver.Server` and `coordinator.GrpcServer`; `PublicPort` and `InternalPort` accessors on the coordinator, needed when binding to ephemeral ports.
- `NewStandalone` applies option defaults and validation; `NumShards` defaults to 1.
- Provider name constants re-exported in `coordinator/option`, so choosing the metadata provider does not require importing `metadata/common`.
- Package docs on `dataserver` and `coordinator` with a full in-process cluster example, and a README section on embedding.

## Starting an embedded server

The simplest form is a standalone single-node server, the embedded equivalent of `oxia standalone`:

```go
import (
	"github.com/oxia-db/oxia/oxia"
	"github.com/oxia-db/oxia/oxiad/dataserver"
)

config := dataserver.StandaloneConfig{}
config.DataServerOptions.Server.Public.BindAddress = "localhost:0"
config.DataServerOptions.Storage.Database.Dir = "./data/db"
config.DataServerOptions.Storage.WAL.Dir = "./data/wal"

server, err := dataserver.NewStandalone(config)
if err != nil {
	return err
}
defer server.Close()

client, err := oxia.NewSyncClient(server.ServiceAddr())
```

A replicated in-process cluster runs a coordinator next to the data servers; the `coordinator` package documentation walks through a three-node example bootstrapped with `WithInitialClusterConfiguration`.

## Tests

- `tests/embedded`: a coordinator plus three data servers in one process through the public API, exercised with the client, plus the standalone form above.
- Unit tests for `SeedClusterConfig` (seeds once, never overwrites, rejects a nil configuration) and for the server options (a nil option or nil handler falls back to the default).
- Existing e2e/mocks/security tests moved to the new constructors where they built servers by hand.

## Context

The use case is a broker written in Go that keeps its metadata in Oxia and wants a single binary for small topologies (3 to 12 nodes), KRaft-style, while larger deployments run Oxia separately. This PR is the minimal library surface for that. Follow-ups I'd like to propose separately, each small and useful on its own:

1. namespaces (with per-namespace key sorting) in `NewStandalone`, allocating shard IDs the way the coordinator does, so a standalone data directory is a valid cluster layout;
2. seeding cluster *status* from a server's existing shards on first coordinated start, the twin of `SeedClusterConfig`;
3. raft metadata provider: membership reconciled to a peer list (`AddVoter`/`RemoveServer`) and a real leader hint under raft;
4. growing an ensemble to a raised `replication_factor`.

Happy to split or reshape any of this to match how you'd like the surface to look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
