### PR TITLE
fix: an inverted range scans nothing instead of tripping pebble's bound invariant

### DIFF
--- a/oxiad/dataserver/database/kvstore/kv_pebble.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble.go
@@ -536,6 +536,9 @@ func (p *Pebble) KeyRangeScanReverse(lowerBound, upperBound string, itOpts Itera
 	if upperBound != "" {
 		ub = p.keyEncoder.Encode(upperBound)
 	}
+	if invertedRange(lb, ub) {
+		return emptyIterator{}, nil
+	}
 	pbit, err := p.db.NewIter(newIterOptions(p.keyEncoder, itOpts, lb, ub))
 	if err != nil {
 		return nil, err
@@ -556,6 +559,9 @@ func (p *Pebble) RangeScan(lowerBound, upperBound string, itOpts IteratorOpts) (
 		ub = p.keyEncoder.Encode(upperBound)
 	}
 
+	if invertedRange(lb, ub) {
+		return emptyIterator{}, nil
+	}
 	pbit, err := p.db.NewIter(newIterOptions(p.keyEncoder, itOpts, lb, ub))
 	if err != nil {
 		return nil, err
@@ -601,6 +607,9 @@ func (b *PebbleBatch) KeyRangeScan(lowerBound, upperBound string) (KeyIterator, 
 func (b *PebbleBatch) RangeScan(lowerBound, upperBound string) (KeyValueIterator, error) {
 	lb := b.p.keyEncoder.Encode(lowerBound)
 	ub := b.p.keyEncoder.Encode(upperBound)
+	if invertedRange(lb, ub) {
+		return emptyIterator{}, nil
+	}
 	pbit, err := b.b.NewIter(&pebble.IterOptions{
 		LowerBound: lb,
 		UpperBound: ub,
@@ -913,3 +922,23 @@ func (s internalRegionSkipper) backward(it *pebble.Iterator) bool {
 	}
 	return it.SeekLT(s.start)
 }
+
+// invertedRange reports a bounded range that holds nothing: a lower bound
+// at or past the upper bound. Encoded keys order bytewise. Pebble leaves an
+// iterator with such bounds undefined and asserts on it in invariant builds,
+// so the range is judged here instead.
+func invertedRange(lowerBound, upperBound []byte) bool {
+	return lowerBound != nil && upperBound != nil && bytes.Compare(lowerBound, upperBound) >= 0
+}
+
+// emptyIterator is the scan of a range that holds nothing.
+type emptyIterator struct{}
+
+func (emptyIterator) Close() error           { return nil }
+func (emptyIterator) Valid() bool            { return false }
+func (emptyIterator) Key() string            { return "" }
+func (emptyIterator) Prev() bool             { return false }
+func (emptyIterator) Next() bool             { return false }
+func (emptyIterator) SeekGE(string) bool     { return false }
+func (emptyIterator) SeekLT(string) bool     { return false }
+func (emptyIterator) Value() ([]byte, error) { return nil, ErrKeyNotFound }

--- a/oxiad/dataserver/database/kvstore/kv_pebble_test.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble_test.go
@@ -1273,3 +1273,45 @@ func TestCompareWithDataset(t *testing.T) {
 		})
 	}
 }
+
+// An inverted range — lower bound at or past the upper bound — scans
+// nothing, on the store and inside a batch, in both directions. Pebble
+// leaves an iterator with inverted bounds undefined and asserts on it in
+// invariant builds (the race detector enables them), so the range must
+// be judged before pebble sees it.
+func TestPebbleRangeScanInvertedBoundsIsEmpty(t *testing.T) {
+	factory, err := NewPebbleKVFactory(NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	kv, err := factory.NewKV(constant.DefaultNamespace, 1, proto.KeySortingType_HIERARCHICAL)
+	assert.NoError(t, err)
+
+	wb := kv.NewWriteBatch()
+	assert.NoError(t, wb.Put("/root/a", []byte("a")))
+	assert.NoError(t, wb.Put("/root/b", []byte("b")))
+	assert.NoError(t, wb.Put("/root/c", []byte("c")))
+	assert.NoError(t, wb.Commit())
+	assert.NoError(t, wb.Close())
+
+	for _, bounds := range [][2]string{{"/root/c", "/root/a"}, {"/root/b", "/root/b"}} {
+		it, err := kv.RangeScan(bounds[0], bounds[1], NoInternalKeys)
+		assert.NoError(t, err)
+		assert.False(t, it.Valid(), "store range scan %v", bounds)
+		assert.NoError(t, it.Close())
+
+		rit, err := kv.KeyRangeScanReverse(bounds[0], bounds[1], NoInternalKeys)
+		assert.NoError(t, err)
+		assert.False(t, rit.Valid(), "store reverse range scan %v", bounds)
+		assert.NoError(t, rit.Close())
+
+		wb = kv.NewWriteBatch()
+		assert.NoError(t, wb.Put("/root/d", []byte("d")))
+		bit, err := wb.RangeScan(bounds[0], bounds[1])
+		assert.NoError(t, err)
+		assert.False(t, bit.Valid(), "batch range scan %v", bounds)
+		assert.NoError(t, bit.Close())
+		assert.NoError(t, wb.Close())
+	}
+
+	assert.NoError(t, kv.Close())
+	assert.NoError(t, factory.Close())
+}


### PR DESCRIPTION
`RangeScan`, `KeyRangeScanReverse` and the batch `RangeScan` pass the caller's bounds straight into `pebble.IterOptions`. When the range is inverted or empty — lower bound at or past the upper bound — pebble's behaviour is undefined: release builds happen to produce an empty iterator, but invariant builds (which the race detector switches on) assert with

```
WARN mergingIter: lower bound violation: <lower> < <upper>
```

inside the leader's apply path. The everyday trigger is a `DeleteRange` whose `start_inclusive >= end_exclusive`; a client expecting a no-op gets a crashed data server under `-race`.

## Fix

Judge the range before pebble sees it. Encoded keys order bytewise, so a lower bound at or past the upper bound returns an iterator that is never valid. Applied to the three bounded constructors; single-bound iterators are unaffected.

## Test

`TestPebbleRangeScanInvertedBoundsIsEmpty` covers the store scan, the reverse scan and the batch scan for both an inverted and an empty range. It fails on `main` under `go test -race` with the assertion above and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zeKZ9GicpAvatkAh1mutZ
