### PR TITLE
fix: skip unchanged shard status writes on release-0.16

### DIFF
--- a/common/time/jitter.go
+++ b/common/time/jitter.go
@@ -1,0 +1,30 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package time
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// Jitter returns a duration uniformly distributed in
+// [interval-maxDeviation, interval+maxDeviation). If maxDeviation is not
+// positive, it returns interval unchanged.
+func Jitter(interval time.Duration, maxDeviation time.Duration) time.Duration {
+	if maxDeviation <= 0 {
+		return interval
+	}
+	return interval - maxDeviation + rand.N(2*maxDeviation) //nolint:gosec
+}

--- a/common/time/jitter_test.go
+++ b/common/time/jitter_test.go
@@ -1,0 +1,33 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package time
+
+import (
+	"testing"
+	stdtime "time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJitter(t *testing.T) {
+	assert.Equal(t, stdtime.Nanosecond, Jitter(stdtime.Nanosecond, 0))
+	assert.Equal(t, stdtime.Nanosecond, Jitter(stdtime.Nanosecond, -stdtime.Nanosecond))
+
+	for range 100 {
+		interval := Jitter(stdtime.Minute, stdtime.Minute/4)
+		assert.GreaterOrEqual(t, interval, 45*stdtime.Second)
+		assert.Less(t, interval, 75*stdtime.Second)
+	}
+}

