### PR TITLE
refactor: simplify periodic shard task handling

### DIFF
--- a/common/time/jitter.go
+++ b/common/time/jitter.go
@@ -1,0 +1,30 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package time
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// Jitter returns a duration uniformly distributed in
+// [interval-maxDeviation, interval+maxDeviation). If maxDeviation is not
+// positive, it returns interval unchanged.
+func Jitter(interval time.Duration, maxDeviation time.Duration) time.Duration {
+	if maxDeviation <= 0 {
+		return interval
+	}
+	return interval - maxDeviation + rand.N(2*maxDeviation) //nolint:gosec
+}

--- a/common/time/jitter_test.go
+++ b/common/time/jitter_test.go
@@ -1,0 +1,33 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package time
+
+import (
+	"testing"
+	stdtime "time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJitter(t *testing.T) {
+	assert.Equal(t, stdtime.Nanosecond, Jitter(stdtime.Nanosecond, 0))
+	assert.Equal(t, stdtime.Nanosecond, Jitter(stdtime.Nanosecond, -stdtime.Nanosecond))
+
+	for range 100 {
+		interval := Jitter(stdtime.Minute, stdtime.Minute/4)
+		assert.GreaterOrEqual(t, interval, 45*stdtime.Second)
+		assert.Less(t, interval, 75*stdtime.Second)
+	}
+}

--- a/oxiad/coordinator/runtime/controller/shard/shard_controller.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math/rand/v2"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -158,7 +157,7 @@ func NewController(
 		dataServerFailureOp:                 make(chan *proto.DataServerIdentity, chanBufferSize),
 		changeEnsembleOp:                    make(chan *action.ChangeEnsembleAction, chanBufferSize),
 
