### PR TITLE
fix: order a multi-shard index scan by secondary key

### DIFF
--- a/oxia/client.go
+++ b/oxia/client.go
@@ -240,6 +240,11 @@ type GetResult struct {
 	// The version information
 	Version Version
 
+	// SecondaryIndexKey is the record's key in the secondary index the
+	// operation read through, when it used one — the order a RangeScan
+	// over an index follows across shards. Empty otherwise.
+	SecondaryIndexKey string
+
 	// The error if the `Get` operation failed
 	Err error
 }

--- a/oxia/proto_utils.go
+++ b/oxia/proto_utils.go
@@ -54,8 +54,9 @@ func toGetResult(r *proto.GetResponse, originalKey string, err error) GetResult 
 		}
 	}
 	gr := GetResult{
-		Value:   r.Value,
-		Version: toVersion(r.Version),
+		Value:             r.Value,
+		Version:           toVersion(r.Version),
+		SecondaryIndexKey: r.GetSecondaryIndexKey(),
 	}
 
 	if r.Key != nil {

--- a/oxia/results_heap.go
+++ b/oxia/results_heap.go
@@ -27,8 +27,17 @@ func (h ResultHeap) Len() int {
 	return len(h)
 }
 
+// Less follows the order the shards themselves produced: a scan through a
+// secondary index is ordered by secondary key, ties by record key; a plain
+// scan by record key.
 func (h ResultHeap) Less(i, j int) bool {
-	return compare.CompareWithSlash([]byte(h[i].gr.Key), []byte(h[j].gr.Key)) < 0
+	a, b := h[i].gr, h[j].gr
+	if a.SecondaryIndexKey != "" && b.SecondaryIndexKey != "" {
+		if c := compare.CompareWithSlash([]byte(a.SecondaryIndexKey), []byte(b.SecondaryIndexKey)); c != 0 {
+			return c < 0
+		}
+	}
+	return compare.CompareWithSlash([]byte(a.Key), []byte(b.Key)) < 0
 }
 
 func (h ResultHeap) Swap(i, j int) {

--- a/oxia/results_heap_test.go
+++ b/oxia/results_heap_test.go
@@ -1,0 +1,70 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oxia
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func resultsChannel(results ...GetResult) chan GetResult {
+	ch := make(chan GetResult, len(results))
+	for _, r := range results {
+		ch <- r
+	}
+	close(ch)
+	return ch
+}
+
+func collectKeys(ch chan GetResult) []string {
+	var keys []string
+	for r := range ch {
+		keys = append(keys, r.Key)
+	}
+	return keys
+}
+
+// A range scan over a secondary index spans every shard; the merge must
+// follow the index's order — secondary key, then record key — not the
+// record keys, which the index deliberately orders differently.
+func TestAggregateRangeScanAcrossShardsOrdersByIndexKey(t *testing.T) {
+	// Each shard yields its own results already in index order.
+	shard1 := resultsChannel(
+		GetResult{Key: "c", SecondaryIndexKey: "idx/1"},
+		GetResult{Key: "a", SecondaryIndexKey: "idx/3"},
+	)
+	shard2 := resultsChannel(
+		GetResult{Key: "b", SecondaryIndexKey: "idx/2"},
+		GetResult{Key: "d", SecondaryIndexKey: "idx/3"},
+	)
+
+	out := make(chan GetResult)
+	go aggregateAndSortRangeScanAcrossShards([]chan GetResult{shard1, shard2}, out)
+
+	assert.Equal(t, []string{"c", "b", "a", "d"}, collectKeys(out),
+		"secondary key ascending, ties by record key")
+}
+
+// Without an index, record keys order the merge as before.
+func TestAggregateRangeScanAcrossShardsOrdersByKey(t *testing.T) {
+	shard1 := resultsChannel(GetResult{Key: "a"}, GetResult{Key: "d"})
+	shard2 := resultsChannel(GetResult{Key: "b"}, GetResult{Key: "c"})
+
+	out := make(chan GetResult)
+	go aggregateAndSortRangeScanAcrossShards([]chan GetResult{shard1, shard2}, out)
+
+	assert.Equal(t, []string{"a", "b", "c", "d"}, collectKeys(out))
+}

--- a/oxiad/dataserver/controller/lead/secondary_indexes.go
+++ b/oxiad/dataserver/controller/lead/secondary_indexes.go
@@ -198,14 +198,20 @@ func (it *secondaryIndexListIterator) Valid() bool {
 }
 
 func (it *secondaryIndexListIterator) Key() string {
-	idxKey := it.it.Key()
-	primaryKey, _, err := database.ParseSecondaryIndexKey(idxKey)
+	primaryKey, _ := it.keys()
+	return primaryKey
+}
+
+// keys splits the current index entry into the record's key and its key in
+// the index.
+func (it *secondaryIndexListIterator) keys() (primaryKey string, secondaryKey string) {
+	primaryKey, secondaryKey, err := database.ParseSecondaryIndexKey(it.it.Key())
 	if err != nil {
 		// This should never happen since we control the key format
 		panic(errors.Wrap(err, "Failed to parse secondary index key"))
 	}
 
-	return primaryKey
+	return primaryKey, secondaryKey
 }
 
 func (*secondaryIndexListIterator) Prev() bool {
@@ -267,7 +273,7 @@ func (it *secondaryIndexRangeIterator) Next() bool {
 }
 
 func (it *secondaryIndexRangeIterator) Value() (*proto.GetResponse, error) {
-	primaryKey := it.Key()
+	primaryKey, secondaryKey := it.listIt.keys()
 	gr, err := it.db.Get(&proto.GetRequest{
 		Key:            primaryKey,
 		IncludeValue:   true,
@@ -276,6 +282,7 @@ func (it *secondaryIndexRangeIterator) Value() (*proto.GetResponse, error) {
 
 	if gr != nil {
 		gr.Key = &primaryKey
+		gr.SecondaryIndexKey = &secondaryKey
 	}
 
 	return gr, err

--- a/oxiad/dataserver/controller/lead/secondary_indexes_test.go
+++ b/oxiad/dataserver/controller/lead/secondary_indexes_test.go
@@ -535,3 +535,45 @@ func TestDoSecondaryGet_UnsupportedComparisonType(t *testing.T) {
 	assert.NoError(t, kvFactory.Close())
 	assert.NoError(t, walFactory.Close())
 }
+
+// A range scan through a secondary index reports each record's secondary
+// key alongside it — the key the scan is ordered by, which a client merging
+// several shards' scans needs to keep that order.
+func TestSecondaryIndices_RangeScanReturnsSecondaryKey(t *testing.T) {
+	var shard int64 = 1
+	kvFactory, _ := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	walFactory := newTestWalFactory(t)
+	lc, _ := NewLeaderController(&option.StorageOptions{}, constant.DefaultNamespace, shard, rpc.NewMockRpcClient(), walFactory, kvFactory, nil)
+	_, _ = lc.NewTerm(&proto.NewTermRequest{Shard: shard, Term: 1})
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
+		Shard:             shard,
+		Term:              1,
+		ReplicationFactor: 1,
+		FollowerMaps:      nil,
+	})
+
+	_, err := lc.WriteBlock(context.Background(), &proto.WriteRequest{
+		Shard: &shard,
+		Puts: []*proto.PutRequest{
+			{Key: "/a", Value: []byte("0"), SecondaryIndexes: []*proto.SecondaryIndex{{IndexName: "my-idx", SecondaryKey: "k2"}}},
+			{Key: "/b", Value: []byte("1"), SecondaryIndexes: []*proto.SecondaryIndex{{IndexName: "my-idx", SecondaryKey: "k1"}}},
+		},
+	})
+	assert.NoError(t, err)
+
+	results, err := scanAll(context.Background(), lc, &proto.RangeScanRequest{
+		Shard:              &shard,
+		StartInclusive:     "k",
+		EndExclusive:       "l",
+		SecondaryIndexName: pb.String("my-idx"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "/b", results[0].GetKey())
+	assert.Equal(t, "k1", results[0].GetSecondaryIndexKey())
+	assert.Equal(t, "/a", results[1].GetKey())
+	assert.Equal(t, "k2", results[1].GetSecondaryIndexKey())
+
+	assert.NoError(t, lc.Close())
+	assert.NoError(t, kvFactory.Close())
+}


### PR DESCRIPTION
A `RangeScan` with `UseIndex` fans out to every shard and merges the per-shard streams through `ResultHeap`, whose `Less` compares **record keys** only. Each shard returns its slice in secondary-key order, so the merge interleaves them by the wrong key: an index scan spanning shards comes back out of secondary-key order, while the same scan on a one-shard namespace is sorted. `compareGetResponse` already applies the right rule (secondary key first, then record key) to multi-shard gets; the scan merge never used it — and could not have, because the server's index range-scan iterator dropped the secondary key while parsing the composite entry (`secondaryIndexGet` does report it).

## Fix

Server: `secondaryIndexRangeIterator.Value()` sets `secondary_index_key` from the composite index entry, as the index `Get` path already does.

Client: `GetResult` gains `SecondaryIndexKey`, filled from the response (empty for plain reads), and `ResultHeap.Less` orders by it when both results carry one, ties by record key; plain scans keep record-key order.

## Tests

- `TestSecondaryIndices_RangeScanReturnsSecondaryKey` (server): each result of an index range scan carries its secondary key.
- `TestAggregateRangeScanAcrossShardsOrdersByIndexKey` (client): two shard streams whose record-key order is the reverse of their index order merge in index order; `…OrdersByKey` pins the plain-scan behaviour.

Found by running a multi-shard namespace in-process under a kv conformance suite that had only ever run against `oxia standalone --shards 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zeKZ9GicpAvatkAh1mutZ
