### PR TITLE
fix: publish restored assignments on coordinator restart

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Installing Go dependencies
         run: |
-          go install github.com/palantir/go-license@latest
+          go install github.com/palantir/go-license@v1.49.0
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.2
 
       - run: make license-check

--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -795,13 +795,12 @@ func NewCoordinator(meta metadata.Provider,
 		c.Info("Checking cluster config", slog.Any("clusterConfig", clusterConfig))
 	}
 	clusterStatus, _, _ = c.statusResource.ApplyChanges(clusterConfig, c.selectNewEnsemble)
-	if len(clusterStatus.Namespaces) == 0 {
-		// No shard controllers will run leader election and publish assignments,
-		// so send the empty assignment set now to make data servers ready.
-		c.Lock()
-		c.computeNewAssignments()
-		c.Unlock()
-	}
+	// Publish the current snapshot after restoring and reconciling status. Shards
+	// that are already healthy do not run a new leader election, so there might
+	// otherwise be no callback to initialize assignments on coordinator restart.
+	c.Lock()
+	c.computeNewAssignments()
+	c.Unlock()
 
 	// init shard controller
 	for ns, shards := range clusterStatus.Namespaces {

--- a/tests/control/control_request_test.go
+++ b/tests/control/control_request_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/common/proto"
 	clientrpc "github.com/oxia-db/oxia/common/rpc"
@@ -63,6 +64,11 @@ func TestControlRequestFeatureEnabled(t *testing.T) {
 	client, err := oxia.NewSyncClient(sa1.Public, oxia.WithNamespace("default"))
 	assert.NoError(t, err)
 	defer client.Close()
+
+	require.Eventually(t, func() bool {
+		shard := coordinatorInstance.StatusResource().Load().Namespaces["default"].Shards[0]
+		return shard.Status == model.ShardStatusSteadyState && shard.Leader != nil
+	}, 10*time.Second, 100*time.Millisecond)
 
 	resource := coordinatorInstance.StatusResource().Load()
 	shardMetadata := resource.Namespaces["default"].Shards[0]

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -472,6 +472,51 @@ func TestCoordinator_NoNamespacesSendsEmptyAssignments(t *testing.T) {
 	}, 10*time.Second, 10*time.Millisecond)
 }
 
+func TestCoordinator_RestartPublishesRestoredAssignments(t *testing.T) {
+	s1, sa1 := newServer(t)
+	defer s1.Close()
+
+	metadataProvider := metadata.NewMetadataProviderMemory()
+	clusterConfig := model.ClusterConfig{
+		Namespaces: []model.NamespaceConfig{{
+			Name:              constant.DefaultNamespace,
+			ReplicationFactor: 1,
+			InitialShardCount: 1,
+		}},
+		Servers: []model.Server{sa1},
+	}
+	clientPool := rpc.NewClientPool(nil, nil)
+	defer clientPool.Close()
+
+	newCoordinator := func() coordinator.Coordinator {
+		coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) {
+			return clusterConfig, nil
+		}, nil, rpc2.NewRpcProvider(clientPool))
+		require.NoError(t, err)
+		return coordinatorInstance
+	}
+
+	coordinatorInstance := newCoordinator()
+	require.Eventually(t, func() bool {
+		shard := coordinatorInstance.StatusResource().Load().Namespaces[constant.DefaultNamespace].Shards[0]
+		return shard.Status == model.ShardStatusSteadyState
+	}, 10*time.Second, 10*time.Millisecond)
+	require.NoError(t, coordinatorInstance.Close())
+
+	coordinatorInstance = newCoordinator()
+	defer coordinatorInstance.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	assignments, err := coordinatorInstance.WaitForNextUpdate(ctx, nil)
+	require.NoError(t, err)
+
+	namespaceAssignments, ok := assignments.Namespaces[constant.DefaultNamespace]
+	require.True(t, ok)
+	require.Len(t, namespaceAssignments.Assignments, 1)
+	assert.Equal(t, sa1.Public, namespaceAssignments.Assignments[0].Leader)
+}
+
 func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 	s1, sa1 := newServer(t)
 	s2, sa2 := newServer(t)


### PR DESCRIPTION
## Motivation

On Oxia 0.16, a coordinator restart restores persisted shard status and verifies the existing ensemble. When every replica already reports the expected role and term, no leader election runs. Since assignment publication was tied to election and change callbacks, the restarted coordinator could retain a nil assignment snapshot indefinitely.

A data server starting afterward would connect to the assignment stream but never receive its first snapshot, leaving its readiness service in NOT_SERVING even though shard replication could recover independently.

The CI workflow also installed `go-license@latest`. Version 1.50.0 now requires Go 1.27, while release-0.16 intentionally remains on Go 1.26.

Fixes #1292.

## Modifications

- Publish the current assignment snapshot immediately after the coordinator applies the initial cluster configuration to persisted status.
- Preserve the existing leader-election updates while covering steady-state coordinator restarts and empty namespace configurations.
- Add an end-to-end regression that establishes a shard, restarts the coordinator with the persisted steady state, and verifies that the restored assignment is available immediately.
- Allow the control integration test to observe the valid transitional assignment with no leader by waiting for the shard to reach steady state before dereferencing its leader.
- Pin `go-license` to v1.49.0, the last release compatible with Go 1.26.