-		periodicTasksInterval: periodTasksInterval,
+		periodicTasksInterval: oxiatime.Jitter(periodTasksInterval, periodTasksInterval/4),
 		logger: slog.With(
 			slog.String("component", "shard-controller"),
 			slog.String("namespace", namespace),
@@ -259,10 +258,7 @@ func (s *controller) run() {
 
 	s.logger.Info("Shard is ready", slog.Any("leader", initShardMeta.Leader))
 
-	// All the shard controllers start together at coordinator startup: spread
-	// the first periodic tick over the interval so the periodic tasks don't
-	// fire as a herd.
-	periodicTasksTimer := time.NewTimer(rand.N(s.periodicTasksInterval)) //nolint:gosec
+	periodicTasksTimer := time.NewTimer(s.periodicTasksInterval)
 	defer periodicTasksTimer.Stop()
 
 	for {
@@ -675,26 +671,36 @@ func (s *controller) handlePeriodicTasks() {
 	mutShardMeta := gproto.CloneOf(common.Must(borrowedMeta, exists,
 		"bug: shard metadata missing while handling periodic tasks: namespace=", s.namespace, " shard=",
 		s.shard).UnsafeBorrow())
+	stateDirty := false
 
 	if len(mutShardMeta.PendingDeleteShardNodes) > 0 {
-		pendingDeleteShardNodes := append([]*proto.DataServerIdentity(nil), mutShardMeta.PendingDeleteShardNodes...)
-		term := mutShardMeta.Term
-		for _, ds := range pendingDeleteShardNodes {
-			s.logger.Info("Deleting shard from removed data server", slog.Any("data-server", ds))
-
-			if _, err := s.rpc.DeleteShard(s.ctx, ds, &proto.DeleteShardRequest{
-				Namespace: s.namespace,
-				Shard:     s.shard,
-				Term:      term,
-			}); err != nil {
-				s.logger.Warn("Failed to delete shard from removed data server", slog.Any("data-server", ds), slog.Any("error", err))
-				return
-			}
-
-			s.logger.Info("Successfully deleted shard from data server", slog.Any("data-server", ds))
+		if err := s.handlePendingDeleteShard(mutShardMeta); err != nil {
+			s.logger.Warn("Failed to handle pending delete shard", slog.Any("error", err))
+		} else {
+			stateDirty = true
 		}
+	}
 
-		mutShardMeta.PendingDeleteShardNodes = nil
+	if stateDirty {
 		s.metadataStore.UpdateShardStatus(s.namespace, s.shard, mutShardMeta)
 	}
+}
+
+func (s *controller) handlePendingDeleteShard(mutShardMeta *proto.ShardMetadata) error {
+	for _, ds := range mutShardMeta.PendingDeleteShardNodes {
+		s.logger.Info("Deleting shard from removed data server", slog.Any("data-server", ds))
+
+		if _, err := s.rpc.DeleteShard(s.ctx, ds, &proto.DeleteShardRequest{
+			Namespace: s.namespace,
+			Shard:     s.shard,
+			Term:      mutShardMeta.Term,
+		}); err != nil {
+			return fmt.Errorf("delete shard from removed data server %s: %w", ds.GetNameOrDefault(), err)
+		}
+
+		s.logger.Info("Successfully deleted shard from data server", slog.Any("data-server", ds))
+	}
+
+	mutShardMeta.PendingDeleteShardNodes = nil
+	return nil
 }

--- a/oxiad/coordinator/runtime/controller/shard/shard_controller_test.go
+++ b/oxiad/coordinator/runtime/controller/shard/shard_controller_test.go
@@ -1224,13 +1224,13 @@ func TestController_ChangeEnsembleRejectsInvalidAction(t *testing.T) {
 	assert.NoError(t, s.validateChangeEnsembleFeatures(action.NewChangeEnsembleAction(shard, s1, s4)))
 }
 
-// Each UpdateShardStatus persists the full cluster status, so re-writing it
-// for every shard on every periodic tick costs O(shards^2) bytes per interval
-// on the metadata backend. The periodic task must not persist when it has no
-// pending-delete bookkeeping to apply.
-func TestController_PeriodicTasksSkipUnchangedPersist(t *testing.T) {
+// Each UpdateShardStatus persists the full cluster status. A periodic tick
+// should only persist after it changes shard state.
+func TestController_PeriodicTasksPersistOnlyDirtyState(t *testing.T) {
 	var shard int64 = 5
 	metadata := newTestMetadata(t, memory.NewProvider(metadatacodec.ClusterStatusCodec, metadatacommon.WatchDisabled, ""), &proto.ClusterConfiguration{})
+	rpc := mockutils.NewRpcProvider()
+	pendingDeleteNode := &proto.DataServerIdentity{Public: "s2:9091", Internal: "s2:8191"}
 
 	shardMeta := &proto.ShardMetadata{
 		Status: proto.ShardStatusSteadyState,
@@ -1247,6 +1247,8 @@ func TestController_PeriodicTasksSkipUnchangedPersist(t *testing.T) {
 		namespace:     constant.DefaultNamespace,
 		shard:         shard,
 		metadataStore: metadata,
+		rpc:           rpc,
+		ctx:           t.Context(),
 		logger:        slog.Default(),
 	}
 
@@ -1256,6 +1258,24 @@ func TestController_PeriodicTasksSkipUnchangedPersist(t *testing.T) {
 	// Steady state without pending-delete nodes: no persist
 	s.handlePeriodicTasks()
 	borrowedAfter, _ := metadata.GetShardStatus(constant.DefaultNamespace, shard)
+	assert.Same(t, borrowedBefore.UnsafeBorrow(), borrowedAfter.UnsafeBorrow())
+
+	updatedShardMeta := gproto.CloneOf(shardMeta)
+	updatedShardMeta.PendingDeleteShardNodes = []*proto.DataServerIdentity{pendingDeleteNode}
+	metadata.UpdateShardStatus(constant.DefaultNamespace, shard, updatedShardMeta)
+	borrowedBefore, _ = metadata.GetShardStatus(constant.DefaultNamespace, shard)
+
+	rpc.GetNode(pendingDeleteNode).DeleteShardResponse(nil)
+	s.handlePeriodicTasks()
+	rpc.GetNode(pendingDeleteNode).ExpectDeleteShardRequest(t, shard, shardMeta.Term)
+
+	borrowedAfter, _ = metadata.GetShardStatus(constant.DefaultNamespace, shard)
+	assert.NotSame(t, borrowedBefore.UnsafeBorrow(), borrowedAfter.UnsafeBorrow())
+	assert.Empty(t, borrowedAfter.UnsafeBorrow().PendingDeleteShardNodes)
+
+	borrowedBefore = borrowedAfter
+	s.handlePeriodicTasks()
+	borrowedAfter, _ = metadata.GetShardStatus(constant.DefaultNamespace, shard)
 	assert.Same(t, borrowedBefore.UnsafeBorrow(), borrowedAfter.UnsafeBorrow())
 }
 


### PR DESCRIPTION
## Motivation

Periodic shard mutations are currently persisted inside individual task branches, which makes adding more periodic work harder to keep consistent. The initial periodic delay is also randomized separately from the interval stored on the controller.

Store the jittered cadence directly on each controller and centralize the decision to persist periodic state changes while preserving the existing wait-after-completion scheduling semantics.

## Modifications

- Add `common/time.Jitter` and assign each shard controller one fixed interval in the range `[75%, 125%)` of the configured interval.
- Keep the one-shot timer and reset it after each handler finishes, preventing queued ticks from causing immediate retries after slow periodic RPCs.
- Track periodic mutations with a method-local `stateDirty` flag and persist once when state changed.
- Keep processing future periodic work when pending-delete cleanup fails.
- Expand regression coverage for dirty-state persistence and the shared jitter utility's range and boundary behavior.

## Testing

- `go test ./common/time ./oxiad/coordinator/runtime/controller/shard -run 'TestJitter|TestController_PeriodicTasksPersistOnlyDirtyState' -count=1`
- `go test -race ./common/time ./oxiad/coordinator/runtime/controller/shard -run 'TestJitter|TestController_PeriodicTasksPersistOnlyDirtyState' -count=1`
- `go test ./common/time ./oxiad/coordinator/... -count=1`
- `go test -race ./common/time ./oxiad/coordinator/runtime/controller/shard -count=1`
- `go vet ./common/time ./oxiad/coordinator/runtime/controller/shard/...`
- `golangci-lint run ./common/time ./oxiad/coordinator/runtime/controller/shard/...`
- `git diff --check`

Signed-off-by: mattisonchao <mattisonchao@gmail.com>