--- a/oxiad/coordinator/controller/shard_controller.go
+++ b/oxiad/coordinator/controller/shard_controller.go
@@ -503,7 +503,7 @@ func (s *shardController) handlePeriodicTasks() {
 	stateDirty := false
 
 	if len(mutShardMeta.PendingDeleteShardNodes) > 0 {
-		if err := s.handlePendingDeleteShard(&mutShardMeta); err != nil {
+		if err := s.handlePendingDeleteShard(mutShardMeta); err != nil {
 			s.log.Warn("Failed to handle pending delete shard", "error", err)
 		} else {
 			// Clear the pending-delete nodes in the canonical local view. The RPCs
@@ -521,14 +521,14 @@ func (s *shardController) handlePeriodicTasks() {
 	}
 }
 
-func (s *shardController) handlePendingDeleteShard(mutShardMeta *model.ShardMetadata) error {
-	for _, ds := range mutShardMeta.PendingDeleteShardNodes {
+func (s *shardController) handlePendingDeleteShard(shardMeta model.ShardMetadata) error {
+	for _, ds := range shardMeta.PendingDeleteShardNodes {
 		s.log.Info("Deleting shard from removed data server", slog.Any("data-server", ds))
 
 		if _, err := s.rpc.DeleteShard(s.ctx, ds, &proto.DeleteShardRequest{
 			Namespace: s.namespace,
 			Shard:     s.shard,
-			Term:      mutShardMeta.Term,
+			Term:      shardMeta.Term,
 		}); err != nil {
 			s.log.Warn("Failed to delete shard from removed data server", slog.Any("data-server", ds), slog.Any("error", err))
 			return err
@@ -537,6 +537,5 @@ func (s *shardController) handlePendingDeleteShard(mutShardMeta *model.ShardMeta
 		s.log.Info("Successfully deleted shard from data server", slog.Any("data-server", ds))
 	}
 
-	mutShardMeta.PendingDeleteShardNodes = nil
 	return nil
 }

--- a/oxiad/coordinator/controller/shard_controller.go
+++ b/oxiad/coordinator/controller/shard_controller.go
@@ -144,7 +144,7 @@ func NewShardController(
 		dataServerFailureOp:                 make(chan model.Server, chanBufferSize),
 		changeEnsembleOp:                    make(chan *action.ChangeEnsembleAction, chanBufferSize),
 
-		periodicTasksInterval: periodTasksInterval,
+		periodicTasksInterval: oxiatime.Jitter(periodTasksInterval, periodTasksInterval/4),
 		log: slog.With(
 			slog.String("component", "shard-controller"),
 			slog.String("namespace", namespace),
@@ -225,7 +225,8 @@ func (s *shardController) run(initShardMeta *model.ShardMetadata) {
 
 	s.log.Info("Shard is ready", slog.Any("leader", initShardMeta.Leader))
 
-	periodicTasksTimer := time.NewTicker(s.periodicTasksInterval)
+	periodicTasksTimer := time.NewTimer(s.periodicTasksInterval)
+	defer periodicTasksTimer.Stop()
 
 	for {
 		select {
@@ -240,6 +241,7 @@ func (s *shardController) run(initShardMeta *model.ShardMetadata) {
 			s.onChangeEnsemble(op)
 		case <-periodicTasksTimer.C:
 			s.handlePeriodicTasks()
+			periodicTasksTimer.Reset(s.periodicTasksInterval)
 		case electionAction := <-s.electionOp:
 			newLeader := s.onElectLeader(nil)
 			electionAction.Done(newLeader.GetIdentifier())
@@ -498,18 +500,25 @@ func (s *shardController) SyncServerAddress() {
 
 func (s *shardController) handlePeriodicTasks() {
 	mutShardMeta := s.metadata.Load()
+	stateDirty := false
 
 	if len(mutShardMeta.PendingDeleteShardNodes) > 0 {
-		var err error
-		if err = s.handlePendingDeleteShard(&mutShardMeta); err != nil {
+		if err := s.handlePendingDeleteShard(&mutShardMeta); err != nil {
 			s.log.Warn("Failed to handle pending delete shard", "error", err)
-			return
+		} else {
+			// Clear the pending-delete nodes in the canonical local view. The RPCs
+			// above leave a window where another operation can update the metadata,
+			// so avoid replacing the complete snapshot loaded before those RPCs.
+			mutShardMeta = s.metadata.Compute(func(metadata *model.ShardMetadata) {
+				metadata.PendingDeleteShardNodes = nil
+			})
+			stateDirty = true
 		}
 	}
 
-	// Update the shard status
-	s.statusResource.UpdateShardMetadata(s.namespace, s.shard, mutShardMeta)
-	s.metadata.Store(mutShardMeta)
+	if stateDirty {
+		s.statusResource.UpdateShardMetadata(s.namespace, s.shard, mutShardMeta)
+	}
 }
 
 func (s *shardController) handlePendingDeleteShard(mutShardMeta *model.ShardMetadata) error {

--- a/oxiad/coordinator/controller/shard_controller_test.go
+++ b/oxiad/coordinator/controller/shard_controller_test.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"log/slog"
 	"math/rand"
 	"sync"
 	"testing"
@@ -179,6 +180,59 @@ func TestShardController(t *testing.T) {
 
 	rpc.GetNode(s1).expectNewTermRequest(t, shard, 4, true)
 	assert.NoError(t, sc.Close())
+}
+
+// Each UpdateShardMetadata persists the full cluster status. A periodic tick
+// should only persist after it finishes pending shard deletes.
+func TestShardController_PeriodicTasksPersistPendingDeleteChanges(t *testing.T) {
+	const shard int64 = 5
+	pendingDeleteNode := model.Server{Public: "s1:9091", Internal: "s1:8191"}
+	shardMetadata := model.ShardMetadata{
+		Status: model.ShardStatusSteadyState,
+		Term:   1,
+	}
+
+	meta := metadata.NewMetadataProviderMemory()
+	defer meta.Close()
+	statusResource := resource.NewStatusResource(meta)
+	status := model.NewClusterStatus()
+	status.Namespaces[constant.DefaultNamespace] = model.NamespaceStatus{
+		Shards: map[int64]model.ShardMetadata{shard: shardMetadata},
+	}
+	statusResource.Update(status)
+	rpc := newMockRpcProvider()
+
+	controller := &shardController{
+		namespace:      constant.DefaultNamespace,
+		shard:          shard,
+		metadata:       NewMetadata(shardMetadata),
+		statusResource: statusResource,
+		rpc:            rpc,
+		ctx:            t.Context(),
+		log:            slog.Default(),
+	}
+
+	before := statusResource.Load()
+	controller.handlePeriodicTasks()
+	assert.Same(t, before, statusResource.Load())
+
+	updatedMetadata := controller.metadata.Compute(func(metadata *model.ShardMetadata) {
+		metadata.PendingDeleteShardNodes = []model.Server{pendingDeleteNode}
+	})
+	statusResource.UpdateShardMetadata(constant.DefaultNamespace, shard, updatedMetadata)
+	before = statusResource.Load()
+	rpc.GetNode(pendingDeleteNode).DeleteShardResponse(nil)
+	controller.handlePeriodicTasks()
+	rpc.GetNode(pendingDeleteNode).expectDeleteShardRequest(t, shard, shardMetadata.Term)
+
+	after := statusResource.Load()
+	assert.NotSame(t, before, after)
+	assert.Empty(t, after.Namespaces[constant.DefaultNamespace].Shards[shard].PendingDeleteShardNodes)
+	assert.Empty(t, controller.metadata.Load().PendingDeleteShardNodes)
+
+	before = after
+	controller.handlePeriodicTasks()
+	assert.Same(t, before, statusResource.Load())
 }
 
 func TestShardController_StartingWithLeaderAlreadyPresent(t *testing.T) {


### PR DESCRIPTION
## Motivation

On `release-0.16`, every shard controller unconditionally persists its shard metadata on every periodic tick. `UpdateShardMetadata` clones and stores the full cluster status, so a cluster with S shards performs O(S²) bytes of metadata writes per interval even when the status is unchanged. This can saturate the ConfigMap provider and keep controller event loops blocked behind status serialization and Kubernetes API calls.

This backports the post-#1217 periodic-task behavior to `release-0.16`: periodic work records whether it changed shard state and persists status only when needed.

## Modifications

- Track periodic mutations with a method-local `stateDirty` flag and persist once when state changed.
- Keep processing future periodic work when pending-delete cleanup fails.
- Clear completed pending-delete state with `Metadata.Compute` so a snapshot loaded before the delete RPCs cannot overwrite concurrent local metadata changes.
- Keep the pending-delete RPC helper read-only and commit local state changes only in the periodic-task handler.
- Add `common/time.Jitter` and assign each shard controller one fixed interval in the range `[75%, 125%)` of the configured interval.
- Use a one-shot timer reset after each handler finishes, preventing queued ticks from causing immediate retries after slow periodic RPCs.
- Add regression coverage for dirty-state persistence and the shared jitter utility's range and boundary behavior.
